### PR TITLE
fix: close two branch-cleanup gaps in reviewer self-destruct paths

### DIFF
--- a/.agentception/prompts/parallel-pr-review.md
+++ b/.agentception/prompts/parallel-pr-review.md
@@ -476,6 +476,14 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
     cd "$REPO"
     git worktree remove --force "$WORKTREE"
     git worktree prune
+    # Clean up local branch ref (engineer's feat/* branch lives here after worktree removal)
+    git branch -D "$BRANCH" 2>/dev/null || true
+    # For CLOSED (not merged) PRs GitHub does NOT auto-delete the branch — remove it explicitly.
+    # For MERGED PRs GitHub auto-deletes; the push --delete is a safe no-op if already gone.
+    STILL_EXISTS=$(git ls-remote --heads origin "$BRANCH" 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$STILL_EXISTS" -gt 0 ]; then
+      git push origin --delete "$BRANCH" 2>/dev/null || true
+    fi
 
 STEP 3 — CHECKOUT & SYNC (only if STEP 2 shows the PR is open and unreviewed):
 
@@ -913,6 +921,9 @@ STEP 5.5 — MERGE ORDER GATE (sequential chain safety):
         cd "$REPO"
         git worktree remove --force "$WORKTREE"
         git worktree prune
+        # PR is still open (blocked on gate) — do NOT delete the remote branch.
+        # Clean up only the local tracking branch so it doesn't accumulate in main repo.
+        git branch -D "$BRANCH" 2>/dev/null || true
         exit 1
       fi
       sleep 60


### PR DESCRIPTION
## Summary

Traced why \`feat/*\` and \`agent/*\` branches were accumulating after completed agent runs. Two early-exit self-destruct paths in \`parallel-pr-review.md\` were missing branch cleanup:

1. **STEP 2 early exit** (PR already merged/closed/approved): Worktree was removed but \`\$BRANCH\` was never cleaned up locally. For CLOSED-without-merge PRs, GitHub does NOT auto-delete the branch, so the remote ref also accumulated. Added \`git branch -D "\$BRANCH"\` and a guarded \`git push origin --delete\` (checks with \`ls-remote\` first).

2. **STEP 5.5 MERGE_AFTER timeout early exit**: Same — worktree removed, local branch left dangling. Remote intentionally kept (PR still open, gate timed out). Added \`git branch -D "\$BRANCH"\` only.

The engineer's STEP 7 and reviewer's STEP 9 (normal paths) were already correct.

## Test plan
- [ ] PR reviewer that finds PR already merged/closed → no orphaned local or remote branch
- [ ] PR reviewer that times out on MERGE_AFTER gate → no orphaned local branch