### PR TITLE
docs: document ENRICHED_MANIFEST: block in coordinator.md and integrate.md

### DIFF
--- a/.agentception/roles/coordinator.md
+++ b/.agentception/roles/coordinator.md
@@ -37,6 +37,60 @@ Read from GitHub labels only:
 
 Every `.agent-task` you write includes `ATTEMPT_N=0`. If a child reports back with `ATTEMPT_N > 2`: do not retry. File a `bug` issue, include the `.agent-task` and last output, escalate to the human.
 
+## ENRICHED_MANIFEST: block
+
+When the `.agent-task` file contains an `ENRICHED_MANIFEST:` key followed by a fenced JSON block, the manifest is **pre-enriched**. Skip the Phase Planner and classification steps entirely.
+
+### What the manifest contains
+
+```
+ENRICHED_MANIFEST:
+```json
+{
+  "initiative": "my-feature",
+  "phases": [
+    {
+      "label": "0-foundation",
+      "description": "...",
+      "depends_on": [],
+      "issues": [
+        {
+          "title": "Add DB schema",
+          "body": "...",
+          "labels": ["phase-0/foundation", "type/feature"],
+          "phase": "0-foundation",
+          "depends_on": [],
+          "can_parallel": true,
+          "acceptance_criteria": ["..."],
+          "tests_required": ["..."],
+          "docs_required": ["..."]
+        }
+      ],
+      "parallel_groups": [["Add DB schema"]]
+    }
+  ]
+}
+```
+```
+
+| Field | Meaning |
+|-------|---------|
+| `phases[*].issues` | Fully-specified GitHub issue payloads — title, body, labels, acceptance criteria, tests, and docs are all set. |
+| `phases[*].parallel_groups` | Lists of issue titles that can be created in the same GitHub API batch. No title in a group may depend on another title in the same group (invariant enforced by `/api/plan/launch`). |
+| `phases[*].depends_on` | Phase-level dependency labels. Phases whose `depends_on` list is empty can start immediately. Later phases wait for all listed phases to complete. |
+| `issues[*].depends_on` | Issue-level dependency titles. References the `title` field (not number) of blocking issues. |
+
+### Coordinator job: execute, not interpret
+
+The depends_on graph has already been validated — no cycles, invariant guaranteed by `/api/plan/launch` before the manifest reaches the `.agent-task` file. You do not need to re-validate or re-interpret the manifest.
+
+Your execution loop:
+
+1. **Process phases in order** — `depends_on` is empty for the first eligible phase. Do not start a phase until all phases listed in its `depends_on` are complete (all issues merged).
+2. **Within a phase, use `parallel_groups` to batch** — each group is one wave. Create all issues in a group concurrently; wait for all to resolve before starting the next group.
+3. **Dispatch one engineer agent per issue** — pass the issue title, body, labels, and `depends_on` titles as the `.agent-task` payload.
+4. **Require a PR URL from every agent** — "Done" without a URL is not done.
+
 ## Failure Modes to Avoid
 
 - Implementing anything yourself.
@@ -44,3 +98,4 @@ Every `.agent-task` you write includes `ATTEMPT_N=0`. If a child reports back wi
 - Accepting "Done" without a PR URL.
 - Continuing past `ATTEMPT_N > 2` without escalating.
 - Dispatching `phase-1/db-schema` work without human approval.
+- Re-running Phase Planner or re-classifying issues when `ENRICHED_MANIFEST:` is present — the manifest is the source of truth.

--- a/docs/guides/integrate.md
+++ b/docs/guides/integrate.md
@@ -70,3 +70,84 @@ The component lives in `agentception/static/js/base.js` and is exported as `batc
 ```
 
 The `x-cloak` attribute prevents a flash of the bar before Alpine initialises. The `[x-cloak] { display: none !important }` rule is defined in `_foundation.scss`.
