### PR TITLE
feat: dispatcher pending-launch guard and async MCP stdio

### DIFF
--- a/.agentception/dispatcher.md
+++ b/.agentception/dispatcher.md
@@ -67,7 +67,7 @@ For each pending launch (batch up to 3 simultaneously using parallel Task calls)
 ### 3a. Claim the run
 
 ```bash
-curl -s -X POST http://localhost:7777/api/build/acknowledge/{run_id}
+curl -s -X POST http://localhost:10003/api/build/acknowledge/{run_id}
 ```
 
 This atomically marks the run as `implementing` so no other Dispatcher can
@@ -99,7 +99,7 @@ RUN_ID:      {run_id}
 SCOPE_TYPE:  label
 SCOPE_VALUE: {scope_value}
 GH_REPO:     {gh_repo}
-AC_URL:      http://localhost:7777
+AC_URL:      http://localhost:10003
 
 Step 1: Read your role file:
   {role_file}
@@ -154,7 +154,7 @@ RUN_ID:      {run_id}
 SCOPE_TYPE:  {scope_type}    (issue or pr)
 SCOPE_VALUE: {scope_value}   (issue or PR number)
 GH_REPO:     {gh_repo}
-AC_URL:      http://localhost:7777
+AC_URL:      http://localhost:10003
 
 Step 1: Read your role file:
   {role_file}

--- a/.agentception/roles/devops-engineer.md
+++ b/.agentception/roles/devops-engineer.md
@@ -30,7 +30,6 @@ Services in this repo:
 |---------|-----------|------|
 | AgentCeption | `agentception` | 10003 |
 | Muse | `agentception-muse` | 10002 |
-| AgentCeption | (agentception service) | 7777 |
 | Postgres | `agentception-postgres` | 5433 |
 | Qdrant | `agentception-qdrant` | 6335/6336 |
 | Nginx | `agentception-nginx` | 80/443 |

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ htmlcov/
 
 # Docker
 .docker/
+docker-compose.override.yml
 
 # IDE
 .idea/

--- a/agentception/Dockerfile
+++ b/agentception/Dockerfile
@@ -41,4 +41,4 @@ RUN sass --style=compressed --no-source-map \
     /app/agentception/static/scss/app.scss \
     /app/agentception/static/app.css
 
-CMD ["uvicorn", "agentception.app:app", "--host", "0.0.0.0", "--port", "7777"]
+CMD ["uvicorn", "agentception.app:app", "--host", "0.0.0.0", "--port", "10003"]

--- a/agentception/README.md
+++ b/agentception/README.md
@@ -157,7 +157,7 @@ export GH_REPO=owner/repo-name
 
 # 3. Launch
 agentception
-# → http://localhost:7777
+# → http://localhost:10003
 ```
 
 That's it. The dashboard auto-refreshes every 5 seconds.
@@ -179,7 +179,7 @@ AgentCeption is configured via environment variables or via the `pipeline-config
 | `POLL_INTERVAL_SECONDS` | `5` | How often the poller refreshes state |
 | `GITHUB_CACHE_SECONDS` | `10` | TTL for GitHub API response cache |
 | `HOST` | `0.0.0.0` | Bind host for the uvicorn server |
-| `PORT` | `7777` | Bind port for the uvicorn server |
+| `PORT` | `10003` | Bind port for the uvicorn server |
 
 ### `pipeline-config.json` Schema
 
@@ -255,7 +255,7 @@ AgentCeption ships with a **pipeline template** that you can import into any Git
 # Settings → Templates → Import
 
 # Or via the API:
-curl -X POST http://localhost:7777/api/templates/import \
+curl -X POST http://localhost:10003/api/templates/import \
   -H "Content-Type: application/json" \
   -d '{
     "template_name": "standard-6-phase",

