### PR TITLE
feat: wire active_labels_order to build board phase list

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -1085,17 +1085,25 @@ def _compute_locked(
 async def get_issues_grouped_by_phase(
     repo: str,
     initiative: str | None = None,
+    phase_order: list[str] | None = None,
 ) -> list[PhaseGroupRow]:
-    """Return issues grouped by phase, ordered phase-0..3.
+    """Return issues grouped by phase, ordered according to *phase_order*.
+
+    *phase_order* is the caller-supplied list of phase label strings that
+    defines which phases appear in the result and in what order.  When
+    omitted it falls back to ``_PHASE_ORDER`` (``["phase-0".."phase-3"]``)
+    for backward compatibility.  Pass ``settings.active_labels_order`` from
+    ``pipeline-config.json`` to make the Build board reflect the project
+    configuration rather than the hard-coded default.
 
     When *initiative* is supplied the result is scoped to that initiative:
     - Only issues carrying that initiative label are included.
-    - All four phases are always present in the result (even if empty) so
-      the UI can render the full gate structure.
+    - Every phase in *phase_order* is present in the result (even if empty)
+      so the UI can render the full gate structure.
     - No ``"unphased"`` bucket is emitted.
 
     When *initiative* is ``None`` the legacy behaviour is preserved:
-    phase-0..3 first, then remaining label buckets, then ``"unphased"``.
+    configured phases first, then remaining label buckets, then ``"unphased"``.
 
     Each group dict contains:
     - ``label``    — phase label string
@@ -1105,6 +1113,7 @@ async def get_issues_grouped_by_phase(
 
     Falls back to ``[]`` on DB error.
     """
+    effective_phase_order: list[str] = phase_order if phase_order else _PHASE_ORDER
     try:
         async with get_session() as session:
             result = await session.execute(
@@ -1155,13 +1164,13 @@ async def get_issues_grouped_by_phase(
         # Build ordered list; compute complete set first so we can evaluate
         # deps in a single pass.
         complete_phases: set[str] = set()
-        for phase in _PHASE_ORDER:
+        for phase in effective_phase_order:
             issues = groups.get(phase, [])
             if bool(issues) and all(i["state"] == "closed" for i in issues):
                 complete_phases.add(phase)
 
         ordered: list[PhaseGroupRow] = []
-        for phase in _PHASE_ORDER:
+        for phase in effective_phase_order:
             issues = groups.pop(phase, [])
             complete = phase in complete_phases
             deps = phase_deps.get(phase, [])

--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -36,6 +36,7 @@ from agentception.db.queries import (
     get_issues_grouped_by_phase,
     get_runs_for_issue_numbers,
 )
+from agentception.readers.pipeline_config import read_pipeline_config
 from ._shared import _TEMPLATES
 
 
@@ -102,6 +103,26 @@ def _available_roles() -> dict[str, list[str]]:
 
 
 # ---------------------------------------------------------------------------
+# Phase-order helper
+# ---------------------------------------------------------------------------
+
+
+async def _phase_order() -> list[str] | None:
+    """Return the configured phase label order from pipeline-config.json.
+
+    Returns ``None`` when the config is absent or unreadable so that
+    ``get_issues_grouped_by_phase`` falls back to its built-in default
+    (``["phase-0".."phase-3"]``) rather than rendering an empty board.
+    """
+    try:
+        cfg = await read_pipeline_config()
+        return cfg.active_labels_order if cfg.active_labels_order else None
+    except Exception as exc:
+        logger.warning("⚠️ Could not read pipeline config for build board: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
 # /build — full Mission Control page
 # ---------------------------------------------------------------------------
 
@@ -127,7 +148,9 @@ async def build_page(
             url=f"/build?initiative={initiatives[0]}", status_code=302
         )
 
-    groups = await get_issues_grouped_by_phase(repo, initiative=initiative)
+    groups = await get_issues_grouped_by_phase(
+        repo, initiative=initiative, phase_order=await _phase_order()
+    )
 
     all_issue_numbers = [i["number"] for g in groups for i in g["issues"]]
     runs = await get_runs_for_issue_numbers(all_issue_numbers)
@@ -179,7 +202,9 @@ async def build_board_partial(
 ) -> HTMLResponse:
     """Return the phase-grouped board as an HTML partial for HTMX polling."""
     repo = settings.gh_repo
-    groups = await get_issues_grouped_by_phase(repo, initiative=initiative)
+    groups = await get_issues_grouped_by_phase(
+        repo, initiative=initiative, phase_order=await _phase_order()
+    )
 
     all_issue_numbers = [i["number"] for g in groups for i in g["issues"]]
     runs = await get_runs_for_issue_numbers(all_issue_numbers)

--- a/agentception/tests/test_pipeline_panel.py
+++ b/agentception/tests/test_pipeline_panel.py
@@ -94,39 +94,39 @@ def _make_pipeline_cfg(labels: list[str]) -> object:
 def test_overview_returns_200_with_phase_lanes(
     client: TestClient, state_with_lanes: PipelineState, labels: list[str]
 ) -> None:
-    """GET / must return HTTP 200 even when phase lanes are populated."""
+    """GET /overview must return HTTP 200 even when phase lanes are populated."""
     mock_cfg = AsyncMock(return_value=_make_pipeline_cfg(labels))
     with (
         patch("agentception.routes.ui.overview.get_state", return_value=state_with_lanes),
         patch("agentception.routes.ui.overview.read_pipeline_config", mock_cfg),
     ):
-        response = client.get("/")
+        response = client.get("/overview")
     assert response.status_code == 200
 
 
 def test_overview_contains_phase_lanes_section(
     client: TestClient, state_with_lanes: PipelineState, labels: list[str]
 ) -> None:
-    """GET / HTML must include the phase-lanes CSS class when lanes are computed."""
+    """GET /overview HTML must include the phase-lanes CSS class when lanes are computed."""
     mock_cfg = AsyncMock(return_value=_make_pipeline_cfg(labels))
     with (
         patch("agentception.routes.ui.overview.get_state", return_value=state_with_lanes),
         patch("agentception.routes.ui.overview.read_pipeline_config", mock_cfg),
     ):
-        response = client.get("/")
+        response = client.get("/overview")
     assert "phase-lanes" in response.text
 
 
 def test_overview_phase_lanes_show_label_names(
     client: TestClient, state_with_lanes: PipelineState, labels: list[str]
 ) -> None:
-    """GET / HTML must render the phase label names inside the lane strip."""
+    """GET /overview HTML must render the phase label names inside the lane strip."""
     mock_cfg = AsyncMock(return_value=_make_pipeline_cfg(labels))
     with (
         patch("agentception.routes.ui.overview.get_state", return_value=state_with_lanes),
         patch("agentception.routes.ui.overview.read_pipeline_config", mock_cfg),
     ):
-        response = client.get("/")
+        response = client.get("/overview")
     for lbl in labels:
         assert lbl in response.text
 
@@ -134,20 +134,20 @@ def test_overview_phase_lanes_show_label_names(
 def test_overview_phase_lanes_gate_badges_present(
     client: TestClient, state_with_lanes: PipelineState, labels: list[str]
 ) -> None:
-    """GET / HTML must include at least one phase-gate-badge element."""
+    """GET /overview HTML must include at least one phase-gate-badge element."""
     mock_cfg = AsyncMock(return_value=_make_pipeline_cfg(labels))
     with (
         patch("agentception.routes.ui.overview.get_state", return_value=state_with_lanes),
         patch("agentception.routes.ui.overview.read_pipeline_config", mock_cfg),
     ):
-        response = client.get("/")
+        response = client.get("/overview")
     assert "phase-gate-badge" in response.text
 
 
 def test_overview_waiting_lane_shows_blocker_link(
     client: TestClient, state_with_lanes: PipelineState, labels: list[str]
 ) -> None:
-    """GET / HTML must render blocker issue links for waiting-status lanes.
+    """GET /overview HTML must render blocker issue links for waiting-status lanes.
 
     Phase ac-ui/1-design-tokens has open issues while ac-ui/0-critical-bugs
     also has open issues, so it must be gated (waiting) and show blockers.
@@ -157,7 +157,7 @@ def test_overview_waiting_lane_shows_blocker_link(
         patch("agentception.routes.ui.overview.get_state", return_value=state_with_lanes),
         patch("agentception.routes.ui.overview.read_pipeline_config", mock_cfg),
     ):
-        response = client.get("/")
+        response = client.get("/overview")
     # The blocker links point to upstream phase issues (#10 or #11).
     assert "blocker-link" in response.text or "#10" in response.text or "#11" in response.text
 


### PR DESCRIPTION
## Summary
- `get_issues_grouped_by_phase()` in `db/queries.py` now accepts an optional `phase_order: list[str] | None` parameter, replacing the hardcoded `_PHASE_ORDER = ["phase-0".."phase-3"]`
- `build_ui.py` reads `active_labels_order` from `pipeline-config.json` via `_phase_order()` helper and passes it to both `build_page` and `build_board_partial`
- The Build board phase columns are now driven by the same config that already controls the overview and DAG pages — edit labels in the Config UI at `/config` and the Build board reflects the change immediately

## Backward compatibility
Callers that omit `phase_order` fall back to the original `["phase-0", "phase-1", "phase-2", "phase-3"]` default. No existing behaviour changes unless `active_labels_order` is configured.

## Bug fix
Three tests in `test_pipeline_panel.py` were hitting `GET /` (now the Plan page) instead of `GET /overview` — updated to use the correct route.

## Test plan
- [x] mypy clean on all changed files
- [x] 36 tests pass (`test_pipeline_panel`, `test_agentception_plan_api`, `test_agentception_ui_plan`)