### PR TITLE
fix: resolve 21 mypy errors blocking CI

### DIFF
--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -501,10 +501,10 @@ def handle_request(
 
     Never raises.
     """
-    request_id: int | str | None = raw.get("id")  # type: ignore[assignment]
-    # Narrow: id must be int | str | None per spec; cast safely.
-    if not isinstance(request_id, (int, str, type(None))):
-        request_id = None
+    _raw_id: object = raw.get("id")
+    request_id: int | str | None = (
+        _raw_id if isinstance(_raw_id, (int, str)) else None
+    )
 
     jsonrpc = raw.get("jsonrpc")
     if jsonrpc != "2.0":

--- a/agentception/routes/ui/agents.py
+++ b/agentception/routes/ui/agents.py
@@ -506,11 +506,11 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
             id=str(db_run.get("id", agent_id)),
             role=str(db_run.get("role", "unknown")),
             status=synth_status,
-            issue_number=db_run.get("issue_number"),  # type: ignore[arg-type]
-            pr_number=db_run.get("pr_number"),  # type: ignore[arg-type]
-            branch=db_run.get("branch"),  # type: ignore[arg-type]
-            batch_id=db_run.get("batch_id"),  # type: ignore[arg-type]
-            worktree_path=db_run.get("worktree_path"),  # type: ignore[arg-type]
+            issue_number=db_run.get("issue_number"),
+            pr_number=db_run.get("pr_number"),
+            branch=db_run.get("branch"),
+            batch_id=db_run.get("batch_id"),
+            worktree_path=db_run.get("worktree_path"),
         )
 
     # Filesystem transcript takes priority — it's the live Cursor session.

--- a/agentception/routes/ui/org_chart.py
+++ b/agentception/routes/ui/org_chart.py
@@ -30,7 +30,7 @@ import logging
 from pathlib import Path
 from typing import Annotated, Any, TypedDict
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 from fastapi import APIRouter, Form, HTTPException
 from fastapi.responses import HTMLResponse, JSONResponse
 from starlette.requests import Request
@@ -232,7 +232,7 @@ def _save_preset(name: str, roles: list[dict[str, Any]]) -> str:
         raw: object = yaml.safe_load(raw_text)
         if not isinstance(raw, dict):
             raw = {}
-        raw_dict: dict[str, Any] = raw  # type: ignore[assignment]
+        raw_dict: dict[str, Any] = raw
     except Exception:
         raw_dict = {}
 

--- a/agentception/routes/ui/plan_ui.py
+++ b/agentception/routes/ui/plan_ui.py
@@ -35,7 +35,7 @@ from pydantic import BaseModel
 from starlette.requests import Request
 
 from agentception.readers.phase_planner import plan_phases
-from agentception.readers.llm_phase_planner import _strip_fences  # type: ignore[attr-defined]
+from agentception.readers.llm_phase_planner import _strip_fences
 from agentception.services.llm import call_openrouter_stream
 from ._shared import _TEMPLATES
 
@@ -282,7 +282,7 @@ async def plan_preview(body: PlanDraftRequest) -> StreamingResponse:
     """
     from agentception.config import settings as _cfg
     from agentception.models import PlanSpec
-    from agentception.readers.llm_phase_planner import _YAML_SYSTEM_PROMPT  # type: ignore[attr-defined]
+    from agentception.readers.llm_phase_planner import _YAML_SYSTEM_PROMPT
 
     dump = body.dump.strip()
     if not dump:

--- a/agentception/tests/test_agentception_analyze_partial.py
+++ b/agentception/tests/test_agentception_analyze_partial.py
@@ -39,10 +39,10 @@ def _make_analysis(
     return IssueAnalysis(
         number=number,
         dependencies=dependencies or [],
-        parallelism=parallelism,  # type: ignore[arg-type]
-        conflict_risk=conflict_risk,  # type: ignore[arg-type]
+        parallelism=parallelism,
+        conflict_risk=conflict_risk,
         modifies_files=modifies_files or [],
-        recommended_role=recommended_role,  # type: ignore[arg-type]
+        recommended_role=recommended_role,
         recommended_merge_after=recommended_merge_after,
     )
 

--- a/agentception/tests/test_agentception_mcp_plan.py
+++ b/agentception/tests/test_agentception_mcp_plan.py
@@ -626,7 +626,9 @@ async def test_plan_get_labels_filters_non_dict_items() -> None:
     labels = result["labels"]
     assert isinstance(labels, list)
     assert len(labels) == 1
-    assert labels[0]["name"] == "valid"  # type: ignore[index]
+    first_label = labels[0]
+    assert isinstance(first_label, dict)
+    assert first_label["name"] == "valid"
 
 
 # ---------------------------------------------------------------------------
@@ -679,9 +681,11 @@ def test_plan_validate_manifest_computed_fields_authoritative() -> None:
 def test_plan_validate_manifest_multi_issue_total() -> None:
     """total_issues reflects actual number of issues across all phases."""
     manifest = _minimal_manifest_dict()
-    phase = manifest["phases"][0]  # type: ignore[index]
+    phases = manifest["phases"]
+    assert isinstance(phases, list)
+    phase = phases[0]
     assert isinstance(phase, dict)
-    issue_list = phase["issues"]  # type: ignore[index]
+    issue_list = phase["issues"]
     assert isinstance(issue_list, list)
     issue_list.append({
         "title": "Second issue",
@@ -694,7 +698,7 @@ def test_plan_validate_manifest_multi_issue_total() -> None:
         "tests_required": ["test_second"],
         "docs_required": [],
     })
-    phase["parallel_groups"] = [["Bootstrap repo", "Second issue"]]  # type: ignore[index]
+    phase["parallel_groups"] = [["Bootstrap repo", "Second issue"]]
     result = plan_validate_manifest(json.dumps(manifest))
     assert result.get("valid") is True
     assert result.get("total_issues") == 2

--- a/agentception/tests/test_issue_creator.py
+++ b/agentception/tests/test_issue_creator.py
@@ -111,7 +111,7 @@ async def test_file_issues_emits_start_event() -> None:
         events = await _collect(file_issues(spec))
 
     assert events[0]["t"] == "start"
-    start: StartEvent = events[0]  # type: ignore[assignment]
+    start: StartEvent = events[0]
     assert start["total"] == 2
     assert start["initiative"] == "test-initiative"
 
@@ -132,7 +132,7 @@ async def test_file_issues_emits_label_event() -> None:
 
     label_events = [e for e in events if e["t"] == "label"]
     assert label_events, "Expected at least one 'label' event"
-    label: LabelEvent = label_events[0]  # type: ignore[assignment]
+    label: LabelEvent = label_events[0]
     assert isinstance(label["text"], str) and label["text"]
 
 
@@ -177,7 +177,7 @@ async def test_file_issues_emits_done_event_last() -> None:
         events = await _collect(file_issues(spec))
 
     assert events[-1]["t"] == "done"
-    done: DoneEvent = events[-1]  # type: ignore[assignment]
+    done: DoneEvent = events[-1]
     assert done["total"] == 2
     assert done["initiative"] == "test-initiative"
     assert len(done["issues"]) == 2
@@ -273,7 +273,7 @@ async def test_file_issues_yields_error_on_label_failure() -> None:
     assert events[0]["t"] == "start"
     assert events[1]["t"] == "label"
     assert events[2]["t"] == "error"
-    error: FilingErrorEvent = events[2]  # type: ignore[assignment]
+    error: FilingErrorEvent = events[2]
     assert "rate limited" in error["detail"]
     # No issue events should have been emitted.
     assert all(e["t"] != "issue" for e in events)

--- a/agentception/tests/test_pipeline_panel.py
+++ b/agentception/tests/test_pipeline_panel.py
@@ -210,7 +210,7 @@ def test_compute_phase_lanes_blockers_point_to_upstream(labels: list[str]) -> No
     assert waiting_lane["gate_status"] == "waiting"
     raw_blockers = waiting_lane["blockers"]
     assert isinstance(raw_blockers, list)
-    blocker_numbers = [b["number"] for b in raw_blockers]  # type: ignore[index]  # PhaseLane is dict[str,object]; "blockers" value is typed object
+    blocker_numbers = [b["number"] for b in raw_blockers]
     assert 10 in blocker_numbers
 
 


### PR DESCRIPTION
Fixes the mypy job failure on PR #57 (dev → main).

## What failed

All 21 CI errors were pre-existing `# type: ignore` comments that became unused under a newer mypy, plus one unreachable statement introduced by an annotation+ignore combination.

## Fixes

| File | Change |
|------|--------|
| `mcp/server.py` | Fix unreachable guard: type `request_id` as `object` first, narrow with `isinstance` instead of annotating `int\|str\|None` and then checking |
| `routes/ui/org_chart.py` | Remove unused `type: ignore[import-untyped]` (yaml stubs now available) and `type: ignore[assignment]` |
| `routes/ui/plan_ui.py` | Remove unused `type: ignore[attr-defined]` on private imports (`_strip_fences`, `_YAML_SYSTEM_PROMPT`) |
| `routes/ui/agents.py` | Remove 5 unused `type: ignore[arg-type]` on `db_run.get()` calls |
| `tests/test_issue_creator.py` | Remove 4 unused `type: ignore[assignment]` |
| `tests/test_agentception_mcp_plan.py` | Remove unused ignores; fix real type errors by adding `isinstance` narrowing before subscripting `object` values from `dict[str, object]` payloads |
| `tests/test_pipeline_panel.py` | Remove unused `type: ignore[index]` |
| `tests/test_agentception_analyze_partial.py` | Remove 3 unused `type: ignore[arg-type]` |

`mypy agentception/ tests/` → `Success: no issues found in 142 source files` ✅