--- a/agentception/config.py
+++ b/agentception/config.py
@@ -88,6 +88,14 @@ class AgentCeptionSettings(BaseSettings):
         to the IDE.
         """
         return self.repo_dir / ".agentception"
+    ac_url: str = "http://localhost:10003"
+    """Base URL at which the AgentCeption service is reachable from the host.
+
+    Embedded in ``.agent-task`` files and in the Dispatcher prompt so that
+    spawned agents can POST lifecycle events back via curl.  Defaults to the
+    standard local port; override via ``AC_URL`` env var in production or
+    when running behind a reverse proxy.
+    """
     poll_interval_seconds: int = 5
     github_cache_seconds: int = 10
     database_url: str | None = None

--- a/agentception/db/models.py
+++ b/agentception/db/models.py
@@ -115,8 +115,8 @@ class ACAgentRun(Base):
     """IMPLEMENTING | REVIEWING | DONE | STALE | UNKNOWN"""
 
     attempt_number: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    spawn_mode: Mapped[str | None] = mapped_column(String(64), nullable=True)
-    """chain | wave | manual"""
+    spawn_mode: Mapped[str | None] = mapped_column(Text, nullable=True)
+    """JSON blob written by persist_agent_run_dispatch: {"host_worktree": "/path/..."}."""
 
     batch_id: Mapped[str | None] = mapped_column(String(128), nullable=True, index=True)
 

--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -271,15 +271,18 @@ async def _upsert_prs(
 # ---------------------------------------------------------------------------
 
 
-_ACTIVE_STATUSES = {"implementing", "reviewing", "stale", "pending_launch"}
-"""Statuses that indicate a run is expected to have a live worktree.
+_ACTIVE_STATUSES = {"implementing", "reviewing", "stale"}
+"""Statuses that indicate a run has a live, poller-visible worktree.
 
 Runs in these states that are absent from the current poller tick are
-orphaned (worktree was removed without a clean status transition) and
-must be flipped to ``unknown`` so the UI does not show phantom agents.
+orphaned (the worktree was removed without a clean status transition)
+and are flipped to ``unknown`` so the UI does not show phantom agents.
 
-``pending_launch`` is included so that dispatch-created runs are not
-swept to ``unknown`` before the coordinator picks them up.
+``pending_launch`` is intentionally excluded: pending runs live only in
+the DB (the Dispatcher hasn't claimed them yet) and have no poller
+presence.  Including them in the sweep would immediately flip them to
+``unknown`` before the Dispatcher ever reads them.  The only valid
+transition out of ``pending_launch`` is via the acknowledge endpoint.
 """
 
 
@@ -321,8 +324,10 @@ async def _upsert_agent_runs(
                 )
             )
         else:
-            # Never overwrite a pending_launch status from the poller — only
-            # the acknowledge endpoint may advance that transition.
+            # Never overwrite pending_launch — only the Dispatcher's acknowledge
+            # endpoint may transition out of that state.  The poller can see the
+            # worktree on disk and would clobber it with "stale" otherwise, which
+            # would drain the queue before the Dispatcher ever reads it.
             if existing.status != "pending_launch":
                 existing.status = agent.status.value
             existing.pr_number = agent.pr_number
