### PR TITLE
docs: cold-clone E2E verification — verified setup guide and env/build audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,27 +1,37 @@
 # ── Database ────────────────────────────────────────────────────────────────
-# PostgreSQL connection string for the AgentCeption database.
-# For local development the docker-compose.yml postgres service uses these defaults.
-DATABASE_URL=postgresql+asyncpg://agentception:agentception@postgres:5432/agentception
+# Password for the Postgres database.
+# REQUIRED — there is no default. Generate with: openssl rand -hex 16
+# Used by docker-compose.yml to set POSTGRES_PASSWORD and build AC_DATABASE_URL.
+DB_PASSWORD=
 
 # ── GitHub ──────────────────────────────────────────────────────────────────
 # Personal access token with repo + issues scope.
 # Create at: https://github.com/settings/tokens
-AC_GITHUB_TOKEN=ghp_...
+# Optional when using gh CLI auth via ~/.config/gh volume mount (see docker-compose.yml).
+AC_GITHUB_TOKEN=
 
 # The GitHub repo this AgentCeption instance manages (owner/repo).
+# REQUIRED — replace with your own repo.
 AC_GH_REPO=cgcardona/your-repo
 
 # ── LLM (OpenRouter) ────────────────────────────────────────────────────────
 # API key from https://openrouter.ai/keys
 # Required for Phase 1A planning (brain dump → PlanSpec YAML).
-AC_OPENROUTER_API_KEY=sk-or-...
+AC_OPENROUTER_API_KEY=
 
-# ── Worktrees ────────────────────────────────────────────────────────────────
+# ── Paths ────────────────────────────────────────────────────────────────────
+# Host-side absolute path to the cloned agentception repo.
+# Used so the container can run git operations against the repo.
+# Defaults to /app (the container working directory) when not set.
+AC_REPO_DIR=
+
 # Host path where agent git worktrees are created.
 # Must be accessible from both the host (for Cursor) and the container.
+# Set this to an absolute path (no ~ expansion in compose env values).
 AC_HOST_WORKTREES_DIR=~/.agentception/worktrees
 
 # Container-internal path that maps to AC_HOST_WORKTREES_DIR.
+# Add a corresponding volume entry in docker-compose.override.yml if you change this.
 AC_WORKTREES_DIR=/worktrees
 
 # ── Service ──────────────────────────────────────────────────────────────────

--- a/agentception/config.py
+++ b/agentception/config.py
@@ -65,18 +65,18 @@ class AgentCeptionSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="AC_")
 
     cursor_projects_dir: Path = Path.home() / ".cursor/projects"
-    worktrees_dir: Path = Path.home() / ".agentception/worktrees/maestro"
-    host_worktrees_dir: Path = Path.home() / ".agentception/worktrees/maestro"
+    worktrees_dir: Path = Path.home() / ".agentception/worktrees"
+    host_worktrees_dir: Path = Path.home() / ".agentception/worktrees"
     """Host-side path to the worktrees directory.
 
     Inside Docker, ``worktrees_dir`` is the container path (``/worktrees``).
     ``host_worktrees_dir`` is the corresponding path on the developer's machine
-    (e.g. ``~/.agentception/worktrees/maestro``), used to generate paths that the
+    (e.g. ``~/.agentception/worktrees``), used to generate paths that the
     user can open directly in Cursor and that the agent-task file embeds.
     Set via ``AC_HOST_WORKTREES_DIR`` in docker-compose.override.yml.
     """
     repo_dir: Path = Path.cwd()
-    gh_repo: str = "cgcardona/maestro"
+    gh_repo: str = "cgcardona/agentception"
 
     @property
     def ac_dir(self) -> Path:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       AC_DATABASE_URL: "postgresql+asyncpg://agentception:${DB_PASSWORD}@postgres:5432/agentception"
       # gh CLI / git repo settings — override via .env or docker-compose.override.yml
       AC_GH_REPO: ${AC_GH_REPO:-cgcardona/agentception}
