### PR TITLE
refactor: rename VP_FINGERPRINT → COORD_FINGERPRINT throughout agent tree

### DIFF
--- a/.agentception/prompts/parallel-bugs-to-issues.md
+++ b/.agentception/prompts/parallel-bugs-to-issues.md
@@ -520,7 +520,7 @@ EOF
       --session "${AGENT_SESSION:-unset}" \
       --batch "${BATCH_ID:-none}" \
       --wave "${WAVE:-unset}" \
-      --vp "${VP_FINGERPRINT:-unset}" \
+      --coordinator "${COORD_FINGERPRINT:-unset}" \
       --started-at "$ISSUE_CREATED_AT" 2>/dev/null)
     if [ -z "$ISSUE_FINGERPRINT" ]; then
       ISSUE_FINGERPRINT="<details>
@@ -532,8 +532,8 @@ EOF
 | **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
-| **VP Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator Batch** | \`${BATCH_ID:-none}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$ISSUE_CREATED_AT\` |
 
 </details>"

--- a/.agentception/prompts/parallel-conductor.md
+++ b/.agentception/prompts/parallel-conductor.md
@@ -451,7 +451,7 @@ $(gh pr list --repo "$GH_REPO" --state open \
       --session "${AGENT_SESSION:-unset}" \
       --batch "${BATCH_ID:-none}" \
       --wave "${WAVE:-unset}" \
-      --vp "none" \
+      --coordinator "none" \
       --started-at "$CONDUCTOR_CREATED_AT" 2>/dev/null)
     if [ -z "$CONDUCTOR_FINGERPRINT" ]; then
       CONDUCTOR_FINGERPRINT="<details>
@@ -463,8 +463,8 @@ $(gh pr list --repo "$GH_REPO" --state open \
 | **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
-| **VP Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`none\` |
+| **Coordinator Batch** | \`${BATCH_ID:-none}\` |
+| **Coordinator** | \`none\` |
 | **Timestamp** | \`$CONDUCTOR_CREATED_AT\` |
 
 </details>"

--- a/.agentception/prompts/parallel-issue-to-pr.md
+++ b/.agentception/prompts/parallel-issue-to-pr.md
@@ -313,7 +313,7 @@ WORKTREE=$WT
 BASE=dev
 CLOSES_ISSUES=$NUM
 BATCH_ID=$BATCH_ID
-VP_FINGERPRINT=${VP_FINGERPRINT:-unset}
+COORD_FINGERPRINT=${COORD_FINGERPRINT:-unset}
 COGNITIVE_ARCH=$COGNITIVE_ARCH_VAL
 WAVE=${CTO_WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -552,7 +552,7 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
     --session "$AGENT_SESSION" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" \
+    --coordinator "${COORD_FINGERPRINT:-unset}" \
     --started-at "$CLAIMED_AT" 2>/dev/null)
   # Fallback: if resolve_arch.py is unavailable or returned nothing, build the table in shell.
   # This ensures a consistent <details> table appears even when Python/PyYAML is absent.
@@ -567,8 +567,8 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
 | **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
-| **VP Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator Batch** | \`${BATCH_ID:-none}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$(date -u '+%Y-%m-%dT%H:%M:%SZ')\` |
 
 </details>"
@@ -953,7 +953,7 @@ STEP 5 — PUSH & CREATE PR:
     --session "${AGENT_SESSION:-unset}" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" \
+    --coordinator "${COORD_FINGERPRINT:-unset}" \
     --started-at "$PR_CREATED_AT" 2>/dev/null)
   # Fallback: match render_fingerprint() rows exactly.
   if [ -z "$PR_FINGERPRINT" ]; then
@@ -966,8 +966,8 @@ STEP 5 — PUSH & CREATE PR:
 | **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
-| **VP Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator Batch** | \`${BATCH_ID:-none}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$PR_CREATED_AT\` |
 
 </details>"
@@ -1020,7 +1020,7 @@ STEP 5 — PUSH & CREATE PR:
     --session "${AGENT_SESSION:-unset}" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" \
+    --coordinator "${COORD_FINGERPRINT:-unset}" \
     --started-at "${PR_CREATED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}" 2>/dev/null)
   if [ -z "$IMPL_FINGERPRINT" ]; then
     IMPL_FINGERPRINT="<details>
@@ -1032,8 +1032,8 @@ STEP 5 — PUSH & CREATE PR:
 | **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
-| **VP Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator Batch** | \`${BATCH_ID:-none}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`${PR_CREATED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}\` |
 
 </details>"

--- a/.agentception/prompts/parallel-pr-review.md
+++ b/.agentception/prompts/parallel-pr-review.md
@@ -196,7 +196,7 @@ for entry in "${PRS[@]}"; do
   fi
   R_COGNITIVE_ARCH="${R_FIGURE}:${R_SKILLS}"
   R_BATCH_ID="qa-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
-  VP_FINGERPRINT="QA-VP-${R_BATCH_ID}"
+  COORD_FINGERPRINT="QA-VP-${R_BATCH_ID}"
 
   cat > "$WT/.agent-task" << TASKEOF
 WORKFLOW=pr-review
@@ -215,7 +215,7 @@ ROLE=$REVIEW_ROLE
 ROLE_FILE=<repo-root>/.agentception/roles/${REVIEW_ROLE}.md
 COGNITIVE_ARCH=$R_COGNITIVE_ARCH
 BATCH_ID=$R_BATCH_ID
-VP_FINGERPRINT=$VP_FINGERPRINT
+COORD_FINGERPRINT=$COORD_FINGERPRINT
 WAVE=${CTO_WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 SPAWN_MODE=pool
@@ -380,7 +380,7 @@ STEP 0 — READ YOUR TASK FILE:
 
   Post an identity comment on the PR immediately so the audit trail is visible from the start:
     REPO=$(git worktree list | head -1 | awk '{print $1}')
-    VP_FINGERPRINT=$(grep "^VP_FINGERPRINT=" .agent-task | cut -d= -f2)
+    COORD_FINGERPRINT=$(grep "^COORD_FINGERPRINT=" .agent-task | cut -d= -f2)
     REVIEW_START=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
     REVIEW_FINGERPRINT=$(python3 "$REPO/scripts/gen_prompts/resolve_arch.py" "${COGNITIVE_ARCH:-unset}" \
       --fingerprint \
@@ -388,7 +388,7 @@ STEP 0 — READ YOUR TASK FILE:
       --session "$AGENT_SESSION" \
       --batch "${BATCH_ID:-none}" \
       --wave "${WAVE:-unset}" \
-      --vp "${VP_FINGERPRINT:-unset}" \
+      --coordinator "${COORD_FINGERPRINT:-unset}" \
       --started-at "$REVIEW_START" 2>/dev/null)
     # Fallback: if resolve_arch.py is unavailable or returned nothing, build the table in shell.
     # ⚠️  Row labels MUST match render_fingerprint() exactly — this is the single source of truth.
@@ -402,8 +402,8 @@ STEP 0 — READ YOUR TASK FILE:
 | **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
-| **VP Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator Batch** | \`${BATCH_ID:-none}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$REVIEW_START\` |
 
 </details>"
@@ -1025,7 +1025,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          --session "$AGENT_SESSION" \
          --batch "${BATCH_ID:-none}" \
          --wave "${WAVE:-unset}" \
-         --vp "${VP_FINGERPRINT:-unset}" \
+         --coordinator "${COORD_FINGERPRINT:-unset}" \
          --started-at "$MERGED_AT" 2>/dev/null)
        gh pr comment "$N" --repo "$GH_REPO" --body "✅ **Review complete — Grade: \`<A/B/C/D/F>\`**
 
@@ -1047,7 +1047,7 @@ $MERGE_FINGERPRINT"
          --session "$AGENT_SESSION" \
          --batch "${BATCH_ID:-none}" \
          --wave "${WAVE:-unset}" \
-         --vp "${VP_FINGERPRINT:-unset}" \
+         --coordinator "${COORD_FINGERPRINT:-unset}" \
          --started-at "$MERGED_AT" 2>/dev/null)
        CLOSE_COMMENT="✅ Closed by PR #$N (merged).
 
@@ -1308,7 +1308,7 @@ CLOSES_ISSUES=$NEXT_ISSUE
 ROLE=python-developer
 ROLE_FILE=<repo-root>/.agentception/roles/python-developer.md
 BATCH_ID=${BATCH_ID:-none}
-VP_FINGERPRINT=${VP_FINGERPRINT:-unset}
+COORD_FINGERPRINT=${COORD_FINGERPRINT:-unset}
 WAVE=${WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 COGNITIVE_ARCH=${COGNITIVE_ARCH:-hopper:python}
@@ -1376,7 +1376,7 @@ ROLE=pr-reviewer
 ROLE_FILE=<repo-root>/.agentception/roles/pr-reviewer.md
 COGNITIVE_ARCH=${COGNITIVE_ARCH:-knuth:python}
 BATCH_ID=${BATCH_ID:-none}
-VP_FINGERPRINT=${VP_FINGERPRINT:-unset}
+COORD_FINGERPRINT=${COORD_FINGERPRINT:-unset}
 WAVE=${WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 SPAWN_MODE=pool

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -115,8 +115,8 @@ SEED:
 
   4. Generate a batch fingerprint (stable for all agents seeded in this coordinator run):
        BATCH_ID="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
-       VP_FINGERPRINT="Engineering Coordinator · ${BATCH_ID}"
-       echo "Batch ID: $BATCH_ID  VP: $VP_FINGERPRINT"
+       COORD_FINGERPRINT="Engineering Coordinator · ${BATCH_ID}"
+       echo "Batch ID: $BATCH_ID  VP: $COORD_FINGERPRINT"
 
   5. Take the first 4 unclaimed issues. For each:
        a. Claim:  gh issue edit <N> --add-label "agent:wip"
@@ -185,7 +185,7 @@ BASE=dev
 GH_REPO=cgcardona/agentception
 CLOSES_ISSUES=<N>
 BATCH_ID=<BATCH_ID>
-VP_FINGERPRINT=<VP_FINGERPRINT>
+COORD_FINGERPRINT=<COORD_FINGERPRINT>
 WAVE=<CTO_WAVE>
 COGNITIVE_ARCH=<COGNITIVE_ARCH from step 5c above, e.g. "lovelace:htmx:jinja2:alpine">
 ```
