### PR TITLE
fix: patch polling_loop globally in conftest to eliminate test-suite hang

### DIFF
--- a/agentception/tests/conftest.py
+++ b/agentception/tests/conftest.py
@@ -9,3 +9,35 @@ AgentCeption is a standalone service; its tests must run cleanly in the
 Run the full agentception suite:
     docker compose exec agentception pytest agentception/tests/ -v
 """
+
+import asyncio
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+
+async def _noop_polling_loop() -> None:
+    """No-op replacement for the real polling_loop used across all tests.
+
+    The real polling_loop immediately calls tick(), which makes live GitHub API
+    and subprocess calls.  Replacing it with this coroutine prevents network I/O
+    during TestClient lifespan startup and eliminates the event-loop cleanup hang
+    that occurred after the test run when dangling poller tasks were orphaned.
+    """
+    try:
+        await asyncio.sleep(float("inf"))
+    except asyncio.CancelledError:
+        return
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _patch_polling_loop() -> Generator[None, None, None]:
+    """Patch agentception.app.polling_loop for the entire test session.
+
+    Scoped to session so a single patch covers every TestClient lifespan
+    startup, regardless of which test file triggers it.  Tests that exercise
+    polling_loop directly import it from agentception.poller and are unaffected.
+    """
+    with patch("agentception.app.polling_loop", _noop_polling_loop):
+        yield

--- a/agentception/tests/test_pipeline_panel.py
+++ b/agentception/tests/test_pipeline_panel.py
@@ -13,7 +13,6 @@ Run targeted:
     pytest agentception/tests/test_pipeline_panel.py -v
 """
 
-import asyncio
 import time
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
@@ -29,31 +28,17 @@ from agentception.models import AgentNode, AgentStatus, BoardIssue, PipelineStat
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
 
-async def _noop_polling_loop() -> None:
-    """No-op replacement for the real polling_loop in tests.
-
-    The real polling_loop immediately calls tick() which makes live GitHub API
-    and subprocess calls.  That causes the third+ TestClient startup to hang
-    when those calls block.  This coroutine sleeps until cancelled so the
-    lifespan can start and stop cleanly without any network I/O.
-    """
-    try:
-        await asyncio.sleep(float("inf"))
-    except asyncio.CancelledError:
-        return
-
-
 @pytest.fixture(scope="module")
 def client() -> Generator[TestClient, None, None]:
-    """Module-scoped test client with mocked poller.
+    """Module-scoped test client.
 
     Scoped to module so the lifespan (DB init + poller task) starts and stops
     exactly once for all HTTP route tests in this file, avoiding repeated
-    startup/shutdown overhead and the associated risk of subprocess hangs.
+    startup/shutdown overhead.  The poller is replaced by _noop_polling_loop
+    via the session-scoped autouse fixture in conftest.py.
     """
-    with patch("agentception.app.polling_loop", _noop_polling_loop):
-        with TestClient(app) as c:
-            yield c
+    with TestClient(app) as c:
+        yield c
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

- 19 test files used `TestClient` without mocking `polling_loop`, causing the real poller to start on every lifespan startup and make live GitHub API / subprocess calls
- Orphaned asyncio tasks attached to closed event loops produced a hard hang after all tests passed — requiring Ctrl+C to exit
- QA reviewer agents interpreted this hang as an incomplete test run and looped indefinitely

## Fix

Added a **session-scoped `autouse` fixture** to `conftest.py` that patches `agentception.app.polling_loop` with a `_noop_polling_loop` coroutine for the entire test session. No individual test files needed changing. Also removed the now-redundant local `_noop_polling_loop` + nested patch from `test_pipeline_panel.py` (the only file that had previously addressed this correctly).

The `agentception.poller` import in `test_agentception_poller.py` is unaffected — that test imports `polling_loop` directly from the module, bypassing the app-level patch.

## Results

| | Before | After |
|---|---|---|
| Duration | ~40s + Ctrl+C required | **749 passed in 11.37s** |
| Exit | Hung (6 "Loop is closed" warnings) | **Clean exit, zero warnings** |
| QA agent behaviour | Looped forever | **Can verify pass/fail and proceed** |

## Test plan
- [x] `mypy` clean on changed files
- [x] `749 passed in 11.37s` — full suite, clean exit