### PR TITLE
fix: tojson double-quote violations in overview.html and _spawn_issues.html

### DIFF
--- a/agentception/templates/_spawn_issues.html
+++ b/agentception/templates/_spawn_issues.html
@@ -12,7 +12,7 @@
 {% for iss in issues %}
 <div
   class="spawn-issue-card{% if iss.claimed %} spawn-issue-card--claimed{% endif %}"
-  @click="selectIssue({{ iss | tojson }})"
+  @click='selectIssue({{ iss | tojson }})'
   :class="{
     'spawn-issue-card--selected': selectedIssue?.number === {{ iss.number }},
     'spawn-issue-card--claimed':  {{ 'true' if iss.claimed else 'false' }},

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -586,7 +586,7 @@
     <div
       class="poller-right"
       id="pipeline-control"
-      x-data="pipelineControl({{ poller_paused | tojson }})"
+      x-data='pipelineControl({{ poller_paused | tojson }})'
     >
       <div class="poller-polled">
         <span class="poller-polled__label">Polled</span>


### PR DESCRIPTION
Closes #12.

## Summary
- `overview.html:589` — `x-data="pipelineControl({{ poller_paused | tojson }})"` → single-quoted
- `_spawn_issues.html:15` — `@click="selectIssue({{ iss | tojson }})"` → single-quoted

The browser terminates a double-quoted attribute at the first `"` inside `tojson` output, leaving Alpine.js with a truncated expression. These were latent runtime bugs not introduced by any recent PR.

## Acceptance criteria (from issue)
- [x] `grep -rn 'x-data=".*tojson\|@click=".*tojson\|:class=".*tojson\|x-text=".*tojson' agentception/templates/` returns zero results
- [ ] Manual smoke: overview page loads, pipeline control toggle works, spawn issue selection works