-      AC_REPO_DIR: ${AC_REPO_DIR:-/Users/gabriel/dev/tellurstori/agentception}
-      AC_WORKTREES_DIR: ${AC_WORKTREES_DIR:-/Users/gabriel/.agentception/worktrees/agentception}
+      AC_REPO_DIR: ${AC_REPO_DIR:-/app}
+      AC_WORKTREES_DIR: ${AC_WORKTREES_DIR:-/worktrees}
       AC_OPENROUTER_API_KEY: ${AC_OPENROUTER_API_KEY:-}
     volumes:
       # Mount cursor dir at same absolute path so worktree paths resolve correctly.

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -1,0 +1,195 @@
+# Setup Guide — First Run
+
+This is a verified, step-by-step guide for running AgentCeption from a cold clone.
+Every step was executed against a freshly cloned copy of the repo with no prior environment.
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Docker Desktop (or Docker Engine + Compose v2) | ≥ 24 | `docker compose version` to check |
+| `git` | any | |
+| A GitHub Personal Access Token | — | `repo` + `issues` scope — [create one here](https://github.com/settings/tokens) |
+| An [OpenRouter](https://openrouter.ai/keys) API key | — | Required for Phase 1A planning |
+
+---
+
+## Step 1 — Clone
+
+```bash
+git clone https://github.com/cgcardona/agentception
+cd agentception
+```
+
+---
+
+## Step 2 — Create `.env`
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and fill in the required values:
+
+| Variable | Required | What it is | Where to get it |
+|----------|----------|------------|-----------------|
+| `DB_PASSWORD` | **Yes** | Postgres password. No default — the compose file requires it explicitly. | Generate with `openssl rand -hex 16` |
+| `AC_GH_REPO` | **Yes** | The `owner/repo` this AgentCeption instance orchestrates. | Your GitHub repo |
+| `AC_GITHUB_TOKEN` | Optional | GitHub PAT with `repo` + `issues` scope. If you have `~/.config/gh` configured (via `gh auth login`), the container volume-mounts it and you can leave this blank. | [github.com/settings/tokens](https://github.com/settings/tokens) |
+| `AC_OPENROUTER_API_KEY` | Optional | OpenRouter API key. Required for Phase 1A LLM planning. Without it the service starts, but the planner falls back to a keyword classifier. | [openrouter.ai/keys](https://openrouter.ai/keys) |
+| `AC_HOST_WORKTREES_DIR` | Optional | Host path where agent git worktrees are created. Use an absolute path (no `~` — compose doesn't expand it). | Default: `~/.agentception/worktrees` |
+| `AC_WORKTREES_DIR` | Optional | Container-internal path that maps to `AC_HOST_WORKTREES_DIR`. Add a matching volume in `docker-compose.override.yml` if you change this. | Default: `/worktrees` |
+| `AC_REPO_DIR` | Optional | Absolute path to the cloned agentception repo on the host. Used for git operations inside the container. | Default: `/app` (the container working directory) |
+| `AC_PORT` | Optional | Port the FastAPI app listens on. | Default: `10003` |
+| `AC_LOG_LEVEL` | Optional | Log verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`. | Default: `INFO` |
+
+Minimal `.env` that works for a basic smoke test (no LLM features):
+
+```bash
+DB_PASSWORD=<run: openssl rand -hex 16>
+AC_GH_REPO=owner/your-repo
+```
+
+---
+
+## Step 3 — Build
+
+```bash
+docker compose build
+```
+
+First build downloads the Python 3.11 slim image, installs system packages (git, curl, gh CLI, Dart Sass), installs Python dependencies, and compiles SCSS. Expect **2–5 minutes** on a cold build.
+
+A successful build ends with:
+```
+agentception  Built
+```
+
+---
+
+## Step 4 — Start the stack
+
+```bash
+docker compose up -d
+```
+
+This starts three services:
+
+| Container | Host port | Purpose |
+|-----------|-----------|---------|
+| `agentception-app` | 10003 | FastAPI dashboard + API |
+| `agentception-postgres` | 5433 | Persistent database (offset from 5432 to avoid Maestro collision) |
+| `agentception-qdrant` | 6335 / 6336 | Vector store for semantic search |
+
+Verify they're running:
+```bash
+docker compose ps
+```
+
+All three should show `running` (postgres and agentception will also show `healthy` after a few seconds).
+
+---
+
+## Step 5 — Run database migrations
+
+```bash
+docker compose exec agentception alembic -c agentception/alembic.ini upgrade head
+```
+
+Expected output:
+```
+INFO  [alembic.runtime.migration] Running upgrade  -> ac0001
+INFO  [alembic.runtime.migration] Running upgrade ac0001 -> ac0002
+...
+```
+
+If postgres is still starting, wait 5 seconds and retry.
+
+---
+
+## Step 6 — Verify the dashboard
+
+Open [http://localhost:10003](http://localhost:10003) in your browser. You should see the AgentCeption dashboard with **Build**, **Org Chart**, and **Cognitive Architecture** pages all rendering.
+
+Quick smoke test from the command line:
+
+```bash
+# Basic health ping
+curl -f http://localhost:10003/health
+# → {"status":"ok"}
+
+# Detailed health snapshot (uptime, memory, worktree count, GitHub API latency)
+curl -f http://localhost:10003/api/health/detailed
+# → {"uptime_seconds":..., "memory_rss_mb":..., "active_worktree_count":0, "github_api_latency_ms":...}
+```
+
+Both should return HTTP 200.
+
+---
+
+## Step 7 — Configure Cursor MCP (optional)
+
+To use AgentCeption tools from Cursor, add to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "agentception": {
+      "command": "docker",
+      "args": [
+        "compose", "exec", "-T", "agentception",
+        "python", "-m", "agentception.mcp.stdio_server"
+      ],
+      "cwd": "/absolute/path/to/your/agentception"
+    }
+  }
+}
+```
+
+---
+
+## Stopping the stack
+
+```bash
+# Stop containers, preserve database volumes
+docker compose down
+
+# Stop containers and delete all volumes (fresh start)
+docker compose down -v
+```
+
+---
+
+## Troubleshooting
+
+**`DB_PASSWORD` error on `docker compose up`**
+
+`.env` must have `DB_PASSWORD=<some-value>`. There is no default — the compose file requires it explicitly.
+
+```bash
+grep DB_PASSWORD .env   # should show a non-empty value
+```
+
+**Build fails: `No module named 'setuptools.backends'`**
+
+This indicates a mismatch between pip and the build backend. Make sure your local `pyproject.toml` uses `build-backend = "setuptools.build_meta"` (not `setuptools.backends.legacy:build`). Pull the latest `main` — this was fixed in [#970](https://github.com/cgcardona/agentception/pull/970).
+
+**Port 10003 already in use**
+
+Another service is occupying that port. Stop it, or change the host port in `docker-compose.yml`:
+```yaml
+ports:
+  - "127.0.0.1:10004:10003"   # use 10004 on the host instead
+```
+
+**Alembic migration fails with "connection refused"**
+
+Postgres is still starting. Wait a few seconds and retry.
+
+**Dashboard returns 502 / connection refused**
+
+The app is still starting. Wait ~15 seconds and refresh. Check logs with `docker compose logs agentception`.
+
+**`gh` CLI commands fail inside the container**
+
+The container volume-mounts `~/.config/gh` read-only. Run `gh auth login` on the host first, then restart the container.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ Repository = "https://github.com/cgcardona/agentception"
 
 [build-system]
 requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary

Performs a real cold-clone verification of `cgcardona/agentception` and fixes all issues discovered, producing a verified first-run setup guide.

## Issues Found and Fixed

### 1. Build failure: `No module named 'setuptools.backends'` (critical)
- **Root cause:** `pyproject.toml` used `build-backend = "setuptools.backends.legacy:build"` which requires setuptools ≥ 69. Pip's isolated build environment could resolve `setuptools>=68` to 68.x, which doesn't have the `setuptools.backends` subpackage. This caused `docker compose build` to fail on a cold clone.
- **Fix:** Changed to `build-backend = "setuptools.build_meta"` (the classic backend, available since setuptools 40+). No version cliff.

### 2. Hardcoded host paths in `docker-compose.yml` (critical for portability)
- `AC_REPO_DIR` defaulted to `/Users/gabriel/dev/tellurstori/agentception`
- `AC_WORKTREES_DIR` defaulted to `/Users/gabriel/.agentception/worktrees/agentception`
- **Fix:** Changed defaults to `/app` and `/worktrees` (container-local paths that work on any machine).

### 3. `DB_PASSWORD` missing from `.env.example` (critical)
- The compose file requires `DB_PASSWORD` with **no default**, but it wasn't in `.env.example` at all, making the first-run experience completely broken.
- **Fix:** Added `DB_PASSWORD` with clear documentation. Removed the confusing `DATABASE_URL` entry (wrong variable name — compose uses `DB_PASSWORD` to build `AC_DATABASE_URL` internally).

### 4. Wrong `gh_repo` and `worktrees_dir` defaults in `config.py`
- Both defaults pointed to `cgcardona/maestro` / `~/.agentception/worktrees/maestro` — Maestro-specific paths that have no meaning in a standalone agentception deployment.
- **Fix:** Updated to `cgcardona/agentception` and `~/.agentception/worktrees`.

### 5. New: `docs/guides/setup.md`
- Step-by-step verified first-run guide: clone → build → up → alembic → /health → dashboard.
- Complete env var reference table with descriptions and sources for each variable.
- Troubleshooting section for all failure modes encountered during verification.

## Cold-Clone Verification Results

Executed against a freshly cloned copy at `/tmp/agentception-verify-20260304T181149Z/`:

| Step | Result |
|------|--------|
| `git clone` | ✅ |
| `docker compose build` | ✅ (after build-backend fix) |
| `docker compose up -d` | ✅ (all 3 services healthy) |
| `alembic upgrade head` | ✅ (ac0001 → ac0004) |
| `GET /health` → `{"status":"ok"}` | ✅ |
| `GET /` → 200 dashboard HTML | ✅ |
| `GET /api/health/detailed` → HealthSnapshot JSON | ✅ |
| `.env.example` covers all compose vars | ✅ |

Closes cgcardona/maestro#970

---
🤖 Session: `eng-20260304T181051Z-63ea` | Arch: `the_architect:devops`