### PR TITLE
fix: initiative phase grouping, cognitive archetypes, table rename, poller sync

### DIFF
--- a/.agentception/role-versions.json
+++ b/.agentception/role-versions.json
@@ -1,5 +1,21 @@
 {
-  "versions": {},
+  "versions": {
+    "cto": {
+      "current": "v2",
+      "history": [
+        {
+          "sha": "abcdef1234567890abcdef1234567890abcdef12",
+          "label": "v1",
+          "timestamp": 1772675813
+        },
+        {
+          "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "label": "v2",
+          "timestamp": 1772675813
+        }
+      ]
+    }
+  },
   "ab_mode": {
     "enabled": false,
     "target_role": null,

--- a/agentception/alembic/env.py
+++ b/agentception/alembic/env.py
@@ -45,7 +45,7 @@ def run_migrations_offline() -> None:
         dialect_opts={"paramstyle": "named"},
         compare_type=True,
         compare_server_default=True,
-        version_table="alembic_version_ac",
+        version_table="alembic_version",
     )
     with context.begin_transaction():
         context.run_migrations()
@@ -58,8 +58,8 @@ def _do_run_migrations(connection: Connection) -> None:
         compare_type=True,
         compare_server_default=True,
         # Separate version table so AgentCeption migrations don't collide with
-        # Separate alembic_version table avoids conflicts with other services.
-        version_table="alembic_version_ac",
+        # Standard alembic_version table.
+        version_table="alembic_version",
     )
     with context.begin_transaction():
         context.run_migrations()

--- a/agentception/alembic/versions/0001_initial_schema.py
+++ b/agentception/alembic/versions/0001_initial_schema.py
@@ -14,16 +14,16 @@ Create Date: 2026-03-02
 import sqlalchemy as sa
 from alembic import op
 
-revision = "ac0001"
+revision = "0001"
 down_revision = None
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    # ── ac_waves ─────────────────────────────────────────────────────────────
+    # ── waves ─────────────────────────────────────────────────────────────
     op.create_table(
-        "ac_waves",
+        "waves",
         sa.Column("id", sa.String(128), primary_key=True),
         sa.Column("phase_label", sa.String(256), nullable=False),
         sa.Column("role", sa.String(128), nullable=False),
@@ -33,11 +33,11 @@ def upgrade() -> None:
         sa.Column("skip_count", sa.Integer(), nullable=False, server_default="0"),
     )
 
