### PR TITLE
chore: ignore *.db files and delete stale SQLite artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ docker-compose.override.yml
 
 # OS
 .DS_Store
-Thumbs.db
+*.db
 
 # Logs
 *.log


### PR DESCRIPTION
## Summary
- Broadens `.gitignore` from `Thumbs.db` to `*.db` so any SQLite file is never accidentally committed
- Deletes the stale `agentception.db` that was sitting untracked at the repo root (leftover from a misconfigured `DATABASE_URL` — project uses Postgres)

## Test plan
- [ ] Confirm `agentception.db` no longer appears in `git status`
- [ ] Confirm `git check-ignore agentception.db` returns the file