### PR TITLE
fix: stop pipeline-panel tests hanging on third TestClient startup

### DIFF
--- a/agentception/tests/test_pipeline_panel.py
+++ b/agentception/tests/test_pipeline_panel.py
@@ -13,6 +13,7 @@ Run targeted:
     pytest agentception/tests/test_pipeline_panel.py -v
 """
 
+import asyncio
 import time
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
@@ -28,11 +29,31 @@ from agentception.models import AgentNode, AgentStatus, BoardIssue, PipelineStat
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
 
-@pytest.fixture()
+async def _noop_polling_loop() -> None:
+    """No-op replacement for the real polling_loop in tests.
+
+    The real polling_loop immediately calls tick() which makes live GitHub API
+    and subprocess calls.  That causes the third+ TestClient startup to hang
+    when those calls block.  This coroutine sleeps until cancelled so the
+    lifespan can start and stop cleanly without any network I/O.
+    """
+    try:
+        await asyncio.sleep(float("inf"))
+    except asyncio.CancelledError:
+        return
+
+
+@pytest.fixture(scope="module")
 def client() -> Generator[TestClient, None, None]:
-    """Synchronous test client with full lifespan."""
-    with TestClient(app) as c:
-        yield c
+    """Module-scoped test client with mocked poller.
+
+    Scoped to module so the lifespan (DB init + poller task) starts and stops
+    exactly once for all HTTP route tests in this file, avoiding repeated
+    startup/shutdown overhead and the associated risk of subprocess hangs.
+    """
+    with patch("agentception.app.polling_loop", _noop_polling_loop):
+        with TestClient(app) as c:
+            yield c
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- Route tests in `test_pipeline_panel.py` each created a new function-scoped `TestClient`, triggering the full app lifespan (including `polling_loop → tick()`) on every test
- `tick()` makes live GitHub API and subprocess calls; by the third startup those calls blocked indefinitely, hanging the entire test run
- Fix: patch `agentception.app.polling_loop` with `_noop_polling_loop` (sleeps until cancelled, zero network I/O) and promote the `client` fixture to `scope="module"` so the lifespan runs exactly once

## Test plan
- [x] All 13 tests in `test_pipeline_panel.py` pass in ~1s (`pytest agentception/tests/test_pipeline_panel.py -v`)
- [x] `mypy agentception/tests/test_pipeline_panel.py` — clean