-    # ── ac_agent_runs ─────────────────────────────────────────────────────────
+    # ── agent_runs ─────────────────────────────────────────────────────────
     op.create_table(
-        "ac_agent_runs",
+        "agent_runs",
         sa.Column("id", sa.String(512), primary_key=True),
-        sa.Column("wave_id", sa.String(128), sa.ForeignKey("ac_waves.id"), nullable=True),
+        sa.Column("wave_id", sa.String(128), sa.ForeignKey("waves.id"), nullable=True),
         sa.Column("issue_number", sa.Integer(), nullable=True),
         sa.Column("pr_number", sa.Integer(), nullable=True),
         sa.Column("branch", sa.String(256), nullable=True),
@@ -51,14 +51,14 @@ def upgrade() -> None:
         sa.Column("last_activity_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
     )
-    op.create_index("ix_ac_agent_runs_wave_id", "ac_agent_runs", ["wave_id"])
-    op.create_index("ix_ac_agent_runs_issue_number", "ac_agent_runs", ["issue_number"])
-    op.create_index("ix_ac_agent_runs_pr_number", "ac_agent_runs", ["pr_number"])
-    op.create_index("ix_ac_agent_runs_batch_id", "ac_agent_runs", ["batch_id"])
+    op.create_index("ix_agent_runs_wave_id", "agent_runs", ["wave_id"])
+    op.create_index("ix_agent_runs_issue_number", "agent_runs", ["issue_number"])
+    op.create_index("ix_agent_runs_pr_number", "agent_runs", ["pr_number"])
+    op.create_index("ix_agent_runs_batch_id", "agent_runs", ["batch_id"])
 
-    # ── ac_issues ─────────────────────────────────────────────────────────────
+    # ── issues ─────────────────────────────────────────────────────────────
     op.create_table(
-        "ac_issues",
+        "issues",
         sa.Column("github_number", sa.Integer(), primary_key=True),
         sa.Column("repo", sa.String(256), primary_key=True),
         sa.Column("title", sa.String(512), nullable=False),
@@ -72,12 +72,12 @@ def upgrade() -> None:
         sa.Column("first_seen_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=False),
     )
-    op.create_index("ix_ac_issues_state", "ac_issues", ["state"])
-    op.create_index("ix_ac_issues_phase_label", "ac_issues", ["phase_label"])
+    op.create_index("ix_issues_state", "issues", ["state"])
+    op.create_index("ix_issues_phase_label", "issues", ["phase_label"])
 
-    # ── ac_pull_requests ──────────────────────────────────────────────────────
+    # ── pull_requests ──────────────────────────────────────────────────────
     op.create_table(
-        "ac_pull_requests",
+        "pull_requests",
         sa.Column("github_number", sa.Integer(), primary_key=True),
         sa.Column("repo", sa.String(256), primary_key=True),
         sa.Column("title", sa.String(512), nullable=False),
@@ -91,16 +91,16 @@ def upgrade() -> None:
         sa.Column("first_seen_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=False),
     )
-    op.create_index("ix_ac_pull_requests_state", "ac_pull_requests", ["state"])
+    op.create_index("ix_pull_requests_state", "pull_requests", ["state"])
 
-    # ── ac_agent_messages ─────────────────────────────────────────────────────
+    # ── agent_messages ─────────────────────────────────────────────────────
     op.create_table(
-        "ac_agent_messages",
+        "agent_messages",
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
         sa.Column(
             "agent_run_id",
             sa.String(512),
-            sa.ForeignKey("ac_agent_runs.id"),
+            sa.ForeignKey("agent_runs.id"),
             nullable=False,
         ),
         sa.Column("role", sa.String(64), nullable=False),
@@ -110,26 +110,26 @@ def upgrade() -> None:
         sa.Column("recorded_at", sa.DateTime(timezone=True), nullable=False),
     )
     op.create_index(
-        "ix_ac_agent_messages_run_seq",
-        "ac_agent_messages",
+        "ix_agent_messages_run_seq",
+        "agent_messages",
         ["agent_run_id", "sequence_index"],
     )
 
-    # ── ac_role_versions ──────────────────────────────────────────────────────
+    # ── role_versions ──────────────────────────────────────────────────────
     op.create_table(
-        "ac_role_versions",
+        "role_versions",
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
         sa.Column("role_name", sa.String(128), nullable=False),
         sa.Column("content_hash", sa.String(64), nullable=False),
         sa.Column("content", sa.Text(), nullable=False),
         sa.Column("first_seen_at", sa.DateTime(timezone=True), nullable=False),
-        sa.UniqueConstraint("role_name", "content_hash", name="uq_ac_role_versions"),
+        sa.UniqueConstraint("role_name", "content_hash", name="uq_role_versions"),
     )
-    op.create_index("ix_ac_role_versions_role_name", "ac_role_versions", ["role_name"])
+    op.create_index("ix_role_versions_role_name", "role_versions", ["role_name"])
 
-    # ── ac_pipeline_snapshots ─────────────────────────────────────────────────
+    # ── pipeline_snapshots ─────────────────────────────────────────────────
     op.create_table(
-        "ac_pipeline_snapshots",
+        "pipeline_snapshots",
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
         sa.Column("polled_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("active_label", sa.String(256), nullable=True),
@@ -139,15 +139,15 @@ def upgrade() -> None:
         sa.Column("alerts_json", sa.Text(), nullable=False, server_default="[]"),
     )
     op.create_index(
-        "ix_ac_pipeline_snapshots_polled_at", "ac_pipeline_snapshots", ["polled_at"]
+        "ix_pipeline_snapshots_polled_at", "pipeline_snapshots", ["polled_at"]
     )
 
 
 def downgrade() -> None:
-    op.drop_table("ac_pipeline_snapshots")
-    op.drop_table("ac_role_versions")
-    op.drop_table("ac_agent_messages")
-    op.drop_table("ac_pull_requests")
-    op.drop_table("ac_issues")
-    op.drop_table("ac_agent_runs")
-    op.drop_table("ac_waves")
+    op.drop_table("pipeline_snapshots")
+    op.drop_table("role_versions")
+    op.drop_table("agent_messages")
+    op.drop_table("pull_requests")
+    op.drop_table("issues")
+    op.drop_table("agent_runs")
+    op.drop_table("waves")

--- a/agentception/alembic/versions/0002_agent_events.py
+++ b/agentception/alembic/versions/0002_agent_events.py
@@ -1,34 +1,34 @@
 from __future__ import annotations
 
-"""ac_agent_events — structured MCP callback events per agent run
+"""agent_events — structured MCP callback events per agent run
 
 Stores events that agents push via the build_report_* MCP tools.
 Each row is one deliberate signal from a running agent (step start,
 blocker, decision, or completion) — distinct from the raw thinking
-stream captured in ac_agent_messages.
+stream captured in agent_messages.
 
 Revision ID: ac0002
-Revises: ac0001
+Revises: 0001
 Create Date: 2026-03-03
 """
 
 import sqlalchemy as sa
 from alembic import op
 
-revision = "ac0002"
-down_revision = "ac0001"
+revision = "0002"
+down_revision = "0001"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
     op.create_table(
-        "ac_agent_events",
+        "agent_events",
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
         sa.Column(
             "agent_run_id",
             sa.String(512),
-            sa.ForeignKey("ac_agent_runs.id"),
+            sa.ForeignKey("agent_runs.id"),
             nullable=True,
         ),
         sa.Column("issue_number", sa.Integer(), nullable=True),
@@ -40,15 +40,15 @@ def upgrade() -> None:
             "recorded_at", sa.DateTime(timezone=True), nullable=False
         ),
     )
-    op.create_index("ix_ac_agent_events_run", "ac_agent_events", ["agent_run_id"])
-    op.create_index("ix_ac_agent_events_issue", "ac_agent_events", ["issue_number"])
+    op.create_index("ix_agent_events_run", "agent_events", ["agent_run_id"])
+    op.create_index("ix_agent_events_issue", "agent_events", ["issue_number"])
     op.create_index(
-        "ix_ac_agent_events_recorded_at", "ac_agent_events", ["recorded_at"]
+        "ix_agent_events_recorded_at", "agent_events", ["recorded_at"]
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_ac_agent_events_recorded_at", "ac_agent_events")
-    op.drop_index("ix_ac_agent_events_issue", "ac_agent_events")
-    op.drop_index("ix_ac_agent_events_run", "ac_agent_events")
-    op.drop_table("ac_agent_events")
+    op.drop_index("ix_agent_events_recorded_at", "agent_events")
+    op.drop_index("ix_agent_events_issue", "agent_events")
+    op.drop_index("ix_agent_events_run", "agent_events")
+    op.drop_table("agent_events")

--- a/agentception/alembic/versions/0003_initiative_phases.py
+++ b/agentception/alembic/versions/0003_initiative_phases.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""ac_initiative_phases — phase dependency graph per initiative
+"""initiative_phases — phase dependency graph per initiative
 
 Stores the DAG of phase dependencies that was declared in the PlanSpec
 at plan-creation time.  Each row records one phase of one initiative and
@@ -11,22 +11,22 @@ phase swim lane.  When no rows exist for an initiative (e.g. issues were
 created before this feature shipped), every phase is shown as unlocked.
 
 Revision ID: ac0003
-Revises: ac0002
+Revises: 0002
 Create Date: 2026-03-04
 """
 
 import sqlalchemy as sa
 from alembic import op
 
-revision = "ac0003"
-down_revision = "ac0002"
+revision = "0003"
+down_revision = "0002"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
     op.create_table(
-        "ac_initiative_phases",
+        "initiative_phases",
         sa.Column("initiative", sa.String(256), nullable=False, primary_key=True),
         sa.Column("phase_label", sa.String(256), nullable=False, primary_key=True),
         # JSON list of phase label strings this phase depends on, e.g. '["phase-0"]'
@@ -34,12 +34,12 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
     )
     op.create_index(
-        "ix_ac_initiative_phases_initiative",
-        "ac_initiative_phases",
+        "ix_initiative_phases_initiative",
+        "initiative_phases",
         ["initiative"],
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_ac_initiative_phases_initiative", "ac_initiative_phases")
-    op.drop_table("ac_initiative_phases")
+    op.drop_index("ix_initiative_phases_initiative", "initiative_phases")
+    op.drop_table("initiative_phases")

--- a/agentception/alembic/versions/0004_task_runs.py
+++ b/agentception/alembic/versions/0004_task_runs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""add ac_task_runs table
+"""add task_runs table
 
 Revision ID: 0004
 Revises: 0003
@@ -10,15 +10,15 @@ Create Date: 2026-03-03
 import sqlalchemy as sa
 from alembic import op
 
-revision = "ac0004"
-down_revision = "ac0003"
+revision = "0004"
+down_revision = "0003"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
     op.create_table(
-        "ac_task_runs",
+        "task_runs",
         sa.Column("id", sa.String(256), primary_key=True),
         sa.Column("task_type", sa.String(128), nullable=False),
         sa.Column("branch", sa.String(256), nullable=True),
@@ -28,11 +28,11 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
     )
-    op.create_index("ix_ac_task_runs_task_type", "ac_task_runs", ["task_type"])
-    op.create_index("ix_ac_task_runs_status", "ac_task_runs", ["status"])
+    op.create_index("ix_task_runs_task_type", "task_runs", ["task_type"])
+    op.create_index("ix_task_runs_status", "task_runs", ["status"])
 
 
 def downgrade() -> None:
-    op.drop_index("ix_ac_task_runs_status", table_name="ac_task_runs")
-    op.drop_index("ix_ac_task_runs_task_type", table_name="ac_task_runs")
-    op.drop_table("ac_task_runs")
+    op.drop_index("ix_task_runs_status", table_name="task_runs")
+    op.drop_index("ix_task_runs_task_type", table_name="task_runs")
+    op.drop_table("task_runs")

--- a/agentception/alembic/versions/0005_agent_runs_cognitive_arch.py
+++ b/agentception/alembic/versions/0005_agent_runs_cognitive_arch.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""add cognitive_arch column to ac_agent_runs
+"""add cognitive_arch column to agent_runs
 
 Revision ID: 0005
 Revises: 0004
@@ -10,18 +10,18 @@ Create Date: 2026-03-04
 import sqlalchemy as sa
 from alembic import op
 
-revision = "ac0005"
-down_revision = "ac0004"
+revision = "0005"
+down_revision = "0004"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
     op.add_column(
-        "ac_agent_runs",
+        "agent_runs",
         sa.Column("cognitive_arch", sa.String(256), nullable=True),
     )
 
 
 def downgrade() -> None:
-    op.drop_column("ac_agent_runs", "cognitive_arch")
+    op.drop_column("agent_runs", "cognitive_arch")

--- a/agentception/alembic/versions/0006_agent_runs_lineage.py
+++ b/agentception/alembic/versions/0006_agent_runs_lineage.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Add logical_tier and parent_run_id to ac_agent_runs.
+"""Add logical_tier and parent_run_id to agent_runs.
 
 logical_tier  — organisational tier the run reports to in the virtual org chart
                 (executive | coordinator | engineer | reviewer).  Null for legacy rows.
@@ -15,35 +15,35 @@ Create Date: 2026-03-05
 import sqlalchemy as sa
 from alembic import op
 
-revision = "ac0006"
-down_revision = "ac0005"
+revision = "0006"
+down_revision = "0005"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
     op.add_column(
-        "ac_agent_runs",
+        "agent_runs",
         sa.Column("logical_tier", sa.String(64), nullable=True),
     )
     op.add_column(
-        "ac_agent_runs",
+        "agent_runs",
         sa.Column("parent_run_id", sa.String(512), nullable=True),
     )
     op.create_index(
-        "ix_ac_agent_runs_logical_tier",
-        "ac_agent_runs",
+        "ix_agent_runs_logical_tier",
+        "agent_runs",
         ["logical_tier"],
     )
     op.create_index(
-        "ix_ac_agent_runs_parent_run_id",
-        "ac_agent_runs",
+        "ix_agent_runs_parent_run_id",
+        "agent_runs",
         ["parent_run_id"],
     )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_ac_agent_runs_parent_run_id", table_name="ac_agent_runs")
-    op.drop_index("ix_ac_agent_runs_logical_tier", table_name="ac_agent_runs")
-    op.drop_column("ac_agent_runs", "parent_run_id")
-    op.drop_column("ac_agent_runs", "logical_tier")
+    op.drop_index("ix_agent_runs_parent_run_id", table_name="agent_runs")
+    op.drop_index("ix_agent_runs_logical_tier", table_name="agent_runs")
+    op.drop_column("agent_runs", "parent_run_id")
+    op.drop_column("agent_runs", "logical_tier")

--- a/agentception/db/models.py
+++ b/agentception/db/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""AgentCeption ORM models — all tables use the ``ac_`` prefix.
+"""AgentCeption ORM models — all tables — no prefix needed since this is a standalone app.
 
 Entity hierarchy
 ----------------
@@ -61,7 +61,7 @@ from agentception.db.base import Base
 class ACWave(Base):
     """A batch spawn operation — one "Start Wave" click = one ACWave."""
 
-    __tablename__ = "ac_waves"
+    __tablename__ = "waves"
 
     id: Mapped[str] = mapped_column(String(128), primary_key=True)
     """BATCH_ID from the .agent-task file (e.g. ``eng-20260302T084507Z-16da``)."""
@@ -98,13 +98,13 @@ class ACWave(Base):
 class ACAgentRun(Base):
     """Lifecycle of one agent working one issue."""
 
-    __tablename__ = "ac_agent_runs"
+    __tablename__ = "agent_runs"
 
     id: Mapped[str] = mapped_column(String(512), primary_key=True)
     """Worktree basename (e.g. ``issue-732``) or generated UUID for manual spawns."""
 
     wave_id: Mapped[str | None] = mapped_column(
-        String(128), ForeignKey("ac_waves.id"), nullable=True, index=True
+        String(128), ForeignKey("waves.id"), nullable=True, index=True
     )
     issue_number: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
     pr_number: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
@@ -168,7 +168,7 @@ class ACIssue(Base):
     latest GitHub state without hammering the DB on every tick.
     """
 
-    __tablename__ = "ac_issues"
+    __tablename__ = "issues"
 
     github_number: Mapped[int] = mapped_column(Integer, primary_key=True)
     repo: Mapped[str] = mapped_column(String(256), nullable=False, primary_key=True)
@@ -200,8 +200,8 @@ class ACIssue(Base):
     )
 
     __table_args__ = (
-        Index("ix_ac_issues_state", "state"),
-        Index("ix_ac_issues_phase_label", "phase_label"),
+        Index("ix_issues_state", "state"),
+        Index("ix_issues_phase_label", "phase_label"),
     )
 
 
@@ -213,7 +213,7 @@ class ACIssue(Base):
 class ACPullRequest(Base):
     """Mirror of a GitHub pull request, refreshed on every tick via hash-diff."""
 
-    __tablename__ = "ac_pull_requests"
+    __tablename__ = "pull_requests"
 
     github_number: Mapped[int] = mapped_column(Integer, primary_key=True)
     repo: Mapped[str] = mapped_column(String(256), nullable=False, primary_key=True)
@@ -239,7 +239,7 @@ class ACPullRequest(Base):
         DateTime(timezone=True), nullable=False
     )
 
-    __table_args__ = (Index("ix_ac_pull_requests_state", "state"),)
+    __table_args__ = (Index("ix_pull_requests_state", "state"),)
 
 
 # ---------------------------------------------------------------------------
@@ -254,11 +254,11 @@ class ACAgentMessage(Base):
     the 5-second tick loop.  Enables full-text search and ML feature extraction.
     """
 
-    __tablename__ = "ac_agent_messages"
+    __tablename__ = "agent_messages"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     agent_run_id: Mapped[str] = mapped_column(
-        String(512), ForeignKey("ac_agent_runs.id"), nullable=False, index=True
+        String(512), ForeignKey("agent_runs.id"), nullable=False, index=True
     )
     role: Mapped[str] = mapped_column(String(64), nullable=False)
     """user | assistant | tool_call | tool_result | thinking"""
@@ -273,7 +273,7 @@ class ACAgentMessage(Base):
     agent_run: Mapped[ACAgentRun] = relationship("ACAgentRun", back_populates="messages")
 
     __table_args__ = (
-        Index("ix_ac_agent_messages_run_seq", "agent_run_id", "sequence_index"),
+        Index("ix_agent_messages_run_seq", "agent_run_id", "sequence_index"),
     )
 
 
@@ -289,7 +289,7 @@ class ACRoleVersion(Base):
     changes, making this a full audit trail of every prompt change over time.
     """
 
-    __tablename__ = "ac_role_versions"
+    __tablename__ = "role_versions"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     role_name: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
@@ -300,7 +300,7 @@ class ACRoleVersion(Base):
     )
 
     __table_args__ = (
-        UniqueConstraint("role_name", "content_hash", name="uq_ac_role_versions"),
+        UniqueConstraint("role_name", "content_hash", name="uq_role_versions"),
     )
 
 
@@ -325,11 +325,11 @@ class ACAgentEvent(Base):
     these are *intentional* structured reports, not passive transcript reads.
     """
 
-    __tablename__ = "ac_agent_events"
+    __tablename__ = "agent_events"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     agent_run_id: Mapped[str | None] = mapped_column(
-        String(512), ForeignKey("ac_agent_runs.id"), nullable=True, index=True
+        String(512), ForeignKey("agent_runs.id"), nullable=True, index=True
     )
     issue_number: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
     event_type: Mapped[str] = mapped_column(String(64), nullable=False)
@@ -359,7 +359,7 @@ class ACInitiativePhase(Base):
     which is the correct default for plans created before this feature.
     """
 
-    __tablename__ = "ac_initiative_phases"
+    __tablename__ = "initiative_phases"
 
     initiative: Mapped[str] = mapped_column(String(256), primary_key=True)
     phase_label: Mapped[str] = mapped_column(String(256), primary_key=True)
@@ -370,7 +370,7 @@ class ACInitiativePhase(Base):
     )
 
     __table_args__ = (
-        Index("ix_ac_initiative_phases_initiative", "initiative"),
+        Index("ix_initiative_phases_initiative", "initiative"),
     )
 
 
