### PR TITLE
docs: update README Quick Reference with developer experience rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ scripts/
 
 ---
 
+## Quick Reference
+
+| Area | Description |
+|------|-------------|
+| **Developer tools** | [`scripts/dev.sh`](scripts/dev.sh) — Convenience wrapper for mypy / test / cover / build / restart / logs / migrate / shell |
+| **Guides** | [Developer workflow](docs/guides/developer-workflow.md) · [Contributing](docs/guides/contributing.md) — Bind-mount loop, verification order, branch protection, PR & commit conventions |
+| **Changelog** | [`CHANGELOG.md`](CHANGELOG.md) — Release history in Keep a Changelog 1.0.0 format |
+
+---
+
 ## Related Projects
 
 - **[cgcardona/agentception](https://github.com/cgcardona/agentception)** — AI music composition backend for the Muse client. AgentCeption was originally co-located here and has been extracted into this standalone repository.


### PR DESCRIPTION
Closes #64

## Summary

Adds a new **Quick Reference** section to `README.md` (before the Related Projects section) with three rows linking to the developer experience artefacts:

- **Developer tools** → [`scripts/dev.sh`](scripts/dev.sh) with description of all sub-commands
- **Guides** → [Developer workflow](docs/guides/developer-workflow.md) and [Contributing](docs/guides/contributing.md)
- **Changelog** → [`CHANGELOG.md`](CHANGELOG.md)

## Changes

- `README.md`: Added Quick Reference section with a two-column markdown table (Area / Description). Only additions — no existing content modified, reordered, or reformatted.

## Notes

- No Quick Reference section previously existed in `README.md`; this PR creates it.
- Blocked by #62 and #63 which create the linked files (`scripts/dev.sh`, `docs/guides/developer-workflow.md`, `docs/guides/contributing.md`, `CHANGELOG.md`).