### PR TITLE
feat: add GET /api/health/detailed endpoint returning HealthSnapshot JSON

### DIFF
--- a/agentception/alembic/versions/0001_ac_initial_schema.py
+++ b/agentception/alembic/versions/0001_ac_initial_schema.py
@@ -10,7 +10,6 @@ Revision ID: ac0001
 Revises:
 Create Date: 2026-03-02
 """
-from __future__ import annotations
 
 import sqlalchemy as sa
 from alembic import op

--- a/agentception/alembic/versions/0002_ac_agent_events.py
+++ b/agentception/alembic/versions/0002_ac_agent_events.py
@@ -11,7 +11,6 @@ Revision ID: ac0002
 Revises: ac0001
 Create Date: 2026-03-03
 """
-from __future__ import annotations
 
 import sqlalchemy as sa
 from alembic import op

--- a/agentception/alembic/versions/0003_ac_initiative_phases.py
+++ b/agentception/alembic/versions/0003_ac_initiative_phases.py
@@ -14,7 +14,6 @@ Revision ID: ac0003
 Revises: ac0002
 Create Date: 2026-03-04
 """
-from __future__ import annotations
 
 import sqlalchemy as sa
 from alembic import op

--- a/agentception/alembic/versions/0004_ac_task_runs.py
+++ b/agentception/alembic/versions/0004_ac_task_runs.py
@@ -6,7 +6,6 @@ Revision ID: 0004
 Revises: 0003
 Create Date: 2026-03-03
 """
-from __future__ import annotations
 
 import sqlalchemy as sa
 from alembic import op

--- a/agentception/app.py
+++ b/agentception/app.py
@@ -14,7 +14,6 @@ Architecture:
 - HTML pages are rendered via Jinja2 from ``agentception/templates/``.
 - JSON API routes live in ``agentception/routes/``.
 """
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/agentception/config.py
+++ b/agentception/config.py
@@ -14,7 +14,6 @@ defaults.  This is the primary mechanism for multi-repo generalisation (AC-601).
 calls it at the top of every tick so a project switch via the GUI takes effect
 within one polling interval — no service restart required.
 """
-from __future__ import annotations
 
 import json
 import logging

--- a/agentception/db/__init__.py
+++ b/agentception/db/__init__.py
@@ -5,4 +5,3 @@ from __future__ import annotations
 Self-contained: own Base, engine, session factory, and Alembic migration tree.
 Designed for clean extraction to a standalone service — no imports from maestro.db.
 """
-from __future__ import annotations

--- a/agentception/db/base.py
+++ b/agentception/db/base.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 Intentionally isolated from ``maestro.db.database.Base`` so that this package
 can be extracted to its own service without touching the Maestro codebase.
 """
-from __future__ import annotations
 
 from sqlalchemy.orm import DeclarativeBase
 

--- a/agentception/db/engine.py
+++ b/agentception/db/engine.py
@@ -8,7 +8,6 @@ look consistent while remaining fully independent — no cross-imports.
 Schema is owned by Alembic (``agentception/alembic/``).  This module only
 creates the engine and session factory; it never calls ``CREATE TABLE``.
 """
-from __future__ import annotations
 
 import logging
 from collections.abc import AsyncGenerator

--- a/agentception/db/models.py
+++ b/agentception/db/models.py
@@ -36,7 +36,6 @@ ACTaskRun
     when the task file is generated; updated to completed/failed when the
     agent commits or times out.  Physical task file deleted on completion.
 """
-from __future__ import annotations
 
 import datetime
 

--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -13,7 +13,6 @@ ACRoleVersion       — insert-if-not-exists on role file content hash.
 All writes are wrapped in a single ``try/except`` so a DB outage never takes
 down the poller — the dashboard degrades gracefully to filesystem-only mode.
 """
-from __future__ import annotations
 
 import asyncio
 import datetime

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -6,7 +6,6 @@ All functions return plain dicts / lists so callers (routes, poller) have
 zero dependency on SQLAlchemy internals.  Swallows DB errors and returns
 empty results so a database outage degrades gracefully to in-memory state.
 """
-from __future__ import annotations
 
 import json
 import logging

--- a/agentception/intelligence/__init__.py
+++ b/agentception/intelligence/__init__.py
@@ -10,4 +10,3 @@ problems that require human intervention. Guards reason about the *state* of
 the pipeline and produce actionable signals, unlike the readers (data access)
 or routes (HTTP handlers).
 """
-from __future__ import annotations

--- a/agentception/intelligence/ab_mode.py
+++ b/agentception/intelligence/ab_mode.py
@@ -29,7 +29,6 @@ Typical call site (Engineering VP SEED)::
         default_role_file=".cursor/roles/python-developer.md",
     )
 """
-from __future__ import annotations
 
 import logging
 import re

--- a/agentception/intelligence/ab_results.py
+++ b/agentception/intelligence/ab_results.py
@@ -18,7 +18,6 @@ Typical call site (route handler)::
 
     variant_a, variant_b = await compute_ab_results()
 """
-from __future__ import annotations
 
 import logging
 import re

--- a/agentception/intelligence/analyzer.py
+++ b/agentception/intelligence/analyzer.py
@@ -15,7 +15,6 @@ Typical usage::
     print(analysis.recommended_role)   # "python-developer"
     print(analysis.parallelism)        # "safe"
 """
-from __future__ import annotations
 
 import re
 from typing import Literal

--- a/agentception/intelligence/dag.py
+++ b/agentception/intelligence/dag.py
@@ -16,7 +16,6 @@ Typical usage::
     for (src, dst) in dag.edges:
         print(f"#{src} depends on #{dst}")
 """
-from __future__ import annotations
 
 import logging
 

--- a/agentception/intelligence/guards.py
+++ b/agentception/intelligence/guards.py
@@ -21,7 +21,6 @@ Public API:
 - ``detect_out_of_order_prs()``— main detection coroutine; called by poller
                                   and the /api/intelligence/pr-violations route
 """
-from __future__ import annotations
 
 import logging
 import re

--- a/agentception/intelligence/pipeline_lanes.py
+++ b/agentception/intelligence/pipeline_lanes.py
@@ -21,7 +21,6 @@ Given ``labels = [L0, L1, L2, ...]``:
 - ``ready``   — phase has open issues AND **all** upstream phases are done.
   Work can begin here.
 """
-from __future__ import annotations
 
 import logging
 

--- a/agentception/intelligence/role_versions.py
+++ b/agentception/intelligence/role_versions.py
@@ -32,7 +32,6 @@ increments the version label (v1, v2, …). The ``batch_index`` embedded in
 ``get_version_for_batch`` matches the batch-ID timestamp prefix against the
 history to determine which version was active when the batch ran.
 """
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/agentception/intelligence/scaling.py
+++ b/agentception/intelligence/scaling.py
@@ -14,7 +14,6 @@ Typical usage::
     print(recommendation.action)       # "increase_pool"
     print(recommendation.confidence)   # "high"
 """
-from __future__ import annotations
 
 import logging
 from statistics import mean

--- a/agentception/mcp/__init__.py
+++ b/agentception/mcp/__init__.py
@@ -15,4 +15,3 @@ Public surface:
 
 Boundary constraint: zero imports from maestro, muse, kly, or storpheus.
 """
-from __future__ import annotations

--- a/agentception/mcp/build_tools.py
+++ b/agentception/mcp/build_tools.py
@@ -11,7 +11,6 @@ when they finish.
 All four functions are async — they write to ``ac_agent_events`` via the
 persist layer and return a lightweight ack dict.
 """
-from __future__ import annotations
 
 import logging
 

--- a/agentception/mcp/plan_tools.py
+++ b/agentception/mcp/plan_tools.py
@@ -31,7 +31,6 @@ Provides five MCP-exposed functions:
 
 Boundary constraint: zero imports from maestro, muse, kly, or storpheus.
 """
-from __future__ import annotations
 
 import asyncio
 import json

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -19,7 +19,6 @@ Error handling follows the JSON-RPC 2.0 specification:
 
 Boundary constraint: zero imports from maestro, muse, kly, or storpheus.
 """
-from __future__ import annotations
 
 import json
 import logging

--- a/agentception/mcp/types.py
+++ b/agentception/mcp/types.py
@@ -10,7 +10,6 @@ JSON-RPC 2.0 error codes (JSONRPC_ERR_*) are defined as module-level
 constants rather than an Enum so they remain plain ``int`` values that
 serialise to JSON without adaptation.
 """
-from __future__ import annotations
 
 from typing import TypedDict
 

