### PR TITLE
feat: add System Health card to dashboard with HTMX polling

### DIFF
--- a/agentception/routes/ui/__init__.py
+++ b/agentception/routes/ui/__init__.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter
 
 from .ab_testing import router as _ab
 from .agents import router as _agents
+from .health import router as _health
 from .build_ui import router as _build_ui
 from .cognitive_arch import router as _cognitive_arch
 from .api_reference import router as _api_reference
@@ -40,6 +41,7 @@ from ._shared import _find_agent, _TEMPLATES  # noqa: F401
 router = APIRouter(tags=["ui"])
 router.include_router(_plan_ui)   # owns "/" — must be first
 router.include_router(_build_ui)
+router.include_router(_health)
 router.include_router(_overview)
 router.include_router(_agents)
 router.include_router(_telemetry)

--- a/agentception/routes/ui/health.py
+++ b/agentception/routes/ui/health.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""UI route: GET /ui/health/widget — HTMX-polled System Health card fragment.
+
+Calls ``health_collector.collect()`` and renders ``partials/health_card.html``
+with the four HealthSnapshot metrics and a derived ``is_nominal`` flag.
+
+Thresholds (from issue #941):
+  nominal   — github_api_latency_ms < 500 AND memory_rss_mb < 512
+  elevated  — any threshold exceeded (or probe failed, i.e. latency == -1.0)
+"""
+
+import logging
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+from starlette.requests import Request
+
+from agentception.services import health_collector
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_LATENCY_THRESHOLD_MS: float = 500.0
+_MEMORY_THRESHOLD_MB: float = 512.0
+
+
+def _fmt_uptime(seconds: float) -> str:
+    """Format an uptime duration in seconds as a compact human-readable string."""
+    s = int(seconds)
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        return f"{s // 60}m {s % 60}s"
+    h = s // 3600
+    m = (s % 3600) // 60
+    return f"{h}h {m}m"
+
+
+@router.get("/ui/health/widget", response_class=HTMLResponse, tags=["ui", "health"])
+async def health_widget(request: Request) -> HTMLResponse:
+    """Return the System Health card as an HTMX-ready HTML fragment.
+
+    The overview dashboard polls this endpoint every 10 seconds via
+    ``hx-get="/ui/health/widget" hx-trigger="load, every 10s" hx-swap="innerHTML"``.
+
+    The ``is_nominal`` flag controls the status-dot BEM modifier:
+    - ``.health-status-dot--nominal`` (green) when latency < 500 ms AND memory < 512 MB.
+    - ``.health-status-dot--elevated`` (yellow) otherwise, including when the
+      GitHub probe has not yet run (latency == -1.0).
+    """
+    from ._shared import _TEMPLATES
+
+    snapshot = await health_collector.collect()
+
+    latency_ok = 0.0 <= snapshot.github_api_latency_ms < _LATENCY_THRESHOLD_MS
+    memory_ok = snapshot.memory_rss_mb < _MEMORY_THRESHOLD_MB
+    is_nominal = latency_ok and memory_ok
+
+    logger.debug(
+        "⚙️ health widget: uptime=%.1fs mem=%.1fMB latency=%.1fms nominal=%s",
+        snapshot.uptime_seconds,
+        snapshot.memory_rss_mb,
+        snapshot.github_api_latency_ms,
+        is_nominal,
+    )
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "partials/health_card.html",
+        {
+            "snapshot": snapshot,
+            "is_nominal": is_nominal,
+            "uptime_str": _fmt_uptime(snapshot.uptime_seconds),
+        },
+    )

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -731,6 +731,16 @@
     <aside class="github-board" aria-label="GitHub board">
       <h2 class="section-title">GitHub Board</h2>
 
+      {# System Health card — HTMX-polled every 10 s, no page reload needed #}
+      <div
+        class="health-card"
+        hx-get="/ui/health/widget"
+        hx-trigger="load, every 10s"
+        hx-swap="innerHTML"
+        aria-label="System health"
+        aria-live="polite"
+      ></div>
+
       {# Wave control card #}
       <div class="card wave-control-card" x-data="waveControl()" x-init="init()">
         <div class="wave-control-header">

--- a/agentception/templates/partials/health_card.html
+++ b/agentception/templates/partials/health_card.html
@@ -1,0 +1,43 @@
+{#
+  HTMX partial: System Health card.
+
+  Rendered by GET /ui/health/widget and polled every 10 seconds from the
+  overview dashboard via hx-get/hx-trigger/hx-swap="innerHTML".
+
+  Context:
+    snapshot   — HealthSnapshot model instance
+    is_nominal — bool: True when github_api_latency_ms < 500 AND memory_rss_mb < 512
+    uptime_str — human-readable uptime string (e.g. "2h 14m" or "45s")
+#}
+<div class='health-card__header'>
+  <span class='health-card__title'>System Health</span>
+  <span
+    class='health-status-dot {% if is_nominal %}health-status-dot--nominal{% else %}health-status-dot--elevated{% endif %}'
+    title='{% if is_nominal %}Nominal{% else %}Elevated{% endif %}'
+    aria-label='Status: {% if is_nominal %}nominal{% else %}elevated{% endif %}'
+  ></span>
+</div>
+<div class='health-card__grid'>
+  <div class='health-metric'>
+    <span class='health-metric__label'>Uptime</span>
+    <span class='health-metric__value'>{{ uptime_str }}</span>
+  </div>
+  <div class='health-metric'>
+    <span class='health-metric__label'>Memory RSS</span>
+    <span class='health-metric__value'>{{ "%.1f"|format(snapshot.memory_rss_mb) }} MB</span>
+  </div>
+  <div class='health-metric'>
+    <span class='health-metric__label'>Worktrees</span>
+    <span class='health-metric__value'>{{ snapshot.active_worktree_count }}</span>
+  </div>
+  <div class='health-metric'>
+    <span class='health-metric__label'>GitHub Latency</span>
+    <span class='health-metric__value'>
+      {%- if snapshot.github_api_latency_ms < 0 -%}
+        —
+      {%- else -%}
+        {{ snapshot.github_api_latency_ms | int }} ms
+      {%- endif -%}
+    </span>
+  </div>
+</div>

--- a/tests/test_health_widget.py
+++ b/tests/test_health_widget.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+"""Tests for GET /ui/health/widget — the HTMX System Health card fragment.
+
+Covers:
+  - 200 response with HTML content-type
+  - Rendered fragment contains the required CSS classes
+  - Status dot is --nominal when thresholds are satisfied
+  - Status dot is --elevated when latency threshold is exceeded
+  - Status dot is --elevated when memory threshold is exceeded
+  - Status dot is --elevated when latency sentinel (-1.0) is present
+  - _fmt_uptime helper formats durations correctly
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from agentception.app import app
+from agentception.models.health import HealthSnapshot
+from agentception.routes.ui.health import _fmt_uptime
+
+_NOMINAL_SNAPSHOT = HealthSnapshot(
+    uptime_seconds=3725.0,
+    memory_rss_mb=128.0,
+    active_worktree_count=3,
+    github_api_latency_ms=42.0,
+)
+
+_ELEVATED_LATENCY_SNAPSHOT = HealthSnapshot(
+    uptime_seconds=60.0,
+    memory_rss_mb=128.0,
+    active_worktree_count=1,
+    github_api_latency_ms=600.0,
+)
+
+_ELEVATED_MEMORY_SNAPSHOT = HealthSnapshot(
+    uptime_seconds=60.0,
+    memory_rss_mb=600.0,
+    active_worktree_count=1,
+    github_api_latency_ms=100.0,
+)
+
+_PROBE_FAILED_SNAPSHOT = HealthSnapshot(
+    uptime_seconds=10.0,
+    memory_rss_mb=64.0,
+    active_worktree_count=0,
+    github_api_latency_ms=-1.0,
+)
+
+
+@pytest.mark.anyio
+async def test_health_widget_returns_200() -> None:
+    with patch(
+        "agentception.routes.ui.health.health_collector.collect",
+        new=AsyncMock(return_value=_NOMINAL_SNAPSHOT),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/ui/health/widget")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_health_widget_returns_html_content_type() -> None:
+    with patch(
+        "agentception.routes.ui.health.health_collector.collect",
+        new=AsyncMock(return_value=_NOMINAL_SNAPSHOT),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/ui/health/widget")
+
+    assert "text/html" in response.headers.get("content-type", "")
+
+
+@pytest.mark.anyio
+async def test_health_widget_contains_health_card_class() -> None:
+    with patch(
+        "agentception.routes.ui.health.health_collector.collect",
+        new=AsyncMock(return_value=_NOMINAL_SNAPSHOT),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/ui/health/widget")
+
+    assert "health-card" in response.text
+
+
+@pytest.mark.anyio
+async def test_health_widget_contains_health_metric_class() -> None:
+    with patch(
+        "agentception.routes.ui.health.health_collector.collect",
+        new=AsyncMock(return_value=_NOMINAL_SNAPSHOT),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/ui/health/widget")
+
+    assert "health-metric" in response.text
+
+
+@pytest.mark.anyio
+async def test_health_widget_contains_health_status_dot() -> None:
+    with patch(
+        "agentception.routes.ui.health.health_collector.collect",
+        new=AsyncMock(return_value=_NOMINAL_SNAPSHOT),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/ui/health/widget")
+
+    assert "health-status-dot" in response.text
+
+
+@pytest.mark.anyio
+async def test_health_widget_nominal_dot_when_thresholds_satisfied() -> None:
+    with patch(
+        "agentception.routes.ui.health.health_collector.collect",
+        new=AsyncMock(return_value=_NOMINAL_SNAPSHOT),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/ui/health/widget")
+
+    assert "health-status-dot--nominal" in response.text
+    assert "health-status-dot--elevated" not in response.text
+
+
+@pytest.mark.anyio
+async def test_health_widget_elevated_dot_when_latency_exceeded() -> None:
+    with patch(
+        "agentception.routes.ui.health.health_collector.collect",
+        new=AsyncMock(return_value=_ELEVATED_LATENCY_SNAPSHOT),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/ui/health/widget")
+
+    assert "health-status-dot--elevated" in response.text
+    assert "health-status-dot--nominal" not in response.text
+
+
+@pytest.mark.anyio
+async def test_health_widget_elevated_dot_when_memory_exceeded() -> None:
+    with patch(
+        "agentception.routes.ui.health.health_collector.collect",
+        new=AsyncMock(return_value=_ELEVATED_MEMORY_SNAPSHOT),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/ui/health/widget")
+
+    assert "health-status-dot--elevated" in response.text
+
+
+@pytest.mark.anyio
+async def test_health_widget_elevated_dot_when_probe_failed() -> None:
+    """Sentinel latency value (-1.0) must result in --elevated status dot."""
+    with patch(
+        "agentception.routes.ui.health.health_collector.collect",
+        new=AsyncMock(return_value=_PROBE_FAILED_SNAPSHOT),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/ui/health/widget")
+
+    assert "health-status-dot--elevated" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _fmt_uptime
+# ---------------------------------------------------------------------------
+
+
+def test_fmt_uptime_seconds_only() -> None:
+    assert _fmt_uptime(45.0) == "45s"
+
+
+def test_fmt_uptime_minutes_and_seconds() -> None:
+    assert _fmt_uptime(125.0) == "2m 5s"
+
+
+def test_fmt_uptime_hours_and_minutes() -> None:
+    assert _fmt_uptime(3725.0) == "1h 2m"
+
+
+def test_fmt_uptime_zero() -> None:
+    assert _fmt_uptime(0.0) == "0s"


### PR DESCRIPTION
## Summary
- Adds a System Health card to the main AgentCeption dashboard sidebar, polling \`/ui/health/widget\` every 10 seconds via HTMX
- Shows uptime, memory RSS, active worktree count, and GitHub API latency in a 2×2 \`.health-card\` grid
- Status dot is \`--nominal\` (green) when \`github_api_latency_ms < 500\` AND \`memory_rss_mb < 512\`, \`--elevated\` (yellow) otherwise

## What's added
- \`agentception/routes/ui/health.py\` — \`GET /ui/health/widget\` route (thin handler, delegates to \`health_collector\`)
- \`agentception/templates/partials/health_card.html\` — Jinja2 fragment with 2×2 metric grid and status dot
- \`agentception/routes/ui/__init__.py\` — registers the health UI router
- \`agentception/templates/overview.html\` — HTMX polling \`<div class="health-card">\` added to right sidebar
- \`tests/test_health_widget.py\` — 13 tests: 9 route integration tests + 4 \`_fmt_uptime\` unit tests, all pass ✅

## Status dot thresholds
- 🟢 **nominal**: \`github_api_latency_ms < 500\` AND \`memory_rss_mb < 512\`
- 🟡 **elevated**: any threshold exceeded, or probe failed (\`latency == -1.0\`)

## Dependencies
- HealthSnapshot model (PR #5 ✅)
- health_collector service (PR #7 ✅)
- GET /api/health/detailed (PR #8 ✅)
- _health_card.scss styles (PR #10 ✅ merged)

Closes cgcardona/maestro#941

---
🤖 Session: `eng-20260304T175717Z-2048` | Arch: `shannon:fastapi:python`