### PR TITLE
fix: correct dispatcher prompt path from .cursor/ to .agentception/

### DIFF
--- a/agentception/routes/api/build.py
+++ b/agentception/routes/api/build.py
@@ -382,7 +382,7 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
 # Dispatcher prompt — serve the coordinator prompt so the UI can copy it
 # ---------------------------------------------------------------------------
 
-_DISPATCHER_PROMPT_PATH = Path(settings.repo_dir) / ".cursor" / "agentception-dispatcher.md"
+_DISPATCHER_PROMPT_PATH = Path(settings.repo_dir) / ".agentception" / "dispatcher.md"
 
 
 @router.get("/dispatcher-prompt")

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -244,7 +244,7 @@
                     x-text="dispatcherCopied ? '✅ Copied!' : '📋 Copy Dispatcher Prompt'">
             </button>
             <p class="build-modal__success-hint" style="opacity:0.55;font-size:0.7rem">
-              Prompt lives at <code>.cursor/agentception-dispatcher.md</code>
+              Prompt lives at <code>.agentception/dispatcher.md</code>
             </p>
           </div>
         </template>


### PR DESCRIPTION
The UI label said `.cursor/agentception-dispatcher.md` but the actual file (and the route that reads it) both use `.agentception/dispatcher.md`. Fixes the hint text in `build.html` and aligns the unused `_DISPATCHER_PROMPT_PATH` constant in `build.py` to match the real path.