+
+---
+
+## ENRICHED_MANIFEST: .agent-task format
+
+When `POST /api/plan/launch` spawns a coordinator agent via `plan_spawn_coordinator()`, it writes an `.agent-task` file to the coordinator's git worktree. That file uses a structured key-value format with one special multi-line block: `ENRICHED_MANIFEST:`.
+
+### File format
+
+```
+WORKFLOW=bugs-to-issues
+BATCH_ID=coordinator-20260305-142201
+BRANCH=coordinator/20260305-142201
+WORKTREE=/tmp/worktrees/coordinator-20260305-142201
+
+ENRICHED_MANIFEST:
+```json
+{
+  "initiative": "my-feature",
+  "phases": [...],
+  "total_issues": 12,
+  "estimated_waves": 4
+}
+```
+```
+
+The single-line key-value pairs above `ENRICHED_MANIFEST:` are parsed as `KEY=VALUE`. Everything between the opening ` ```json ` fence and its closing ` ``` ` is the JSON payload — parse it as `EnrichedManifest`.
+
+### EnrichedManifest schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `initiative` | `string \| null` | Human-readable batch name (e.g. `"auth-rewrite"`). Optional. |
+| `phases` | `EnrichedPhase[]` | Ordered phase list. Index 0 is the earliest (no deps). |
+| `total_issues` | `int` | Computed invariant — sum of all `phases[*].issues` lengths. Do not override. |
+| `estimated_waves` | `int` | Computed invariant — critical-path length through the full dependency graph. |
+
+#### EnrichedPhase fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `label` | `string` | Short slug used as the GitHub phase label (e.g. `"0-foundation"`). |
+| `description` | `string` | One-sentence summary of the phase. |
+| `depends_on` | `string[]` | Labels of phases that must fully complete before this phase begins. Empty for the first phase. |
+| `issues` | `EnrichedIssue[]` | Fully-specified GitHub issue payloads for this phase. |
+| `parallel_groups` | `string[][]` | Partition of issue titles into concurrent batches. Each sub-list is one execution wave. |
+
+#### EnrichedIssue fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | `string` | GitHub issue title. |
+| `body` | `string` | Full Markdown issue body (pre-written by the LLM). |
+| `labels` | `string[]` | GitHub label names to apply at creation time. |
+| `phase` | `string` | Phase label this issue belongs to. |
+| `depends_on` | `string[]` | Titles (not numbers) of issues that must be merged before this one begins. |
+| `can_parallel` | `bool` | Whether this issue can run concurrently with others in its `parallel_groups` entry. |
+| `acceptance_criteria` | `string[]` | Checklist items that define "done" for this issue. |
+| `tests_required` | `string[]` | Test cases that must be written. |
+| `docs_required` | `string[]` | Documentation sections that must be updated. |
+
+### Invariants guaranteed by `/api/plan/launch`
+
+- **No dependency cycles** — the `depends_on` graph is a DAG. The API validates this before writing the `.agent-task` file.
+- **No intra-group dependencies** — no title in a `parallel_groups` entry may appear in the `depends_on` list of any other title in the same group.
+- **`total_issues` and `estimated_waves` are computed** — they are derived by `EnrichedManifest` model validators and are always consistent with the actual data.
+
+Coordinator agents reading this block must **execute** — not re-validate or re-interpret. See `coordinator.md` for the execution loop.
+
+### Producing an ENRICHED_MANIFEST: block
+
+Use the `plan_spawn_coordinator` MCP tool:
+
+```python
+result = await plan_spawn_coordinator(manifest_json)
+# Returns: {"worktree": str, "branch": str, "agent_task_path": str, "batch_id": str}
+```
+
+Or call `POST /api/plan/launch` from the Build dashboard — it invokes `plan_spawn_coordinator` internally and returns the same shape.
+
+Do not write `.agent-task` files with `ENRICHED_MANIFEST:` blocks by hand. Always go through `plan_spawn_coordinator` so the manifest is validated before it reaches the coordinator.


### PR DESCRIPTION
## Summary

Closes #44 — add ENRICHED_MANIFEST: documentation to coordinator.md and docs/guides/integrate.md.

- Added `## ENRICHED_MANIFEST: block` section to `.agentception/roles/coordinator.md`
- Added `## ENRICHED_MANIFEST: .agent-task format` section to `docs/guides/integrate.md`

## Root Cause / Motivation

`coordinator.md` had no mention of `ENRICHED_MANIFEST:`. Without documentation, coordinator agents would treat the manifest as unknown content and fall back to interpretation instead of direct execution.

`plan_spawn_coordinator()` in `agentception/mcp/plan_tools.py` already writes an `ENRICHED_MANIFEST: ```json ... ``` ` block to the coordinator `.agent-task` when called from `POST /api/plan/launch`. The data model (`EnrichedManifest`, `EnrichedPhase`, `EnrichedIssue`) was in place but not documented for agent consumers.

## Solution

### coordinator.md
- Documents when to skip Phase Planner/classification (presence of `ENRICHED_MANIFEST:`)
- Explains the manifest structure: `phases[*].issues` (fully-specified payloads), `phases[*].parallel_groups` (concurrent batches), phase-level `depends_on`
- Specifies the execution loop: process phases in dependency order, use `parallel_groups` to batch GitHub API calls, dispatch one engineer agent per issue
- Adds to Failure Modes: do not re-run Phase Planner when manifest is present

### docs/guides/integrate.md
- Documents the full `.agent-task` file format with `ENRICHED_MANIFEST:` block
- Full schema reference for `EnrichedManifest`, `EnrichedPhase`, and `EnrichedIssue`
- Lists invariants guaranteed by `/api/plan/launch` (no cycles, no intra-group deps, computed fields)
- Shows how to produce a manifest block via `plan_spawn_coordinator` MCP tool

## Verification

- [x] No code changes (docs only)
- [x] `coordinator.md` has `ENRICHED_MANIFEST:` section
- [x] `docs/guides/integrate.md` documents the format with full schema reference
- [x] No mypy or pytest runs required

---
<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Role** | `python-developer` |
| **Architecture** | `feynman:python` |
| **Batch** | `eng-20260305T142538Z-5f28` |
| **VP** | `Engineering VP · eng-20260305T142538Z-5f28` |

</details>