### PR TITLE
chore: add node_modules to .gitignore and sync role-versions

### DIFF
--- a/.agentception/role-versions.json
+++ b/.agentception/role-versions.json
@@ -1,7 +1,7 @@
 {
   "versions": {
     "cto": {
-      "current": "v2",
+      "current": "v6",
       "history": [
         {
           "sha": "abcdef1234567890abcdef1234567890abcdef12",
@@ -12,6 +12,26 @@
           "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
           "label": "v2",
           "timestamp": 1772675813
+        },
+        {
+          "sha": "abcdef1234567890abcdef1234567890abcdef12",
+          "label": "v3",
+          "timestamp": 1772721363
+        },
+        {
+          "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "label": "v4",
+          "timestamp": 1772721363
+        },
+        {
+          "sha": "abcdef1234567890abcdef1234567890abcdef12",
+          "label": "v5",
+          "timestamp": 1772721590
+        },
+        {
+          "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "label": "v6",
+          "timestamp": 1772721590
         }
       ]
     }

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,9 @@ logs/
 # Alembic
 alembic/versions/__pycache__/
 
+# Node
+node_modules/
+package-lock.json
+
 # Agent ephemeral briefing files — never committed
 .agent-task


### PR DESCRIPTION
## Summary

- Added `node_modules/` and `package-lock.json` to `.gitignore` — these were missing, causing them to surface as untracked files after the JS dependency install
- Commits `role-versions.json` drift accumulated during recent agent dispatch runs

## Test plan
- [ ] Verify `node_modules/` no longer appears in `git status` after `npm install`
- [ ] Confirm no other files were inadvertently included