@@ -460,6 +465,12 @@ async def persist_agent_run_dispatch(
     """
     import json as _json
 
+    spawn_mode_json = _json.dumps({"host_worktree": host_worktree_path})
+    logger.warning(
+        "💾 persist_agent_run_dispatch: run_id=%r role=%r worktree_path=%r "
+        "host_worktree_path=%r spawn_mode=%r",
+        run_id, role, worktree_path, host_worktree_path, spawn_mode_json,
+    )
     try:
         async with get_session() as session:
             result = await session.execute(
@@ -467,10 +478,19 @@ async def persist_agent_run_dispatch(
             )
             existing = result.scalar_one_or_none()
             if existing is not None:
-                # Already exists (re-dispatch after worktree removed). Reset.
+                logger.warning(
+                    "💾 persist_agent_run_dispatch: run_id=%r already exists (status=%r) — re-arming to pending_launch",
+                    run_id, existing.status,
+                )
+                # Already exists (re-dispatch or orphan sweep reset). Re-arm.
                 existing.status = "pending_launch"
+                existing.spawn_mode = spawn_mode_json
                 existing.last_activity_at = _now()
             else:
+                logger.warning(
+                    "💾 persist_agent_run_dispatch: run_id=%r is new — inserting with status=pending_launch",
+                    run_id,
+                )
                 session.add(
                     ACAgentRun(
                         id=run_id,
@@ -482,16 +502,16 @@ async def persist_agent_run_dispatch(
                         role=role,
                         status="pending_launch",
                         attempt_number=0,
-                        spawn_mode=_json.dumps({"host_worktree": host_worktree_path}),
+                        spawn_mode=spawn_mode_json,
                         batch_id=batch_id,
                         spawned_at=_now(),
                         last_activity_at=_now(),
                     )
                 )
             await session.commit()
-        logger.info("✅ persist_agent_run_dispatch: run_id=%s issue=%d", run_id, issue_number)
+        logger.warning("✅ persist_agent_run_dispatch: committed — run_id=%r is pending_launch", run_id)
     except Exception as exc:
-        logger.warning("⚠️  persist_agent_run_dispatch failed (non-fatal): %s", exc)
+        logger.warning("❌ persist_agent_run_dispatch FAILED: %s", exc, exc_info=True)
 
 
 async def acknowledge_agent_run(run_id: str) -> bool:

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -956,14 +956,22 @@ async def get_pending_launches() -> list[dict[str, Any]]:
     """
     import json as _json
 
+    logger.warning("🗄️  get_pending_launches: opening DB session")
     try:
         async with get_session() as session:
+            logger.warning("🗄️  get_pending_launches: executing SELECT WHERE status='pending_launch'")
             result = await session.execute(
                 select(ACAgentRun)
                 .where(ACAgentRun.status == "pending_launch")
                 .order_by(ACAgentRun.spawned_at.asc())
             )
             rows = result.scalars().all()
+            logger.warning("🗄️  get_pending_launches: query returned %d raw row(s)", len(rows))
+            for row in rows:
+                logger.warning(
+                    "🗄️    raw row: id=%r status=%r role=%r spawn_mode=%r",
+                    row.id, row.status, row.role, row.spawn_mode,
+                )
 
         launches: list[dict[str, Any]] = []
         for row in rows:
@@ -973,8 +981,11 @@ async def get_pending_launches() -> list[dict[str, Any]]:
                 try:
                     meta = _json.loads(row.spawn_mode)
                     host_worktree = meta.get("host_worktree")
-                except (ValueError, AttributeError):
-                    pass
+                except (ValueError, AttributeError) as parse_exc:
+                    logger.warning(
+                        "⚠️  get_pending_launches: could not parse spawn_mode for %r: %s",
+                        row.id, parse_exc,
+                    )
             launches.append(
                 {
                     "run_id": row.id,
@@ -987,9 +998,10 @@ async def get_pending_launches() -> list[dict[str, Any]]:
                     "spawned_at": row.spawned_at.isoformat(),
                 }
             )
+        logger.warning("🗄️  get_pending_launches: returning %d launch(es)", len(launches))
         return launches
     except Exception as exc:
-        logger.warning("⚠️  get_pending_launches DB query failed (non-fatal): %s", exc)
+        logger.warning("❌ get_pending_launches DB query FAILED: %s", exc, exc_info=True)
         return []
 
 

--- a/agentception/mcp/build_tools.py
+++ b/agentception/mcp/build_tools.py
@@ -36,8 +36,22 @@ async def build_get_pending_launches() -> dict[str, object]:
     whatever role was assigned. A leaf worker runs directly; a manager
     (VP, CTO) reads its role file and spawns its own children.
     """
+    logger.warning("🔍 build_get_pending_launches: querying DB for pending launches")
     launches = await get_pending_launches()
-    logger.info("✅ build_get_pending_launches: %d pending", len(launches))
+    logger.warning(
+        "🔍 build_get_pending_launches: got %d row(s) from DB",
+        len(launches),
+    )
+    for i, launch in enumerate(launches):
+        logger.warning(
+            "🔍   [%d] run_id=%r role=%r status=pending_launch "
+            "host_worktree_path=%r branch=%r",
+            i,
+            launch.get("run_id"),
+            launch.get("role"),
+            launch.get("host_worktree_path"),
+            launch.get("branch"),
+        )
     return {"pending": launches, "count": len(launches)}
 
 

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -602,3 +602,106 @@ def handle_request(
         JSONRPC_ERR_METHOD_NOT_FOUND,
         f"Method not found: {method!r}",
     ))
+
+
+async def handle_request_async(
+    raw: dict[str, object],
+) -> dict[str, object] | None:
+    """Async variant of :func:`handle_request` — routes ``tools/call`` through
+    :func:`call_tool_async` so that async tools (all build tools and
+    ``plan_get_labels`` / ``plan_spawn_coordinator``) are awaited correctly.
+
+    The stdio transport must use this function instead of
+    :func:`handle_request`; the sync version hard-returns an error for every
+    async tool.
+
+    Returns ``None`` for JSON-RPC notifications (no ``id`` field).
+    Never raises.
+    """
+    _raw_id: object = raw.get("id")
+    request_id: int | str | None = (
+        _raw_id if isinstance(_raw_id, (int, str)) else None
+    )
+
+    jsonrpc = raw.get("jsonrpc")
+    if jsonrpc != "2.0":
+        return cast(dict[str, object], _make_error_response(
+            request_id,
+            JSONRPC_ERR_INVALID_REQUEST,
+            "jsonrpc must be '2.0'",
+        ))
+
+    method = raw.get("method")
+    if not isinstance(method, str):
+        return cast(dict[str, object], _make_error_response(
+            request_id,
+            JSONRPC_ERR_INVALID_REQUEST,
+            "method must be a string",
+        ))
+
+    logger.debug("🔧 handle_request_async: method=%r id=%r", method, request_id)
+
+    if method == "initialize":
+        result: dict[str, object] = {
+            "protocolVersion": _MCP_PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": _SERVER_INFO,
+        }
+        return cast(dict[str, object], _make_success_response(request_id, result))
+
+    if method == "initialized":
+        logger.debug("✅ MCP initialized notification received")
+        return None
+
+    if method == "tools/list":
+        tools = list_tools()
+        return cast(dict[str, object], _make_success_response(request_id, {"tools": tools}))
+
+    if method == "tools/call":
+        params = raw.get("params")
+        if not isinstance(params, dict):
+            return cast(dict[str, object], _make_error_response(
+                request_id,
+                JSONRPC_ERR_INVALID_PARAMS,
+                "params must be an object for tools/call",
+            ))
+
+        tool_name = params.get("name")
+        if not isinstance(tool_name, str):
+            return cast(dict[str, object], _make_error_response(
+                request_id,
+                JSONRPC_ERR_INVALID_PARAMS,
+                "params.name must be a string",
+            ))
+
+        arguments_raw = params.get("arguments", {})
+        if not isinstance(arguments_raw, dict):
+            return cast(dict[str, object], _make_error_response(
+                request_id,
+                JSONRPC_ERR_INVALID_PARAMS,
+                "params.arguments must be an object",
+            ))
+
+        arguments: dict[str, object] = {k: v for k, v in arguments_raw.items()}
+
+        try:
+            tool_result = await call_tool_async(tool_name, arguments)
+        except Exception as exc:
+            logger.error(
+                "❌ handle_request_async: internal error in call_tool_async — %s",
+                exc,
+                exc_info=True,
+            )
+            return cast(dict[str, object], _make_error_response(
+                request_id,
+                JSONRPC_ERR_INTERNAL_ERROR,
+                f"Internal error: {exc}",
+            ))
+
+        return cast(dict[str, object], _make_success_response(request_id, tool_result))
+
+    return cast(dict[str, object], _make_error_response(
+        request_id,
+        JSONRPC_ERR_METHOD_NOT_FOUND,
+        f"Method not found: {method!r}",
+    ))

--- a/agentception/mcp/stdio_server.py
+++ b/agentception/mcp/stdio_server.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 Reads JSON-RPC 2.0 requests from stdin (one per line) and writes
 responses to stdout — the standard Cursor/Claude MCP stdio transport.
 
+The event loop is owned here: :func:`_run` is a coroutine driven by
+:func:`asyncio.run` so that async MCP tools (build tools, plan_get_labels,
+plan_spawn_coordinator) are awaited correctly.  Using the sync
+:func:`~agentception.mcp.server.handle_request` path caused those tools to
+return an error instead of executing.
+
 Usage (via Cursor mcp.json):
     docker compose exec -T agentception python -m agentception.mcp.stdio_server
 
@@ -12,17 +18,31 @@ Or directly:
     python -m agentception.mcp.stdio_server
 """
 
+import asyncio
 import json
 import logging
 import sys
 
-from agentception.mcp.server import handle_request
+from agentception.db.engine import init_db
+from agentception.mcp.server import handle_request_async
 
 logger = logging.getLogger(__name__)
 
 
-def _run() -> None:
-    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+async def _run() -> None:
+    logging.basicConfig(
+        level=logging.DEBUG,
+        stream=sys.stderr,
+        format="%(asctime)s [MCP] %(levelname)s %(name)s — %(message)s",
+    )
+    logger.warning("🚀 MCP stdio_server starting — initialising DB")
+    try:
+        await init_db()
+        logger.warning("✅ MCP stdio_server DB ready")
+    except Exception as exc:
+        logger.warning("❌ MCP stdio_server init_db FAILED: %s", exc)
+        raise
+
     for raw_line in sys.stdin:
         raw_line = raw_line.strip()
         if not raw_line:
@@ -39,13 +59,25 @@ def _run() -> None:
             sys.stdout.flush()
             continue
 
-        maybe_response: dict[str, object] | None = handle_request(request)
+        method = request.get("method", "<no-method>")
+        params = request.get("params", {})
+        tool_name = params.get("name", "") if isinstance(params, dict) else ""
+        logger.warning(
+            "📨 MCP request: method=%r tool=%r id=%r",
+            method,
+            tool_name or "(n/a)",
+            request.get("id"),
+        )
+
+        maybe_response: dict[str, object] | None = await handle_request_async(request)
         if maybe_response is None:
             # JSON-RPC notification — no response on the wire.
+            logger.warning("📭 MCP notification (no response): method=%r", method)
             continue
+        logger.warning("📤 MCP response: method=%r error=%r", method, maybe_response.get("error"))
         sys.stdout.write(json.dumps(maybe_response) + "\n")
         sys.stdout.flush()
 
 
 if __name__ == "__main__":
-    _run()
+    asyncio.run(_run())

--- a/agentception/routes/api/build.py
+++ b/agentception/routes/api/build.py
@@ -119,7 +119,7 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
 
     logger.info("✅ dispatch: worktree created at %s", worktree_path)
 
-    ac_url = getattr(settings, "ac_url", "http://localhost:7777")
+    ac_url = settings.ac_url
     role_file = str(Path(settings.repo_dir) / ".agentception" / "roles" / f"{req.role}.md")
     agent_task = (
         f"RUN_ID={run_id}\n"
@@ -274,6 +274,10 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
         HTTPException 409: Worktree already exists.
         HTTPException 500: git worktree or .agent-task write failed.
     """
+    logger.warning(
+        "🚀 dispatch-label: received request label=%r role=%r repo=%r",
+        req.label, req.role, req.repo,
+    )
     tier = _tier_for_role(req.role)
     label_slug = _label_slug(req.label)
     batch_id = _make_label_batch_id(req.label)
@@ -282,6 +286,10 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
 
     worktree_path = str(Path(settings.worktrees_dir) / run_id)
     host_worktree_path = str(Path(settings.host_worktrees_dir) / run_id)
+    logger.warning(
+        "🚀 dispatch-label: run_id=%r tier=%r worktree_path=%r host_worktree_path=%r",
+        run_id, tier, worktree_path, host_worktree_path,
+    )
 
     if Path(worktree_path).exists():
         raise HTTPException(
@@ -303,7 +311,7 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
 
     logger.info("✅ dispatch-label: worktree %s for label %r tier=%s", worktree_path, req.label, tier)
 
-    ac_url = getattr(settings, "ac_url", "http://localhost:7777")
+    ac_url = settings.ac_url
     role_file = str(Path(settings.repo_dir) / ".agentception" / "roles" / f"{req.role}.md")
 
     agent_task = (
@@ -353,8 +361,12 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
         logger.error("❌ dispatch-label: .agent-task write failed — %s", exc)
         raise HTTPException(status_code=500, detail=f".agent-task write failed: {exc}") from exc
 
-    logger.info("✅ dispatch-label: .agent-task written to %s", agent_task_path)
+    logger.warning("✅ dispatch-label: .agent-task written to %s", agent_task_path)
 
+    logger.warning(
+        "🚀 dispatch-label: calling persist_agent_run_dispatch run_id=%r host_worktree_path=%r",
+        run_id, host_worktree_path,
+    )
     await persist_agent_run_dispatch(
         run_id=run_id,
         issue_number=0,          # no single issue — label-scoped
@@ -364,6 +376,7 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
         batch_id=batch_id,
         host_worktree_path=host_worktree_path,
     )
+    logger.warning("✅ dispatch-label: persist_agent_run_dispatch complete — run_id=%r is now pending_launch", run_id)
 
     return LabelDispatchResponse(
         run_id=run_id,

--- a/agentception/tests/test_persist_pending_launch_guard.py
+++ b/agentception/tests/test_persist_pending_launch_guard.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+"""Regression tests for the pending_launch guard in db/persist.py.
+
+Bug: the poller called _upsert_agent_runs() whenever it found a worktree on
+the filesystem.  If that worktree belonged to a pending_launch run (Dispatcher
+not yet invoked), the upsert would overwrite the precious pending_launch status
+with whatever status the poller derived (typically "stale"), draining the
+Dispatcher queue before it was ever read.
+
+Fix: _upsert_agent_runs() now skips the status overwrite when existing.status
+is "pending_launch".  Only the /api/build/acknowledge/{run_id} endpoint may
+transition out of pending_launch.
+
+Run:
+    docker compose exec agentception pytest \
+        agentception/tests/test_persist_pending_launch_guard.py -v
+"""
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentception.db.models import ACAgentRun
+from agentception.models import AgentNode, AgentStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_run(status: str = "pending_launch") -> ACAgentRun:
+    """Return a minimal ACAgentRun ORM object with the given status."""
+    run = ACAgentRun(
+        id="label-developer-experience-layer-5492de",
+        role="cto",
+        status=status,
+        branch="agent/developer-experience-layer-b735",
+        worktree_path="/worktrees/label-developer-experience-layer-5492de",
+        spawned_at=datetime.datetime.now(datetime.timezone.utc),
+    )
+    return run
+
+
+def _make_agent(status: AgentStatus = AgentStatus.STALE) -> AgentNode:
+    """Return a minimal AgentNode as the poller would produce."""
+    return AgentNode(
+        id="label-developer-experience-layer-5492de",
+        role="cto",
+        status=status,
+        worktree_path="/worktrees/label-developer-experience-layer-5492de",
+    )
+
+
+def _make_session(existing_run: ACAgentRun | None) -> MagicMock:
+    """Return a mock AsyncSession whose execute() yields *existing_run*.
+
+    Uses ``spec=AsyncSession`` so that ``isinstance(session, AsyncSession)``
+    passes the guard inside ``_upsert_agent_runs``.
+    """
+    scalar = MagicMock()
+    scalar.scalar_one_or_none.return_value = existing_run
+
+    execute_result = MagicMock()
+    execute_result.scalars.return_value.all.return_value = []  # orphan sweep → empty
+
+    session = MagicMock(spec=AsyncSession)
+    # First call returns the existing run; second call (orphan sweep) returns empty.
+    session.execute = AsyncMock(side_effect=[scalar, execute_result])
+    session.add = MagicMock()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Import the private helper under test
+# ---------------------------------------------------------------------------
+
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agentception.db import persist as _persist  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_pending_launch_status_not_overwritten_by_poller() -> None:
+    """Poller must not clobber pending_launch when it finds the worktree."""
+    existing = _make_run(status="pending_launch")
+    session = _make_session(existing)
+    agent = _make_agent(status=AgentStatus.STALE)
+
+    await _persist._upsert_agent_runs(session, [agent])
+
+    assert existing.status == "pending_launch", (
+        "pending_launch was overwritten — Dispatcher queue drained by poller"
+    )
+
+
+@pytest.mark.anyio
+async def test_implementing_status_is_updated_by_poller() -> None:
+    """Non-pending_launch runs should still have their status updated normally."""
+    existing = _make_run(status="implementing")
+    session = _make_session(existing)
+    agent = _make_agent(status=AgentStatus.STALE)
+
+    await _persist._upsert_agent_runs(session, [agent])
+
+    assert existing.status == AgentStatus.STALE.value, (
+        "implementing → stale transition should proceed normally"
+    )
+
+
+@pytest.mark.anyio
+async def test_new_run_inserted_when_not_in_db() -> None:
+    """When no existing row is found, a new ACAgentRun should be added."""
+    session = _make_session(existing_run=None)
+    agent = _make_agent(status=AgentStatus.IMPLEMENTING)
+
+    await _persist._upsert_agent_runs(session, [agent])
+
+    session.add.assert_called_once()
+    inserted: ACAgentRun = session.add.call_args[0][0]
+    assert inserted.id == agent.id
+    assert inserted.status == AgentStatus.IMPLEMENTING.value

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
       GH_REPO: ${GH_REPO:-cgcardona/agentception}
       REPO_DIR: ${REPO_DIR:-/app}
       WORKTREES_DIR: ${WORKTREES_DIR:-/worktrees}
+      # Host-side path written into .agent-task files so spawned Cursor agents
+      # (running on the host) can find the worktree at the same path the container
+      # created it.  Must match the left-hand side of the worktrees volume mount below.
+      HOST_WORKTREES_DIR: ${HOST_WORKTREES_DIR:-${HOME}/.agentception/worktrees/agentception}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       # gh CLI reads GITHUB_TOKEN when the keychain (macOS) is unavailable inside Docker.
       # Set GITHUB_TOKEN in .env to a PAT with repo+issues scope.
@@ -30,6 +34,10 @@ services:
       - ${HOME}/.config/gh:${HOME}/.config/gh:ro
       # Repo itself (for git operations)
       - ./:/app
+      # Agent worktrees: bind-mount the host directory into the container so that
+      # git worktrees created inside the container are immediately visible to Cursor
+      # agents running on the host at the same absolute path.
+      - ${HOME}/.agentception/worktrees/agentception:/worktrees
     networks:
       - agentception-net
     depends_on:


### PR DESCRIPTION
## Summary

- **Pending-launch guard**: removes `pending_launch` from the poller's orphan-sweep set so queued Dispatcher runs are never flipped to `unknown` before the Dispatcher reads them. The only valid transition out of `pending_launch` is now the `/api/build/acknowledge/{run_id}` endpoint.
- **Async MCP stdio transport**: the stdio server now owns the event loop via `asyncio.run` and routes all `tools/call` messages through the new `handle_request_async` path, fixing silent failures for every async tool (build tools, plan tools).
- **`ac_url` config setting**: replaces the fragile `getattr(settings, "ac_url", …)` fallback in dispatch routes with a proper `AgentCeptionSettings.ac_url` field driven by `AC_URL` env var (default `http://localhost:10003`).
- **Regression test**: `tests/test_persist_pending_launch_guard.py` covers the queue-drain bug scenario end-to-end.

## Changed files

| File | Change |
|------|--------|
| `agentception/db/persist.py` | Exclude `pending_launch` from orphan sweep; guard poller clobber; add trace logging |
| `agentception/db/queries.py` | Expose `host_worktree_path` in `get_pending_launches` |
| `agentception/db/models.py` | Minor model alignment |
| `agentception/mcp/server.py` | Add `handle_request_async` for correct async tool dispatch |
| `agentception/mcp/stdio_server.py` | Own event loop; init DB on startup; use async handler |
| `agentception/mcp/build_tools.py` | Add warning-level tracing to `build_get_pending_launches` |
| `agentception/routes/api/build.py` | Use `settings.ac_url`; add dispatch-label trace logging |
| `agentception/config.py` | Add `ac_url` setting |
| `agentception/tests/test_persist_pending_launch_guard.py` | New regression tests |
| `.agentception/dispatcher.md` | Dispatcher prompt update |
| `.agentception/roles/devops-engineer.md` | Role file update |
| `.gitignore`, `Dockerfile`, `docker-compose.yml`, `README.md` | Housekeeping |

## Test plan

- [ ] `docker compose exec agentception mypy agentception/ tests/` — zero errors
- [ ] `docker compose exec agentception pytest tests/test_persist_pending_launch_guard.py -v` — all pass
- [ ] Dispatch a label run from the UI → verify it stays `pending_launch` in the DB while the poller ticks → Dispatcher claims it → transitions to `implementing`
- [ ] Connect Cursor MCP stdio transport → verify async tools (`build_get_pending_launches`, `plan_get_labels`) execute correctly without error