### PR TITLE
fix: require mandatory comment before gh pr close and clarify D/F grade protocol

### DIFF
--- a/.agentception/agent-command-policy.md
+++ b/.agentception/agent-command-policy.md
@@ -569,6 +569,14 @@ npm publish / pip publish       ← publishing packages
 gh pr merge <N>   ← without having first output "Grade: X" and "Approved for merge"
 ```
 
+### Closing a PR without a mandatory explanation comment
+```
+gh pr close <N>   ← FORBIDDEN unless gh pr comment with the exact reason runs FIRST.
+                  ← For D/F grade: do NOT close the PR — leave it open for the engineer to fix.
+                  ← The only valid reason to close (not merge) a PR is if it is fundamentally
+                  ← broken and must be re-opened from scratch. Even then, comment first.
+```
+
 ---
 
 ## Hard Rules (apply regardless of tier)
@@ -606,7 +614,24 @@ gh pr merge <N>   ← without having first output "Grade: X" and "Approved for m
    | while read ISSUE_NUM; do gh issue close "$ISSUE_NUM" ...; done
    ```
 
-8. **`GH_REPO` is always `cgcardona/agentception` — hardcoded, never derived.**
+8. **Never run `gh pr close` without first posting a mandatory explanation comment.**
+   An agent-closed PR with no comment is untraceable — it leaves the human with no way to
+   understand what failed or what to do next. The required sequence is:
+   ```bash
+   # ✅ Correct — explain before closing:
+   gh pr comment "$N" --repo "$GH_REPO" --body "❌ Closing PR without merge.
+   Reason: <exact reason — D/F grade, fundamental design flaw, etc.>
+   Grade (if reviewed): <grade>
+   Next steps: <what the engineer or human should do>"
+   gh pr close "$N" --repo "$GH_REPO"
+
+   # ❌ Wrong — silent close, leaves humans with no context:
+   gh pr close "$N" --repo "$GH_REPO"
+   ```
+   **For D/F grade: do NOT close the PR.** Leave it open so the engineer can push fixes
+   to the existing branch. File a GitHub issue describing the failures instead and self-destruct.
+
+9. **`GH_REPO` is always `cgcardona/agentception` — hardcoded, never derived.**
    The local path (e.g. `/Users/<you>`) contains the local repo directory which is
    NOT the GitHub org. Using `gh` without `--repo "$GH_REPO"` or with a derived slug causes
    "Forbidden" / "Repository not found" errors.

--- a/.agentception/prompts/parallel-pr-review.md
+++ b/.agentception/prompts/parallel-pr-review.md
@@ -887,7 +887,18 @@ STEP 5 — REVIEW:
      A       → proceed to STEP 5.5 (merge order gate)
      B       → fix in place per GRADE B protocol above, upgrade to A, then STEP 5.5
      C       → fix in place per GRADE C protocol above, re-grade, then STEP 5.5
-     D or F  → DO NOT merge. File a GitHub issue (bug + batch label). Self-destruct. Report to user.
+     D or F  → DO NOT merge. DO NOT close the PR. Leave it OPEN so the engineer can push fixes.
+               File a GitHub issue (bug + batch label) describing the failures. Self-destruct.
+               Report to user.
+
+  ⚠️  NEVER run `gh pr close` for a D/F grade — a closed PR destroys the branch context and
+  leaves no audit trail. The PR must stay OPEN so the engineer sees it and can iterate.
+  The only time a reviewer may close a PR (not merge it) is if the PR is so fundamentally
+  wrong it must be replaced with a fresh branch — and even then, you MUST post an explanatory
+  comment FIRST:
+    gh pr comment "$N" --repo "$GH_REPO" --body "❌ Closing PR without merge.
+  Reason: <exact reason>  Grade: <grade>  Next steps: <what engineer should do>"
+    gh pr close "$N" --repo "$GH_REPO"
 
 STEP 5.5 — MERGE ORDER GATE (sequential chain safety):
   Read the MERGE_AFTER field from .agent-task:


### PR DESCRIPTION
## Summary

PR #101 was silently closed by an agent with no comment — no explanation, no audit trail. The root cause: no prompt or policy forbade \`gh pr close\` or required an explanation comment before running it. The LLM hallucinated it as a logical cleanup step.

- **`agent-command-policy.md`**: Added \`gh pr close\` to the Red (forbidden) section — it is forbidden without a preceding \`gh pr comment\` explaining the reason. Added Hard Rule #8 with the exact required comment format. Clarified D/F grade = leave the PR open, never close it.
- **`parallel-pr-review.md`**: Expanded the D/F grade decision block to explicitly say DO NOT close the PR; leave it open so the engineer can push fixes. Added the rare-case close protocol (comment first) for when a fresh branch is genuinely needed.

## Test plan
- [ ] Reviewer that gives a D/F grade leaves the PR open with a filed GitHub issue
- [ ] Any future PR close by an agent includes an explanatory comment visible in the PR timeline