### PR TITLE
chore: set typing ceiling to zero Any, rename from ratchet to ceiling

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -28,7 +28,7 @@ When uncertain: (1) preserve existing patterns, (2) prefer smaller changes over 
 - **Dev bind mounts are active.** `docker-compose.override.yml` bind-mounts `agentception/`, `tests/`, `scripts/`, and `pyproject.toml` into the container. Host file edits are **instantly visible** inside the container — no rebuild needed for code changes. Only rebuild (`docker compose build agentception && docker compose up -d`) when you change `requirements.txt`, `Dockerfile`, or `entrypoint.sh`.
 - **Verification order: mypy → tests → docs.** Always run mypy first. Fix type errors before running tests so you only need one test pass.
 - **Mypy:** `docker compose exec agentception mypy agentception/ tests/` — must be clean before any commit.
-- **Typing ratchet:** `python tools/typing_audit.py --dirs agentception/ tests/ --max-any 10`. Never raise the ceiling without justification.
+- **Typing ceiling:** `python tools/typing_audit.py --dirs agentception/ tests/ --max-any 0`. Zero `Any` is the hard ceiling — never raise it.
 - **Tests:** Run individual files yourself; user runs full suite. Regression test for every bug fix: `test_<what_broke>_<fixed_behavior>`.
 - **Show full output:** Never truncate, pipe through `head`/`tail`, or hide shell output.
 - **After tests pass:** Update affected docs, then commit — don't wait to be asked.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # CI workflow for cgcardona/agentception
 # Runs on every PR targeting main and on pushes to main.
-# Jobs run in dependency order: typecheck → (ratchet + test) → smoke
+# Jobs run in dependency order: typecheck → (typing-ceiling + test) → smoke
 name: CI
 
 on:
@@ -32,9 +32,9 @@ jobs:
             run --rm agentception \
             mypy agentception/ tests/
 
-  # ── 2. Typing ratchet ────────────────────────────────────────────────────
-  typing-ratchet:
-    name: Typing ratchet (max-any 10)
+  # ── 2. Typing ceiling ────────────────────────────────────────────────────
+  typing-ceiling:
+    name: Typing ceiling (zero Any)
     runs-on: ubuntu-latest
     needs: typecheck
     steps:
@@ -44,13 +44,13 @@ jobs:
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml build agentception
 
-      - name: Enforce Any ceiling
-        # tools/typing_audit.py counts Any-ish patterns.
-        # --max-any 10 matches the ratchet ceiling agreed in AGENTS.md.
+      - name: Enforce zero-Any ceiling
+        # tools/typing_audit.py counts Any-ish patterns and fails if count > threshold.
+        # --max-any 0 means no Any is tolerated at all.
         run: |
           docker compose -f docker-compose.yml -f docker-compose.ci.yml \
             run --rm agentception \
-            python tools/typing_audit.py --dirs agentception/ tests/ --max-any 10
+            python tools/typing_audit.py --dirs agentception/ tests/ --max-any 0
 
   # ── 3. Test suite ─────────────────────────────────────────────────────────
   test:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ This codebase is read and modified by humans and agents alike. Strong, explicit 
 | Layer | Command | Threshold |
 |-------|---------|-----------|
 | Local | `docker compose exec agentception mypy agentception/ tests/` | strict, 0 errors |
-| Typing ratchet | `python tools/typing_audit.py --dirs agentception/ tests/ --max-any 0` | blocks commit |
+| Typing ceiling | `python tools/typing_audit.py --dirs agentception/ tests/ --max-any 0` | blocks commit |
 | CI | `python -m mypy agentception/` | blocks PR merge |
 
 ### Jinja2 + Alpine.js / HTMX: always single-quote attributes containing `tojson`

--- a/tools/typing_audit.py
+++ b/tools/typing_audit.py
@@ -7,7 +7,7 @@ Usage:
     python tools/typing_audit.py                        # agentception/ + tests/
     python tools/typing_audit.py --json artifacts/typing_audit.json
     python tools/typing_audit.py --dirs agentception/ tests/
-    python tools/typing_audit.py --dirs agentception/ --max-any 10
+    python tools/typing_audit.py --dirs agentception/ --max-any 0
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- `--max-any 10` → `--max-any 0` everywhere: no `Any` is tolerated at all
- Rename "Typing ratchet" → "Typing ceiling" in CI job name, comments, `.cursorrules`, and `AGENTS.md`

The term "ratchet" was agent-generated jargon for the pattern of a CI check that can only tighten over time. "Ceiling" is clearer: it's the maximum number of `Any`-ish patterns allowed (now zero).

**Files changed:** `.github/workflows/ci.yml`, `.cursorrules`, `AGENTS.md`, `tools/typing_audit.py`