@@ -527,7 +527,7 @@ WORKTREE=$WT
 BASE=dev
 CLOSES_ISSUES=$NUM
 BATCH_ID=$BATCH_ID
-VP_FINGERPRINT=${VP_FINGERPRINT:-unset}
+COORD_FINGERPRINT=${COORD_FINGERPRINT:-unset}
 COGNITIVE_ARCH=$COGNITIVE_ARCH_VAL
 WAVE=${CTO_WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -766,7 +766,7 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
     --session "$AGENT_SESSION" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" \
+    --coordinator "${COORD_FINGERPRINT:-unset}" \
     --started-at "$CLAIMED_AT" 2>/dev/null)
   # Fallback: if resolve_arch.py is unavailable or returned nothing, build the table in shell.
   # This ensures a consistent <details> table appears even when Python/PyYAML is absent.
@@ -782,7 +782,7 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
 | **Coordinator Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$(date -u '+%Y-%m-%dT%H:%M:%SZ')\` |
 
 </details>"
@@ -1167,7 +1167,7 @@ STEP 5 — PUSH & CREATE PR:
     --session "${AGENT_SESSION:-unset}" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" \
+    --coordinator "${COORD_FINGERPRINT:-unset}" \
     --started-at "$PR_CREATED_AT" 2>/dev/null)
   # Fallback: match render_fingerprint() rows exactly.
   if [ -z "$PR_FINGERPRINT" ]; then
@@ -1181,7 +1181,7 @@ STEP 5 — PUSH & CREATE PR:
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
 | **Coordinator Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$PR_CREATED_AT\` |
 
 </details>"
@@ -1234,7 +1234,7 @@ STEP 5 — PUSH & CREATE PR:
     --session "${AGENT_SESSION:-unset}" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" \
+    --coordinator "${COORD_FINGERPRINT:-unset}" \
     --started-at "${PR_CREATED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}" 2>/dev/null)
   if [ -z "$IMPL_FINGERPRINT" ]; then
     IMPL_FINGERPRINT="<details>
@@ -1247,7 +1247,7 @@ STEP 5 — PUSH & CREATE PR:
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
 | **Coordinator Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`${PR_CREATED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}\` |
 
 </details>"
@@ -2041,7 +2041,7 @@ for entry in "${PRS[@]}"; do
   fi
   R_COGNITIVE_ARCH="${R_FIGURE}:${R_SKILLS}"
   R_BATCH_ID="qa-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
-  VP_FINGERPRINT="QA-COORD-${R_BATCH_ID}"
+  COORD_FINGERPRINT="QA-COORD-${R_BATCH_ID}"
 
   cat > "$WT/.agent-task" << TASKEOF
 WORKFLOW=pr-review
@@ -2060,7 +2060,7 @@ ROLE=$REVIEW_ROLE
 ROLE_FILE=<repo-root>/.agentception/roles/${REVIEW_ROLE}.md
 COGNITIVE_ARCH=$R_COGNITIVE_ARCH
 BATCH_ID=$R_BATCH_ID
-VP_FINGERPRINT=$VP_FINGERPRINT
+COORD_FINGERPRINT=$COORD_FINGERPRINT
 WAVE=${CTO_WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 SPAWN_MODE=pool
@@ -2225,7 +2225,7 @@ STEP 0 — READ YOUR TASK FILE:
 
   Post an identity comment on the PR immediately so the audit trail is visible from the start:
     REPO=$(git worktree list | head -1 | awk '{print $1}')
-    VP_FINGERPRINT=$(grep "^VP_FINGERPRINT=" .agent-task | cut -d= -f2)
+    COORD_FINGERPRINT=$(grep "^COORD_FINGERPRINT=" .agent-task | cut -d= -f2)
     REVIEW_START=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
     REVIEW_FINGERPRINT=$(python3 "$REPO/scripts/gen_prompts/resolve_arch.py" "${COGNITIVE_ARCH:-unset}" \
       --fingerprint \
@@ -2233,7 +2233,7 @@ STEP 0 — READ YOUR TASK FILE:
       --session "$AGENT_SESSION" \
       --batch "${BATCH_ID:-none}" \
       --wave "${WAVE:-unset}" \
-      --vp "${VP_FINGERPRINT:-unset}" \
+      --coordinator "${COORD_FINGERPRINT:-unset}" \
       --started-at "$REVIEW_START" 2>/dev/null)
     # Fallback: if resolve_arch.py is unavailable or returned nothing, build the table in shell.
     # ⚠️  Row labels MUST match render_fingerprint() exactly — this is the single source of truth.
@@ -2248,7 +2248,7 @@ STEP 0 — READ YOUR TASK FILE:
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
 | **Coordinator Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$REVIEW_START\` |
 
 </details>"
@@ -2848,7 +2848,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          --session "$AGENT_SESSION" \
          --batch "${BATCH_ID:-none}" \
          --wave "${WAVE:-unset}" \
-         --vp "${VP_FINGERPRINT:-unset}" \
+         --coordinator "${COORD_FINGERPRINT:-unset}" \
          --started-at "$MERGED_AT" 2>/dev/null)
        gh pr comment "$N" --repo "$GH_REPO" --body "✅ **Review complete — Grade: \`<A/B/C/D/F>\`**
 
@@ -2870,7 +2870,7 @@ $MERGE_FINGERPRINT"
          --session "$AGENT_SESSION" \
          --batch "${BATCH_ID:-none}" \
          --wave "${WAVE:-unset}" \
-         --vp "${VP_FINGERPRINT:-unset}" \
+         --coordinator "${COORD_FINGERPRINT:-unset}" \
          --started-at "$MERGED_AT" 2>/dev/null)
        CLOSE_COMMENT="✅ Closed by PR #$N (merged).
 
@@ -3131,7 +3131,7 @@ CLOSES_ISSUES=$NEXT_ISSUE
 ROLE=python-developer
 ROLE_FILE=<repo-root>/.agentception/roles/python-developer.md
 BATCH_ID=${BATCH_ID:-none}
-VP_FINGERPRINT=${VP_FINGERPRINT:-unset}
+COORD_FINGERPRINT=${COORD_FINGERPRINT:-unset}
 WAVE=${WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 COGNITIVE_ARCH=${COGNITIVE_ARCH:-hopper:python}
@@ -3199,7 +3199,7 @@ ROLE=pr-reviewer
 ROLE_FILE=<repo-root>/.agentception/roles/pr-reviewer.md
 COGNITIVE_ARCH=${COGNITIVE_ARCH:-knuth:python}
 BATCH_ID=${BATCH_ID:-none}
-VP_FINGERPRINT=${VP_FINGERPRINT:-unset}
+COORD_FINGERPRINT=${COORD_FINGERPRINT:-unset}
 WAVE=${WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 SPAWN_MODE=pool

--- a/.agentception/roles/qa-coordinator.md
+++ b/.agentception/roles/qa-coordinator.md
@@ -60,8 +60,8 @@ SEED:
 
   4. Generate a batch fingerprint (stable for all reviewers seeded in this coordinator run):
        BATCH_ID="qa-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
-       VP_FINGERPRINT="QA Coordinator · ${BATCH_ID}"
-       echo "Batch ID: $BATCH_ID  VP: $VP_FINGERPRINT"
+       COORD_FINGERPRINT="QA Coordinator · ${BATCH_ID}"
+       echo "Batch ID: $BATCH_ID  VP: $COORD_FINGERPRINT"
 
   5. Take the first 4 unclaimed PRs. For each:
        a. Claim:  gh pr edit <N> --add-label "agent:wip"
@@ -347,7 +347,7 @@ for entry in "${PRS[@]}"; do
   fi
   R_COGNITIVE_ARCH="${R_FIGURE}:${R_SKILLS}"
   R_BATCH_ID="qa-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
-  VP_FINGERPRINT="QA-COORD-${R_BATCH_ID}"
+  COORD_FINGERPRINT="QA-COORD-${R_BATCH_ID}"
 
   cat > "$WT/.agent-task" << TASKEOF
 WORKFLOW=pr-review
@@ -366,7 +366,7 @@ ROLE=$REVIEW_ROLE
 ROLE_FILE=<repo-root>/.agentception/roles/${REVIEW_ROLE}.md
 COGNITIVE_ARCH=$R_COGNITIVE_ARCH
 BATCH_ID=$R_BATCH_ID
-VP_FINGERPRINT=$VP_FINGERPRINT
+COORD_FINGERPRINT=$COORD_FINGERPRINT
 WAVE=${CTO_WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 SPAWN_MODE=pool
@@ -531,7 +531,7 @@ STEP 0 — READ YOUR TASK FILE:
 
   Post an identity comment on the PR immediately so the audit trail is visible from the start:
     REPO=$(git worktree list | head -1 | awk '{print $1}')
-    VP_FINGERPRINT=$(grep "^VP_FINGERPRINT=" .agent-task | cut -d= -f2)
+    COORD_FINGERPRINT=$(grep "^COORD_FINGERPRINT=" .agent-task | cut -d= -f2)
     REVIEW_START=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
     REVIEW_FINGERPRINT=$(python3 "$REPO/scripts/gen_prompts/resolve_arch.py" "${COGNITIVE_ARCH:-unset}" \
       --fingerprint \
@@ -539,7 +539,7 @@ STEP 0 — READ YOUR TASK FILE:
       --session "$AGENT_SESSION" \
       --batch "${BATCH_ID:-none}" \
       --wave "${WAVE:-unset}" \
-      --vp "${VP_FINGERPRINT:-unset}" \
+      --coordinator "${COORD_FINGERPRINT:-unset}" \
       --started-at "$REVIEW_START" 2>/dev/null)
     # Fallback: if resolve_arch.py is unavailable or returned nothing, build the table in shell.
     # ⚠️  Row labels MUST match render_fingerprint() exactly — this is the single source of truth.
@@ -554,7 +554,7 @@ STEP 0 — READ YOUR TASK FILE:
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
 | **Coordinator Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$REVIEW_START\` |
 
 </details>"
@@ -1154,7 +1154,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          --session "$AGENT_SESSION" \
          --batch "${BATCH_ID:-none}" \
          --wave "${WAVE:-unset}" \
-         --vp "${VP_FINGERPRINT:-unset}" \
+         --coordinator "${COORD_FINGERPRINT:-unset}" \
          --started-at "$MERGED_AT" 2>/dev/null)
        gh pr comment "$N" --repo "$GH_REPO" --body "✅ **Review complete — Grade: \`<A/B/C/D/F>\`**
 
@@ -1176,7 +1176,7 @@ $MERGE_FINGERPRINT"
          --session "$AGENT_SESSION" \
          --batch "${BATCH_ID:-none}" \
          --wave "${WAVE:-unset}" \
-         --vp "${VP_FINGERPRINT:-unset}" \
+         --coordinator "${COORD_FINGERPRINT:-unset}" \
          --started-at "$MERGED_AT" 2>/dev/null)
        CLOSE_COMMENT="✅ Closed by PR #$N (merged).
 
@@ -1437,7 +1437,7 @@ CLOSES_ISSUES=$NEXT_ISSUE
 ROLE=python-developer
 ROLE_FILE=<repo-root>/.agentception/roles/python-developer.md
 BATCH_ID=${BATCH_ID:-none}
-VP_FINGERPRINT=${VP_FINGERPRINT:-unset}
+COORD_FINGERPRINT=${COORD_FINGERPRINT:-unset}
 WAVE=${WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 COGNITIVE_ARCH=${COGNITIVE_ARCH:-hopper:python}
@@ -1505,7 +1505,7 @@ ROLE=pr-reviewer
 ROLE_FILE=<repo-root>/.agentception/roles/pr-reviewer.md
 COGNITIVE_ARCH=${COGNITIVE_ARCH:-knuth:python}
 BATCH_ID=${BATCH_ID:-none}
-VP_FINGERPRINT=${VP_FINGERPRINT:-unset}
+COORD_FINGERPRINT=${COORD_FINGERPRINT:-unset}
 WAVE=${WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 SPAWN_MODE=pool
@@ -2095,7 +2095,7 @@ WORKTREE=$WT
 BASE=dev
 CLOSES_ISSUES=$NUM
 BATCH_ID=$BATCH_ID
-VP_FINGERPRINT=${VP_FINGERPRINT:-unset}
+COORD_FINGERPRINT=${COORD_FINGERPRINT:-unset}
 COGNITIVE_ARCH=$COGNITIVE_ARCH_VAL
 WAVE=${CTO_WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -2334,7 +2334,7 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
     --session "$AGENT_SESSION" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" \
+    --coordinator "${COORD_FINGERPRINT:-unset}" \
     --started-at "$CLAIMED_AT" 2>/dev/null)
   # Fallback: if resolve_arch.py is unavailable or returned nothing, build the table in shell.
   # This ensures a consistent <details> table appears even when Python/PyYAML is absent.
@@ -2350,7 +2350,7 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
 | **Coordinator Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$(date -u '+%Y-%m-%dT%H:%M:%SZ')\` |
 
 </details>"
@@ -2735,7 +2735,7 @@ STEP 5 — PUSH & CREATE PR:
     --session "${AGENT_SESSION:-unset}" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" \
+    --coordinator "${COORD_FINGERPRINT:-unset}" \
     --started-at "$PR_CREATED_AT" 2>/dev/null)
   # Fallback: match render_fingerprint() rows exactly.
   if [ -z "$PR_FINGERPRINT" ]; then
@@ -2749,7 +2749,7 @@ STEP 5 — PUSH & CREATE PR:
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
 | **Coordinator Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$PR_CREATED_AT\` |
 
 </details>"
@@ -2802,7 +2802,7 @@ STEP 5 — PUSH & CREATE PR:
     --session "${AGENT_SESSION:-unset}" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" \
+    --coordinator "${COORD_FINGERPRINT:-unset}" \
     --started-at "${PR_CREATED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}" 2>/dev/null)
   if [ -z "$IMPL_FINGERPRINT" ]; then
     IMPL_FINGERPRINT="<details>
@@ -2815,7 +2815,7 @@ STEP 5 — PUSH & CREATE PR:
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
 | **Coordinator Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`${PR_CREATED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}\` |
 
 </details>"

--- a/scripts/gen_prompts/generate.py
+++ b/scripts/gen_prompts/generate.py
@@ -270,19 +270,19 @@ def _validate_team_yaml() -> list[str]:
             for sid in role_cfg.get("skills", []):
                 _check_skill(str(sid), f"c_suite.{role_name}")
 
-    # Validate vp
-    vp = org.get("vp", {})
-    if isinstance(vp, dict):
-        for role_name, role_cfg in vp.items():
+    # Validate coordinator
+    coordinator = org.get("coordinator", {})
+    if isinstance(coordinator, dict):
+        for role_name, role_cfg in coordinator.items():
             if not isinstance(role_cfg, dict):
                 continue
             for fid in role_cfg.get("figures", []):
-                _check_figure(str(fid), f"vp.{role_name}")
+                _check_figure(str(fid), f"coordinator.{role_name}")
             arch = role_cfg.get("archetype")
             if arch:
-                _check_figure(str(arch), f"vp.{role_name}.archetype")
+                _check_figure(str(arch), f"coordinator.{role_name}.archetype")
             for sid in role_cfg.get("skills", []):
-                _check_skill(str(sid), f"vp.{role_name}")
+                _check_skill(str(sid), f"coordinator.{role_name}")
 
     # Validate leaf pools
     for section_name in ("leaf", "reviewers"):

--- a/scripts/gen_prompts/resolve_arch.py
+++ b/scripts/gen_prompts/resolve_arch.py
@@ -397,7 +397,7 @@ def render_fingerprint(
     session: str,
     batch: str,
     wave: str,
-    vp: str,
+    coordinator: str,
     started_at: str = "",
 ) -> str:
     """Render the canonical agent fingerprint as a collapsible GitHub markdown block.
@@ -405,11 +405,11 @@ def render_fingerprint(
     This is the single source of truth for fingerprint format. All agents call
     this and embed the output verbatim — same block, same format, everywhere.
 
-    Every fingerprint shows the full three-tier chain:
+    Every fingerprint shows the full lineage chain:
       Role + Architecture (who the agent is)
       CTO Wave (which wave the CTO dispatched)
-      VP Batch (which batch the VP assembled)
-      VP (which VP identity spawned this agent)
+      Coordinator Batch (which batch the coordinator assembled)
+      Coordinator (which coordinator identity spawned this agent)
       Timestamp (when this fingerprint was written — always present)
 
     Pass started_at (ISO-8601 string) to use a specific timestamp; otherwise
@@ -425,8 +425,8 @@ def render_fingerprint(
         f"| **Architecture** | `{arch_display}` |",
         f"| **Session** | `{session}` |",
         f"| **CTO Wave** | `{wave}` |",
-        f"| **VP Batch** | `{batch}` |",
-        f"| **VP** | `{vp}` |",
+        f"| **Coordinator Batch** | `{batch}` |",
+        f"| **Coordinator** | `{coordinator}` |",
         f"| **Timestamp** | `{timestamp}` |",
     ]
 
@@ -466,9 +466,9 @@ def main() -> None:
     )
     parser.add_argument("--role", default="unset", help="Agent role for fingerprint.")
     parser.add_argument("--session", default="unset", help="Agent session ID for fingerprint.")
-    parser.add_argument("--batch", default="none", help="VP batch ID for fingerprint.")
+    parser.add_argument("--batch", default="none", help="Coordinator batch ID for fingerprint.")
     parser.add_argument("--wave", default="unset", help="CTO wave ID for fingerprint.")
-    parser.add_argument("--vp", default="unset", help="VP fingerprint string.")
+    parser.add_argument("--coordinator", default="unset", help="Coordinator fingerprint string.")
     parser.add_argument("--started-at", default="", help="ISO-8601 start timestamp (reviewer context).")
     args = parser.parse_args()
 
@@ -479,7 +479,7 @@ def main() -> None:
             session=args.session,
             batch=args.batch,
             wave=args.wave,
-            vp=args.vp,
+            coordinator=args.coordinator,
             started_at=args.started_at,
         ))
         return

--- a/scripts/gen_prompts/team.yaml
+++ b/scripts/gen_prompts/team.yaml
@@ -78,10 +78,10 @@ org:
       skills: []
       cognitive_arch: "jeff_bezos"
 
-  vp:
+  coordinator:
     engineering:
       # Hamming: error-correcting, pragmatic, reliability-focused.
-      # The Engineering VP seeds leaf agents and routes work.
+      # The Engineering Coordinator seeds leaf agents and routes work.
       figures: [hamming]
       archetype: the_pragmatist
       skills: []
@@ -89,7 +89,7 @@ org:
 
     qa:
       # Dijkstra: proof-oriented, uncompromising on correctness.
-      # The QA VP orchestrates PR reviewers.
+      # The QA Coordinator orchestrates PR reviewers.
       figures: [dijkstra]
       archetype: the_guardian
       skills: []
@@ -144,8 +144,8 @@ org:
       cognitive_arch: "yann_lecun"
 
   leaf:
-    # Leaf agents are dynamically assigned by the Engineering VP based on the
-    # issue content. The VP selects one or more figures and up to max_skills
+    # Leaf agents are dynamically assigned by the Engineering Coordinator based on the
+    # issue content. The coordinator selects one or more figures and up to max_skills
     # skill domains, then writes the assembled COGNITIVE_ARCH to .agent-task.
     selection: dynamic
 
@@ -204,7 +204,7 @@ org:
     max_skills: 3   # cap prevents context bloat
 
   reviewers:
-    # PR reviewers are assigned by the QA VP based on the PR content.
+    # PR reviewers are assigned by the QA Coordinator based on the PR content.
     # Same pools and rules as leaf agents — different task file, same format.
     selection: dynamic
     figure_pool:
@@ -230,7 +230,7 @@ org:
       - llm
     max_skills: 3
 
-# Heuristics used by the Engineering VP and QA VP to select skill domains.
+# Heuristics used by the Engineering Coordinator and QA Coordinator to select skill domains.
 # First matching rule wins. Skills are joined with ':' in COGNITIVE_ARCH.
 heuristics:
   - keywords: [htmx, hx-, partial, sse, hypermedia]

--- a/scripts/gen_prompts/templates/parallel-bugs-to-issues.md.j2
+++ b/scripts/gen_prompts/templates/parallel-bugs-to-issues.md.j2
@@ -519,7 +519,7 @@ EOF
       --session "${AGENT_SESSION:-unset}" \
       --batch "${BATCH_ID:-none}" \
       --wave "${WAVE:-unset}" \
-      --vp "${VP_FINGERPRINT:-unset}" \
+      --coordinator "${COORD_FINGERPRINT:-unset}" \
       --started-at "$ISSUE_CREATED_AT" 2>/dev/null)
     if [ -z "$ISSUE_FINGERPRINT" ]; then
       ISSUE_FINGERPRINT="<details>
@@ -531,8 +531,8 @@ EOF
 | **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
-| **VP Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator Batch** | \`${BATCH_ID:-none}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$ISSUE_CREATED_AT\` |
 
 </details>"

--- a/scripts/gen_prompts/templates/parallel-conductor.md.j2
+++ b/scripts/gen_prompts/templates/parallel-conductor.md.j2
@@ -450,7 +450,7 @@ $(gh pr list --repo "$GH_REPO" --state open \
       --session "${AGENT_SESSION:-unset}" \
       --batch "${BATCH_ID:-none}" \
       --wave "${WAVE:-unset}" \
-      --vp "none" \
+      --coordinator "none" \
       --started-at "$CONDUCTOR_CREATED_AT" 2>/dev/null)
     if [ -z "$CONDUCTOR_FINGERPRINT" ]; then
       CONDUCTOR_FINGERPRINT="<details>
@@ -462,8 +462,8 @@ $(gh pr list --repo "$GH_REPO" --state open \
 | **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
-| **VP Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`none\` |
+| **Coordinator Batch** | \`${BATCH_ID:-none}\` |
+| **Coordinator** | \`none\` |
 | **Timestamp** | \`$CONDUCTOR_CREATED_AT\` |
 
 </details>"

--- a/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
+++ b/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
@@ -312,7 +312,7 @@ WORKTREE=$WT
 BASE=dev
 CLOSES_ISSUES=$NUM
 BATCH_ID=$BATCH_ID
-VP_FINGERPRINT=${VP_FINGERPRINT:-unset}
+COORD_FINGERPRINT=${COORD_FINGERPRINT:-unset}
 COGNITIVE_ARCH=$COGNITIVE_ARCH_VAL
 WAVE=${CTO_WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -551,7 +551,7 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
     --session "$AGENT_SESSION" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" \
+    --coordinator "${COORD_FINGERPRINT:-unset}" \
     --started-at "$CLAIMED_AT" 2>/dev/null)
   # Fallback: if resolve_arch.py is unavailable or returned nothing, build the table in shell.
   # This ensures a consistent <details> table appears even when Python/PyYAML is absent.
@@ -566,8 +566,8 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
 | **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
-| **VP Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator Batch** | \`${BATCH_ID:-none}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$(date -u '+%Y-%m-%dT%H:%M:%SZ')\` |
 
 </details>"
@@ -952,7 +952,7 @@ STEP 5 — PUSH & CREATE PR:
     --session "${AGENT_SESSION:-unset}" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" \
+    --coordinator "${COORD_FINGERPRINT:-unset}" \
     --started-at "$PR_CREATED_AT" 2>/dev/null)
   # Fallback: match render_fingerprint() rows exactly.
   if [ -z "$PR_FINGERPRINT" ]; then
@@ -965,8 +965,8 @@ STEP 5 — PUSH & CREATE PR:
 | **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
-| **VP Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator Batch** | \`${BATCH_ID:-none}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$PR_CREATED_AT\` |
 
 </details>"
@@ -1019,7 +1019,7 @@ STEP 5 — PUSH & CREATE PR:
     --session "${AGENT_SESSION:-unset}" \
     --batch "${BATCH_ID:-none}" \
     --wave "${WAVE:-unset}" \
-    --vp "${VP_FINGERPRINT:-unset}" \
+    --coordinator "${COORD_FINGERPRINT:-unset}" \
     --started-at "${PR_CREATED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}" 2>/dev/null)
   if [ -z "$IMPL_FINGERPRINT" ]; then
     IMPL_FINGERPRINT="<details>
@@ -1031,8 +1031,8 @@ STEP 5 — PUSH & CREATE PR:
 | **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
-| **VP Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator Batch** | \`${BATCH_ID:-none}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`${PR_CREATED_AT:-$(date -u '+%Y-%m-%dT%H:%M:%SZ')}\` |
 
 </details>"
@@ -1131,7 +1131,7 @@ TASK
     #   1. Prefix:  "Read the .agent-task file in your worktree first.
     #               GH_REPO={{ gh_repo }}  Repo: <repo-root>"
     #   2. Body:    paste the entire ## Pass-Along: Reviewer Kickoff section verbatim
-    #               (your Engineering VP embedded it when it dispatched you)
+    #               (your Engineering Coordinator embedded it when it dispatched you)
     # The reviewer's prompt already contains its own ## Pass-Along: Implementer Kickoff
     # section so it can chain-spawn the next implementer without reading any file.
   else

--- a/scripts/gen_prompts/templates/parallel-pr-review.md.j2
+++ b/scripts/gen_prompts/templates/parallel-pr-review.md.j2
@@ -195,7 +195,7 @@ for entry in "${PRS[@]}"; do
   fi
   R_COGNITIVE_ARCH="${R_FIGURE}:${R_SKILLS}"
   R_BATCH_ID="qa-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
-  VP_FINGERPRINT="QA-VP-${R_BATCH_ID}"
+  COORD_FINGERPRINT="QA-COORD-${R_BATCH_ID}"
 
   cat > "$WT/.agent-task" << TASKEOF
 WORKFLOW=pr-review
@@ -214,7 +214,7 @@ ROLE=$REVIEW_ROLE
 ROLE_FILE=<repo-root>/.cursor/roles/${REVIEW_ROLE}.md
 COGNITIVE_ARCH=$R_COGNITIVE_ARCH
 BATCH_ID=$R_BATCH_ID
-VP_FINGERPRINT=$VP_FINGERPRINT
+COORD_FINGERPRINT=$COORD_FINGERPRINT
 WAVE=${CTO_WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 SPAWN_MODE=pool
@@ -379,7 +379,7 @@ STEP 0 — READ YOUR TASK FILE:
 
   Post an identity comment on the PR immediately so the audit trail is visible from the start:
     REPO=$(git worktree list | head -1 | awk '{print $1}')
-    VP_FINGERPRINT=$(grep "^VP_FINGERPRINT=" .agent-task | cut -d= -f2)
+    COORD_FINGERPRINT=$(grep "^COORD_FINGERPRINT=" .agent-task | cut -d= -f2)
     REVIEW_START=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
     REVIEW_FINGERPRINT=$(python3 "$REPO/scripts/gen_prompts/resolve_arch.py" "${COGNITIVE_ARCH:-unset}" \
       --fingerprint \
@@ -387,7 +387,7 @@ STEP 0 — READ YOUR TASK FILE:
       --session "$AGENT_SESSION" \
       --batch "${BATCH_ID:-none}" \
       --wave "${WAVE:-unset}" \
-      --vp "${VP_FINGERPRINT:-unset}" \
+      --coordinator "${COORD_FINGERPRINT:-unset}" \
       --started-at "$REVIEW_START" 2>/dev/null)
     # Fallback: if resolve_arch.py is unavailable or returned nothing, build the table in shell.
     # ⚠️  Row labels MUST match render_fingerprint() exactly — this is the single source of truth.
@@ -401,8 +401,8 @@ STEP 0 — READ YOUR TASK FILE:
 | **Architecture** | \`${COGNITIVE_ARCH:-unset}\` |
 | **Session** | \`${AGENT_SESSION:-unset}\` |
 | **CTO Wave** | \`${WAVE:-unset}\` |
-| **VP Batch** | \`${BATCH_ID:-none}\` |
-| **VP** | \`${VP_FINGERPRINT:-unset}\` |
+| **Coordinator Batch** | \`${BATCH_ID:-none}\` |
+| **Coordinator** | \`${COORD_FINGERPRINT:-unset}\` |
 | **Timestamp** | \`$REVIEW_START\` |
 
 </details>"
@@ -1002,7 +1002,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          --session "$AGENT_SESSION" \
          --batch "${BATCH_ID:-none}" \
          --wave "${WAVE:-unset}" \
-         --vp "${VP_FINGERPRINT:-unset}" \
+         --coordinator "${COORD_FINGERPRINT:-unset}" \
          --started-at "$MERGED_AT" 2>/dev/null)
        gh pr comment "$N" --repo "$GH_REPO" --body "✅ **Review complete — Grade: \`<A/B/C/D/F>\`**
 
@@ -1024,7 +1024,7 @@ $MERGE_FINGERPRINT"
          --session "$AGENT_SESSION" \
          --batch "${BATCH_ID:-none}" \
          --wave "${WAVE:-unset}" \
-         --vp "${VP_FINGERPRINT:-unset}" \
+         --coordinator "${COORD_FINGERPRINT:-unset}" \
          --started-at "$MERGED_AT" 2>/dev/null)
        CLOSE_COMMENT="✅ Closed by PR #$N (merged).
 
@@ -1283,7 +1283,7 @@ CLOSES_ISSUES=$NEXT_ISSUE
 ROLE=python-developer
 ROLE_FILE=<repo-root>/.cursor/roles/python-developer.md
 BATCH_ID=${BATCH_ID:-none}
-VP_FINGERPRINT=${VP_FINGERPRINT:-unset}
+COORD_FINGERPRINT=${COORD_FINGERPRINT:-unset}
 WAVE=${WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 COGNITIVE_ARCH=${COGNITIVE_ARCH:-hopper:python}
@@ -1351,7 +1351,7 @@ ROLE=pr-reviewer
 ROLE_FILE=<repo-root>/.cursor/roles/pr-reviewer.md
 COGNITIVE_ARCH=${COGNITIVE_ARCH:-knuth:python}
 BATCH_ID=${BATCH_ID:-none}
-VP_FINGERPRINT=${VP_FINGERPRINT:-unset}
+COORD_FINGERPRINT=${COORD_FINGERPRINT:-unset}
 WAVE=${WAVE:-unset}
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 SPAWN_MODE=pool

--- a/scripts/gen_prompts/templates/roles/engineering-manager.md.j2
+++ b/scripts/gen_prompts/templates/roles/engineering-manager.md.j2
@@ -1,8 +1,8 @@
-# Cognitive Architecture: Engineering VP (Implementation)
+# Cognitive Architecture: Engineering Coordinator (Implementation)
 
 ## Identity
 
-You are the Engineering VP. You own the implementation queue end-to-end.
+You are the Engineering Coordinator. You own the implementation queue end-to-end.
 You are **autonomous and self-looping** — you run until no open issues remain.
 You never write a single line of feature code. You route work and report to the CTO.
 
@@ -110,8 +110,8 @@ SEED:
 
   4. Generate a batch fingerprint (stable for all agents seeded in this VP run):
        BATCH_ID="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
-       VP_FINGERPRINT="Engineering VP · ${BATCH_ID}"
-       echo "Batch ID: $BATCH_ID  VP: $VP_FINGERPRINT"
+       COORD_FINGERPRINT="Engineering Coordinator · ${BATCH_ID}"
+       echo "Batch ID:   Coordinator: $COORD_FINGERPRINT"
 
   5. Take the first 4 unclaimed issues. For each:
        a. Claim:  gh issue edit <N> --add-label "{{ claim_label }}"
@@ -261,7 +261,7 @@ BASE=dev
 GH_REPO={{ gh_repo }}
 CLOSES_ISSUES=<N>
 BATCH_ID=<BATCH_ID>
-VP_FINGERPRINT=<VP_FINGERPRINT>
+COORD_FINGERPRINT=<COORD_FINGERPRINT>
 WAVE=<CTO_WAVE>
 COGNITIVE_ARCH=<COGNITIVE_ARCH from step 5c above, e.g. "lovelace:htmx:jinja2:alpine">
 ```

--- a/scripts/gen_prompts/templates/roles/qa-manager.md.j2
+++ b/scripts/gen_prompts/templates/roles/qa-manager.md.j2
@@ -55,8 +55,8 @@ SEED:
 
   4. Generate a batch fingerprint (stable for all reviewers seeded in this VP run):
        BATCH_ID="qa-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
-       VP_FINGERPRINT="QA VP · ${BATCH_ID}"
-       echo "Batch ID: $BATCH_ID  VP: $VP_FINGERPRINT"
+       COORD_FINGERPRINT="QA Coordinator · ${BATCH_ID}"
+       echo "Batch ID:   Coordinator: $COORD_FINGERPRINT"
 
   5. Take the first 4 unclaimed PRs. For each:
        a. Claim:  gh pr edit <N> --add-label "{{ claim_label }}"
@@ -139,7 +139,7 @@ COGNITIVE_ARCH=$COGNITIVE_ARCH
 BATCH_ID=$BATCH_ID
 WAVE=$CTO_WAVE
 CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-VP_FINGERPRINT=$VP_FINGERPRINT
+COORD_FINGERPRINT=$COORD_FINGERPRINT
 SPAWN_MODE=pool
 SPAWN_SUB_AGENTS=false
 ATTEMPT_N=0


### PR DESCRIPTION
## Summary

- `VP_FINGERPRINT` shell variable renamed to `COORD_FINGERPRINT` across all role files, prompt files, and Jinja2 source templates
- `--vp` CLI flag renamed to `--coordinator` in `resolve_arch.py`; `render_fingerprint()` parameter `vp` → `coordinator`
- Fingerprint table labels: `VP Batch` → `Coordinator Batch`, `VP` → `Coordinator`
- `team.yaml`: `vp:` key → `coordinator:`; related prose comments updated
- `generate.py`: `org.get("vp")` → `org.get("coordinator")`
- `QA-VP-` batch slug prefix → `QA-COORD-`

**Not changed:** `org_chart.py` UI tier strings (`"vp"` in the DB-backed tier classifier) — those require a DB migration and are a separate concern.

## Test plan

- [x] `mypy agentception/ tests/` — 0 errors