--- a/agentception/models.py
+++ b/agentception/models.py
@@ -6,7 +6,6 @@ These types are the shared contract between the background poller, the API
 routes, and the frontend templates. Keep them flat — no nested Pydantic
 models that reference external services.
 """
-from __future__ import annotations
 
 import logging
 from enum import Enum

--- a/agentception/models/__init__.py
+++ b/agentception/models/__init__.py
@@ -1,0 +1,1099 @@
+from __future__ import annotations
+
+"""Domain models for the AgentCeption dashboard.
+
+These types are the shared contract between the background poller, the API
+routes, and the frontend templates. Keep them flat — no nested Pydantic
+models that reference external services.
+"""
+
+import logging
+from enum import Enum
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+logger = logging.getLogger(__name__)
+
+# Path to the canonical role taxonomy — two directories up from this file (repo root).
+_TAXONOMY_PATH: Path = (
+    Path(__file__).parent.parent / "scripts" / "gen_prompts" / "role-taxonomy.yaml"
+)
+
+
+def _load_valid_roles() -> frozenset[str]:
+    """Load spawnable role slugs from role-taxonomy.yaml at import time.
+
+    Extracts every entry with ``spawnable: true`` from the three-tier org
+    hierarchy and returns their slugs as an immutable set. This keeps
+    ``VALID_ROLES`` automatically in sync with the taxonomy without manual
+    list maintenance.
+
+    Logs a warning and returns an empty frozenset when the taxonomy file is
+    absent (e.g. during tests that run against an isolated module).
+    """
+    if not _TAXONOMY_PATH.exists():
+        logger.warning(
+            "⚠️ role-taxonomy.yaml not found at %s — VALID_ROLES will be empty",
+            _TAXONOMY_PATH,
+        )
+        return frozenset()
+    raw: object = yaml.safe_load(_TAXONOMY_PATH.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        logger.warning("⚠️ role-taxonomy.yaml has unexpected structure — VALID_ROLES will be empty")
+        return frozenset()
+    roles: set[str] = set()
+    for level in raw.get("levels", []):
+        if not isinstance(level, dict):
+            continue
+        for role in level.get("roles", []):
+            if isinstance(role, dict) and role.get("spawnable") is True:
+                slug = role.get("slug")
+                if isinstance(slug, str):
+                    roles.add(slug)
+    return frozenset(roles)
+
+
+#: Roles that can be assigned to a spawned leaf agent via POST /api/control/spawn.
+#: Derived dynamically from ``scripts/gen_prompts/role-taxonomy.yaml`` (spawnable: true entries).
+#: Orchestration roles (cto, engineering-coordinator, qa-coordinator, coordinator) are
+#: spawnable only through the CTO pipeline — their taxonomy entries have spawnable: false.
+VALID_ROLES: frozenset[str] = _load_valid_roles()
+
+
+class AgentStatus(str, Enum):
+    """Lifecycle state of a single pipeline agent, derived from filesystem + GitHub signals."""
+
+    IMPLEMENTING = "implementing"
+    REVIEWING = "reviewing"
+    DONE = "done"
+    STALE = "stale"
+    UNKNOWN = "unknown"
+
+
+class AgentNode(BaseModel):
+    """A single agent in the pipeline tree.
+
+    Represents one Cursor/Claude agent instance that is either actively working
+    or has completed its assigned task. Children are spawned sub-agents.
+    """
+
+    id: str
+    role: str
+    status: AgentStatus
+    issue_number: int | None = None
+    pr_number: int | None = None
+    branch: str | None = None
+    batch_id: str | None = None
+    worktree_path: str | None = None
+    transcript_path: str | None = None
+    message_count: int = 0
+    last_activity_mtime: float = 0.0
+    children: list[AgentNode] = []
+    cognitive_arch: str | None = None
+
+
+class StaleClaim(BaseModel):
+    """A GitHub issue with ``agent:wip`` label but no corresponding local worktree.
+
+    Produced by :func:`~agentception.intelligence.guards.detect_stale_claims`
+    and included in :class:`PipelineState` so the dashboard can surface a
+    one-click "Clear Label" fix button for each stale claim.
+    """
+
+    issue_number: int
+    issue_title: str
+    worktree_path: str  # expected path that does not exist
+
+
+class BoardIssue(BaseModel):
+    """Lightweight issue summary for the overview board sidebar.
+
+    Populated from ``ac_issues`` (Postgres) by the poller and carried in every
+    SSE broadcast so the sidebar updates live without page reloads or HTMX
+    polling.  Only fields needed for the board card are included; full issue
+    detail is always available on GitHub.
+    """
+
+    number: int
+    title: str
+    state: str = "open"
+    labels: list[str] = []
+    claimed: bool = False
+    phase_label: str | None = None
+    last_synced_at: str | None = None
+
+
+class PipelineState(BaseModel):
+    """Snapshot of the entire Maestro pipeline at a point in time.
+
+    Aggregated by the background poller and served to the dashboard UI.
+    ``polled_at`` is a UNIX timestamp — compare with ``time.time()`` to know
+    how stale the data is.
+    ``stale_claims`` provides structured data for the "Clear Label" UI action;
+    the same claims also appear as human-readable strings in ``alerts``.
+    ``board_issues`` carries the unclaimed issues for the active phase so the
+    sidebar updates via SSE without any extra requests.
+
+    SSE-expanded fields (updated every tick from Postgres):
+    ``closed_issues_count`` — issues closed in the last 24 hours.
+    ``merged_prs_count`` — PRs merged in the last 24 hours.
+    ``stale_branches`` — local git branch names that match feat/issue-N but
+    have no corresponding live worktree (leftover from failed/manual runs).
+    """
+
+    active_label: str | None
+    issues_open: int
+    prs_open: int
+    agents: list[AgentNode]
+    alerts: list[str] = []
+    stale_claims: list[StaleClaim] = []
+    board_issues: list[BoardIssue] = []
+    polled_at: float
+    closed_issues_count: int = 0
+    merged_prs_count: int = 0
+    stale_branches: list[str] = []
+    pending_approval: list[dict[str, object]] = []
+
+    @classmethod
+    def empty(cls) -> PipelineState:
+        """Return a zero-value PipelineState for pre-first-tick callers.
+
+        Routes and the API endpoint use this when ``get_state()`` returns
+        ``None`` (i.e. the background poller hasn't completed its first tick).
+        Callers should treat ``agents == []`` as "loading", not "no agents."
+        """
+        import time
+
+        return cls(
+            active_label=None,
+            issues_open=0,
+            prs_open=0,
+            agents=[],
+            alerts=[],
+            stale_claims=[],
+            board_issues=[],
+            polled_at=time.time(),
+            closed_issues_count=0,
+            merged_prs_count=0,
+            stale_branches=[],
+            pending_approval=[],
+        )
+
+
+class TaskFile(BaseModel):
+    """Parsed content of a ``.agent-task`` file from a worktree.
+
+    Every field maps 1-to-1 with a ``KEY=value`` line in the task file.
+    Unknown keys are silently ignored. All fields are optional to ensure
+    graceful handling of missing or malformed task files.
+    """
+
+    task: str | None = None
+    gh_repo: str | None = None
+    issue_number: int | None = None
+    pr_number: int | None = None
+    branch: str | None = None
+    worktree: str | None = None
+    role: str | None = None
+    base: str | None = None
+    batch_id: str | None = None
+    closes_issues: list[int] = []
+    spawn_sub_agents: bool = False
+    spawn_mode: str | None = None
+    merge_after: str | None = None
+    attempt_n: int = 0
+    required_output: str | None = None
+    on_block: str | None = None
+    cognitive_arch: str | None = None
+
+
+class AbModeConfig(BaseModel):
+    """A/B mode configuration for role file experimentation (AC-504).
+
+    When ``enabled`` is true the Engineering VP alternates between two role
+    files for the ``target_role`` based on whether the BATCH_ID timestamp
+    second is even (variant A) or odd (variant B).  This enables controlled
+    experiments where successive batches see different role prompts so outcomes
+    can be compared with everything else held constant.
+
+    ``variant_a_file`` and ``variant_b_file`` are paths relative to the
+    repository root (e.g. ``.cursor/roles/python-developer.md``).
+    """
+
+    enabled: bool = False
+    target_role: str | None = None
+    variant_a_file: str | None = None
+    variant_b_file: str | None = None
+
+
+class ProjectConfig(BaseModel):
+    """A single project entry in ``pipeline-config.json``.
+
+    Each project maps to a distinct GitHub repository and local workspace.
+    The ``active_project`` field in :class:`PipelineConfig` selects which
+    project the AgentCeption dashboard currently targets.
+
+    ``worktrees_dir`` supports ``~`` expansion (e.g. ``~/.agentception/worktrees/maestro``).
+    ``cursor_project_id`` is the Cursor project slug used to locate transcript files.
+    """
+
+    name: str
+    gh_repo: str
+    repo_dir: str
+    worktrees_dir: str
+    cursor_project_id: str | None = None
+    active_labels_order: list[str] = []
+
+
+class PipelineConfig(BaseModel):
+    """Validated shape of ``.agentception/pipeline-config.json``.
+
+    This is the single source of truth for pipeline allocation.  The CTO and
+    Engineering VP role files read this model at the start of every loop/seed
+    cycle.  The ``PUT /api/config`` route validates incoming bodies against
+    this schema before persisting them to disk.
+
+    ``projects`` lists all configured projects; ``active_project`` is the name
+    of the currently active one.  When ``active_project`` is set, the dashboard
+    targets the corresponding project's ``gh_repo``, ``repo_dir``, and
+    ``worktrees_dir`` instead of the defaults in :class:`AgentCeptionSettings`.
+    """
+
+    max_eng_vps: int = Field(gt=0, description="Maximum number of engineering VPs")
+    max_qa_vps: int = Field(gt=0, description="Maximum number of QA VPs")
+    pool_size_per_vp: int = Field(gt=0, description="Pool size per VP")
+    active_labels_order: list[str]
+    ab_mode: AbModeConfig = AbModeConfig()
+    projects: list[ProjectConfig] = []
+    active_project: str | None = None
+    approval_required_labels: list[str] = ["db-schema", "security", "api-contract"]
+
+
+class SpawnRequest(BaseModel):
+    """Request body for ``POST /api/control/spawn``.
+
+    Callers provide the issue number they want an agent to tackle and an
+    optional role override. The endpoint verifies the issue is open and
+    unclaimed before creating the worktree.
+    """
+
+    issue_number: int
+    role: str = "python-developer"
+
+    @field_validator("role")
+    @classmethod
+    def validate_role(cls, v: str) -> str:
+        """Reject unknown roles early so errors surface at the boundary, not in git."""
+        if v not in VALID_ROLES:
+            raise ValueError(f"role must be one of {sorted(VALID_ROLES)}, got {v!r}")
+        return v
+
+
+class SpawnResult(BaseModel):
+    """Response for a successful ``POST /api/control/spawn``.
+
+    Contains enough information for the user (or a future automation layer)
+    to launch a Cursor Task pointed at the new worktree.
+    ``agent_task`` is the raw text of the ``.agent-task`` file that was
+    written — callers can display it or pass it directly to the Task tool.
+
+    ``worktree`` is the container-side path (``/worktrees/issue-N``).
+    ``host_worktree`` is the equivalent host-side path the user can open in
+    AgentCeption (``~/.agentception/worktrees/maestro/issue-N``).
+    ``spawned_at`` is an ISO-8601 UTC timestamp indicating when the worktree
+    was created (included for display in the HTML success panel).
+    """
+
+    spawned: int
+    worktree: str
+    host_worktree: str
+    branch: str
+    agent_task: str
+    spawned_at: str = ""
+
+
+class SpawnConductorRequest(BaseModel):
+    """Request body for ``POST /api/control/spawn-conductor``.
+
+    ``phases`` is a non-empty list of phase label strings to run the conductor
+    against.  ``org`` optionally scopes the conductor to a specific org name
+    (passed through to the ``.agent-task`` file; leave ``None`` for the default).
+    """
+
+    phases: list[str]
+    org: str | None = None
+
+
+class SpawnConductorResult(BaseModel):
+    """Response for a successful ``POST /api/control/spawn-conductor``.
+
+    ``wave_id`` is the auto-generated conductor ID (e.g. ``conductor-20260303-142201``).
+    ``host_worktree`` is the path the user should open in Cursor to activate the agent.
+    ``agent_task`` is the raw ``.agent-task`` content written to disk.
+    """
+
+    wave_id: str
+    worktree: str
+    host_worktree: str
+    branch: str
+    agent_task: str
+
+
+class SpawnCoordinatorRequest(BaseModel):
+    """Request body for ``POST /api/control/spawn-coordinator``.
+
+    ``plan_text`` is the user's raw unstructured text — feature ideas, bug
+    descriptions, or any free-form list of work items.  The coordinator agent
+    reads this field from its ``.agent-task`` file and runs the Phase Planner
+    step in ``parallel-bugs-to-issues.md``, producing labelled GitHub issues.
+
+    ``label_prefix`` optionally scopes the generated phase labels to a named
+    initiative (e.g. ``"q2-rewrite"`` → labels like ``phase-1/q2-rewrite``).
+    Leave blank for the default label scheme.
+    """
+
+    plan_text: str
+    label_prefix: str = ""
+
+
+class SpawnCoordinatorResult(BaseModel):
+    """Response for a successful ``POST /api/control/spawn-coordinator``.
+
+    ``slug`` is the worktree directory name (e.g. ``brain-dump-20260301-143022``).
+    ``host_worktree`` is the path the user should open in Cursor to activate
+    the coordinator agent.  ``agent_task`` is the raw ``.agent-task`` content
+    written to disk — useful for display and debugging.
+    """
+
+    slug: str
+    worktree: str
+    host_worktree: str
+    branch: str
+    agent_task: str
+
+
+class PlanRequest(BaseModel):
+    """Request body for ``POST /api/brain-dump/plan``.
+
+    ``dump`` is the raw brain-dump text submitted by the user.  The Phase
+    Planner analyses it and groups work items into sequenced phases without
+    creating any GitHub resources.
+    """
+
+    dump: str
+
+
+class PhasePreview(BaseModel):
+    """A single phase in the brain-dump plan preview.
+
+    Each phase groups related work items that can be implemented in parallel.
+    ``depends_on`` lists the labels of phases that must complete before this
+    one can start — the UI renders these as dependency arrows.
+    """
+
+    label: str
+    description: str
+    estimated_issue_count: int
+    depends_on: list[str] = []
+
+
+class PlanResult(BaseModel):
+    """Response for ``POST /api/brain-dump/plan``.
+
+    ``phases`` is ordered: index 0 is the earliest phase (foundation),
+    later entries depend on earlier ones.  The UI shows these as a phase
+    card deck before asking the user to confirm and fire the coordinator.
+    """
+
+    phases: list[PhasePreview]
+
+
+class SwitchProjectRequest(BaseModel):
+    """Request body for ``POST /api/config/switch-project``.
+
+    ``project_name`` must match the ``name`` field of one of the entries in
+    ``PipelineConfig.projects``.  If no match is found the endpoint returns
+    HTTP 404 rather than silently writing an invalid ``active_project`` value.
+    """
+
+    project_name: str
+
+
+class RoleMeta(BaseModel):
+    """Metadata for a managed role or cursor configuration file.
+
+    Used by the Role Studio API (AC-301) to describe each file without
+    returning full content — callers fetch content separately via GET /api/roles/{slug}.
+    ``last_commit_sha`` and ``last_commit_message`` are empty strings when the
+    file has never been committed (e.g. in tests with a temp directory).
+    """
+
+    slug: str
+    path: str
+    line_count: int
+    mtime: float
+    last_commit_sha: str
+    last_commit_message: str
+
+
+class RoleUpdateRequest(BaseModel):
+    """Request body for ``PUT /api/roles/{slug}`` (Role Studio AC-301).
+
+    Wraps the raw ``content`` string so FastAPI can validate and document the
+    request body rather than accepting an untyped naked dict.
+    """
+
+    content: str
+
+
+class RoleContent(BaseModel):
+    """Response for ``GET /api/roles/{slug}`` — full file content with metadata.
+
+    Returned by the Role Studio reader endpoint so the UI (AC-302/303) has
+    both the Markdown source and the git provenance in one round-trip.
+    """
+
+    slug: str
+    content: str
+    meta: RoleMeta
+
+
+class RoleUpdateResponse(BaseModel):
+    """Response for ``PUT /api/roles/{slug}`` — diff and refreshed metadata.
+
+    ``diff`` is the raw output of ``git diff HEAD -- <path>`` immediately after
+    writing; an empty string means the written content was identical to what
+    was already committed.
+    """
+
+    slug: str
+    diff: str
+    meta: RoleMeta
+
+
+class RoleDiffRequest(BaseModel):
+    """Request body for ``POST /api/roles/{slug}/diff`` (AC-303).
+
+    ``content`` is the proposed file content to diff against the HEAD-committed
+    version.  No file is written to disk — this is a pure preview operation.
+    Using a POST body avoids URL-length limits for large managed files (e.g.
+    PARALLEL_PR_REVIEW.md which exceeds Nginx's default 4 KB URI limit).
+    """
+
+    content: str
+
+
+class RoleDiffResponse(BaseModel):
+    """Response for ``POST /api/roles/{slug}/diff`` — diff of proposed vs HEAD.
+
+    ``diff`` is a unified diff string comparing ``content`` against
+    the HEAD-committed version.  An empty string means the proposed content is
+    identical to the committed file.  No file is written to disk.
+    """
+
+    slug: str
+    diff: str
+
+
+class RoleCommitRequest(BaseModel):
+    """Request body for ``POST /api/roles/{slug}/commit`` (AC-303).
+
+    ``content`` is written to the managed file and then staged + committed in
+    one atomic operation.  The commit message is generated automatically.
+    """
+
+    content: str
+
+
+class RoleCommitResponse(BaseModel):
+    """Response for ``POST /api/roles/{slug}/commit`` — resulting commit SHA.
+
+    ``commit_sha`` is the full 40-character SHA of the newly created commit.
+    ``message`` is the commit subject line that was used.
+    """
+
+    slug: str
+    commit_sha: str
+    message: str
+
+
+class RoleVersionEntry(BaseModel):
+    """A single entry in a role's version history (AC-503).
+
+    Records the git SHA, human-readable version label, and UNIX timestamp of
+    one committed change to the role file.  Entries are ordered chronologically
+    (oldest first) inside ``RoleVersionInfo.history``.
+    """
+
+    sha: str
+    label: str
+    timestamp: int
+
+
+class RoleVersionInfo(BaseModel):
+    """Version tracking data for a single role slug (AC-503).
+
+    ``current`` is the label of the most recently recorded version.  ``history``
+    is the chronologically ordered list of all version entries (oldest first).
+    An empty ``history`` means the slug has never been committed through the
+    Role Studio commit endpoint.
+    """
+
+    current: str
+    history: list[RoleVersionEntry]
+
+
+class RoleVersionsResponse(BaseModel):
+    """Response for ``GET /api/roles/{slug}/versions`` (AC-503).
+
+    Returns structured version history for a single role slug so the Role
+    Studio UI can display a timeline of changes and link each version to its
+    git commit SHA.
+    """
+
+    slug: str
+    versions: RoleVersionInfo
+
+
+class RoleHistoryEntry(BaseModel):
+    """One git log entry for a role file's revision history."""
+
+    sha: str
+    date: str
+    subject: str
+
+
+# ---------------------------------------------------------------------------
+# Cognitive Architecture API — taxonomy, personas, atoms
+# ---------------------------------------------------------------------------
+
+
+class TaxonomyRole(BaseModel):
+    """A single role entry in the org hierarchy taxonomy.
+
+    Returned by ``GET /api/roles/taxonomy`` as part of a level's role list.
+    Combines metadata from ``role-taxonomy.yaml`` with a live ``file_exists``
+    flag so the GUI can show which roles have been authored.
+    """
+
+    slug: str
+    label: str
+    title: str
+    category: str
+    description: str
+    spawnable: bool
+    compatible_figures: list[str]
+    compatible_skill_domains: list[str]
+    file_exists: bool
+
+
+class TaxonomyLevel(BaseModel):
+    """One tier of the org hierarchy (C-Suite, VP Level, Workers).
+
+    Contains the full ordered list of ``TaxonomyRole`` entries for that tier.
+    """
+
+    id: str
+    label: str
+    description: str
+    roles: list[TaxonomyRole]
+
+
+class TaxonomyResponse(BaseModel):
+    """Response for ``GET /api/roles/taxonomy``.
+
+    Returns the complete three-tier org hierarchy so the GUI can render the
+    hierarchy browser and the primitive composer's compatible-figures dropdowns.
+    """
+
+    levels: list[TaxonomyLevel]
+
+
+class PersonaEntry(BaseModel):
+    """A single persona/figure from the cognitive architecture library.
+
+    Returned by ``GET /api/roles/personas``.  Each entry corresponds to one
+    YAML file in ``scripts/gen_prompts/cognitive_archetypes/figures/``.
+    The ``prompt_prefix`` is the injected context block used at spawn time.
+    """
+
+    id: str
+    display_name: str
+    layer: str
+    extends: str
+    description: str
+    prompt_prefix: str
+    overrides: dict[str, str]
+
+
+class PersonasResponse(BaseModel):
+    """Response for ``GET /api/roles/personas``."""
+
+    personas: list[PersonaEntry]
+
+
+class AtomValue(BaseModel):
+    """A single named value within an atom dimension."""
+
+    id: str
+    label: str
+    description: str
+
+
+class AtomDimension(BaseModel):
+    """One cognitive atom dimension (e.g. epistemic_style, quality_bar).
+
+    Returned by ``GET /api/roles/atoms`` so the primitive composer can render
+    dropdowns for each atom and its valid values.
+    """
+
+    dimension: str
+    description: str
+    values: list[AtomValue]
+
+
+class AtomsResponse(BaseModel):
+    """Response for ``GET /api/roles/atoms``."""
+
+    atoms: list[AtomDimension]
+
+
+# ---------------------------------------------------------------------------
+# Template export / import  (AC-602)
+# ---------------------------------------------------------------------------
+
+
+class TemplateExportRequest(BaseModel):
+    """Request body for ``POST /api/templates/export``.
+
+    ``name`` and ``version`` are embedded in the manifest inside the archive
+    so that importers know what they are applying.
+    """
+
+    name: str
+    version: str
+
+
+class TemplateManifest(BaseModel):
+    """Metadata record written as ``template-manifest.json`` inside the archive.
+
+    Included in every exported template so importers can surface provenance
+    without unpacking the whole tarball.
+    """
+
+    name: str
+    version: str
+    created_at: str
+    gh_repo: str
+    files: list[str]
+
+
+class TemplateConflict(BaseModel):
+    """A single file that already exists in the target repo's ``.cursor/`` directory.
+
+    Surfaced by the import endpoint before any file is overwritten so the
+    caller can decide whether to proceed.
+    """
+
+    path: str
+    exists: bool
+
+
+class TemplateImportResult(BaseModel):
+    """Response for ``POST /api/templates/import``.
+
+    ``extracted`` lists every file path that was written (relative to the
+    target repo root).  ``conflicts`` lists files that already existed — they
+    are still overwritten, but the caller is informed so the UI can display
+    a warning banner.
+    """
+
+    name: str
+    version: str
+    extracted: list[str]
+    conflicts: list[TemplateConflict]
+
+
+class TemplateListEntry(BaseModel):
+    """Summary of one previously exported template stored on disk.
+
+    Represents a single ``.tar.gz`` archive in the templates store directory.
+    ``size_bytes`` is the archive size (not uncompressed size).
+    """
+
+    filename: str
+    name: str
+    version: str
+    created_at: str
+    gh_repo: str
+    size_bytes: int
+
+
+class OrgTreeRole(BaseModel):
+    """A single role entry in the org tree returned by ``GET /api/org/tree``.
+
+    ``figures`` holds the first two compatible figures from the taxonomy so the
+    D3 tree can render avatar chips without a second round-trip.
+    ``assigned_phases`` is reserved for future phase-assignment features and
+    is always an empty list in the current implementation.
+    """
+
+    slug: str
+    name: str
+    tier: str
+    assigned_phases: list[str]
+    figures: list[str]
+
+
+class OrgTreeNode(BaseModel):
+    """One node in the org hierarchy tree returned by ``GET /api/org/tree``.
+
+    The root node represents the active preset; its children are the
+    leadership and workers tiers; each tier's ``roles`` list holds the
+    individual role cards rendered by the D3 tree.
+    """
+
+    name: str
+    id: str
+    tier: str
+    roles: list[OrgTreeRole]
+    children: list["OrgTreeNode"]
+
+
+OrgTreeNode.model_rebuild()
+
+
+# ---------------------------------------------------------------------------
+# PlanSpec — YAML schema contract for plan-step-v2 pipeline (AC-867)
+# ---------------------------------------------------------------------------
+
+
+class PlanIssue(BaseModel):
+    """A single GitHub issue to be created within a plan phase.
+
+    ``id`` is a stable kebab-case slug (e.g. ``"auth-001"``) used as the
+    canonical dependency reference.  ``depends_on`` lists *IDs* (not titles)
+    of other issues — this avoids silent breakage when titles are edited in
+    the review editor.  ``title`` is the issue title; ``body`` is the
+    Markdown description.
+    """
+
+    id: str
+    title: str
+    body: str
+    depends_on: list[str] = []  # issue IDs, not titles
+
+
+class PlanPhase(BaseModel):
+    """A sequenced phase grouping related issues in a PlanSpec.
+
+    ``label`` is a short slug used as the GitHub phase label (e.g.
+    ``"0-foundation"``).  ``description`` is a one-sentence human summary.
+    ``depends_on`` lists labels of phases that must complete before this one
+    starts.  ``issues`` is the ordered list of issues to create.
+
+    Raises ``ValueError`` if ``issues`` is empty — a phase with no issues
+    cannot advance the pipeline.
+    """
+
+    label: str
+    description: str
+    depends_on: list[str] = []
+    issues: list[PlanIssue]
+
+    @field_validator("issues")
+    @classmethod
+    def issues_must_be_non_empty(cls, v: list[PlanIssue]) -> list[PlanIssue]:
+        """A phase must contain at least one issue."""
+        if not v:
+            raise ValueError("phases must each contain at least one issue")
+        return v
+
+
+class PlanSpec(BaseModel):
+    """Root schema for the plan-step-v2 YAML contract.
+
+    ``initiative`` is a short human name for the batch (e.g. ``"auth-rewrite"``).
+    ``phases`` is an ordered list of :class:`PlanPhase` objects; index 0 is the
+    foundation phase that has no dependencies.
+
+    Invariants enforced at construction time:
+    - ``phases`` must be non-empty.
+    - Phase ``depends_on`` labels must all reference labels that appear
+      earlier in the list (strict DAG; no forward references, no cycles).
+
+    Round-trip serialization:
+    - :meth:`to_yaml` produces clean YAML with no Pydantic internals.
+    - :meth:`from_yaml` parses and validates; raises :class:`ValueError` on
+      malformed input.
+    """
+
+    initiative: str
+    phases: list[PlanPhase]
+
+    @field_validator("phases")
+    @classmethod
+    def phases_must_be_non_empty(cls, v: list[PlanPhase]) -> list[PlanPhase]:
+        """At least one phase is required."""
+        if not v:
+            raise ValueError("PlanSpec must contain at least one phase")
+        return v
+
+    @model_validator(mode="after")
+    def validate_issue_ids_unique(self) -> "PlanSpec":
+        """Ensure all issue IDs are unique across the entire plan."""
+        seen: set[str] = set()
+        for phase in self.phases:
+            for issue in phase.issues:
+                if issue.id in seen:
+                    raise ValueError(
+                        f"Duplicate issue id {issue.id!r} — every issue must have a unique id"
+                    )
+                seen.add(issue.id)
+        return self
+
+    @model_validator(mode="after")
+    def validate_issue_depends_on(self) -> "PlanSpec":
+        """Ensure issue depends_on references valid issue IDs defined earlier in the plan."""
+        all_ids: set[str] = {issue.id for phase in self.phases for issue in phase.issues}
+        for phase in self.phases:
+            for issue in phase.issues:
+                for dep in issue.depends_on:
+                    if dep not in all_ids:
+                        raise ValueError(
+                            f"Issue {issue.id!r} depends_on {dep!r} which is not a "
+                            f"known issue id in this plan"
+                        )
+                    if dep == issue.id:
+                        raise ValueError(f"Issue {issue.id!r} cannot depend on itself")
+        return self
+
+    @model_validator(mode="after")
+    def validate_phase_dag(self) -> "PlanSpec":
+        """Ensure phase depends_on references form a valid DAG.
+
+        Each phase may only depend on phases that appear *before* it in the
+        list.  Forward references and cycles are both rejected.  This is a
+        necessary (though not sufficient) condition for a valid DAG: because
+        phases are linearly ordered and can only reference earlier entries,
+        the dependency graph is acyclic by construction.
+        """
+        seen: set[str] = set()
+        for phase in self.phases:
+            for dep in phase.depends_on:
+                if dep not in seen:
+                    raise ValueError(
+                        f"Phase {phase.label!r} depends_on {dep!r} which is not a "
+                        f"previously defined phase label (forward reference or cycle)"
+                    )
+            seen.add(phase.label)
+        return self
+
+    def to_yaml(self) -> str:
+        """Serialize to a clean YAML string.
+
+        Uses PyYAML ``safe_dump`` with ``default_flow_style=False`` and
+        ``sort_keys=False`` so the output preserves insertion order and omits
+        Pydantic-internal fields.
+        """
+        data: dict[str, object] = {
+            "initiative": self.initiative,
+            "phases": [
+                {
+                    "label": phase.label,
+                    "description": phase.description,
+                    "depends_on": phase.depends_on,
+                    "issues": [
+                        {
+                            "id": issue.id,
+                            "title": issue.title,
+                            "body": issue.body,
+                            "depends_on": issue.depends_on,
+                        }
+                        for issue in phase.issues
+                    ],
+                }
+                for phase in self.phases
+            ],
+        }
+        return yaml.safe_dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+    @classmethod
+    def from_yaml(cls, text: str) -> "PlanSpec":
+        """Parse and validate a YAML string into a PlanSpec.
+
+        Raises:
+            ValueError: If the YAML is malformed, missing required fields,
+                or violates any PlanSpec invariant (empty phases, bad deps).
+        """
+        try:
+            raw: object = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Malformed YAML: {exc}") from exc
+        if not isinstance(raw, dict):
+            raise ValueError(f"Expected a YAML mapping at the top level, got {type(raw).__name__}")
+        try:
+            return cls.model_validate(raw)
+        except Exception as exc:
+            raise ValueError(f"PlanSpec validation failed: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# EnrichedManifest — coordinator input contract for plan-step-v2 (AC-868)
+# ---------------------------------------------------------------------------
+
+
+class EnrichedIssue(BaseModel):
+    """A fully-specified GitHub issue generated by the LLM coordinator.
+
+    Carries the complete contract for one unit of work: the Markdown body,
+    GitHub label set, phase membership, dependency titles, parallelizability
+    assessment, and the three acceptance criteria lists that appear verbatim
+    in the issue body.
+
+    ``depends_on`` references *titles* (not numbers) of other issues that must
+    be merged before this one can begin.  Titles are used because issue numbers
+    are not known until after creation.
+    """
+
+    title: str
+    body: str
+    labels: list[str]
+    phase: str
+    depends_on: list[str] = []
+    can_parallel: bool = True
+    acceptance_criteria: list[str]
+    tests_required: list[str]
+    docs_required: list[str]
+
+
+class EnrichedPhase(BaseModel):
+    """A sequenced execution phase in an EnrichedManifest.
+
+    Groups related :class:`EnrichedIssue` objects that share a lifecycle
+    stage.  ``parallel_groups`` partitions issue titles into sets that can
+    run concurrently — no title in a group may appear in the ``depends_on``
+    list of any other title in the same group.
+
+    Raises ``ValueError`` if any ``parallel_groups`` entry violates the
+    no-intra-group-dependency invariant.
+    """
+
+    label: str
+    description: str
+    depends_on: list[str] = []
+    issues: list[EnrichedIssue]
+    parallel_groups: list[list[str]]
+
+    @model_validator(mode="after")
+    def validate_parallel_groups_invariant(self) -> "EnrichedPhase":
+        """Enforce that no issue in a parallel group depends on another in the same group.
+
+        For every group G and every title T in G, none of T's ``depends_on``
+        entries may also appear in G.  Violating this would schedule a
+        depender and its dependency in the same execution wave, which is
+        incorrect — the dependency must complete before the depender starts.
+        """
+        issue_deps: dict[str, set[str]] = {
+            issue.title: set(issue.depends_on) for issue in self.issues
+        }
+        for group in self.parallel_groups:
+            group_set = set(group)
+            for title in group:
+                deps = issue_deps.get(title, set())
+                intra_deps = deps & group_set - {title}
+                if intra_deps:
+                    raise ValueError(
+                        f"Issue {title!r} depends on {sorted(intra_deps)} "
+                        f"which are in the same parallel group — "
+                        f"dependent and dependency cannot run concurrently"
+                    )
+        return self
+
+
+def _compute_wave_depths(phases: list[EnrichedPhase]) -> dict[str, int]:
+    """Return a mapping from issue title to its critical-path depth (1-indexed).
+
+    Depth 1 = no dependencies (first wave).
+    Depth N = all dependencies are in waves <= N-1.
+
+    Uses memoised DFS over the dependency graph built from all issues across
+    all phases.  Unknown dependency titles (titles not in the manifest) are
+    silently ignored — they are treated as if they have depth 0 so the
+    computation remains valid even for cross-manifest references.
+    """
+    all_issues: dict[str, EnrichedIssue] = {}
+    for phase in phases:
+        for issue in phase.issues:
+            all_issues[issue.title] = issue
+
+    wave_depth: dict[str, int] = {}
+
+    def get_depth(title: str, visiting: frozenset[str]) -> int:
+        if title in wave_depth:
+            return wave_depth[title]
+        if title not in all_issues or title in visiting:
+            return 0
+        issue = all_issues[title]
+        max_dep_depth = max(
+            (get_depth(dep, visiting | {title}) for dep in issue.depends_on),
+            default=0,
+        )
+        depth = 1 + max_dep_depth
+        wave_depth[title] = depth
+        return depth
+
+    for title in all_issues:
+        get_depth(title, frozenset())
+
+    return wave_depth
+
+
+class EnrichedManifest(BaseModel):
+    """Root coordinator input contract for the plan-step-v2 pipeline.
+
+    Produced by the LLM coordinator after enriching a :class:`PlanSpec` with
+    full issue bodies, labels, acceptance criteria, tests, and docs.  Consumed
+    by the issue-creation step that writes each :class:`EnrichedIssue` to
+    GitHub.
+
+    ``total_issues`` and ``estimated_waves`` are computed invariants —
+    callers do not supply them.  They are derived by the ``model_validator``
+    so that downstream consumers can always trust their values.
+
+    Invariants enforced at construction time:
+    - ``phases`` must be non-empty.
+    - ``total_issues`` equals ``sum(len(p.issues) for p in phases)``.
+    - ``estimated_waves`` equals the longest dependency chain across all
+      issues in all phases (critical-path length through the dep graph).
+    """
+
+    initiative: str | None = None
+    phases: list[EnrichedPhase]
+    total_issues: int = 0
+    estimated_waves: int = 0
+
+    @field_validator("phases")
+    @classmethod
+    def phases_must_be_non_empty(cls, v: list[EnrichedPhase]) -> list[EnrichedPhase]:
+        """At least one phase is required."""
+        if not v:
+            raise ValueError("EnrichedManifest must contain at least one phase")
+        return v
+
+    @model_validator(mode="after")
+    def compute_invariants(self) -> "EnrichedManifest":
+        """Compute total_issues and estimated_waves from the phases graph.
+
+        Both values are derived — never trust a caller-supplied value.
+        Setting them here guarantees they are always consistent with the
+        actual phase/issue data regardless of how the model was constructed.
+        """
+        self.total_issues = sum(len(p.issues) for p in self.phases)
+
+        wave_depths = _compute_wave_depths(self.phases)
+        self.estimated_waves = max(wave_depths.values(), default=1)
+
+        return self

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -14,7 +14,6 @@ Public surface used by API routes:
 Public surface used by ``app.py`` lifespan:
 - ``polling_loop()``  — the long-running background coroutine
 """
-from __future__ import annotations
 
 import asyncio
 import dataclasses

--- a/agentception/readers/__init__.py
+++ b/agentception/readers/__init__.py
@@ -6,4 +6,3 @@ Each reader is responsible for collecting raw data from a specific source
 (filesystem worktrees, Cursor transcript files, GitHub API). The poller
 orchestrates them into a unified ``PipelineState``.
 """
-from __future__ import annotations

--- a/agentception/readers/active_label_override.py
+++ b/agentception/readers/active_label_override.py
@@ -10,7 +10,6 @@ Operators can override this by calling :func:`set_pin` with any label string.
 The override is cleared by :func:`clear_pin` or on process restart — it is
 intentionally not persisted so a restart always returns to automatic mode.
 """
-from __future__ import annotations
 
 _pin: str | None = None
 

--- a/agentception/readers/context_pack.py
+++ b/agentception/readers/context_pack.py
@@ -18,7 +18,6 @@ at the top of the user prompt before passing to the LLM.
 All fetches are best-effort — a GitHub error returns an empty pack rather
 than failing the plan request.
 """
-from __future__ import annotations
 
 import logging
 

--- a/agentception/readers/git.py
+++ b/agentception/readers/git.py
@@ -13,7 +13,6 @@ Public API:
     list_git_stash()           → stash entries
     get_worktree_detail(slug)  → on-demand detail: commits, diff-stat, task file
 """
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -17,7 +17,6 @@ Usage::
     issues = await get_open_issues(label="agentception/0-scaffold")
     label  = await get_active_label()
 """
-from __future__ import annotations
 
 import asyncio
 import json

--- a/agentception/readers/issue_creator.py
+++ b/agentception/readers/issue_creator.py
@@ -22,7 +22,6 @@ Labels applied to every issue
 The phase label acts as the execution gate: agents (or humans) know not to
 start a phase-1 issue until all phase-0 issues are closed.
 """
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/agentception/readers/llm_phase_planner.py
+++ b/agentception/readers/llm_phase_planner.py
@@ -20,7 +20,6 @@ loop is entirely self-contained.  MCP enters only after the user approves the
 YAML and a coordinator worktree is spawned -- the coordinator agent (in Cursor)
 calls ``plan_get_labels()`` and similar tools as it files GitHub issues.
 """
-from __future__ import annotations
 
 import json
 import logging

--- a/agentception/readers/phase_planner.py
+++ b/agentception/readers/phase_planner.py
@@ -20,7 +20,6 @@ Phase definitions (load-bearing order):
 
 Empty or whitespace-only dumps raise a ``ValueError``.
 """
-from __future__ import annotations
 
 import re
 

--- a/agentception/readers/pipeline_config.py
+++ b/agentception/readers/pipeline_config.py
@@ -11,7 +11,6 @@ The dashboard exposes GET/PUT ``/api/config`` routes (see
 ``agentception/routes/api.py``) so operators can adjust allocation without
 restarting the service.
 """
-from __future__ import annotations
 
 import json
 from pathlib import Path

--- a/agentception/readers/templates.py
+++ b/agentception/readers/templates.py
@@ -21,7 +21,6 @@ records provenance (name, version, created_at, gh_repo, file list).
 Exported archives are stored under ``~/.agentception/templates/`` so they
 persist across service restarts and are accessible from the UI.
 """
-from __future__ import annotations
 
 import io
 import json

--- a/agentception/readers/transcripts.py
+++ b/agentception/readers/transcripts.py
@@ -16,7 +16,6 @@ Public API:
     extract_pr_urls()             → all GitHub PR URLs found in messages
     index_transcripts()           → metadata list for the browser list view
 """
-from __future__ import annotations
 
 import json
 import logging

--- a/agentception/readers/worktrees.py
+++ b/agentception/readers/worktrees.py
@@ -9,7 +9,6 @@ This is the primary filesystem signal for the poller — it tells the dashboard
 which agents are actively working and what they are working on. Combine with
 transcript data for richer status information.
 """
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/agentception/routes/__init__.py
+++ b/agentception/routes/__init__.py
@@ -20,4 +20,3 @@ Additional standalone routers (control, intelligence, roles, templates_api)
 are registered directly from their own modules and are not part of these
 two sub-packages.
 """
-from __future__ import annotations

--- a/agentception/routes/api/__init__.py
+++ b/agentception/routes/api/__init__.py
@@ -9,13 +9,13 @@ symbol is ``router``).
 ``app.py`` does ``from agentception.routes.api import router as api_router`` — that
 import path continues to work unchanged.
 """
-from __future__ import annotations
 
 from fastapi import APIRouter
 
 from .build import router as _build
 from .config import router as _config
 from .control import router as _control
+from .health import router as _health
 from .intelligence import router as _intelligence
 from .issues import router as _issues
 from .pipeline import router as _pipeline
@@ -29,6 +29,7 @@ router.include_router(_build)
 router.include_router(_pipeline)
 router.include_router(_control)
 router.include_router(_config)
+router.include_router(_health)
 router.include_router(_intelligence)
 router.include_router(_telemetry)
 router.include_router(_worktrees)

--- a/agentception/routes/api/_shared.py
+++ b/agentception/routes/api/_shared.py
@@ -9,7 +9,6 @@ Contains:
 - ``_resolve_cognitive_arch``: derives COGNITIVE_ARCH string from issue body.
 - ``_issue_is_claimed_api``: checks ``agent:wip`` label presence.
 """
-from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path

--- a/agentception/routes/api/build.py
+++ b/agentception/routes/api/build.py
@@ -17,7 +17,6 @@ Three audiences:
 
 See ``agentception/docs/agent-tree-protocol.md`` for the full tier spec.
 """
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/agentception/routes/api/health.py
+++ b/agentception/routes/api/health.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""API route: GET /api/health/detailed — detailed system health snapshot.
+
+Thin handler — all collection logic lives in ``agentception.services.health_collector``.
+"""
+
+import logging
+
+from fastapi import APIRouter
+
+from agentception.models.health import HealthSnapshot
+from agentception.services import health_collector
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/health/detailed", response_model=HealthSnapshot, tags=["health"])
+async def get_health_detailed() -> HealthSnapshot:
+    """Return a point-in-time system health snapshot.
+
+    Collects uptime, memory RSS, active worktree count, and GitHub API latency.
+    Always returns 200 — individual metrics signal failure through sentinel values
+    (e.g. ``github_api_latency_ms: -1.0`` when the probe fails).
+    """
+    return await health_collector.collect()

--- a/agentception/routes/api/plan.py
+++ b/agentception/routes/api/plan.py
@@ -37,7 +37,6 @@ Steps:
 
 Boundary: zero imports from maestro/, muse/, kly/, or storpheus/.
 """
-from __future__ import annotations
 
 import asyncio
 import json

--- a/agentception/routes/api/wizard.py
+++ b/agentception/routes/api/wizard.py
@@ -10,7 +10,6 @@ Step 2 — Org Chart:   complete when pipeline-config.json has a non-null active
 Step 3 — Launch Wave: active when ac_waves has a wave started in the last 24 h
                       that has not yet completed (completed_at IS NULL).
 """
-from __future__ import annotations
 
 import datetime
 import json

--- a/agentception/routes/control.py
+++ b/agentception/routes/control.py
@@ -12,7 +12,6 @@ Why a separate router?
 - Prefix ``/api/control`` signals to callers that these are write operations,
   not reads.
 """
-from __future__ import annotations
 
 import asyncio
 import json

--- a/agentception/routes/intelligence.py
+++ b/agentception/routes/intelligence.py
@@ -17,7 +17,6 @@ Why a dedicated router?
 - ``/api/intelligence/`` signals to callers that these endpoints act on
   machine-detected anomalies rather than direct user operations.
 """
-from __future__ import annotations
 
 import logging
 

--- a/agentception/routes/roles.py
+++ b/agentception/routes/roles.py
@@ -15,7 +15,6 @@ Also exposes the cognitive architecture meta-API:
 - ``GET /api/roles/personas`` — all figure YAMLs as structured JSON for the GUI
 - ``GET /api/roles/atoms`` — all atom dimension YAMLs for the primitive composer
 """
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/agentception/routes/templates_api.py
+++ b/agentception/routes/templates_api.py
@@ -12,7 +12,6 @@ Endpoints:
 - ``GET /api/templates`` — list previously exported templates
 - ``GET /api/templates/{filename}`` — download a stored template archive
 """
-from __future__ import annotations
 
 import logging
 

--- a/agentception/routes/ui/__init__.py
+++ b/agentception/routes/ui/__init__.py
@@ -10,7 +10,6 @@ old ``ui.py`` module.
 ``app.py`` does ``from agentception.routes.ui import router as ui_router`` — that
 import path continues to work unchanged.
 """
-from __future__ import annotations
 
 from fastapi import APIRouter
 

--- a/agentception/routes/ui/_shared.py
+++ b/agentception/routes/ui/_shared.py
@@ -8,7 +8,6 @@ This module is the single source of truth for:
 - ``_find_agent`` / ``_issue_is_claimed``: also re-exported from the package
   ``__init__`` so that api.py imports keep working without circular dependencies.
 """
-from __future__ import annotations
 
 import datetime
 import logging

--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -12,7 +12,6 @@ The board shows all issues grouped by phase with live PR/agent-run status.
 The inspector panel streams events from ``ac_agent_events`` and thinking
 messages from ``ac_agent_messages`` for a selected agent run.
 """
-from __future__ import annotations
 
 import asyncio
 import json

--- a/agentception/routes/ui/cognitive_arch.py
+++ b/agentception/routes/ui/cognitive_arch.py
@@ -14,7 +14,6 @@ This route is intentionally decoupled from the persona-resolution logic in
 *all* entries including ones that would fail persona resolution (e.g. draft
 figures without a complete ``prompt_injection`` block).
 """
-from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field

--- a/agentception/routes/ui/org_chart.py
+++ b/agentception/routes/ui/org_chart.py
@@ -24,7 +24,6 @@ Preset definitions are loaded from ``org-presets.yaml`` at the repo root.
 Role list and phase assignments are persisted to ``pipeline-config.json``
 under the ``active_org_roles`` key so they survive page reloads.
 """
-from __future__ import annotations
 
 import json
 import logging

--- a/agentception/routes/ui/plan_ui.py
+++ b/agentception/routes/ui/plan_ui.py
@@ -24,7 +24,6 @@ on a ``data:`` line followed by ``\\n\\n``.  Event shapes::
 The browser accumulates ``chunk`` texts, shows them live, then on ``done``
 loads the canonical validated YAML into the Monaco editor.
 """
-from __future__ import annotations
 
 import json
 import logging

--- a/agentception/services/health_collector.py
+++ b/agentception/services/health_collector.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+"""health_collector — gathers point-in-time system health metrics.
+
+Single public coroutine: ``collect() -> HealthSnapshot``.
+
+Metrics gathered:
+- ``uptime_seconds``   — wall-clock seconds since this module was first imported.
+- ``memory_rss_mb``   — process RSS via ``resource.getrusage`` (stdlib; no psutil dep).
+- ``active_worktree_count`` — subdirectory count under ``settings.worktrees_dir``.
+- ``github_api_latency_ms`` — round-trip to ``https://api.github.com`` via httpx.
+                              Returns -1.0 on any network or timeout error.
+"""
+
+import logging
+import resource
+import sys
+import time
+
+import httpx
+
+from agentception.config import settings
+from agentception.models.health import HealthSnapshot
+
+logger = logging.getLogger(__name__)
+
+# Module-load time used as the process start reference for uptime.
+_START_TIME: float = time.monotonic()
+
+# GitHub probe endpoint — just the root, cheap and always available.
+_GITHUB_PROBE_URL: str = "https://api.github.com"
+_PROBE_TIMEOUT_S: float = 5.0
+
+
+def _memory_rss_mb() -> float:
+    """Return the process Resident Set Size in megabytes.
+
+    ``resource.getrusage(RUSAGE_SELF).ru_maxrss`` returns:
+    - bytes on macOS (darwin)
+    - kilobytes on Linux (including Docker containers)
+    """
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    # macOS reports bytes; Linux (Docker) reports kilobytes.
+    divisor = 1024.0 * 1024.0 if sys.platform == "darwin" else 1024.0
+    return rss / divisor
+
+
+def _active_worktree_count() -> int:
+    """Count direct subdirectories of ``settings.worktrees_dir``.
+
+    Each checkout lives in its own subdirectory (e.g. ``issue-123/``).
+    Returns 0 if the directory does not exist yet.
+    """
+    worktrees_dir = settings.worktrees_dir
+    if not worktrees_dir.exists():
+        return 0
+    return sum(1 for p in worktrees_dir.iterdir() if p.is_dir())
+
+
+async def _probe_github_latency_ms() -> float:
+    """Return the round-trip time of a HEAD request to the GitHub API root.
+
+    Returns -1.0 if the request fails or times out — the endpoint contract
+    documents -1.0 as the sentinel for "probe has not yet run or failed."
+    """
+    try:
+        async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT_S) as client:
+            start = time.monotonic()
+            await client.head(_GITHUB_PROBE_URL)
+            elapsed_ms = (time.monotonic() - start) * 1000.0
+            return round(elapsed_ms, 3)
+    except Exception:
+        logger.warning("⚠️ GitHub API latency probe failed — returning -1.0")
+        return -1.0
+
+
+async def collect() -> HealthSnapshot:
+    """Gather and return a point-in-time HealthSnapshot.
+
+    Delegates each metric to a focused helper so callers of this module
+    never touch psutil, resource, or httpx directly.
+    """
+    uptime = round(time.monotonic() - _START_TIME, 3)
+    memory = round(_memory_rss_mb(), 3)
+    worktrees = _active_worktree_count()
+    latency = await _probe_github_latency_ms()
+
+    logger.debug(
+        "✅ Health snapshot collected: uptime=%.1fs mem=%.1fMB worktrees=%d gh_latency=%.1fms",
+        uptime,
+        memory,
+        worktrees,
+        latency,
+    )
+
+    return HealthSnapshot(
+        uptime_seconds=uptime,
+        memory_rss_mb=memory,
+        active_worktree_count=worktrees,
+        github_api_latency_ms=latency,
+    )

--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -24,7 +24,6 @@ Two public entry points:
 The key is read from ``settings.openrouter_api_key`` (env var
 ``AC_OPENROUTER_API_KEY``).  A missing key raises ``RuntimeError``.
 """
-from __future__ import annotations
 
 import asyncio
 import json

--- a/agentception/telemetry.py
+++ b/agentception/telemetry.py
@@ -13,7 +13,6 @@ data to display.
 
 Consumed by ``GET /api/telemetry/waves`` and future timeline UI components.
 """
-from __future__ import annotations
 
 import asyncio
 import logging

--- a/agentception/tests/conftest.py
+++ b/agentception/tests/conftest.py
@@ -9,4 +9,3 @@ AgentCeption is a standalone service; its tests must run cleanly in the
 Run the full agentception suite:
     docker compose exec agentception pytest agentception/tests/ -v
 """
-from __future__ import annotations

--- a/agentception/tests/e2e/test_agentception_workflow_e2e.py
+++ b/agentception/tests/e2e/test_agentception_workflow_e2e.py
@@ -16,7 +16,6 @@ Workflow under test:
 Run targeted:
     docker compose exec agentception pytest agentception/tests/e2e/test_agentception_workflow_e2e.py -v -m e2e
 """
-from __future__ import annotations
 
 import logging
 from collections.abc import Generator

--- a/agentception/tests/test_a11y.py
+++ b/agentception/tests/test_a11y.py
@@ -9,7 +9,6 @@ Verifies that structural a11y requirements are present in the rendered HTML:
 Run targeted:
     pytest agentception/tests/test_a11y.py -v
 """
-from __future__ import annotations
 
 import pathlib
 

--- a/agentception/tests/test_agentception_ab_mode.py
+++ b/agentception/tests/test_agentception_ab_mode.py
@@ -12,7 +12,6 @@ Covers:
 Run targeted:
     docker compose exec agentception pytest agentception/tests/test_agentception_ab_mode.py -v
 """
-from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 

--- a/agentception/tests/test_agentception_ab_results.py
+++ b/agentception/tests/test_agentception_ab_results.py
@@ -11,7 +11,6 @@ Covers the three acceptance criteria from issue #638:
 Run targeted:
     docker compose exec agentception pytest agentception/tests/test_agentception_ab_results.py -v
 """
-from __future__ import annotations
 
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch

--- a/agentception/tests/test_agentception_analyze_partial.py
+++ b/agentception/tests/test_agentception_analyze_partial.py
@@ -8,7 +8,6 @@ HTML fragment with analysis results for a single GitHub issue.
 Run targeted:
     pytest agentception/tests/test_agentception_analyze_partial.py -v
 """
-from __future__ import annotations
 
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch

--- a/agentception/tests/test_agentception_analyzer.py
+++ b/agentception/tests/test_agentception_analyzer.py
@@ -6,7 +6,6 @@ All tests call the synchronous _analyze_body helper directly so no event loop,
 GitHub CLI, or network access is required.  The async analyze_issue function is
 covered by an integration smoke-test that is skipped in CI.
 """
-from __future__ import annotations
 
 import pytest
 

--- a/agentception/tests/test_agentception_cognitive_arch.py
+++ b/agentception/tests/test_agentception_cognitive_arch.py
@@ -7,7 +7,6 @@ Verifies that the cognitive architecture browser route:
 - Renders figure and skill-domain data into the page
 - Degrades gracefully when the YAML directories are absent
 """
-from __future__ import annotations
 
 import textwrap
 from collections.abc import Generator

--- a/agentception/tests/test_agentception_control.py
+++ b/agentception/tests/test_agentception_control.py
@@ -10,7 +10,6 @@ Tests cover:
 Run targeted:
     pytest agentception/tests/test_agentception_control.py -v
 """
-from __future__ import annotations
 
 from collections.abc import Generator
 from pathlib import Path

--- a/agentception/tests/test_agentception_controls.py
+++ b/agentception/tests/test_agentception_controls.py
@@ -13,7 +13,6 @@ so they never touch the real repository filesystem.
 Run targeted:
     pytest agentception/tests/test_agentception_controls.py -v
 """
-from __future__ import annotations
 
 import importlib
 from collections.abc import Generator

--- a/agentception/tests/test_agentception_dag.py
+++ b/agentception/tests/test_agentception_dag.py
@@ -8,7 +8,6 @@ Covers:
 - GET /dag  — HTML page (dag_page_returns_200, d3_cdn)
 - GET /api/dag — JSON endpoint (returns nodes and edges)
 """
-from __future__ import annotations
 
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch

--- a/agentception/tests/test_agentception_enriched_manifest.py
+++ b/agentception/tests/test_agentception_enriched_manifest.py
@@ -11,7 +11,6 @@ Invariants verified:
 - Empty phases raises ValueError.
 - Invalid parallel_groups (dep within group) raises ValidationError.
 """
-from __future__ import annotations
 
 import pytest
 from pydantic import ValidationError

--- a/agentception/tests/test_agentception_extraction.py
+++ b/agentception/tests/test_agentception_extraction.py
@@ -6,7 +6,6 @@ These tests verify that the agentception/ package is fully self-contained and
 ready for extraction into a standalone repository.  They must all pass before
 any extraction attempt.
 """
-from __future__ import annotations
 
 import re
 import tomllib

--- a/agentception/tests/test_agentception_github.py
+++ b/agentception/tests/test_agentception_github.py
@@ -10,7 +10,6 @@ module level gives complete control over return values and exit codes.
 Run targeted:
     pytest agentception/tests/test_agentception_github.py -v
 """
-from __future__ import annotations
 
 import asyncio
 import json

--- a/agentception/tests/test_agentception_guards.py
+++ b/agentception/tests/test_agentception_guards.py
@@ -15,7 +15,6 @@ Coverage:
 Run targeted:
     pytest agentception/tests/test_agentception_guards.py -v
 """
-from __future__ import annotations
 
 from pathlib import Path
 from unittest.mock import AsyncMock, patch

--- a/agentception/tests/test_agentception_mcp_plan.py
+++ b/agentception/tests/test_agentception_mcp_plan.py
@@ -12,7 +12,6 @@ Covers:
 
 Boundary: zero imports from maestro, muse, kly, or storpheus.
 """
-from __future__ import annotations
 
 import json
 import os

--- a/agentception/tests/test_agentception_models.py
+++ b/agentception/tests/test_agentception_models.py
@@ -8,7 +8,6 @@ hand-maintained frozenset, and that the set stays in sync with the YAML file.
 Run targeted:
     pytest agentception/tests/test_agentception_models.py -v
 """
-from __future__ import annotations
 
 from pathlib import Path
 

--- a/agentception/tests/test_agentception_org_chart.py
+++ b/agentception/tests/test_agentception_org_chart.py
@@ -17,7 +17,6 @@ Covers:
 Run targeted:
     docker compose exec agentception pytest agentception/tests/test_agentception_org_chart.py -v
 """
-from __future__ import annotations
 
 import json
 import tempfile

--- a/agentception/tests/test_agentception_pipeline_config.py
+++ b/agentception/tests/test_agentception_pipeline_config.py
@@ -8,7 +8,6 @@ Covers:
 - GET /api/config returns current config
 - PUT /api/config validates schema and persists changes
 """
-from __future__ import annotations
 
 import json
 from pathlib import Path

--- a/agentception/tests/test_agentception_plan_api.py
+++ b/agentception/tests/test_agentception_plan_api.py
@@ -22,7 +22,6 @@ do not require a live git repository or network access.
 
 Boundary: zero imports from maestro/, muse/, kly/, or storpheus/.
 """
-from __future__ import annotations
 
 import json
 import uuid

--- a/agentception/tests/test_agentception_plan_spec.py
+++ b/agentception/tests/test_agentception_plan_spec.py
@@ -9,7 +9,6 @@ These tests verify:
 - from_yaml() rejects malformed YAML strings.
 - Empty phases / empty issues lists are rejected.
 """
-from __future__ import annotations
 
 import textwrap
 

--- a/agentception/tests/test_agentception_poller.py
+++ b/agentception/tests/test_agentception_poller.py
@@ -12,7 +12,6 @@ Coverage:
 Run targeted:
     pytest agentception/tests/test_agentception_poller.py -v
 """
-from __future__ import annotations
 
 import asyncio
 import time

--- a/agentception/tests/test_agentception_role_versions.py
+++ b/agentception/tests/test_agentception_role_versions.py
@@ -12,7 +12,6 @@ Covers:
 Run targeted:
     docker compose exec agentception pytest agentception/tests/test_agentception_role_versions.py -v
 """
-from __future__ import annotations
 
 import json
 import time

--- a/agentception/tests/test_agentception_roles.py
+++ b/agentception/tests/test_agentception_roles.py
@@ -17,7 +17,6 @@ Covers:
 Run targeted:
     pytest agentception/tests/test_agentception_roles.py -v
 """
-from __future__ import annotations
 
 from collections.abc import Generator
 from pathlib import Path

--- a/agentception/tests/test_agentception_run_conductor.py
+++ b/agentception/tests/test_agentception_run_conductor.py
@@ -11,7 +11,6 @@ Covers:
 Run targeted:
     pytest agentception/tests/test_agentception_run_conductor.py -v
 """
-from __future__ import annotations
 
 import datetime
 from collections.abc import Generator

--- a/agentception/tests/test_agentception_scaffold.py
+++ b/agentception/tests/test_agentception_scaffold.py
@@ -8,7 +8,6 @@ the FastAPI app itself — before any reader or poller logic is wired in.
 Run targeted:
     pytest agentception/tests/test_agentception_scaffold.py -v
 """
-from __future__ import annotations
 
 from collections.abc import Generator
 

--- a/agentception/tests/test_agentception_scaling.py
+++ b/agentception/tests/test_agentception_scaling.py
@@ -16,7 +16,6 @@ Coverage:
 Run targeted:
     pytest agentception/tests/test_agentception_scaling.py -v
 """
-from __future__ import annotations
 
 import time
 from unittest.mock import AsyncMock, patch

--- a/agentception/tests/test_agentception_spawn.py
+++ b/agentception/tests/test_agentception_spawn.py
@@ -9,7 +9,6 @@ filesystem side-effects.
 Run targeted:
     pytest agentception/tests/test_agentception_spawn.py -v
 """
-from __future__ import annotations
 
 import asyncio
 from collections.abc import Generator

--- a/agentception/tests/test_agentception_spawn_conductor.py
+++ b/agentception/tests/test_agentception_spawn_conductor.py
@@ -9,7 +9,6 @@ side-effects beyond the tmp_path sandbox.
 Run targeted:
     pytest agentception/tests/test_agentception_spawn_conductor.py -v
 """
-from __future__ import annotations
 
 from collections.abc import Generator
 from pathlib import Path

--- a/agentception/tests/test_agentception_telemetry.py
+++ b/agentception/tests/test_agentception_telemetry.py
@@ -8,7 +8,6 @@ Covers the four acceptance criteria from issue #620:
 - ended_at is None when any worktree in the batch is still active
 - Empty worktree list returns empty waves
 """
-from __future__ import annotations
 
 import os
 from pathlib import Path

--- a/agentception/tests/test_agentception_templates.py
+++ b/agentception/tests/test_agentception_templates.py
@@ -9,7 +9,6 @@ Covers:
 - test_import_detects_conflicts
 - API endpoint integration tests (export, import, list, download)
 """
-from __future__ import annotations
 
 import io
 import json

--- a/agentception/tests/test_agentception_transcripts.py
+++ b/agentception/tests/test_agentception_transcripts.py
@@ -8,7 +8,6 @@ All tests use temporary directories — no dependency on live ~/.cursor/projects
 Run targeted:
     pytest agentception/tests/test_agentception_transcripts.py -v
 """
-from __future__ import annotations
 
 import json
 from pathlib import Path

--- a/agentception/tests/test_agentception_ui_agent.py
+++ b/agentception/tests/test_agentception_ui_agent.py
@@ -14,7 +14,6 @@ background polling, no filesystem reads.
 Run targeted:
     docker compose exec agentception pytest agentception/tests/test_agentception_ui_agent.py -v
 """
-from __future__ import annotations
 
 import time
 from collections.abc import Generator

--- a/agentception/tests/test_agentception_ui_config.py
+++ b/agentception/tests/test_agentception_ui_config.py
@@ -14,7 +14,6 @@ tests remain independent of the on-disk pipeline-config.json.
 Run targeted:
     pytest agentception/tests/test_agentception_ui_config.py -v
 """
-from __future__ import annotations
 
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch

--- a/agentception/tests/test_agentception_ui_overview.py
+++ b/agentception/tests/test_agentception_ui_overview.py
@@ -8,7 +8,6 @@ All tests are synchronous — no live GitHub calls, no background polling.
 Run targeted:
     pytest agentception/tests/test_agentception_ui_overview.py -v
 """
-from __future__ import annotations
 
 import time
 from collections.abc import Generator

--- a/agentception/tests/test_agentception_ui_plan.py
+++ b/agentception/tests/test_agentception_ui_plan.py
@@ -12,7 +12,6 @@ Covers:
 Run targeted:
     pytest agentception/tests/test_agentception_ui_plan.py -v
 """
-from __future__ import annotations
 
 import textwrap
 from collections.abc import Generator

--- a/agentception/tests/test_agentception_ui_telemetry.py
+++ b/agentception/tests/test_agentception_ui_telemetry.py
@@ -11,7 +11,6 @@ Covers:
 Run targeted:
     pytest agentception/tests/test_agentception_ui_telemetry.py -v
 """
-from __future__ import annotations
 
 import time
 from collections.abc import Generator

--- a/agentception/tests/test_agentception_wizard.py
+++ b/agentception/tests/test_agentception_wizard.py
@@ -18,7 +18,6 @@ network, no filesystem side-effects, no DB required.
 Run targeted:
     pytest agentception/tests/test_agentception_wizard.py -v
 """
-from __future__ import annotations
 
 import datetime
 import json

--- a/agentception/tests/test_agentception_worktrees.py
+++ b/agentception/tests/test_agentception_worktrees.py
@@ -8,7 +8,6 @@ and parses their .agent-task files into TaskFile models.
 Run targeted:
     pytest agentception/tests/test_agentception_worktrees.py -v
 """
-from __future__ import annotations
 
 import os
 from pathlib import Path

--- a/agentception/tests/test_agents_page.py
+++ b/agentception/tests/test_agents_page.py
@@ -10,7 +10,6 @@ Verifies:
 Run targeted:
     pytest agentception/tests/test_agents_page.py -v
 """
-from __future__ import annotations
 
 from collections.abc import Generator
 

--- a/agentception/tests/test_brain_dump_plan.py
+++ b/agentception/tests/test_brain_dump_plan.py
@@ -14,7 +14,6 @@ Covers:
 Run targeted:
     docker compose exec agentception pytest agentception/tests/test_brain_dump_plan.py -v
 """
-from __future__ import annotations
 
 from collections.abc import Generator
 

--- a/agentception/tests/test_dag_resize.py
+++ b/agentception/tests/test_dag_resize.py
@@ -10,7 +10,6 @@ refactoring.
 Run targeted:
     pytest agentception/tests/test_dag_resize.py -v
 """
-from __future__ import annotations
 
 import pathlib
 

--- a/agentception/tests/test_health_endpoint.py
+++ b/agentception/tests/test_health_endpoint.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+"""Tests for GET /api/health/detailed endpoint.
+
+Tests cover:
+- 200 status code returned.
+- Response body matches HealthSnapshot schema (all 4 fields present).
+- Each field is the correct type.
+- health_collector.collect() is the sole delegate (no business logic in route).
+
+Run targeted:
+    pytest agentception/tests/test_health_endpoint.py -v
+"""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+from agentception.models.health import HealthSnapshot
+
+_MOCK_SNAPSHOT = HealthSnapshot(
+    uptime_seconds=42.0,
+    memory_rss_mb=128.5,
+    active_worktree_count=3,
+    github_api_latency_ms=55.2,
+)
+
+
+@pytest.fixture()
+def client() -> Generator[TestClient, None, None]:
+    """Synchronous test client with lifespan handled."""
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def mock_collect() -> Generator[AsyncMock, None, None]:
+    """Patch health_collector.collect for all tests in this module."""
+    with patch(
+        "agentception.routes.api.health.health_collector.collect",
+        new_callable=AsyncMock,
+        return_value=_MOCK_SNAPSHOT,
+    ) as mock:
+        yield mock
+
+
+# ── Status code ───────────────────────────────────────────────────────────────
+
+
+def test_health_detailed_returns_200(client: TestClient) -> None:
+    """GET /api/health/detailed must return HTTP 200."""
+    response = client.get("/api/health/detailed")
+    assert response.status_code == 200
+
+
+# ── Schema shape ──────────────────────────────────────────────────────────────
+
+
+def test_health_detailed_response_has_all_four_fields(client: TestClient) -> None:
+    """Response body must contain all four HealthSnapshot fields."""
+    body = client.get("/api/health/detailed").json()
+    assert "uptime_seconds" in body
+    assert "memory_rss_mb" in body
+    assert "active_worktree_count" in body
+    assert "github_api_latency_ms" in body
+
+
+# ── Field types ───────────────────────────────────────────────────────────────
+
+
+def test_health_detailed_uptime_seconds_is_float(client: TestClient) -> None:
+    body = client.get("/api/health/detailed").json()
+    assert isinstance(body["uptime_seconds"], float)
+
+
+def test_health_detailed_memory_rss_mb_is_float(client: TestClient) -> None:
+    body = client.get("/api/health/detailed").json()
+    assert isinstance(body["memory_rss_mb"], float)
+
+
+def test_health_detailed_active_worktree_count_is_int(client: TestClient) -> None:
+    body = client.get("/api/health/detailed").json()
+    assert isinstance(body["active_worktree_count"], int)
+
+
+def test_health_detailed_github_api_latency_ms_is_float(client: TestClient) -> None:
+    body = client.get("/api/health/detailed").json()
+    assert isinstance(body["github_api_latency_ms"], float)
+
+
+# ── Delegation ────────────────────────────────────────────────────────────────
+
+
+def test_health_detailed_delegates_to_collect(
+    client: TestClient, mock_collect: AsyncMock
+) -> None:
+    """Route must call health_collector.collect() exactly once per request."""
+    client.get("/api/health/detailed")
+    mock_collect.assert_awaited_once()
+
+
+def test_health_detailed_returns_collect_values(client: TestClient) -> None:
+    """Values in the response must match what collect() returned."""
+    body = client.get("/api/health/detailed").json()
+    assert body["uptime_seconds"] == _MOCK_SNAPSHOT.uptime_seconds
+    assert body["memory_rss_mb"] == _MOCK_SNAPSHOT.memory_rss_mb
+    assert body["active_worktree_count"] == _MOCK_SNAPSHOT.active_worktree_count
+    assert body["github_api_latency_ms"] == _MOCK_SNAPSHOT.github_api_latency_ms

--- a/agentception/tests/test_issue_creator.py
+++ b/agentception/tests/test_issue_creator.py
@@ -10,7 +10,6 @@ The test suite verifies:
   - A gh failure during issue creation yields an error event and halts.
   - A gh failure during body edit is non-fatal (logged, iteration continues).
 """
-from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from typing import Any

--- a/agentception/tests/test_pipeline_panel.py
+++ b/agentception/tests/test_pipeline_panel.py
@@ -12,7 +12,6 @@ Covers:
 Run targeted:
     pytest agentception/tests/test_pipeline_panel.py -v
 """
-from __future__ import annotations
 
 import time
 from collections.abc import Generator

--- a/agentception/tests/test_settings_page.py
+++ b/agentception/tests/test_settings_page.py
@@ -10,7 +10,6 @@ Covers:
 Run targeted:
     pytest agentception/tests/test_settings_page.py -v
 """
-from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 

--- a/agentception/tests/test_template_globals.py
+++ b/agentception/tests/test_template_globals.py
@@ -9,7 +9,6 @@ source of truth for the GitHub repo slug.
 Run targeted:
     docker compose exec agentception pytest agentception/tests/test_template_globals.py -v
 """
-from __future__ import annotations
 
 from agentception.config import settings
 from agentception.routes.ui._shared import _TEMPLATES

--- a/agentception/tests/test_toast.py
+++ b/agentception/tests/test_toast.py
@@ -9,7 +9,6 @@ Verifies:
 Run targeted:
     pytest agentception/tests/test_toast.py -v
 """
-from __future__ import annotations
 
 import json
 from collections.abc import Generator


### PR DESCRIPTION
## Summary
- Adds `GET /api/health/detailed` route registered in `agentception/routes/api/__init__.py`
- New `agentception/services/health_collector.py` — collects uptime, RSS memory, worktree count, and GitHub API latency
- Thin handler in `agentception/routes/api/health.py` delegates entirely to `health_collector.collect()`

## What's added
- `agentception/services/health_collector.py` — `collect() -> HealthSnapshot` async function
- `agentception/routes/api/health.py` — `GET /api/health/detailed` handler (7 lines of logic)
- `agentception/tests/test_health_endpoint.py` — 8 tests: 200 status, schema shape, field types, delegation
- Fix: 103 files had a duplicate `from __future__ import annotations` from the maestro→agentception migration; removed all duplicates so the test suite can collect cleanly
- Fix: merged `models.py` content into `models/__init__.py` so the `models/` package exposes the same symbols as the old flat module

## Test results
```
8 passed in 0.70s
```

## Notes
- Depends on: HealthSnapshot (PR #5) — now merged ✅
- `health_collector` implemented directly (no separate PR needed)
- Maestro issue: cgcardona/maestro#939

---
<details><summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Session** | `eng-20260304T174500Z-939a` |
| **Batch** | `eng-20260304T172000Z-batch2` |
| **Arch** | `shannon:fastapi:python` |

</details>