### PR TITLE
chore: align Plan page copy with README voice

### DIFF
--- a/agentception/routes/ui/plan_ui.py
+++ b/agentception/routes/ui/plan_ui.py
@@ -87,10 +87,10 @@ _PLAN_SEEDS = [
     {
         "label": "🏗️ Tech debt",
         "text": (
-            "- Replace legacy jQuery with Alpine across all pages\n"
-            "- Remove the deprecated v1 API endpoints\n"
-            "- Add mypy strict mode to the agentception module\n"
-            "- Consolidate duplicate GitHub fetch helpers"
+            "- Consolidate duplicate GitHub fetch helpers into a single client\n"
+            "- Add missing type coverage to the remaining untyped modules\n"
+            "- Extract business logic out of route handlers into services\n"
+            "- Replace inline SQL strings with typed SQLAlchemy queries"
         ),
     },
 ]

--- a/agentception/templates/plan.html
+++ b/agentception/templates/plan.html
@@ -66,8 +66,8 @@
      ══════════════════════════════════════════════════════════════════════ #}
   <div class="plan-write" x-show="step === 'write'" x-transition.opacity>
 
-    <h1 class="plan-title">Messy thoughts → shipped work.</h1>
-    <p class="plan-sub">Dump everything — bugs, features, ideas, debt. Claude will structure it into phased GitHub issues.</p>
+    <h1 class="plan-title">One brain dump away.</h1>
+    <p class="plan-sub">Paste anything — a rough idea, a wall of text, a list of tasks, a complaint about what's broken. Claude structures it into a phase-gated plan of GitHub issues.</p>
 
     <div class="plan-textarea-wrap" :class="{'plan-textarea-wrap--focused': focused}">
       <textarea
@@ -79,7 +79,7 @@
         @blur="focused = false"
         @input="autoGrow($refs.textarea)"
         @keydown.meta.enter.prevent="submit()"
-        placeholder="e.g.&#10;- Fix the flaky login test when DB is slow&#10;- Migrate auth middleware to JWT&#10;- Add dark mode toggle&#10;- CSV export breaks for reports over 10k rows&#10;- Refactor legacy jQuery to Alpine.js&#10;..."
+        placeholder="e.g.&#10;- Auth is broken on mobile and rate limiting is missing on public endpoints&#10;- Build a billing dashboard: Stripe, invoice emails, subscription management&#10;- The agent dispatch UI needs dark mode and Slack notifications&#10;- Export hangs for datasets over 10k rows&#10;&#10;Or just paste a wall of text — Claude will sort it out."
         :disabled="submitting"
         spellcheck="true"
       ></textarea>

--- a/agentception/tests/e2e/test_agentception_workflow_e2e.py
+++ b/agentception/tests/e2e/test_agentception_workflow_e2e.py
@@ -39,7 +39,7 @@ _SAMPLE_DUMP = (
     "- Login fails intermittently on mobile\n"
     "- Migrate auth to JWT with refresh tokens\n"
     "- Add dark mode toggle across the dashboard\n"
-    "- Refactor legacy jQuery to Alpine.js\n"
+    "- Extract business logic out of route handlers into services\n"
 )
 
 

--- a/agentception/tests/test_brain_dump_plan.py
+++ b/agentception/tests/test_brain_dump_plan.py
@@ -81,7 +81,7 @@ def test_classify_tech_debt_keywords_return_phase_3() -> None:
     correctly resolve to Phase 1 — they are excluded here so this test focuses
     on unambiguous tech-debt items only.
     """
-    assert _classify("Refactor legacy jQuery to Alpine") == 3
+    assert _classify("Consolidate duplicate fetch helpers into a typed client") == 3
     assert _classify("Consolidate duplicate GitHub fetch helpers") == 3
     assert _classify("Write integration tests for the billing flow") == 3
     assert _classify("Document the public interface contract") == 3
@@ -93,7 +93,7 @@ def test_plan_phases_groups_bugs_and_features() -> None:
         "- Login fails intermittently on mobile\n"
         "- Migrate auth to JWT with refresh tokens\n"
         "- Add dark mode toggle\n"
-        "- Refactor legacy jQuery to Alpine\n"
+        "- Consolidate duplicate fetch helpers into a typed client\n"
     )
     result = plan_phases(dump)
     assert isinstance(result, PlanResult)


### PR DESCRIPTION
## Summary

- **h1**: "Messy thoughts → shipped work." → **"One brain dump away."** — pulled directly from the README's closing line
- **Subtitle**: updated to match the README's exact workflow description: *"Paste anything — a rough idea, a wall of text, a list of tasks, a complaint about what's broken. Claude structures it into a phase-gated plan of GitHub issues."*
- **Placeholder**: removed self-referential "Refactor legacy jQuery to Alpine.js" (jQuery is already gone) and "CSV export" generic example; replaced with product-relevant examples and a note that unstructured prose is fine
- **Tech debt seed chip**: removed two items that no longer exist ("Replace legacy jQuery", "Remove deprecated v1 endpoints" — both shipped) and replaced with current actionable debt
- **Test fixtures**: updated `test_brain_dump_plan.py` and `test_agentception_workflow_e2e.py` to replace the jQuery fixture input with equivalent tech-debt items

## Test plan

- [x] `test_brain_dump_plan.py` — 13 passed
- [x] `test_agentception_workflow_e2e.py` — 4 passed