@@ -393,7 +393,7 @@ class ACTaskRun(Base):
     jobs, cognitive-arch enrichment runs, and any future non-issue tasks.
     """
 
-    __tablename__ = "ac_task_runs"
+    __tablename__ = "task_runs"
 
     id: Mapped[str] = mapped_column(String(256), primary_key=True)
     """Stable task identifier, e.g. ``cog-arch-systems-language-designers``."""
@@ -432,7 +432,7 @@ class ACPipelineSnapshot(Base):
     Use for trend charts, SLA analysis, and anomaly detection.
     """
 
-    __tablename__ = "ac_pipeline_snapshots"
+    __tablename__ = "pipeline_snapshots"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     polled_at: Mapped[datetime.datetime] = mapped_column(

--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -626,7 +626,7 @@ async def persist_agent_event(
     payload: dict[str, object],
     agent_run_id: str | None = None,
 ) -> None:
-    """Write one structured agent event row to ``ac_agent_events``.
+    """Write one structured agent event row to ``agent_events``.
 
     Called by the ``build_report_*`` HTTP endpoints when a running agent
     signals a lifecycle change.  The optional ``agent_run_id`` is included

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -400,7 +400,7 @@ async def get_board_issues(
     include_claimed: bool = False,
     limit: int = 50,
 ) -> list[BoardIssueRow]:
-    """Return open issues from ``ac_issues``, optionally filtered by phase label.
+    """Return open issues from ``issues``, optionally filtered by phase label.
 
     Returns dicts shaped like the ``gh`` CLI JSON output so existing templates
     work without changes.  Falls back to ``[]`` on any DB error.
@@ -518,7 +518,7 @@ async def get_agent_run_history(
     limit: int = 100,
     status: str | None = None,
 ) -> list[AgentRunRow]:
-    """Return recent agent runs from ``ac_agent_runs``, newest first."""
+    """Return recent agent runs from ``agent_runs``, newest first."""
     try:
         async with get_session() as session:
             stmt = (
@@ -567,7 +567,7 @@ async def get_agent_run_detail(
     """Return a single agent run with its transcript messages.
 
     ``run_id`` is the worktree basename (e.g. ``issue-732``), which is the
-    primary key stored in ``ac_agent_runs``.
+    primary key stored in ``agent_runs``.
     """
     try:
         async with get_session() as session:
@@ -618,7 +618,7 @@ async def get_agent_run_detail(
 
 
 async def get_open_prs_db(repo: str, limit: int = 50) -> list[OpenPRRow]:
-    """Return open PRs from ``ac_pull_requests``."""
+    """Return open PRs from ``pull_requests``."""
     try:
         async with get_session() as session:
             result = await session.execute(
@@ -652,7 +652,7 @@ async def get_issue_detail(
     repo: str,
     number: int,
 ) -> IssueDetailRow | None:
-    """Return full detail for a single issue from ``ac_issues``.
+    """Return full detail for a single issue from ``issues``.
 
     Includes linked PR (via ``closes_issue_number``) and all agent runs
     that worked on this issue.  Returns ``None`` when the issue is not in DB.
@@ -730,7 +730,7 @@ async def get_all_issues(
     state: str | None = None,
     limit: int = 200,
 ) -> list[AllIssueRow]:
-    """Return issues from ``ac_issues``, optionally filtered by state."""
+    """Return issues from ``issues``, optionally filtered by state."""
     try:
         async with get_session() as session:
             stmt = (
@@ -769,7 +769,7 @@ async def get_pr_detail(
     repo: str,
     number: int,
 ) -> PRDetailRow | None:
-    """Return full detail for a single PR from ``ac_pull_requests``.
+    """Return full detail for a single PR from ``pull_requests``.
 
     Includes linked issue and agent runs that worked on this PR.
     Returns ``None`` when the PR is not in DB.
@@ -843,7 +843,7 @@ async def get_all_prs(
     state: str | None = None,
     limit: int = 200,
 ) -> list[AllPRRow]:
-    """Return PRs from ``ac_pull_requests``, optionally filtered by state."""
+    """Return PRs from ``pull_requests``, optionally filtered by state."""
     try:
         async with get_session() as session:
             stmt = (
@@ -884,7 +884,7 @@ async def get_waves_from_db(limit: int = 100) -> list[WaveRow]:
 
     Used by ``telemetry.aggregate_waves()`` when no ``.agent-task`` files exist
     on the filesystem (i.e. all worktrees have been cleaned up).  Groups rows
-    in ``ac_agent_runs`` by ``batch_id``, then shapes them into the same
+    in ``agent_runs`` by ``batch_id``, then shapes them into the same
     structure expected by ``WaveSummary`` so D3 charts work without changes.
 
     Returns dicts with keys: batch_id, started_at (UNIX float), ended_at
@@ -971,7 +971,7 @@ async def get_closed_issues_count(repo: str, hours: int = 24) -> int:
         async with get_session() as session:
             result = await session.execute(
                 text(
-                    "SELECT COUNT(*) FROM ac_issues "
+                    "SELECT COUNT(*) FROM issues "
                     "WHERE repo = :repo AND state = 'closed' AND closed_at >= :cutoff"
                 ).bindparams(repo=repo, cutoff=cutoff)
             )
@@ -990,7 +990,7 @@ async def get_merged_prs_count(repo: str, hours: int = 24) -> int:
         async with get_session() as session:
             result = await session.execute(
                 text(
-                    "SELECT COUNT(*) FROM ac_pull_requests "
+                    "SELECT COUNT(*) FROM pull_requests "
                     "WHERE repo = :repo AND state = 'merged' AND merged_at >= :cutoff"
                 ).bindparams(repo=repo, cutoff=cutoff)
             )
@@ -1071,7 +1071,7 @@ async def get_initiative_phase_deps(initiative: str) -> dict[str, list[str]]:
 
     Returns ``{}`` (no deps — all phases unlocked) when the initiative has no
     stored dep graph.  This is the correct default for initiatives created
-    before ``ac_initiative_phases`` was introduced.
+    before ``initiative_phases`` was introduced.
 
     Falls back to ``{}`` on DB error.
     """
@@ -1313,7 +1313,7 @@ def _compute_agent_status(
 async def _get_step_data_for_runs(run_ids: list[str]) -> dict[str, _RunStepData]:
     """Return step-event summary keyed by run_id.
 
-    Queries ``ac_agent_events`` for ``step_start`` events and returns, per run:
+    Queries ``agent_events`` for ``step_start`` events and returns, per run:
 
     * ``current_step`` — step name from the most-recent event's JSON payload
       (``{"step": "<name>"}``); ``None`` if no events exist or payload is malformed.

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -334,7 +334,7 @@ async def _build_board_issues(
     active_label: str | None,
     gh_repo: str,
 ) -> list[BoardIssue]:
-    """Query ``ac_issues`` for unclaimed issues in the active phase.
+    """Query ``issues`` for unclaimed issues in the active phase.
 
     Called after ``persist_tick`` so the DB already has the freshest data.
     Returns ``[]`` on any error — poller continues without board data.

--- a/agentception/tests/test_lineage_fields.py
+++ b/agentception/tests/test_lineage_fields.py
@@ -178,8 +178,8 @@ def test_migration_0006_has_indexes() -> None:
     """Migration 0006 creates indexes for both new columns."""
     content = _migration_0006_content()
     assert "create_index" in content
-    assert "ix_ac_agent_runs_logical_tier" in content
-    assert "ix_ac_agent_runs_parent_run_id" in content
+    assert "ix_agent_runs_logical_tier" in content
+    assert "ix_agent_runs_parent_run_id" in content
 
 
 def test_migration_0006_has_downgrade() -> None:


### PR DESCRIPTION
## Summary

- **Fix build board blank phases**: initiative-scoped phase labels (e.g. `agentception-ux-phase1b-to-phase3/2-ux-impl`) were not matched by the old `phase-N` regex; `get_issues_grouped_by_phase` now handles both label formats and dynamically derives phase order when the configured order doesn't match the active initiative
- **Disable interaction on complete phases**: Launch button hidden and issue card `@click` stripped for phases where all issues are closed; `build-issue--done` CSS class (`pointer-events: none`) added as an extra guard
- **New cognitive architecture figures**: Scott Forstall (`the_visionary` — father of iOS, Steve Jobs's closest engineering lieutenant) and Avie Tevanian (`the_architect` — Apple CSTO, architect of Mac OS X/NeXTSTEP); assigned to `ios-developer`, `mobile-developer`, `architect`, `csto`
- **Fix coordinator cognitive arch injection bug**: `_build_coordinator_task` was looking up `'coordinator'` (→ Satya Nadella) instead of `'engineering-coordinator'` (→ von Neumann); fixed. Added explicit `'conductor'` key for the wave conductor
- **Drop `ac_` prefix from all table names**: AgentCeption is no longer in a monorepo — namespace prefixes are noise. All 10 tables, all index/constraint names, all 6 migration files renamed. Schema dropped and rebuilt clean; all migrations apply in sequence
- **Poller sync verified**: live `tick()` run confirmed GitHub → DB pipeline writes correctly to new table names with correct `open`/`closed` states

## Test plan

- [ ] All 736 tests pass (`pytest agentception/tests/ -q`)
- [ ] `mypy agentception/ tests/` — zero errors
- [ ] Build board for `agentception-ux-phase1b-to-phase3` initiative shows issues in phases
- [ ] Complete phases (Phase-0, Phase-1) have no Launch button and non-clickable cards
- [ ] DB tables: `issues`, `agent_runs`, `waves`, etc. (no `ac_` prefix anywhere)
- [ ] Poller tick syncs GitHub state every 5s — closed issues show as closed on board