### PR TITLE
refactor: VP → Coordinator domain refactor (PRs 1–3)

### DIFF
--- a/.agentception/role-versions.json
+++ b/.agentception/role-versions.json
@@ -1,7 +1,7 @@
 {
   "versions": {
     "cto": {
-      "current": "v8",
+      "current": "v14",
       "history": [
         {
           "sha": "abcdef1234567890abcdef1234567890abcdef12",
@@ -42,6 +42,36 @@
           "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
           "label": "v8",
           "timestamp": 1772724160
+        },
+        {
+          "sha": "abcdef1234567890abcdef1234567890abcdef12",
+          "label": "v9",
+          "timestamp": 1772726341
+        },
+        {
+          "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "label": "v10",
+          "timestamp": 1772726341
+        },
+        {
+          "sha": "abcdef1234567890abcdef1234567890abcdef12",
+          "label": "v11",
+          "timestamp": 1772726371
+        },
+        {
+          "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "label": "v12",
+          "timestamp": 1772726371
+        },
+        {
+          "sha": "abcdef1234567890abcdef1234567890abcdef12",
+          "label": "v13",
+          "timestamp": 1772726507
+        },
+        {
+          "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "label": "v14",
+          "timestamp": 1772726507
         }
       ]
     }

--- a/.agentception/roles/cdo.md
+++ b/.agentception/roles/cdo.md
@@ -35,8 +35,8 @@ You are responsible for:
 
 You are NOT responsible for:
 - Application databases used by the product (those are Engineering's databases; you get a read replica).
-- Model architecture research (that's VP ML).
-- Infrastructure uptime (that's VP Infrastructure, though you depend on it).
+- Model architecture research (that's ML Coordinator).
+- Infrastructure uptime (that's Infrastructure Coordinator, though you depend on it).
 
 ## Operating Principles
 

--- a/.agentception/roles/ciso.md
+++ b/.agentception/roles/ciso.md
@@ -35,7 +35,7 @@ You are responsible for:
 
 You are NOT responsible for:
 - Software architecture (that's the CTO and architects).
-- General infrastructure uptime (that's VP Infrastructure).
+- General infrastructure uptime (that's Infrastructure Coordinator).
 - Legal interpretation of compliance requirements (that's Legal).
 
 ## Operating Principles

--- a/.agentception/roles/cpo.md
+++ b/.agentception/roles/cpo.md
@@ -34,7 +34,7 @@ You are responsible for:
 
 You are NOT responsible for:
 - How it is built (that's the CTO and Engineering VP).
-- What it looks like (that's VP Design, though you approve it fits the product narrative).
+- What it looks like (that's Design Coordinator, though you approve it fits the product narrative).
 - Financial modeling (that's the CFO).
 
 ## Operating Principles

--- a/.agentception/roles/data-coordinator.md
+++ b/.agentception/roles/data-coordinator.md
@@ -1,6 +1,6 @@
-# Role: VP of Data & Analytics
+# Role: Data Coordinator
 
-You are the VP of Data. You own the organization's analytics infrastructure — the pipelines, warehouses, and tools that transform raw event data into organizational intelligence. You do not run ML research (that's VP ML); you run the data platform that ML research depends on.
+You are the Data Coordinator. You own the organization's analytics infrastructure — the pipelines, warehouses, and tools that transform raw event data into organizational intelligence. You do not run ML research (that's the ML Coordinator); you run the data platform that ML research depends on.
 
 ## Decision Hierarchy
 

--- a/.agentception/roles/design-coordinator.md
+++ b/.agentception/roles/design-coordinator.md
@@ -1,6 +1,6 @@
-# Role: VP of Design / UX
+# Role: Design Coordinator
 
-You are the VP of Design. You own the end-to-end user experience — how the product looks, feels, and works. In an HTMX + Alpine.js + Jinja2 stack, design is not separate from engineering; it is woven into every template, every interaction, every state transition. You collaborate tightly with frontend engineers because your design is expressed in code.
+You are the Design Coordinator. You own the end-to-end user experience — how the product looks, feels, and works. In an HTMX + Alpine.js + Jinja2 stack, design is not separate from engineering; it is woven into every template, every interaction, every state transition. You collaborate tightly with frontend engineers because your design is expressed in code.
 
 ## Decision Hierarchy
 

--- a/.agentception/roles/infrastructure-coordinator.md
+++ b/.agentception/roles/infrastructure-coordinator.md
@@ -1,6 +1,6 @@
-# Role: VP of Infrastructure / DevOps
+# Role: Infrastructure Coordinator
 
-You are the VP of Infrastructure. You own platform reliability — the Docker containers, CI/CD pipelines, observability stack, and cloud infrastructure that every other engineering team depends on. You are the team that enables every other team to ship safely and fast.
+You are the Infrastructure Coordinator. You own platform reliability — the Docker containers, CI/CD pipelines, observability stack, and cloud infrastructure that every other engineering team depends on. You are the team that enables every other team to ship safely and fast.
 
 ## Decision Hierarchy
 

--- a/.agentception/roles/ml-coordinator.md
+++ b/.agentception/roles/ml-coordinator.md
@@ -1,6 +1,6 @@
-# Role: VP of Machine Learning / AI
+# Role: ML Coordinator
 
-You are the VP of ML/AI. You own the machine learning lifecycle — from data and training through evaluation, deployment, and production monitoring. In this codebase, that means the AgentCeption LLM pipeline (Claude via OpenRouter), the Muse music generation system (MIDI-native, Muse protocol), and any future ML capabilities. You are a practitioner, not a theorist.
+You are the ML Coordinator. You own the machine learning lifecycle — from data and training through evaluation, deployment, and production monitoring. In this codebase, that means the AgentCeption LLM pipeline (Claude via OpenRouter), the Muse music generation system (MIDI-native, Muse protocol), and any future ML capabilities. You are a practitioner, not a theorist.
 
 ## Decision Hierarchy
 

--- a/.agentception/roles/mobile-coordinator.md
+++ b/.agentception/roles/mobile-coordinator.md
@@ -1,6 +1,6 @@
-# Role: VP of Mobile
+# Role: Mobile Coordinator
 
-You are the VP of Mobile. You own the iOS/macOS client strategy and the engineering team that builds the Muse client — a macOS application (never iOS; this is a desktop professional tool). You are the executive responsible for the experience that musicians actually touch. Backend APIs serve your needs; you define those needs precisely.
+You are the Mobile Coordinator. You own the iOS/macOS client strategy and the engineering team that builds the Muse client — a macOS application (never iOS; this is a desktop professional tool). You are the executive responsible for the experience that musicians actually touch. Backend APIs serve your needs; you define those needs precisely.
 
 ## Decision Hierarchy
 

--- a/.agentception/roles/platform-coordinator.md
+++ b/.agentception/roles/platform-coordinator.md
@@ -1,6 +1,6 @@
-# Role: VP of Platform Engineering
+# Role: Platform Coordinator
 
-You are the VP of Platform Engineering. You own the internal developer platform — the SDKs, APIs, and developer tooling that every other team at the company uses to build on top of the core product. You are building infrastructure for other engineers; your customers are internal.
+You are the Platform Coordinator. You own the internal developer platform — the SDKs, APIs, and developer tooling that every other team at the company uses to build on top of the core product. You are building infrastructure for other engineers; your customers are internal.
 
 ## Decision Hierarchy
 

--- a/.agentception/roles/product-coordinator.md
+++ b/.agentception/roles/product-coordinator.md
@@ -1,6 +1,6 @@
-# Role: VP of Product
+# Role: Product Coordinator
 
-You are the VP of Product. You own roadmap execution and product discovery. You translate the CPO's strategy into a concrete, sequenced backlog that engineering can execute. You are the bridge between customer insight and shipped product — relentlessly eliminating ambiguity so that no engineer ever wonders what "done" means.
+You are the Product Coordinator. You own roadmap execution and product discovery. You translate the CPO's strategy into a concrete, sequenced backlog that engineering can execute. You are the bridge between customer insight and shipped product — relentlessly eliminating ambiguity so that no engineer ever wonders what "done" means.
 
 ## Decision Hierarchy
 

--- a/.agentception/roles/security-coordinator.md
+++ b/.agentception/roles/security-coordinator.md
@@ -1,6 +1,6 @@
-# Role: VP of Security
+# Role: Security Coordinator
 
-You are the VP of Security. You own application and infrastructure security — the concrete technical controls that translate the CISO's threat model into code, configuration, and process. You are an engineer first; security is the domain. You ship security improvements the same way engineers ship features: with PRs, tests, and documentation.
+You are the Security Coordinator. You own application and infrastructure security — the concrete technical controls that translate the CISO's threat model into code, configuration, and process. You are an engineer first; security is the domain. You ship security improvements the same way engineers ship features: with PRs, tests, and documentation.
 
 ## Decision Hierarchy
 

--- a/agentception/alembic/versions/0008_logical_tier_coordinator_leaf.py
+++ b/agentception/alembic/versions/0008_logical_tier_coordinator_leaf.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Normalise logical_tier values to the 2-type coordinator/leaf model.
+
+The 4-level tier vocabulary (executive | coordinator | engineer | reviewer)
+is replaced by a simple 2-type structural distinction:
+
+  coordinator — surveys its scope and spawns children (any depth)
+  leaf        — works on a single issue or PR
+
+Mapping applied to existing rows:
+  executive  → coordinator   (CTO is a coordinator, not a special tier)
+  coordinator → coordinator  (no change)
+  engineer   → leaf
+  reviewer   → leaf
+
+No column added or removed — only stored string values are updated.
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-03-05
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE agent_runs SET logical_tier = 'coordinator'"
+            " WHERE logical_tier = 'executive'"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE agent_runs SET logical_tier = 'leaf'"
+            " WHERE logical_tier IN ('engineer', 'reviewer')"
+        )
+    )
+
+
+def downgrade() -> None:
+    # Reverse mapping is lossy for the executive→coordinator case.
+    # We restore 'leaf' rows based on role name heuristics; 'coordinator'
+    # rows that were originally 'executive' cannot be distinguished from
+    # genuine coordinator rows — they remain 'coordinator'.
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE agent_runs SET logical_tier = 'engineer'"
+            " WHERE logical_tier = 'leaf'"
+            "   AND role NOT IN ('pr-reviewer')"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE agent_runs SET logical_tier = 'reviewer'"
+            " WHERE logical_tier = 'leaf'"
+            "   AND role IN ('pr-reviewer')"
+        )
+    )

--- a/agentception/db/models.py
+++ b/agentception/db/models.py
@@ -124,19 +124,16 @@ class ACAgentRun(Base):
     """Cognitive architecture string at spawn time, e.g. ``guido_van_rossum:python``."""
 
     logical_tier: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
-    """Organizational tier this run reports to, independent of which agent physically spawned it.
+    """Node type in the agent tree.
 
-    Values: ``executive`` | ``coordinator`` | ``engineer`` | ``reviewer``.
-    A reviewer chain-spawned directly by an engineer still has ``logical_tier='reviewer'``
-    even though no qa-coordinator physically ran; the org chart renders it under the
-    qa-coordinator logical node. Null for legacy rows created before migration 0006.
+    Values: ``coordinator`` | ``leaf``.
+    A coordinator surveys its scope and spawns children; a leaf works one issue/PR.
+    Null for legacy rows created before migration 0006. Normalised in migration 0008.
     """
 
     parent_run_id: Mapped[str | None] = mapped_column(String(512), nullable=True, index=True)
     """Run ID of the agent that physically spawned this one (spawn-lineage tracking).
 
-    Separate from ``logical_tier`` — a reviewer chain-spawned by an engineer has
-    ``parent_run_id`` pointing to the engineer's run and ``logical_tier='reviewer'``.
     Null for top-level dispatches and legacy rows.
     """
 

--- a/agentception/intelligence/scaling.py
+++ b/agentception/intelligence/scaling.py
@@ -11,8 +11,9 @@ Typical usage::
     from agentception.intelligence.scaling import compute_recommendation
 
     recommendation = await compute_recommendation(state, waves)
-    print(recommendation.action)       # "increase_pool"
-    print(recommendation.confidence)   # "high"
+    print(recommendation.action)        # "increase_coordinator_limit"
+    print(recommendation.target_role)   # "qa-coordinator"
+    print(recommendation.confidence)    # "high"
 """
 
 import logging
@@ -31,10 +32,10 @@ logger = logging.getLogger(__name__)
 # Fewer waves → "low" confidence because duration estimates are noisy.
 _MIN_WAVES_FOR_HIGH_CONFIDENCE = 3
 
-# Threshold: PR backlog large enough to warrant an extra QA VP.
+# Threshold: PR backlog large enough to warrant an extra QA coordinator.
 _PR_BACKLOG_THRESHOLD = 2
 
-# Threshold: queue depth that signals under-staffed Engineering VPs.
+# Threshold: queue depth that signals under-staffed engineering coordinators.
 _QUEUE_DEPTH_THRESHOLD = 4
 
 # Threshold: fast average wave duration (minutes) that indicates agents can
@@ -48,14 +49,19 @@ _MAX_SAFE_POOL_SIZE = 8
 class ScalingRecommendation(BaseModel):
     """A single scaling recommendation produced by :func:`compute_recommendation`.
 
-    The ``action`` field drives the dashboard and CTO role prompt — it is
-    a machine-readable verb pair that tells the operator exactly what to change.
+    The ``action`` field drives the dashboard and coordinator role prompts — it
+    is a machine-readable verb that tells the operator exactly what to change.
+
+    ``target_role`` is set for ``increase_coordinator_limit`` actions and
+    identifies which coordinator role slug to bump (e.g. ``"qa-coordinator"``).
+
     ``confidence`` reflects how many completed waves of history are available:
     fewer than :data:`_MIN_WAVES_FOR_HIGH_CONFIDENCE` completed waves always
     yields ``"low"`` confidence even when the thresholds are clearly breached.
     """
 
-    action: Literal["increase_eng_vps", "increase_qa_vps", "increase_pool", "no_change"]
+    action: Literal["increase_coordinator_limit", "increase_pool", "no_change"]
+    target_role: str | None = None
     reason: str
     current_value: int
     recommended_value: int
@@ -70,9 +76,9 @@ async def compute_recommendation(
 
     Decision rules (evaluated in priority order, first match wins):
 
-    1. ``pr_backlog >= 2`` and ``max_qa_vps < 2``  →  increase QA VPs.
-    2. ``queue_depth > 4`` and ``avg_duration < 20`` and ``pool_size_per_vp < 8``
-       →  increase pool size per VP.
+    1. ``pr_backlog >= 2`` and ``qa-coordinator`` limit < 2  →  increase QA coordinator limit.
+    2. ``queue_depth > 4`` and ``avg_duration < 20`` and ``pool_size < 8``
+       →  increase pool size.
     3. Otherwise  →  no change.
 
     Confidence is always ``"low"`` when fewer than
@@ -110,22 +116,26 @@ async def compute_recommendation(
     completed_wave_count = len(completed_durations)
     confidence: Literal["high", "medium", "low"] = _classify_confidence(completed_wave_count)
 
-    # ── Rule 1: QA VP backlog ─────────────────────────────────────────────────
-    if pr_backlog >= _PR_BACKLOG_THRESHOLD and config.max_qa_vps < 2:
+    qa_limit = config.coordinator_limits.get("qa-coordinator", 1)
+
+    # ── Rule 1: QA coordinator backlog ───────────────────────────────────────
+    if pr_backlog >= _PR_BACKLOG_THRESHOLD and qa_limit < 2:
         logger.info(
-            "⚠️  PR backlog %d ≥ %d and max_qa_vps=%d < 2 — recommending increase_qa_vps",
+            "⚠️  PR backlog %d ≥ %d and qa-coordinator limit=%d < 2"
+            " — recommending increase_coordinator_limit",
             pr_backlog,
             _PR_BACKLOG_THRESHOLD,
-            config.max_qa_vps,
+            qa_limit,
         )
         return ScalingRecommendation(
-            action="increase_qa_vps",
+            action="increase_coordinator_limit",
+            target_role="qa-coordinator",
             reason=(
                 f"PR backlog ({pr_backlog}) has reached the threshold of "
-                f"{_PR_BACKLOG_THRESHOLD} but only {config.max_qa_vps} QA VP(s) are "
-                "configured.  Adding a second QA VP will clear the review queue faster."
+                f"{_PR_BACKLOG_THRESHOLD} but only {qa_limit} QA coordinator(s) are "
+                "configured.  Adding a second QA coordinator will clear the review queue faster."
             ),
-            current_value=config.max_qa_vps,
+            current_value=qa_limit,
             recommended_value=2,
             confidence=confidence,
         )
@@ -134,9 +144,9 @@ async def compute_recommendation(
     if (
         queue_depth > _QUEUE_DEPTH_THRESHOLD
         and avg_duration < _AVG_DURATION_FAST_THRESHOLD
-        and config.pool_size_per_vp < _MAX_SAFE_POOL_SIZE
+        and config.pool_size < _MAX_SAFE_POOL_SIZE
     ):
-        new_pool = min(config.pool_size_per_vp + 2, _MAX_SAFE_POOL_SIZE)
+        new_pool = min(config.pool_size + 2, _MAX_SAFE_POOL_SIZE)
         logger.info(
             "⚠️  Queue depth %d > %d, avg_duration=%.1f min < %.0f — recommending increase_pool",
             queue_depth,
@@ -146,14 +156,15 @@ async def compute_recommendation(
         )
         return ScalingRecommendation(
             action="increase_pool",
+            target_role=None,
             reason=(
                 f"Issue queue depth ({queue_depth}) exceeds {_QUEUE_DEPTH_THRESHOLD} "
                 f"while agents complete waves in {avg_duration:.1f} min on average — "
                 f"well under the {_AVG_DURATION_FAST_THRESHOLD:.0f}-min threshold.  "
-                f"Increasing pool size from {config.pool_size_per_vp} to {new_pool} "
+                f"Increasing pool size from {config.pool_size} to {new_pool} "
                 "will absorb the backlog without overloading reviewers."
             ),
-            current_value=config.pool_size_per_vp,
+            current_value=config.pool_size,
             recommended_value=new_pool,
             confidence=confidence,
         )
@@ -162,6 +173,7 @@ async def compute_recommendation(
     logger.info("✅ Pipeline is balanced — no scaling action recommended")
     return ScalingRecommendation(
         action="no_change",
+        target_role=None,
         reason=(
             "Current queue depth, PR backlog, and agent throughput are within "
             "acceptable bounds.  No scaling adjustment is required."

--- a/agentception/mcp/build_tools.py
+++ b/agentception/mcp/build_tools.py
@@ -16,7 +16,7 @@ import logging
 
 from agentception.db.persist import persist_agent_event
 from agentception.db.queries import get_pending_launches
-from agentception.services.spawn_child import ScopeType, SpawnChildError, spawn_child
+from agentception.services.spawn_child import NodeType, ScopeType, SpawnChildError, spawn_child
 
 logger = logging.getLogger(__name__)
 
@@ -34,8 +34,8 @@ async def build_get_pending_launches() -> dict[str, object]:
       - ``batch_id``           — batch fingerprint
 
     The ``role`` field is the tree entry point — the Dispatcher spawns
-    whatever role was assigned. A leaf worker runs directly; a manager
-    (VP, CTO) reads its role file and spawns its own children.
+    whatever role was assigned. A leaf worker runs directly; a coordinator
+    reads its role file and spawns its own children.
     """
     logger.warning("🔍 build_get_pending_launches: querying DB for pending launches")
     launches = await get_pending_launches()
@@ -138,6 +138,7 @@ async def build_report_decision(
 async def build_spawn_child(
     parent_run_id: str,
     role: str,
+    node_type: str,
     scope_type: str,
     scope_value: str,
     gh_repo: str,
@@ -147,15 +148,18 @@ async def build_spawn_child(
 ) -> dict[str, object]:
     """Create a child agent node in the tree and return its worktree path.
 
-    Any manager agent — CTO, coordinator, or any future tier — calls this
-    tool to atomically spawn a child.  The tool creates the worktree, writes
-    the ``.agent-task`` file (with COGNITIVE_ARCH, SCOPE_TYPE, SCOPE_VALUE,
-    PARENT_RUN_ID, and all required fields), registers the DB record, and
-    auto-acknowledges the run so the caller can immediately fire a Task call.
+    Any coordinator agent calls this tool to atomically spawn a child.
+    The tool creates the worktree, writes the ``.agent-task`` file (with
+    NODE_TYPE, COGNITIVE_ARCH, SCOPE_TYPE, SCOPE_VALUE, PARENT_RUN_ID, and
+    all required fields), registers the DB record, and auto-acknowledges the
+    run so the caller can immediately fire a Task call.
 
     Args:
         parent_run_id:  ``run_id`` of the calling agent (lineage tracking).
         role:           Child's role slug (e.g. ``"engineering-coordinator"``).
+        node_type:      ``"coordinator"`` if the child surveys a scope and spawns
+                        its own children; ``"leaf"`` if it works one issue/PR.
+                        The caller always knows which type it is spawning.
         scope_type:     ``"label"``, ``"issue"``, or ``"pr"``.
         scope_value:    Label string, or issue/PR number as a string.
         gh_repo:        ``"owner/repo"`` string.
@@ -165,9 +169,16 @@ async def build_spawn_child(
 
     Returns:
         On success: ``{"ok": True, "run_id": ..., "host_worktree_path": ...,
-                       "tier": ..., "role": ..., "cognitive_arch": ...}``
+                       "node_type": ..., "role": ..., "cognitive_arch": ...}``
         On failure: ``{"ok": False, "error": "<reason>"}``
     """
+    if node_type == "coordinator":
+        nt: NodeType = "coordinator"
+    elif node_type == "leaf":
+        nt = "leaf"
+    else:
+        return {"ok": False, "error": f"node_type must be coordinator/leaf, got {node_type!r}"}
+
     if scope_type == "label":
         scope: ScopeType = "label"
     elif scope_type == "issue":
@@ -181,6 +192,7 @@ async def build_spawn_child(
         result = await spawn_child(
             parent_run_id=parent_run_id,
             role=role,
+            node_type=nt,
             scope_type=scope,
             scope_value=scope_value,
             gh_repo=gh_repo,
@@ -193,14 +205,14 @@ async def build_spawn_child(
         return {"ok": False, "error": str(exc)}
 
     logger.info(
-        "✅ build_spawn_child: spawned run_id=%r role=%r scope=%s:%s",
-        result.run_id, result.role, result.scope_type, result.scope_value,
+        "✅ build_spawn_child: spawned run_id=%r role=%r node_type=%r scope=%s:%s",
+        result.run_id, result.role, result.node_type, result.scope_type, result.scope_value,
     )
     return {
         "ok": True,
         "run_id": result.run_id,
         "host_worktree_path": result.host_worktree_path,
-        "tier": result.tier,
+        "node_type": result.node_type,
         "role": result.role,
         "cognitive_arch": result.cognitive_arch,
         "agent_task_path": result.agent_task_path,

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -207,16 +207,15 @@ TOOLS: list[ACToolDef] = [
         name="build_spawn_child",
         description=(
             "Create a child agent node in the agent tree. "
-            "Any manager agent (CTO, coordinator, or any future tier) calls this "
-            "to atomically create a worktree, write a .agent-task file with "
-            "COGNITIVE_ARCH and full lineage fields, register a DB record, and "
-            "auto-acknowledge the run. Returns {ok, run_id, host_worktree_path, "
-            "tier, role, cognitive_arch, agent_task_path, scope_type, scope_value}. "
+            "Any coordinator agent calls this to atomically create a worktree, "
+            "write a .agent-task file with NODE_TYPE, COGNITIVE_ARCH, and full "
+            "lineage fields, register a DB record, and auto-acknowledge the run. "
+            "Returns {ok, run_id, host_worktree_path, node_type, role, "
+            "cognitive_arch, agent_task_path, scope_type, scope_value}. "
             "After calling this tool, immediately fire a Task with the briefing: "
             "'Read your .agent-task at {host_worktree_path}/.agent-task and follow "
             "the instructions for your role.' "
-            "This is the canonical way to grow the agent tree at runtime — replaces "
-            "manual worktree creation and shell-embedded .agent-task writing."
+            "This is the canonical way to grow the agent tree at runtime."
         ),
         inputSchema={
             "type": "object",
@@ -229,10 +228,15 @@ TOOLS: list[ACToolDef] = [
                     "type": "string",
                     "description": "Child role slug (e.g. 'engineering-coordinator', 'python-developer').",
                 },
+                "node_type": {
+                    "type": "string",
+                    "enum": ["coordinator", "leaf"],
+                    "description": "'coordinator' if the child surveys a scope and spawns its own children; 'leaf' if it works one issue/PR.",
+                },
                 "scope_type": {
                     "type": "string",
                     "enum": ["label", "issue", "pr"],
-                    "description": "'label' for manager/coordinator nodes, 'issue' for engineer nodes, 'pr' for reviewer nodes.",
+                    "description": "'label' for coordinator nodes, 'issue' for leaf engineer nodes, 'pr' for leaf reviewer nodes.",
                 },
                 "scope_value": {
                     "type": "string",
@@ -256,7 +260,7 @@ TOOLS: list[ACToolDef] = [
                     "description": "Explicit skill list override for COGNITIVE_ARCH (bypasses keyword extraction).",
                 },
             },
-            "required": ["parent_run_id", "role", "scope_type", "scope_value", "gh_repo"],
+            "required": ["parent_run_id", "role", "node_type", "scope_type", "scope_value", "gh_repo"],
             "additionalProperties": False,
         },
     ),
@@ -539,18 +543,20 @@ async def call_tool_async(
     if name == "build_spawn_child":
         parent_run_id = arguments.get("parent_run_id")
         role = arguments.get("role")
+        node_type = arguments.get("node_type")
         scope_type = arguments.get("scope_type")
         scope_value = arguments.get("scope_value")
         gh_repo = arguments.get("gh_repo")
         if (
             not isinstance(parent_run_id, str)
             or not isinstance(role, str)
+            or not isinstance(node_type, str)
             or not isinstance(scope_type, str)
             or not isinstance(scope_value, str)
             or not isinstance(gh_repo, str)
         ):
             err_text = _tool_result_to_text(
-                {"error": "parent_run_id, role, scope_type, scope_value, gh_repo (strings) are required"}
+                {"error": "parent_run_id, role, node_type, scope_type, scope_value, gh_repo (strings) are required"}
             )
             return ACToolResult(
                 content=[ACToolContent(type="text", text=err_text)],
@@ -567,6 +573,7 @@ async def call_tool_async(
         result = await build_spawn_child(
             parent_run_id=parent_run_id,
             role=role,
+            node_type=node_type,
             scope_type=scope_type,
             scope_value=scope_value,
             gh_repo=gh_repo,

--- a/agentception/models/__init__.py
+++ b/agentception/models/__init__.py
@@ -79,8 +79,8 @@ class AgentNode(BaseModel):
     Represents one Cursor/Claude agent instance that is either actively working
     or has completed its assigned task. Children are spawned sub-agents.
 
-    ``logical_tier`` is the organisational tier this run reports to regardless
-    of who physically spawned it (executive | coordinator | engineer | reviewer).
+    ``logical_tier`` is the structural node type (``coordinator`` | ``leaf``).
+    A coordinator surveys its scope and spawns children; a leaf works one issue/PR.
     ``parent_run_id`` is the run_id of the agent that physically spawned this one.
     Both are used by the UI to build the virtual org chart with inferred nodes.
     """
@@ -242,7 +242,7 @@ class TaskFile(BaseModel):
     on_block: str | None = None
     cognitive_arch: str | None = None
     logical_tier: str | None = None
-    """Organisational tier (executive | coordinator | engineer | reviewer). Added in 0006."""
+    """Node type in the agent tree (``coordinator`` | ``leaf``). Added in 0006, normalised in 0008."""
     parent_run_id: str | None = None
     """Run ID of the agent that physically spawned this one. Added in 0006."""
 
@@ -293,20 +293,26 @@ class ProjectConfig(BaseModel):
 class PipelineConfig(BaseModel):
     """Validated shape of ``.agentception/pipeline-config.json``.
 
-    This is the single source of truth for pipeline allocation.  The CTO and
-    Engineering VP role files read this model at the start of every loop/seed
-    cycle.  The ``PUT /api/config`` route validates incoming bodies against
-    this schema before persisting them to disk.
+    This is the single source of truth for pipeline allocation.  Coordinator
+    role files read this model at the start of every loop/seed cycle.  The
+    ``PUT /api/config`` route validates incoming bodies against this schema
+    before persisting them to disk.
 
     ``projects`` lists all configured projects; ``active_project`` is the name
     of the currently active one.  When ``active_project`` is set, the dashboard
     targets the corresponding project's ``gh_repo``, ``repo_dir``, and
     ``worktrees_dir`` instead of the defaults in :class:`AgentCeptionSettings`.
+
+    Allocation fields:
+      ``coordinator_limits`` — max concurrent instances per coordinator role slug.
+      ``pool_size``          — number of leaf agents per coordinator instance.
     """
 
-    max_eng_vps: int = Field(gt=0, description="Maximum number of engineering VPs")
-    max_qa_vps: int = Field(gt=0, description="Maximum number of QA VPs")
-    pool_size_per_vp: int = Field(gt=0, description="Pool size per VP")
+    coordinator_limits: dict[str, int] = Field(
+        default={"engineering-coordinator": 1, "qa-coordinator": 1},
+        description="Max concurrent instances per coordinator role slug.",
+    )
+    pool_size: int = Field(default=4, gt=0, description="Leaf agents per coordinator.")
     active_labels_order: list[str]
     ab_mode: AbModeConfig = AbModeConfig()
     projects: list[ProjectConfig] = []

--- a/agentception/readers/pipeline_config.py
+++ b/agentception/readers/pipeline_config.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 """Pipeline configuration reader/writer for AgentCeption.
 
 The canonical source of truth for pipeline allocation parameters is
-``.agentception/pipeline-config.json`` in the repository root.  The CTO and
-Engineering VP role files read this file at the start of every loop/seed
-cycle instead of relying on hardcoded constants.
+``.agentception/pipeline-config.json`` in the repository root.  Coordinator
+role files read this file at the start of every loop/seed cycle instead of
+relying on hardcoded constants.
 
 The dashboard exposes GET/PUT ``/api/config`` routes (see
 ``agentception/routes/api.py``) so operators can adjust allocation without
@@ -21,10 +21,9 @@ from agentception.models import PipelineConfig
 # Default values mirror the spec exactly — used when the config file is absent.
 # Kept as a typed dict so tests can inspect individual keys without constructing
 # a full PipelineConfig.
-_DEFAULTS: dict[str, int | list[str]] = {
-    "max_eng_vps": 1,
-    "max_qa_vps": 1,
-    "pool_size_per_vp": 4,
+_DEFAULTS: dict[str, int | dict[str, int] | list[str]] = {
+    "coordinator_limits": {"engineering-coordinator": 1, "qa-coordinator": 1},
+    "pool_size": 4,
     "active_labels_order": [
         "ac-ui/0-critical-bugs",
         "ac-ui/1-design-tokens",

--- a/agentception/routes/api/_shared.py
+++ b/agentception/routes/api/_shared.py
@@ -77,14 +77,14 @@ ROLE_DEFAULT_FIGURE: dict[str, str] = {
     "ciso":                      "bruce_schneier",
     "cmo":                       "paul_graham",
     # VP roles
-    "vp-platform":               "patrick_collison",
-    "vp-infrastructure":         "linus_torvalds",
-    "vp-data":                   "shannon",
-    "vp-ml":                     "andrej_karpathy",
-    "vp-design":                 "don_norman",
-    "vp-mobile":                 "wozniak",
-    "vp-security":               "bruce_schneier",
-    "vp-product":                "steve_jobs",
+    "platform-coordinator":               "patrick_collison",
+    "infrastructure-coordinator":         "linus_torvalds",
+    "data-coordinator":                   "shannon",
+    "ml-coordinator":                     "andrej_karpathy",
+    "design-coordinator":                 "don_norman",
+    "mobile-coordinator":                 "wozniak",
+    "security-coordinator":               "bruce_schneier",
+    "product-coordinator":                "steve_jobs",
     # Fallback — generic but capable default
     "data-scientist":            "fei_fei_li",
 }

--- a/agentception/routes/api/build.py
+++ b/agentception/routes/api/build.py
@@ -36,7 +36,12 @@ from agentception.db.persist import acknowledge_agent_run, persist_agent_event, 
 from agentception.db.queries import get_agent_run_teardown, get_pending_launches
 from agentception.mcp.plan_advance_phase import plan_advance_phase as _plan_advance_phase
 from agentception.routes.api._shared import _resolve_cognitive_arch
-from agentception.services.spawn_child import SpawnChildError, ScopeType, spawn_child
+from agentception.services.spawn_child import (
+    NodeType,
+    SpawnChildError,
+    ScopeType,
+    spawn_child,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -198,33 +203,24 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
 
 
 # ---------------------------------------------------------------------------
-# Tier → GitHub scope mapping (mirrors agent-tree-protocol.md)
+# Node type helpers for the dispatch-label endpoint
 # ---------------------------------------------------------------------------
 
-# Maps each role slug to its canonical tier.
-_ROLE_TIER: dict[str, str] = {
-    "cto": "executive",
-    "engineering-coordinator": "coordinator",
-    "qa-coordinator": "coordinator",
-    "pr-reviewer": "reviewer",
-}
-_ENGINEERING_ROLES = {
-    "python-developer", "frontend-developer", "typescript-developer",
-    "react-developer", "go-developer", "rust-developer", "api-developer",
-    "devops-engineer", "data-engineer", "site-reliability-engineer",
-    "security-engineer", "mobile-developer", "ios-developer",
-    "android-developer", "full-stack-developer", "architect",
-    "technical-writer", "test-engineer", "ml-engineer", "ml-researcher",
-    "systems-programmer", "rails-developer", "database-architect",
-    "muse-specialist",
-}
-for _r in _ENGINEERING_ROLES:
-    _ROLE_TIER[_r] = "engineer"
+#: Role slugs known to be coordinators (spawn children rather than working directly).
+_COORDINATOR_ROLES: frozenset[str] = frozenset({
+    # C-suite
+    "cto", "csto", "ceo", "cpo", "coo", "cdo", "cfo", "ciso", "cmo",
+    # Domain coordinators
+    "engineering-coordinator", "qa-coordinator", "coordinator", "conductor",
+    "platform-coordinator", "infrastructure-coordinator", "data-coordinator",
+    "ml-coordinator", "design-coordinator", "mobile-coordinator",
+    "security-coordinator", "product-coordinator",
+})
 
 
-def _tier_for_role(role: str) -> str:
-    """Derive the protocol tier for a role slug."""
-    return _ROLE_TIER.get(role, "engineer")
+def _node_type_for_role(role: str) -> NodeType:
+    """Return ``"coordinator"`` for roles that spawn children; ``"leaf"`` otherwise."""
+    return "coordinator" if role in _COORDINATOR_ROLES else "leaf"
 
 
 # ---------------------------------------------------------------------------
@@ -249,7 +245,7 @@ class LabelDispatchResponse(BaseModel):
     """Successful label-dispatch response."""
 
     run_id: str
-    tier: str
+    node_type: str
     role: str
     label: str
     worktree: str
@@ -291,7 +287,7 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
         "🚀 dispatch-label: received request label=%r role=%r repo=%r",
         req.label, req.role, req.repo,
     )
-    tier = _tier_for_role(req.role)
+    node_type = _node_type_for_role(req.role)
     label_slug = _label_slug(req.label)
     batch_id = _make_label_batch_id(req.label)
     run_id = f"label-{label_slug}-{uuid.uuid4().hex[:6]}"
@@ -300,8 +296,8 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
     worktree_path = str(Path(settings.worktrees_dir) / run_id)
     host_worktree_path = str(Path(settings.host_worktrees_dir) / run_id)
     logger.warning(
-        "🚀 dispatch-label: run_id=%r tier=%r worktree_path=%r host_worktree_path=%r",
-        run_id, tier, worktree_path, host_worktree_path,
+        "🚀 dispatch-label: run_id=%r node_type=%r worktree_path=%r host_worktree_path=%r",
+        run_id, node_type, worktree_path, host_worktree_path,
     )
 
     if Path(worktree_path).exists():
@@ -322,7 +318,7 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
         logger.error("❌ dispatch-label: git worktree add failed — %s", err)
         raise HTTPException(status_code=500, detail=f"git worktree add failed: {err}")
 
-    logger.info("✅ dispatch-label: worktree %s for label %r tier=%s", worktree_path, req.label, tier)
+    logger.info("✅ dispatch-label: worktree %s for label %r node_type=%s", worktree_path, req.label, node_type)
 
     ac_url = settings.ac_url
     role_file = str(Path(settings.repo_dir) / ".agentception" / "roles" / f"{req.role}.md")
@@ -335,8 +331,7 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
         f"# See agentception/docs/agent-tree-protocol.md for the full spec.\n\n"
         f"RUN_ID={run_id}\n"
         f"ROLE={req.role}\n"
-        f"TIER={tier}\n"
-        f"LOGICAL_TIER={tier}\n"
+        f"NODE_TYPE={node_type}\n"
         f"SCOPE_TYPE=label\n"
         f"SCOPE_VALUE={req.label}\n"
         f"GH_REPO={req.repo}\n"
@@ -348,21 +343,13 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
         f"ROLE_FILE={role_file}\n"
         f"COGNITIVE_ARCH={label_cognitive_arch}\n"
         f"\n"
-        f"# GitHub queries for this tier ({tier}):\n"
+        f"# GitHub queries for this node (node_type={node_type}, scope_type=label):\n"
     )
 
-    if tier == "executive":
+    if node_type == "coordinator":
         agent_task += (
             f"# gh issue list --repo {req.repo} --label '{req.label}' --state open --json number,title,labels --limit 200\n"
             f"# gh pr list --repo {req.repo} --base dev --state open --json number,title,headRefName --limit 200\n"
-        )
-    elif tier == "coordinator" and req.role == "engineering-coordinator":
-        agent_task += (
-            f"# gh issue list --repo {req.repo} --label '{req.label}' --state open --json number,title,labels --limit 200\n"
-        )
-    elif tier == "coordinator" and req.role == "qa-coordinator":
-        agent_task += (
-            f"# gh pr list --repo {req.repo} --base dev --state open --json number,title,headRefName,reviewDecision --limit 200\n"
         )
 
     agent_task_path = str(Path(worktree_path) / ".agent-task")
@@ -394,14 +381,14 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
         batch_id=batch_id,
         host_worktree_path=host_worktree_path,
         cognitive_arch=label_cognitive_arch,
-        logical_tier=tier,
+        logical_tier=node_type,
         parent_run_id=req.parent_run_id,
     )
     logger.warning("✅ dispatch-label: persist_agent_run_dispatch complete — run_id=%r is now pending_launch", run_id)
 
     return LabelDispatchResponse(
         run_id=run_id,
-        tier=tier,
+        node_type=node_type,
         role=req.role,
         label=req.label,
         worktree=worktree_path,
@@ -485,6 +472,8 @@ class SpawnChildRequest(BaseModel):
     """``run_id`` of the calling manager agent (for lineage tracking)."""
     role: str
     """Child's role slug (e.g. ``"engineering-coordinator"``, ``"python-developer"``)."""
+    node_type: NodeType
+    """``"coordinator"`` if the child spawns children; ``"leaf"`` if it works one issue/PR."""
     scope_type: Literal["label", "issue", "pr"]
     """``"label"``, ``"issue"``, or ``"pr"``."""
     scope_value: str
@@ -505,7 +494,7 @@ class SpawnChildResponse(BaseModel):
     run_id: str
     host_worktree_path: str
     worktree_path: str
-    tier: str
+    node_type: str
     role: str
     cognitive_arch: str
     agent_task_path: str
@@ -541,6 +530,7 @@ async def spawn_child_node(req: SpawnChildRequest) -> SpawnChildResponse:
         result = await spawn_child(
             parent_run_id=req.parent_run_id,
             role=req.role,
+            node_type=req.node_type,
             scope_type=req.scope_type,
             scope_value=req.scope_value,
             gh_repo=req.gh_repo,

--- a/agentception/routes/intelligence.py
+++ b/agentception/routes/intelligence.py
@@ -136,14 +136,14 @@ async def apply_scaling_advice() -> dict[str, object]:
 
         # Mutate only the field that the recommendation targets.
         new_config: PipelineConfig
-        if rec.action == "increase_qa_vps":
-            new_config = config.model_copy(update={"max_qa_vps": rec.recommended_value})
+        if rec.action == "increase_coordinator_limit" and rec.target_role is not None:
+            new_limits = {**config.coordinator_limits, rec.target_role: rec.recommended_value}
+            new_config = config.model_copy(update={"coordinator_limits": new_limits})
         elif rec.action == "increase_pool":
-            new_config = config.model_copy(update={"pool_size_per_vp": rec.recommended_value})
-        elif rec.action == "increase_eng_vps":
-            new_config = config.model_copy(update={"max_eng_vps": rec.recommended_value})
-        # All Literal branches handled above; mypy may still flag the else as unreachable.
-        # The dead-code guard is kept for runtime safety when called with coerced types.
+            new_config = config.model_copy(update={"pool_size": rec.recommended_value})
+        else:
+            # no_change — already handled above; guard against coerced types at runtime
+            return {"applied": rec.action, "new_value": 0}
 
         await write_pipeline_config(new_config)
         logger.info(

--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -72,9 +72,9 @@ _ROLES_DIR = Path(__file__).parent.parent.parent.parent / ".cursor" / "roles"
 
 _ROLE_GROUPS: dict[str, list[str]] = {
     "C-Suite": ["ceo", "cto", "cpo", "coo", "cfo", "cmo", "cdo", "ciso"],
-    "VPs": [
-        "vp-product", "vp-infrastructure", "vp-platform", "vp-ml",
-        "vp-mobile", "vp-data", "vp-design", "vp-security",
+    "Coordinators": [
+        "product-coordinator", "infrastructure-coordinator", "platform-coordinator", "ml-coordinator",
+        "mobile-coordinator", "data-coordinator", "design-coordinator", "security-coordinator",
     ],
     "Engineering": [
         "python-developer", "typescript-developer", "frontend-developer",

--- a/agentception/routes/ui/org_chart.py
+++ b/agentception/routes/ui/org_chart.py
@@ -10,7 +10,7 @@ Provides:
 - ``GET /api/org/tree`` — returns the active preset as a hierarchical JSON
   tree consumed by the D3 tree visualization in ``org_chart_tree.js``.
 - ``GET /api/org/taxonomy`` — returns the role taxonomy grouped by tier (org-chart view)
-  (c_suite / vp / worker) for the Add Role dropdown.
+  (c_suite / coordinator / worker) for the Add Role dropdown.
 - ``POST /api/org/roles/add`` — adds a role to the active builder org and
   returns a refreshed role list partial.
 - ``DELETE /api/org/roles/{slug}`` — removes a role from the builder org and
@@ -148,9 +148,9 @@ ROLE_TAXONOMY: dict[str, list[str]] = {
         "cto", "ceo", "coo", "cfo", "cpo", "cmo", "cdo", "ciso",
     ],
     "coordinator": [
-        "engineering-coordinator", "qa-coordinator", "vp-product", "vp-data", "vp-design",
-        "vp-infrastructure", "vp-ml", "vp-mobile", "vp-platform",
-        "vp-security", "coordinator",
+        "engineering-coordinator", "qa-coordinator", "product-coordinator", "data-coordinator", "design-coordinator",
+        "infrastructure-coordinator", "ml-coordinator", "mobile-coordinator", "platform-coordinator",
+        "security-coordinator", "coordinator",
     ],
     "worker": [
         "python-developer", "api-developer", "database-architect",
@@ -166,7 +166,8 @@ ROLE_TAXONOMY: dict[str, list[str]] = {
 }
 
 #: Tiers that get the phase-assignment multiselect on their role card.
-_PHASE_ASSIGNABLE_TIERS: frozenset[str] = frozenset({"c_suite", "vp"})
+#: Includes c_suite and coordinator since both are coordinator-type nodes.
+_PHASE_ASSIGNABLE_TIERS: frozenset[str] = frozenset({"c_suite", "coordinator"})
 
 
 def _tier_for_slug(slug: str) -> str:
@@ -337,7 +338,7 @@ def _save_preset(name: str, roles: list[RoleEntry]) -> str:
     workers: list[str] = []
     for entry in roles:
         tier = _tier_for_slug(entry["slug"])
-        if tier in ("c_suite", "vp"):
+        if tier in ("c_suite", "coordinator"):
             leadership.append(entry["slug"])
         else:
             workers.append(entry["slug"])
@@ -580,7 +581,7 @@ async def roles_taxonomy() -> JSONResponse:
         {
           "tiers": {
             "c_suite":  {"label": "C-Suite",         "roles": ["cto", ...]},
-            "vp":       {"label": "VP / Coordinator", "roles": ["vp-engineering", ...]},
+            "coordinator": {"label": "Coordinator", "roles": ["engineering-coordinator", ...]},
             "worker":   {"label": "Worker",           "roles": ["python-developer", ...]}
           }
         }

--- a/agentception/services/spawn_child.py
+++ b/agentception/services/spawn_child.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 """Universal child-node spawner for the AgentCeption agent tree.
 
-Any manager agent — CTO, engineering-coordinator, qa-coordinator, or any
-future tier — calls ``spawn_child()`` to atomically:
+Any coordinator agent calls ``spawn_child()`` to atomically:
 
   1. Create a git worktree for the child.
   2. Resolve COGNITIVE_ARCH for the child's role and scope.
@@ -17,16 +16,25 @@ and a short prompt directing the child to read its ``.agent-task``.
 
 Protocol guarantee
 ------------------
-Every node in the agent tree — regardless of tier, scope type, or which
+Every node in the agent tree — regardless of node type, scope type, or which
 parent spawned it — gets:
 
 - A unique ``run_id`` and git worktree.
-- A ``.agent-task`` file containing ``COGNITIVE_ARCH``, ``SCOPE_TYPE``,
-  ``SCOPE_VALUE``, ``TIER``, ``ROLE``, ``ROLE_FILE``, ``PARENT_RUN_ID``,
-  and ``AC_URL``.
+- A ``.agent-task`` file containing ``NODE_TYPE``, ``COGNITIVE_ARCH``,
+  ``SCOPE_TYPE``, ``SCOPE_VALUE``, ``ROLE``, ``ROLE_FILE``,
+  ``PARENT_RUN_ID``, and ``AC_URL``.
 - A DB row visible on the Build board with full lineage back to its root.
 
-Any subtree rooted at any node behaves identically to the full tree —
+Node types
+----------
+``coordinator``
+    Surveys its GitHub scope and spawns child nodes (coordinators or leaves).
+    Any coordinator can be the tree root — there is no special "executive" tier.
+
+``leaf``
+    Works on a single GitHub issue or PR.  Does not spawn children.
+
+Any subtree rooted at any coordinator behaves identically to the full tree —
 pruning a node makes it the entry point without any protocol change.
 """
 
@@ -40,7 +48,7 @@ from typing import Literal
 
 from agentception.config import settings
 from agentception.db.persist import acknowledge_agent_run, persist_agent_run_dispatch
-from agentception.routes.api._shared import ROLE_DEFAULT_FIGURE, _resolve_cognitive_arch
+from agentception.routes.api._shared import _resolve_cognitive_arch
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +57,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 ScopeType = Literal["label", "issue", "pr"]
+
+#: Structural node type — the only two values used in ``logical_tier``.
+NodeType = Literal["coordinator", "leaf"]
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
@@ -60,11 +71,11 @@ class SpawnChildResult:
         run_id:              Unique run identifier (e.g. ``coord-abc123``).
         host_worktree_path:  Absolute path on the HOST filesystem.
         worktree_path:       Absolute path inside the container.
-        tier:                Protocol tier (executive | coordinator | engineer | reviewer).
-        role:                Role slug (e.g. ``engineering-coordinator``).
-        cognitive_arch:      Resolved COGNITIVE_ARCH string (e.g. ``von_neumann:python``).
+        node_type:           ``"coordinator"`` or ``"leaf"``.
+        role:                Role slug (e.g. ``"engineering-coordinator"``).
+        cognitive_arch:      Resolved COGNITIVE_ARCH string.
         agent_task_path:     Path to the written ``.agent-task`` file.
-        scope_type:          ``label``, ``issue``, or ``pr``.
+        scope_type:          ``"label"``, ``"issue"``, or ``"pr"``.
         scope_value:         Label string or issue/PR number.
     """
 
@@ -72,7 +83,7 @@ class SpawnChildResult:
         "run_id",
         "host_worktree_path",
         "worktree_path",
-        "tier",
+        "node_type",
         "role",
         "cognitive_arch",
         "agent_task_path",
@@ -86,7 +97,7 @@ class SpawnChildResult:
         run_id: str,
         host_worktree_path: str,
         worktree_path: str,
-        tier: str,
+        node_type: str,
         role: str,
         cognitive_arch: str,
         agent_task_path: str,
@@ -96,7 +107,7 @@ class SpawnChildResult:
         self.run_id = run_id
         self.host_worktree_path = host_worktree_path
         self.worktree_path = worktree_path
-        self.tier = tier
+        self.node_type = node_type
         self.role = role
         self.cognitive_arch = cognitive_arch
         self.agent_task_path = agent_task_path
@@ -108,50 +119,13 @@ class SpawnChildResult:
             "run_id": self.run_id,
             "host_worktree_path": self.host_worktree_path,
             "worktree_path": self.worktree_path,
-            "tier": self.tier,
+            "node_type": self.node_type,
             "role": self.role,
             "cognitive_arch": self.cognitive_arch,
             "agent_task_path": self.agent_task_path,
             "scope_type": self.scope_type,
             "scope_value": self.scope_value,
         }
-
-
-# ---------------------------------------------------------------------------
-# Tier mapping (mirrors agent-tree-protocol.md)
-# ---------------------------------------------------------------------------
-
-#: Maps every known role slug to its protocol tier.
-#: Defaults to ``"engineer"`` for any unlisted role.
-_ROLE_TIER: dict[str, str] = {
-    "cto": "executive",
-    "csto": "executive",
-    "ceo": "executive",
-    "cpo": "executive",
-    "coo": "executive",
-    "cdo": "executive",
-    "cfo": "executive",
-    "ciso": "executive",
-    "cmo": "executive",
-    "engineering-coordinator": "coordinator",
-    "qa-coordinator": "coordinator",
-    "coordinator": "coordinator",
-    "conductor": "coordinator",
-    "vp-platform": "coordinator",
-    "vp-infrastructure": "coordinator",
-    "vp-data": "coordinator",
-    "vp-ml": "coordinator",
-    "vp-design": "coordinator",
-    "vp-mobile": "coordinator",
-    "vp-security": "coordinator",
-    "vp-product": "coordinator",
-    "pr-reviewer": "reviewer",
-}
-
-
-def tier_for_role(role: str) -> str:
-    """Return the protocol tier for a role slug."""
-    return _ROLE_TIER.get(role, "engineer")
 
 
 # ---------------------------------------------------------------------------
@@ -189,14 +163,14 @@ def _make_batch_id(scope_type: ScopeType, scope_value: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# .agent-task builder (universal — all scope types)
+# .agent-task builder (universal — all scope types and node types)
 # ---------------------------------------------------------------------------
 
 def _build_child_task(
     *,
     run_id: str,
     role: str,
-    tier: str,
+    node_type: str,
     scope_type: ScopeType,
     scope_value: str,
     gh_repo: str,
@@ -213,7 +187,7 @@ def _build_child_task(
 ) -> str:
     """Build the raw text content of a ``.agent-task`` file for any tree node.
 
-    The format is identical regardless of tier or scope type so that the
+    The format is identical regardless of node type or scope type so that the
     Dispatcher, the universal manager briefing, and all role files can use
     the same parsing logic.
     """
@@ -228,8 +202,7 @@ def _build_child_task(
         "",
         f"RUN_ID={run_id}",
         f"ROLE={role}",
-        f"TIER={tier}",
-        f"LOGICAL_TIER={tier}",
+        f"NODE_TYPE={node_type}",
         f"SCOPE_TYPE={scope_type}",
         f"SCOPE_VALUE={scope_value}",
         f"GH_REPO={gh_repo}",
@@ -258,28 +231,20 @@ def _build_child_task(
     lines += [
         f"CREATED_AT={now}",
         "",
-        f"# GitHub queries for this tier ({tier}):",
+        f"# GitHub queries for this node (node_type={node_type}, scope_type={scope_type}):",
     ]
 
-    # Inline query hints by tier
-    if tier == "executive":
+    # Inline query hints by node type and scope
+    if node_type == "coordinator" and scope_type == "label":
         lines += [
             f"# gh issue list --repo {gh_repo} --label '{scope_value}' --state open --json number,title,labels,assignees --limit 200",
             f"# gh pr list --repo {gh_repo} --base dev --state open --json number,title,headRefName,reviewDecision --limit 200",
         ]
-    elif tier == "coordinator" and role == "engineering-coordinator":
-        lines.append(
-            f"# gh issue list --repo {gh_repo} --label '{scope_value}' --state open --json number,title,labels,assignees --limit 200"
-        )
-    elif tier == "coordinator" and role == "qa-coordinator":
-        lines.append(
-            f"# gh pr list --repo {gh_repo} --base dev --state open --json number,title,headRefName,reviewDecision --limit 200"
-        )
-    elif tier == "engineer" and scope_type == "issue":
+    elif node_type == "leaf" and scope_type == "issue":
         lines.append(
             f"# gh issue view {scope_value} --repo {gh_repo} --json number,title,body,labels"
         )
-    elif tier == "reviewer" and scope_type == "pr":
+    elif node_type == "leaf" and scope_type == "pr":
         lines.append(
             f"# gh pr view {scope_value} --repo {gh_repo} --json number,title,body,files,reviews"
         )
@@ -299,6 +264,7 @@ async def spawn_child(
     *,
     parent_run_id: str,
     role: str,
+    node_type: NodeType,
     scope_type: ScopeType,
     scope_value: str,
     gh_repo: str,
@@ -315,6 +281,10 @@ async def spawn_child(
     Args:
         parent_run_id:  ``run_id`` of the calling agent (lineage tracking).
         role:           Child's role slug (e.g. ``"engineering-coordinator"``).
+        node_type:      ``"coordinator"`` if the child spawns children;
+                        ``"leaf"`` if it works one issue/PR directly.
+                        The caller always knows which type it is spawning —
+                        this is never derived from the role slug.
         scope_type:     ``"label"``, ``"issue"``, or ``"pr"``.
         scope_value:    Label string, or issue/PR number as a string.
         gh_repo:        ``"owner/repo"`` string.
@@ -328,7 +298,6 @@ async def spawn_child(
     Raises:
         :class:`SpawnChildError` if worktree creation or file I/O fails.
     """
-    tier = tier_for_role(role)
     run_id = _make_run_id(scope_type, scope_value)
     branch = _make_branch(scope_type, scope_value)
     batch_id = _make_batch_id(scope_type, scope_value)
@@ -358,8 +327,8 @@ async def spawn_child(
         skills_hint=skills_hint,
     )
     logger.info(
-        "🌳 spawn_child: role=%r tier=%r scope=%s:%s arch=%r",
-        role, tier, scope_type, scope_value, cognitive_arch,
+        "🌳 spawn_child: role=%r node_type=%r scope=%s:%s arch=%r",
+        role, node_type, scope_type, scope_value, cognitive_arch,
     )
 
     # Create git worktree
@@ -381,7 +350,7 @@ async def spawn_child(
     task_content = _build_child_task(
         run_id=run_id,
         role=role,
-        tier=tier,
+        node_type=node_type,
         scope_type=scope_type,
         scope_value=scope_value,
         gh_repo=gh_repo,
@@ -425,7 +394,7 @@ async def spawn_child(
         batch_id=batch_id,
         host_worktree_path=host_worktree_path,
         cognitive_arch=cognitive_arch,
-        logical_tier=tier,
+        logical_tier=node_type,
         parent_run_id=parent_run_id,
     )
 
@@ -437,7 +406,7 @@ async def spawn_child(
         run_id=run_id,
         host_worktree_path=host_worktree_path,
         worktree_path=worktree_path,
-        tier=tier,
+        node_type=node_type,
         role=role,
         cognitive_arch=cognitive_arch,
         agent_task_path=agent_task_path,

--- a/agentception/static/js/config.js
+++ b/agentception/static/js/config.js
@@ -8,9 +8,8 @@
  */
 export function configPanel() {
   const defaults = {
-    max_eng_vps: 1,
-    max_qa_vps: 1,
-    pool_size_per_vp: 4,
+    coordinator_limits: { 'engineering-coordinator': 1, 'qa-coordinator': 1 },
+    pool_size: 4,
     active_labels_order: [],
     ab_mode: { enabled: false, target_role: null, variant_a_file: null, variant_b_file: null },
     projects: [],
@@ -29,13 +28,12 @@ export function configPanel() {
     _dragIdx: null,
 
     // ── Computed capacity ──────────────────────────────────────────────────
+    /** Total leaf agent slots = sum of all coordinator limits × pool_size. */
     get totalAgents() {
-      return (this.config.max_eng_vps + this.config.max_qa_vps) * this.config.pool_size_per_vp;
+      const limits = this.config.coordinator_limits || {};
+      const totalCoordinators = Object.values(limits).reduce((s, v) => s + v, 0);
+      return totalCoordinators * (this.config.pool_size || 1);
     },
-    get engSlots() { return this.config.max_eng_vps * this.config.pool_size_per_vp; },
-    get qaSlots()  { return this.config.max_qa_vps  * this.config.pool_size_per_vp; },
-    get engPct()   { return this.totalAgents ? Math.round(this.engSlots / this.totalAgents * 100) : 50; },
-    get qaPct()    { return this.totalAgents ? Math.round(this.qaSlots  / this.totalAgents * 100) : 50; },
 
     // ── Lifecycle ──────────────────────────────────────────────────────────
     async init() {

--- a/agentception/templates/_org_role_list.html
+++ b/agentception/templates/_org_role_list.html
@@ -6,8 +6,8 @@
     active_org_roles — list of annotated role dicts:
         slug             str   — role identifier
         assigned_phases  list  — currently assigned phase labels
-        tier             str   — "c_suite" | "vp" | "worker"
-        phase_assignable bool  — True for c_suite and vp tiers
+        tier             str   — "c_suite" | "coordinator" | "worker"
+        phase_assignable bool  — True for c_suite and coordinator tiers
     phases     — list[str] — available phase label strings
     tier_labels — dict[str, str] — tier key → human label
 #}

--- a/agentception/templates/config.html
+++ b/agentception/templates/config.html
@@ -99,37 +99,30 @@
 
       <div class="cfg-slider-group">
 
-        <div class="cfg-slider-row">
-          <label class="cfg-slider-label" for="slider-eng-vps">Engineering VPs</label>
-          <p class="cfg-slider-hint">Parallel engineering VP agents in the pipeline</p>
-          <input id="slider-eng-vps"
-                 class="cfg-slider-input"
-                 type="range" min="1" max="8" step="1"
-                 x-model.number="config.max_eng_vps"
-                 aria-label="Max Engineering VPs" />
-          <span class="cfg-slider-value" x-text="config.max_eng_vps"></span>
-        </div>
+        {# Coordinator limits — one slider per entry in coordinator_limits #}
+        <template x-for="[role, limit] in Object.entries(config.coordinator_limits)" :key="role">
+          <div class="cfg-slider-row">
+            <label class="cfg-slider-label" :for="'slider-coord-' + role" x-text="role + ' (max concurrent)'"></label>
+            <p class="cfg-slider-hint">Max parallel instances of this coordinator role</p>
+            <input :id="'slider-coord-' + role"
+                   class="cfg-slider-input"
+                   type="range" min="1" max="8" step="1"
+                   :value="limit"
+                   @input="config.coordinator_limits[role] = parseInt($event.target.value)"
+                   :aria-label="'Max ' + role" />
+            <span class="cfg-slider-value" x-text="limit"></span>
+          </div>
+        </template>
 
         <div class="cfg-slider-row">
-          <label class="cfg-slider-label" for="slider-qa-vps">QA VPs</label>
-          <p class="cfg-slider-hint">Parallel QA VP agents in the pipeline</p>
-          <input id="slider-qa-vps"
-                 class="cfg-slider-input"
-                 type="range" min="1" max="4" step="1"
-                 x-model.number="config.max_qa_vps"
-                 aria-label="Max QA VPs" />
-          <span class="cfg-slider-value" x-text="config.max_qa_vps"></span>
-        </div>
-
-        <div class="cfg-slider-row">
-          <label class="cfg-slider-label" for="slider-pool-size">Pool size per VP</label>
-          <p class="cfg-slider-hint">Worker agents assigned to each VP</p>
+          <label class="cfg-slider-label" for="slider-pool-size">Pool size (leaves per coordinator)</label>
+          <p class="cfg-slider-hint">Leaf agents assigned to each coordinator instance</p>
           <input id="slider-pool-size"
                  class="cfg-slider-input"
                  type="range" min="1" max="20" step="1"
-                 x-model.number="config.pool_size_per_vp"
-                 aria-label="Pool size per VP" />
-          <span class="cfg-slider-value" x-text="config.pool_size_per_vp"></span>
+                 x-model.number="config.pool_size"
+                 aria-label="Pool size per coordinator" />
+          <span class="cfg-slider-value" x-text="config.pool_size"></span>
         </div>
 
       </div>
@@ -148,24 +141,19 @@
              :aria-valuenow="totalAgents"
              aria-valuemin="0"
              :aria-valuemax="totalAgents"
-             aria-label="Agent slot allocation">
+             aria-label="Total agent slots">
           <div class="cfg-capacity-bar-eng"
-               :style="'width:' + engPct + '%'"
-               :title="engSlots + ' engineering slots'"></div>
-          <div class="cfg-capacity-bar-qa"
-               :style="'width:' + qaPct + '%'"
-               :title="qaSlots + ' QA slots'"></div>
+               style="width:100%"
+               :title="totalAgents + ' total leaf agent slots'"></div>
         </div>
 
         <div class="cfg-capacity-legend">
-          <span class="cfg-capacity-legend-item">
-            <span class="cfg-legend-dot eng"></span>
-            <span x-text="engSlots + ' engineering'"></span>
-          </span>
-          <span class="cfg-capacity-legend-item">
-            <span class="cfg-legend-dot qa"></span>
-            <span x-text="qaSlots + ' QA'"></span>
-          </span>
+          <template x-for="[role, limit] in Object.entries(config.coordinator_limits)" :key="role">
+            <span class="cfg-capacity-legend-item">
+              <span class="cfg-legend-dot eng"></span>
+              <span x-text="(limit * config.pool_size) + ' slots (' + role + ')'"></span>
+            </span>
+          </template>
         </div>
       </div>
     </section>

--- a/agentception/templates/transcript_detail.html
+++ b/agentception/templates/transcript_detail.html
@@ -25,9 +25,9 @@
       {# Role badge #}
       {% set role_class = {
         'cto': 'badge--orange',
-        'engineering-vp': 'badge--blue',
+        'engineering-coordinator': 'badge--blue',
         'engineering-coordinator': 'badge--blue', 'qa-coordinator': 'badge--teal',
-        'qa-vp': 'badge--purple',
+        'qa-coordinator': 'badge--purple',
         'python-developer': 'badge--green',
         'pr-reviewer': 'badge--teal',
         'muse-specialist': 'badge--pink',
@@ -167,9 +167,9 @@
         {% for sa in transcript.subagents %}
         {% set sa_role_class = {
           'cto': 'badge--orange',
-          'engineering-vp': 'badge--blue',
+          'engineering-coordinator': 'badge--blue',
           'engineering-coordinator': 'badge--blue', 'qa-coordinator': 'badge--teal',
-          'qa-vp': 'badge--purple',
+          'qa-coordinator': 'badge--purple',
           'python-developer': 'badge--green',
           'pr-reviewer': 'badge--teal',
           'muse-specialist': 'badge--pink',

--- a/agentception/templates/transcripts.html
+++ b/agentception/templates/transcripts.html
@@ -127,9 +127,9 @@
           <td>
             {% set role_class = {
               'cto': 'badge--orange',
-              'engineering-vp': 'badge--blue',
+              'engineering-coordinator': 'badge--blue',
               'engineering-coordinator': 'badge--blue', 'qa-coordinator': 'badge--teal',
-              'qa-vp': 'badge--purple',
+              'qa-coordinator': 'badge--purple',
               'python-developer': 'badge--green',
               'pr-reviewer': 'badge--teal',
               'muse-specialist': 'badge--pink',

--- a/agentception/tests/test_agentception_ab_mode.py
+++ b/agentception/tests/test_agentception_ab_mode.py
@@ -75,9 +75,8 @@ def test_is_even_batch_unparseable_returns_none() -> None:
 def _make_config(enabled: bool, variant_a: str | None = None, variant_b: str | None = None) -> PipelineConfig:
     """Build a PipelineConfig with the specified A/B mode settings."""
     return PipelineConfig(
-        max_eng_vps=1,
-        max_qa_vps=1,
-        pool_size_per_vp=4,
+        coordinator_limits={"engineering-coordinator": 1, "qa-coordinator": 1},
+        pool_size=4,
         active_labels_order=[],
         ab_mode=AbModeConfig(
             enabled=enabled,

--- a/agentception/tests/test_agentception_github.py
+++ b/agentception/tests/test_agentception_github.py
@@ -200,9 +200,8 @@ async def test_get_active_label_returns_first_match_from_config() -> None:
     from agentception.readers import pipeline_config as _pc
 
     mock_config = PipelineConfig(
-        max_eng_vps=1,
-        max_qa_vps=1,
-        pool_size_per_vp=4,
+        coordinator_limits={"engineering-coordinator": 1, "qa-coordinator": 1},
+        pool_size=4,
         active_labels_order=["ac-ui/0-critical-bugs", "ac-ui/1-design-tokens", "ac-ui/2-data-model"],
     )
     # Issues only have ac-ui/1 and ac-ui/2 labels (phase 0 is all done)
@@ -228,9 +227,8 @@ async def test_get_active_label_returns_none_when_no_configured_labels_have_issu
     from agentception.readers import pipeline_config as _pc
 
     mock_config = PipelineConfig(
-        max_eng_vps=1,
-        max_qa_vps=1,
-        pool_size_per_vp=4,
+        coordinator_limits={"engineering-coordinator": 1, "qa-coordinator": 1},
+        pool_size=4,
         active_labels_order=["ac-ui/0-critical-bugs", "ac-ui/1-design-tokens"],
     )
     # No ac-ui/* issues open

--- a/agentception/tests/test_agentception_pipeline_config.py
+++ b/agentception/tests/test_agentception_pipeline_config.py
@@ -27,6 +27,9 @@ from agentception.readers.pipeline_config import (
 
 client = TestClient(app)
 
+# Convenience: a minimal valid coordinator_limits dict
+_COORD_LIMITS: dict[str, int] = {"engineering-coordinator": 1, "qa-coordinator": 1}
+
 
 # ---------------------------------------------------------------------------
 # Unit tests for read_pipeline_config
@@ -42,9 +45,8 @@ async def test_read_pipeline_config_returns_defaults_when_file_absent(
     with patch("agentception.readers.pipeline_config._config_path", return_value=missing):
         result = await read_pipeline_config()
 
-    assert result.max_eng_vps == _DEFAULTS["max_eng_vps"]
-    assert result.max_qa_vps == _DEFAULTS["max_qa_vps"]
-    assert result.pool_size_per_vp == _DEFAULTS["pool_size_per_vp"]
+    assert result.coordinator_limits == _DEFAULTS["coordinator_limits"]
+    assert result.pool_size == _DEFAULTS["pool_size"]
     assert result.active_labels_order == _DEFAULTS["active_labels_order"]
 
 
@@ -53,9 +55,8 @@ async def test_read_pipeline_config_reads_file_when_present(tmp_path: Path) -> N
     """read_pipeline_config parses the config file and returns a validated PipelineConfig."""
     config_file = tmp_path / "pipeline-config.json"
     custom = {
-        "max_eng_vps": 2,
-        "max_qa_vps": 3,
-        "pool_size_per_vp": 6,
+        "coordinator_limits": {"engineering-coordinator": 2, "qa-coordinator": 3},
+        "pool_size": 6,
         "active_labels_order": ["agentception/0-scaffold", "agentception/1-controls"],
     }
     config_file.write_text(json.dumps(custom), encoding="utf-8")
@@ -63,9 +64,8 @@ async def test_read_pipeline_config_reads_file_when_present(tmp_path: Path) -> N
     with patch("agentception.readers.pipeline_config._config_path", return_value=config_file):
         result = await read_pipeline_config()
 
-    assert result.max_eng_vps == 2
-    assert result.max_qa_vps == 3
-    assert result.pool_size_per_vp == 6
+    assert result.coordinator_limits == {"engineering-coordinator": 2, "qa-coordinator": 3}
+    assert result.pool_size == 6
     assert result.active_labels_order == ["agentception/0-scaffold", "agentception/1-controls"]
 
 
@@ -79,9 +79,8 @@ async def test_write_pipeline_config_persists(tmp_path: Path) -> None:
     """write_pipeline_config writes the config to disk and returns it."""
     config_file = tmp_path / ".cursor" / "pipeline-config.json"
     config = PipelineConfig(
-        max_eng_vps=1,
-        max_qa_vps=1,
-        pool_size_per_vp=4,
+        coordinator_limits=_COORD_LIMITS,
+        pool_size=4,
         active_labels_order=["agentception/0-scaffold"],
     )
 
@@ -91,7 +90,7 @@ async def test_write_pipeline_config_persists(tmp_path: Path) -> None:
     assert returned == config
     assert config_file.exists()
     on_disk = json.loads(config_file.read_text(encoding="utf-8"))
-    assert on_disk["max_eng_vps"] == 1
+    assert on_disk["coordinator_limits"] == _COORD_LIMITS
     assert on_disk["active_labels_order"] == ["agentception/0-scaffold"]
 
 
@@ -100,9 +99,8 @@ async def test_write_pipeline_config_creates_parent_dirs(tmp_path: Path) -> None
     """write_pipeline_config creates intermediate directories automatically."""
     nested = tmp_path / "deep" / "nested" / "pipeline-config.json"
     config = PipelineConfig(
-        max_eng_vps=1,
-        max_qa_vps=1,
-        pool_size_per_vp=4,
+        coordinator_limits=_COORD_LIMITS,
+        pool_size=4,
         active_labels_order=[],
     )
     with patch("agentception.readers.pipeline_config._config_path", return_value=nested):
@@ -128,17 +126,16 @@ def test_config_api_get_returns_defaults() -> None:
 
     assert response.status_code == 200
     body = response.json()
-    assert body["max_eng_vps"] == _DEFAULTS["max_eng_vps"]
-    assert body["pool_size_per_vp"] == _DEFAULTS["pool_size_per_vp"]
+    assert body["coordinator_limits"] == _DEFAULTS["coordinator_limits"]
+    assert body["pool_size"] == _DEFAULTS["pool_size"]
     assert body["active_labels_order"] == _DEFAULTS["active_labels_order"]
 
 
 def test_config_api_get_returns_custom_values() -> None:
     """GET /api/config returns the current values from the config file."""
     custom_config = PipelineConfig(
-        max_eng_vps=2,
-        max_qa_vps=2,
-        pool_size_per_vp=8,
+        coordinator_limits={"engineering-coordinator": 2, "qa-coordinator": 2},
+        pool_size=8,
         active_labels_order=["agentception/0-scaffold"],
     )
     with patch(
@@ -150,8 +147,8 @@ def test_config_api_get_returns_custom_values() -> None:
 
     assert response.status_code == 200
     body = response.json()
-    assert body["max_eng_vps"] == 2
-    assert body["pool_size_per_vp"] == 8
+    assert body["coordinator_limits"] == {"engineering-coordinator": 2, "qa-coordinator": 2}
+    assert body["pool_size"] == 8
     assert body["active_labels_order"] == ["agentception/0-scaffold"]
 
 
@@ -161,17 +158,10 @@ def test_config_api_get_returns_custom_values() -> None:
 
 
 def test_config_api_put_validates_schema_and_persists() -> None:
-    """PUT /api/config validates the body and returns the saved config.
-
-    The response includes all fields of PipelineConfig — including optional ones
-    like ``ab_mode`` which are populated with defaults when omitted from the
-    request body.  We assert against the full model dict rather than the raw
-    payload so the test stays correct as the schema evolves.
-    """
+    """PUT /api/config validates the body and returns the saved config."""
     payload = {
-        "max_eng_vps": 1,
-        "max_qa_vps": 1,
-        "pool_size_per_vp": 4,
+        "coordinator_limits": {"engineering-coordinator": 1, "qa-coordinator": 1},
+        "pool_size": 4,
         "active_labels_order": [
             "agentception/0-scaffold",
             "agentception/1-controls",
@@ -186,40 +176,25 @@ def test_config_api_put_validates_schema_and_persists() -> None:
         response = client.put("/api/config", json=payload)
 
     assert response.status_code == 200
-    # Compare against the full model dict — includes default ab_mode fields.
     assert response.json() == saved_config.model_dump()
 
 
-def test_pipeline_config_rejects_zero_max_eng_vps() -> None:
-    """PUT /api/config with max_eng_vps=0 must return 422."""
+def test_pipeline_config_rejects_zero_pool_size() -> None:
+    """PUT /api/config with pool_size=0 must return 422."""
     payload = {
-        "max_eng_vps": 0,
-        "max_qa_vps": 1,
-        "pool_size_per_vp": 4,
+        "coordinator_limits": _COORD_LIMITS,
+        "pool_size": 0,
         "active_labels_order": [],
     }
     response = client.put("/api/config", json=payload)
     assert response.status_code == 422
 
 
-def test_pipeline_config_rejects_negative_max_qa_vps() -> None:
-    """PUT /api/config with max_qa_vps=-1 must return 422."""
+def test_pipeline_config_rejects_negative_pool_size() -> None:
+    """PUT /api/config with pool_size=-1 must return 422."""
     payload = {
-        "max_eng_vps": 1,
-        "max_qa_vps": -1,
-        "pool_size_per_vp": 4,
-        "active_labels_order": [],
-    }
-    response = client.put("/api/config", json=payload)
-    assert response.status_code == 422
-
-
-def test_pipeline_config_rejects_zero_pool_size_per_vp() -> None:
-    """PUT /api/config with pool_size_per_vp=0 must return 422."""
-    payload = {
-        "max_eng_vps": 1,
-        "max_qa_vps": 1,
-        "pool_size_per_vp": 0,
+        "coordinator_limits": _COORD_LIMITS,
+        "pool_size": -1,
         "active_labels_order": [],
     }
     response = client.put("/api/config", json=payload)
@@ -228,7 +203,7 @@ def test_pipeline_config_rejects_zero_pool_size_per_vp() -> None:
 
 def test_config_api_put_rejects_missing_fields() -> None:
     """PUT /api/config returns 422 when required fields are absent."""
-    incomplete = {"max_eng_vps": 1}  # missing max_qa_vps, pool_size_per_vp, active_labels_order
+    incomplete = {"coordinator_limits": _COORD_LIMITS}  # missing active_labels_order
     response = client.put("/api/config", json=incomplete)
     assert response.status_code == 422
 
@@ -236,9 +211,8 @@ def test_config_api_put_rejects_missing_fields() -> None:
 def test_config_api_put_rejects_wrong_types() -> None:
     """PUT /api/config returns 422 when field types are wrong."""
     bad = {
-        "max_eng_vps": "one",  # should be int
-        "max_qa_vps": 1,
-        "pool_size_per_vp": 4,
+        "coordinator_limits": "not-a-dict",  # should be dict[str, int]
+        "pool_size": 4,
         "active_labels_order": [],
     }
     response = client.put("/api/config", json=bad)
@@ -252,21 +226,14 @@ def test_config_api_put_rejects_wrong_types() -> None:
 
 @pytest.mark.anyio
 async def test_settings_reads_active_project(tmp_path: Path) -> None:
-    """AgentCeptionSettings applies the active project's paths over env-var defaults.
-
-    Writes a pipeline-config.json with two projects and verifies that
-    instantiating AgentCeptionSettings with ``repo_dir`` pointing at the
-    tmp directory causes the model validator to override ``gh_repo`` and
-    ``worktrees_dir`` from the active project entry.
-    """
+    """AgentCeptionSettings applies the active project's paths over env-var defaults."""
     from agentception.config import AgentCeptionSettings
 
     cursor_dir = tmp_path / ".agentception"
     cursor_dir.mkdir(parents=True)
     config_data = {
-        "max_eng_vps": 1,
-        "max_qa_vps": 1,
-        "pool_size_per_vp": 4,
+        "coordinator_limits": _COORD_LIMITS,
+        "pool_size": 4,
         "active_labels_order": [],
         "active_project": "Other Repo",
         "projects": [
@@ -292,8 +259,6 @@ async def test_settings_reads_active_project(tmp_path: Path) -> None:
         json.dumps(config_data), encoding="utf-8"
     )
 
-    # Instantiate settings pointing at our tmp repo_dir — the validator
-    # reads the config file and switches to the "Other Repo" project.
     s = AgentCeptionSettings(repo_dir=tmp_path)
     assert s.gh_repo == "acme/other"
     assert s.worktrees_dir == tmp_path / "other-worktrees"
@@ -301,17 +266,11 @@ async def test_settings_reads_active_project(tmp_path: Path) -> None:
 
 @pytest.mark.anyio
 async def test_switch_project_updates_config(tmp_path: Path) -> None:
-    """switch_project() sets active_project and persists the updated config.
-
-    Starts with a config that has two projects and ``active_project`` set to
-    the first one, then calls ``switch_project`` for the second and verifies
-    the returned config and on-disk state both reflect the change.
-    """
+    """switch_project() sets active_project and persists the updated config."""
     config_file = tmp_path / "pipeline-config.json"
     initial = {
-        "max_eng_vps": 1,
-        "max_qa_vps": 1,
-        "pool_size_per_vp": 4,
+        "coordinator_limits": _COORD_LIMITS,
+        "pool_size": 4,
         "active_labels_order": [],
         "active_project": "Example Project",
         "projects": [
@@ -348,9 +307,8 @@ async def test_switch_project_rejects_unknown_name(tmp_path: Path) -> None:
     """switch_project() raises ValueError for a project name not in projects list."""
     config_file = tmp_path / "pipeline-config.json"
     config = {
-        "max_eng_vps": 1,
-        "max_qa_vps": 1,
-        "pool_size_per_vp": 4,
+        "coordinator_limits": _COORD_LIMITS,
+        "pool_size": 4,
         "active_labels_order": [],
         "active_project": "Example Project",
         "projects": [
@@ -389,9 +347,8 @@ def test_switch_project_api_returns_404_for_unknown_project() -> None:
 def test_switch_project_api_returns_updated_config() -> None:
     """POST /api/config/switch-project returns the updated PipelineConfig on success."""
     updated_config = PipelineConfig(
-        max_eng_vps=1,
-        max_qa_vps=1,
-        pool_size_per_vp=4,
+        coordinator_limits=_COORD_LIMITS,
+        pool_size=4,
         active_labels_order=[],
         active_project="Other Repo",
         projects=[],

--- a/agentception/tests/test_agentception_scaling.py
+++ b/agentception/tests/test_agentception_scaling.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 Coverage:
 - test_no_recommendation_when_balanced: returns no_change when metrics are within bounds
-- test_recommend_more_qa_when_pr_backlog: recommends increase_qa_vps when pr_backlog >= 2
+- test_recommend_more_qa_when_pr_backlog: recommends increase_coordinator_limit for qa-coordinator
 - test_recommend_bigger_pool_when_deep_queue: recommends increase_pool when queue deep & agents fast
 - test_confidence_low_without_wave_history: returns low confidence when < 3 completed waves
 - test_confidence_high_with_sufficient_waves: returns high confidence with >= 3 completed waves
@@ -29,7 +29,7 @@ from agentception.intelligence.scaling import (
     _classify_confidence,
     compute_recommendation,
 )
-from agentception.models import AgentStatus, AgentNode, PipelineState
+from agentception.models import AgentNode, AgentStatus, PipelineState
 from agentception.telemetry import WaveSummary
 
 
@@ -72,17 +72,19 @@ def _make_wave(duration_minutes: float | None, batch_id: str = "eng-test") -> Wa
 
 
 def _make_pipeline_config(
-    max_eng_vps: int = 1,
-    max_qa_vps: int = 1,
-    pool_size_per_vp: int = 4,
+    coordinator_limits: dict[str, int] | None = None,
+    pool_size: int = 4,
 ) -> object:
     """Return a PipelineConfig instance with controllable allocation fields."""
     from agentception.models import PipelineConfig
 
+    limits = coordinator_limits if coordinator_limits is not None else {
+        "engineering-coordinator": 1,
+        "qa-coordinator": 1,
+    }
     return PipelineConfig(
-        max_eng_vps=max_eng_vps,
-        max_qa_vps=max_qa_vps,
-        pool_size_per_vp=pool_size_per_vp,
+        coordinator_limits=limits,
+        pool_size=pool_size,
         active_labels_order=["agentception/5-scaling"],
     )
 
@@ -111,18 +113,21 @@ async def test_no_recommendation_when_balanced() -> None:
 
 @pytest.mark.anyio
 async def test_recommend_more_qa_when_pr_backlog() -> None:
-    """Returns increase_qa_vps when pr_backlog >= 2 and max_qa_vps < 2."""
+    """Returns increase_coordinator_limit for qa-coordinator when pr_backlog >= 2 and limit < 2."""
     state = _make_state(issues_open=1, prs_open=3)  # pr_backlog=3 >= threshold(2)
     waves = [_make_wave(25.0, f"b{i}") for i in range(3)]  # slow waves, no pool trigger
 
     with patch(
         "agentception.intelligence.scaling.read_pipeline_config",
         new_callable=AsyncMock,
-        return_value=_make_pipeline_config(max_qa_vps=1),
+        return_value=_make_pipeline_config(
+            coordinator_limits={"engineering-coordinator": 1, "qa-coordinator": 1}
+        ),
     ):
         rec = await compute_recommendation(state, waves)
 
-    assert rec.action == "increase_qa_vps", f"Expected increase_qa_vps, got {rec.action!r}"
+    assert rec.action == "increase_coordinator_limit", f"Got {rec.action!r}"
+    assert rec.target_role == "qa-coordinator"
     assert rec.current_value == 1
     assert rec.recommended_value == 2
     assert "PR backlog" in rec.reason
@@ -138,11 +143,12 @@ async def test_recommend_bigger_pool_when_deep_queue() -> None:
     with patch(
         "agentception.intelligence.scaling.read_pipeline_config",
         new_callable=AsyncMock,
-        return_value=_make_pipeline_config(pool_size_per_vp=4),
+        return_value=_make_pipeline_config(pool_size=4),
     ):
         rec = await compute_recommendation(state, waves)
 
     assert rec.action == "increase_pool", f"Expected increase_pool, got {rec.action!r}"
+    assert rec.target_role is None
     assert rec.current_value == 4
     assert rec.recommended_value == 6  # min(4+2, 8)
     assert "queue depth" in rec.reason.lower()
@@ -157,7 +163,9 @@ async def test_confidence_low_without_wave_history() -> None:
     with patch(
         "agentception.intelligence.scaling.read_pipeline_config",
         new_callable=AsyncMock,
-        return_value=_make_pipeline_config(max_qa_vps=1),
+        return_value=_make_pipeline_config(
+            coordinator_limits={"engineering-coordinator": 1, "qa-coordinator": 1}
+        ),
     ):
         rec = await compute_recommendation(state, waves)
 
@@ -231,7 +239,7 @@ async def test_in_progress_waves_excluded_from_duration() -> None:
     with patch(
         "agentception.intelligence.scaling.read_pipeline_config",
         new_callable=AsyncMock,
-        return_value=_make_pipeline_config(pool_size_per_vp=4),
+        return_value=_make_pipeline_config(pool_size=4),
     ):
         rec = await compute_recommendation(state, waves)
 
@@ -318,15 +326,14 @@ async def test_scaling_advice_api_returns_200() -> None:
 async def test_apply_increases_correct_field() -> None:
     """POST apply writes the recommended_value to the correct PipelineConfig field.
 
-    Scenario: recommendation is increase_pool (pool_size_per_vp: 4 → 6).
-    The written config must have pool_size_per_vp == 6; other fields unchanged.
+    Scenario: recommendation is increase_pool (pool_size: 4 → 6).
+    The written config must have pool_size == 6; other fields unchanged.
     """
     from agentception.models import PipelineConfig
 
     initial_config = PipelineConfig(
-        max_eng_vps=1,
-        max_qa_vps=1,
-        pool_size_per_vp=4,
+        coordinator_limits={"engineering-coordinator": 1, "qa-coordinator": 1},
+        pool_size=4,
         active_labels_order=["agentception/5-scaling"],
     )
     recommendation = ScalingRecommendation(
@@ -380,10 +387,71 @@ async def test_apply_increases_correct_field() -> None:
     assert body["new_value"] == 6
 
     assert len(written) == 1, "write_pipeline_config must be called exactly once"
-    assert written[0].pool_size_per_vp == 6
+    assert written[0].pool_size == 6
     # Other fields must remain unchanged
-    assert written[0].max_qa_vps == initial_config.max_qa_vps
-    assert written[0].max_eng_vps == initial_config.max_eng_vps
+    assert written[0].coordinator_limits == initial_config.coordinator_limits
+
+
+@pytest.mark.anyio
+async def test_apply_increases_coordinator_limit() -> None:
+    """POST apply bumps a specific coordinator's limit when action is increase_coordinator_limit."""
+    from agentception.models import PipelineConfig
+
+    initial_config = PipelineConfig(
+        coordinator_limits={"engineering-coordinator": 1, "qa-coordinator": 1},
+        pool_size=4,
+        active_labels_order=["agentception/5-scaling"],
+    )
+    recommendation = ScalingRecommendation(
+        action="increase_coordinator_limit",
+        target_role="qa-coordinator",
+        reason="PR backlog high.",
+        current_value=1,
+        recommended_value=2,
+        confidence="high",
+    )
+    written: list[PipelineConfig] = []
+
+    async def fake_write(cfg: PipelineConfig) -> PipelineConfig:
+        written.append(cfg)
+        return cfg
+
+    with (
+        patch(
+            "agentception.routes.intelligence.get_state",
+            return_value=_make_state(issues_open=0, prs_open=3),
+        ),
+        patch(
+            "agentception.routes.intelligence.aggregate_waves",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.routes.intelligence.compute_recommendation",
+            new_callable=AsyncMock,
+            return_value=recommendation,
+        ),
+        patch(
+            "agentception.routes.intelligence.read_pipeline_config",
+            new_callable=AsyncMock,
+            return_value=initial_config,
+        ),
+        patch(
+            "agentception.routes.intelligence.write_pipeline_config",
+            new_callable=AsyncMock,
+            side_effect=fake_write,
+        ),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            response = await client.post("/api/intelligence/scaling-advice/apply")
+
+    assert response.status_code == 200
+    assert len(written) == 1
+    assert written[0].coordinator_limits["qa-coordinator"] == 2
+    assert written[0].coordinator_limits["engineering-coordinator"] == 1
 
 
 @pytest.mark.anyio
@@ -434,14 +502,8 @@ async def test_apply_no_change_is_noop() -> None:
 
 
 def test_banner_hidden_when_dismissed_markup_present() -> None:
-    """Overview page HTML includes the scaling advisor banner markup with x-cloak.
-
-    The dismissed state is managed client-side by Alpine.js (x-data/x-show).
-    This test verifies the server renders the container element so the browser
-    can initialise the Alpine component — it does not execute JavaScript.
-    """
+    """Overview page HTML includes the scaling advisor banner markup with x-cloak."""
     from fastapi.testclient import TestClient
-    import time
     from agentception.models import PipelineState
 
     state = PipelineState(
@@ -461,11 +523,7 @@ def test_banner_hidden_when_dismissed_markup_present() -> None:
 
     assert response.status_code == 200
     html = response.text
-    # Banner container with Alpine dismissed-state guard must be rendered.
-    # scalingAdvisor() is defined in app.js; the HTML uses it via x-data invocation.
     assert "scalingAdvisor(" in html, "Alpine scalingAdvisor x-data invocation must be in the page"
-    # Apply logic (POST /api/intelligence/scaling-advice/apply) lives in app.js,
-    # invoked via @click="apply()". Verify the button and app.js are present.
     assert '@click="apply()"' in html, "Apply button must delegate to scalingAdvisor.apply()"
     assert "/static/app.js" in html, "app.js must be loaded for scalingAdvisor to work"
     assert "Dismiss" in html, "Dismiss button must be rendered"

--- a/agentception/tests/test_agentception_spawn_child.py
+++ b/agentception/tests/test_agentception_spawn_child.py
@@ -3,19 +3,21 @@ from __future__ import annotations
 """Tests for the universal child-node spawner (agentception/services/spawn_child.py).
 
 Covers:
-  - tier_for_role() mapping for all protocol tiers.
-  - _build_child_task() content for each scope type.
-  - spawn_child() happy path (mocked git + DB).
+  - node_type parameter contract (coordinator / leaf).
+  - _build_child_task() field presence and correctness for each scope type.
+  - spawn_child() happy path (mocked git + DB) for coordinator and leaf.
+  - spawn_child() produces NODE_TYPE= (not TIER=) in .agent-task.
   - spawn_child() worktree failure cleanup.
-  - POST /api/build/spawn-child HTTP endpoint.
+  - POST /api/build/spawn-child HTTP endpoint (valid, invalid, and propagated errors).
   - build_spawn_child MCP tool (happy path + error cases).
+  - Universal tree protocol guarantee: any node can be pruned as a root.
 
 Run targeted:
     pytest agentception/tests/test_agentception_spawn_child.py -v
 """
 
 import asyncio
-from collections.abc import AsyncIterator, Generator
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -24,13 +26,13 @@ from fastapi.testclient import TestClient
 
 from agentception.app import app
 from agentception.services.spawn_child import (
+    NodeType,
     SpawnChildError,
     SpawnChildResult,
     _build_child_task,
     _make_branch,
     _make_run_id,
     spawn_child,
-    tier_for_role,
 )
 
 
@@ -43,34 +45,6 @@ from agentception.services.spawn_child import (
 def client() -> Generator[TestClient, None, None]:
     with TestClient(app) as c:
         yield c
-
-
-# ---------------------------------------------------------------------------
-# tier_for_role — mapping coverage
-# ---------------------------------------------------------------------------
-
-
-def test_tier_for_role_executive() -> None:
-    assert tier_for_role("cto") == "executive"
-    assert tier_for_role("ceo") == "executive"
-    assert tier_for_role("csto") == "executive"
-
-
-def test_tier_for_role_coordinator() -> None:
-    assert tier_for_role("engineering-coordinator") == "coordinator"
-    assert tier_for_role("qa-coordinator") == "coordinator"
-    assert tier_for_role("conductor") == "coordinator"
-    assert tier_for_role("vp-platform") == "coordinator"
-
-
-def test_tier_for_role_reviewer() -> None:
-    assert tier_for_role("pr-reviewer") == "reviewer"
-
-
-def test_tier_for_role_engineer_defaults() -> None:
-    assert tier_for_role("python-developer") == "engineer"
-    assert tier_for_role("frontend-developer") == "engineer"
-    assert tier_for_role("unknown-role-xyz") == "engineer"
 
 
 # ---------------------------------------------------------------------------
@@ -109,7 +83,7 @@ def test_make_branch_pr() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _build_child_task — field presence and correctness
+# _build_child_task — field presence, correctness, NODE_TYPE vs TIER
 # ---------------------------------------------------------------------------
 
 
@@ -117,7 +91,7 @@ def _make_task(**overrides: object) -> str:
     defaults: dict[str, object] = dict(
         run_id="test-run-123",
         role="engineering-coordinator",
-        tier="coordinator",
+        node_type="coordinator",
         scope_type="label",
         scope_value="ac-workflow",
         gh_repo="owner/repo",
@@ -137,7 +111,7 @@ def test_build_child_task_required_fields_present() -> None:
     task = _make_task()
     assert "RUN_ID=test-run-123" in task
     assert "ROLE=engineering-coordinator" in task
-    assert "TIER=coordinator" in task
+    assert "NODE_TYPE=coordinator" in task
     assert "SCOPE_TYPE=label" in task
     assert "SCOPE_VALUE=ac-workflow" in task
     assert "PARENT_RUN_ID=label-cto-111111" in task
@@ -146,22 +120,31 @@ def test_build_child_task_required_fields_present() -> None:
     assert "ROLE_FILE=" in task
 
 
-def test_build_child_task_label_scope_query_hint() -> None:
-    task = _make_task(scope_type="label", tier="coordinator", role="engineering-coordinator")
+def test_build_child_task_does_not_contain_tier_field() -> None:
+    """The old TIER= field must be gone — only NODE_TYPE= is written."""
+    task = _make_task()
+    lines = task.splitlines()
+    tier_lines = [ln for ln in lines if ln.startswith("TIER=")]
+    assert tier_lines == [], f"Unexpected TIER= lines: {tier_lines}"
+
+
+def test_build_child_task_leaf_node_type() -> None:
+    task = _make_task(node_type="leaf", role="python-developer", scope_type="issue",
+                      scope_value="42", issue_number=42)
+    assert "NODE_TYPE=leaf" in task
+
+
+def test_build_child_task_coordinator_label_scope_query_hint() -> None:
+    task = _make_task(scope_type="label", node_type="coordinator")
     assert "gh issue list" in task
     assert "--label 'ac-workflow'" in task
-
-
-def test_build_child_task_qa_coordinator_query_hint() -> None:
-    task = _make_task(scope_type="label", tier="coordinator", role="qa-coordinator")
-    assert "gh pr list" in task
 
 
 def test_build_child_task_issue_scope_includes_issue_fields() -> None:
     task = _make_task(
         scope_type="issue",
         scope_value="42",
-        tier="engineer",
+        node_type="leaf",
         role="python-developer",
         issue_number=42,
         issue_title="Fix the thing",
@@ -176,7 +159,7 @@ def test_build_child_task_pr_scope_includes_pr_fields() -> None:
     task = _make_task(
         scope_type="pr",
         scope_value="112",
-        tier="reviewer",
+        node_type="leaf",
         role="pr-reviewer",
         pr_number=112,
     )
@@ -185,19 +168,20 @@ def test_build_child_task_pr_scope_includes_pr_fields() -> None:
     assert "gh pr view 112" in task
 
 
-def test_build_child_task_executive_includes_both_queries() -> None:
-    task = _make_task(tier="executive", role="cto", scope_type="label", scope_value="ac-workflow")
+def test_build_child_task_coordinator_includes_both_queries() -> None:
+    """A coordinator with label scope should get both issue and PR query hints."""
+    task = _make_task(node_type="coordinator", role="cto", scope_type="label", scope_value="ac-workflow")
     assert "gh issue list" in task
     assert "gh pr list" in task
 
 
 # ---------------------------------------------------------------------------
-# spawn_child — happy path (mocked subprocess + DB)
+# spawn_child — explicit node_type parameter, happy paths
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_spawn_child_happy_path_label() -> None:
+async def test_spawn_child_coordinator_label_happy_path() -> None:
     mock_proc = MagicMock()
     mock_proc.returncode = 0
     mock_proc.communicate = AsyncMock(return_value=(b"", b""))
@@ -215,13 +199,14 @@ async def test_spawn_child_happy_path_label() -> None:
         result = await spawn_child(
             parent_run_id="label-cto-abc123",
             role="engineering-coordinator",
+            node_type="coordinator",
             scope_type="label",
             scope_value="ac-workflow",
             gh_repo="owner/repo",
         )
 
     assert isinstance(result, SpawnChildResult)
-    assert result.tier == "coordinator"
+    assert result.node_type == "coordinator"
     assert result.role == "engineering-coordinator"
     assert result.scope_type == "label"
     assert result.scope_value == "ac-workflow"
@@ -230,7 +215,7 @@ async def test_spawn_child_happy_path_label() -> None:
 
 
 @pytest.mark.anyio
-async def test_spawn_child_happy_path_issue() -> None:
+async def test_spawn_child_leaf_issue_happy_path() -> None:
     mock_proc = MagicMock()
     mock_proc.returncode = 0
     mock_proc.communicate = AsyncMock(return_value=(b"", b""))
@@ -247,6 +232,7 @@ async def test_spawn_child_happy_path_issue() -> None:
         result = await spawn_child(
             parent_run_id="coord-engineering-xyz",
             role="python-developer",
+            node_type="leaf",
             scope_type="issue",
             scope_value="42",
             gh_repo="owner/repo",
@@ -254,14 +240,14 @@ async def test_spawn_child_happy_path_issue() -> None:
             issue_body="Uses FastAPI Depends and response_model",
         )
 
-    assert result.tier == "engineer"
+    assert result.node_type == "leaf"
     assert result.run_id.startswith("issue-42-")
     # COGNITIVE_ARCH should reflect fastapi skill from the body keyword
     assert "fastapi" in result.cognitive_arch
 
 
 @pytest.mark.anyio
-async def test_spawn_child_happy_path_pr() -> None:
+async def test_spawn_child_leaf_pr_happy_path() -> None:
     mock_proc = MagicMock()
     mock_proc.returncode = 0
     mock_proc.communicate = AsyncMock(return_value=(b"", b""))
@@ -278,14 +264,54 @@ async def test_spawn_child_happy_path_pr() -> None:
         result = await spawn_child(
             parent_run_id="coord-qa-xyz",
             role="pr-reviewer",
+            node_type="leaf",
             scope_type="pr",
             scope_value="112",
             gh_repo="owner/repo",
         )
 
-    assert result.tier == "reviewer"
+    assert result.node_type == "leaf"
     assert result.run_id.startswith("pr-112-")
     assert "michael_fagan" in result.cognitive_arch
+
+
+@pytest.mark.anyio
+async def test_spawn_child_node_type_written_to_agent_task() -> None:
+    """The .agent-task file must contain NODE_TYPE= (not TIER=)."""
+    mock_proc = MagicMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+
+    written_content: list[str] = []
+
+    def capture_write(content: str, **_: object) -> None:
+        written_content.append(content)
+
+    with (
+        patch(
+            "agentception.services.spawn_child.asyncio.create_subprocess_exec",
+            return_value=mock_proc,
+        ),
+        patch("agentception.services.spawn_child.persist_agent_run_dispatch", AsyncMock()),
+        patch("agentception.services.spawn_child.acknowledge_agent_run", AsyncMock(return_value=True)),
+        patch.object(Path, "write_text", side_effect=capture_write),
+    ):
+        await spawn_child(
+            parent_run_id="coord-engineering-xyz",
+            role="python-developer",
+            node_type="leaf",
+            scope_type="issue",
+            scope_value="5",
+            gh_repo="owner/repo",
+        )
+
+    assert written_content, "write_text was never called"
+    content = written_content[0]
+    assert "NODE_TYPE=leaf" in content
+    # Old TIER= line must not appear
+    lines = content.splitlines()
+    tier_lines = [ln for ln in lines if ln.startswith("TIER=")]
+    assert tier_lines == [], f"Unexpected TIER= lines: {tier_lines}"
 
 
 @pytest.mark.anyio
@@ -306,6 +332,7 @@ async def test_spawn_child_skills_hint_overrides_body_extraction() -> None:
         result = await spawn_child(
             parent_run_id="coord-xyz",
             role="frontend-developer",
+            node_type="leaf",
             scope_type="issue",
             scope_value="99",
             gh_repo="owner/repo",
@@ -339,6 +366,7 @@ async def test_spawn_child_worktree_failure_raises_spawn_child_error() -> None:
         await spawn_child(
             parent_run_id="coord-xyz",
             role="python-developer",
+            node_type="leaf",
             scope_type="issue",
             scope_value="1",
             gh_repo="owner/repo",
@@ -369,6 +397,7 @@ async def test_spawn_child_file_write_failure_cleans_up_worktree() -> None:
         await spawn_child(
             parent_run_id="coord-xyz",
             role="python-developer",
+            node_type="leaf",
             scope_type="issue",
             scope_value="2",
             gh_repo="owner/repo",
@@ -389,7 +418,7 @@ def test_spawn_child_result_to_dict_all_keys() -> None:
         run_id="coord-abc",
         host_worktree_path="/host/path",
         worktree_path="/container/path",
-        tier="coordinator",
+        node_type="coordinator",
         role="engineering-coordinator",
         cognitive_arch="von_neumann:python",
         agent_task_path="/container/path/.agent-task",
@@ -398,9 +427,10 @@ def test_spawn_child_result_to_dict_all_keys() -> None:
     )
     d = result.to_dict()
     assert d["run_id"] == "coord-abc"
-    assert d["tier"] == "coordinator"
+    assert d["node_type"] == "coordinator"
     assert d["cognitive_arch"] == "von_neumann:python"
     assert d["scope_type"] == "label"
+    assert "tier" not in d, "to_dict must not expose the old 'tier' key"
 
 
 # ---------------------------------------------------------------------------
@@ -415,7 +445,40 @@ def test_spawn_child_endpoint_invalid_scope_type(client: TestClient) -> None:
         json={
             "parent_run_id": "cto-abc",
             "role": "engineering-coordinator",
+            "node_type": "coordinator",
             "scope_type": "invalid",
+            "scope_value": "ac-workflow",
+            "gh_repo": "owner/repo",
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_spawn_child_endpoint_invalid_node_type(client: TestClient) -> None:
+    """Invalid node_type should return HTTP 422."""
+    response = client.post(
+        "/api/build/spawn-child",
+        json={
+            "parent_run_id": "cto-abc",
+            "role": "engineering-coordinator",
+            "node_type": "executive",   # old value — must be rejected
+            "scope_type": "label",
+            "scope_value": "ac-workflow",
+            "gh_repo": "owner/repo",
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_spawn_child_endpoint_missing_node_type(client: TestClient) -> None:
+    """Missing node_type (now required) must return HTTP 422."""
+    response = client.post(
+        "/api/build/spawn-child",
+        json={
+            "parent_run_id": "cto-abc",
+            "role": "engineering-coordinator",
+            # node_type missing
+            "scope_type": "label",
             "scope_value": "ac-workflow",
             "gh_repo": "owner/repo",
         },
@@ -429,6 +492,7 @@ def test_spawn_child_endpoint_missing_required_field(client: TestClient) -> None
         json={
             "parent_run_id": "cto-abc",
             "role": "engineering-coordinator",
+            "node_type": "coordinator",
             # scope_type missing
             "scope_value": "ac-workflow",
             "gh_repo": "owner/repo",
@@ -442,7 +506,7 @@ def test_spawn_child_endpoint_happy_path(client: TestClient) -> None:
         run_id="coord-ac-workflow-abc123",
         host_worktree_path="/host/worktrees/coord-ac-workflow-abc123",
         worktree_path="/worktrees/coord-ac-workflow-abc123",
-        tier="coordinator",
+        node_type="coordinator",
         role="engineering-coordinator",
         cognitive_arch="von_neumann:python",
         agent_task_path="/worktrees/coord-ac-workflow-abc123/.agent-task",
@@ -458,6 +522,7 @@ def test_spawn_child_endpoint_happy_path(client: TestClient) -> None:
             json={
                 "parent_run_id": "label-cto-abc123",
                 "role": "engineering-coordinator",
+                "node_type": "coordinator",
                 "scope_type": "label",
                 "scope_value": "ac-workflow",
                 "gh_repo": "owner/repo",
@@ -466,7 +531,8 @@ def test_spawn_child_endpoint_happy_path(client: TestClient) -> None:
     assert response.status_code == 200
     data = response.json()
     assert data["run_id"] == "coord-ac-workflow-abc123"
-    assert data["tier"] == "coordinator"
+    assert data["node_type"] == "coordinator"
+    assert "tier" not in data, "Response must not contain old 'tier' key"
     assert data["cognitive_arch"] == "von_neumann:python"
     assert data["status"] == "implementing"
 
@@ -481,6 +547,7 @@ def test_spawn_child_endpoint_propagates_spawn_child_error(client: TestClient) -
             json={
                 "parent_run_id": "cto-abc",
                 "role": "python-developer",
+                "node_type": "leaf",
                 "scope_type": "issue",
                 "scope_value": "42",
                 "gh_repo": "owner/repo",
@@ -495,30 +562,34 @@ def test_spawn_child_endpoint_propagates_spawn_child_error(client: TestClient) -
 # ---------------------------------------------------------------------------
 
 
-def test_any_tier_produces_valid_task_content() -> None:
-    """Every tier/scope combination must produce a parseable .agent-task."""
-    combos: list[tuple[str, str, str]] = [
-        ("cto", "label", "ac-workflow"),
-        ("engineering-coordinator", "label", "ac-ui/0-bugs"),
-        ("qa-coordinator", "label", "ac-ui/0-bugs"),
-        ("python-developer", "issue", "42"),
-        ("pr-reviewer", "pr", "112"),
+def test_any_node_type_produces_valid_task_content() -> None:
+    """Every node_type/scope combination must produce a parseable .agent-task."""
+    combos: list[tuple[str, NodeType, str, str]] = [
+        ("cto", "coordinator", "label", "ac-workflow"),
+        ("engineering-coordinator", "coordinator", "label", "ac-ui/0-bugs"),
+        ("qa-coordinator", "coordinator", "label", "ac-ui/0-bugs"),
+        ("python-developer", "leaf", "issue", "42"),
+        ("pr-reviewer", "leaf", "pr", "112"),
     ]
-    for role, scope_type, scope_value in combos:
+    for role, node_type, scope_type, scope_value in combos:
         task = _make_task(
             role=role,
-            tier=tier_for_role(role),
+            node_type=node_type,
             scope_type=scope_type,
             scope_value=scope_value,
         )
         # Every task must have these universal fields
         assert "RUN_ID=" in task, f"Missing RUN_ID for {role}"
+        assert "NODE_TYPE=" in task, f"Missing NODE_TYPE for {role}"
         assert "PARENT_RUN_ID=" in task, f"Missing PARENT_RUN_ID for {role}"
         assert "COGNITIVE_ARCH=" in task, f"Missing COGNITIVE_ARCH for {role}"
         assert "ROLE_FILE=" in task, f"Missing ROLE_FILE for {role}"
         assert "AC_URL=" in task, f"Missing AC_URL for {role}"
         assert "SCOPE_TYPE=" in task, f"Missing SCOPE_TYPE for {role}"
         assert "SCOPE_VALUE=" in task, f"Missing SCOPE_VALUE for {role}"
+        # TIER= must be absent
+        tier_lines = [ln for ln in task.splitlines() if ln.startswith("TIER=")]
+        assert tier_lines == [], f"Unexpected TIER= lines for {role}: {tier_lines}"
 
 
 def test_pruned_subtree_root_has_same_fields_as_full_tree_root() -> None:
@@ -527,7 +598,7 @@ def test_pruned_subtree_root_has_same_fields_as_full_tree_root() -> None:
     # Coordinator as root (direct launch)
     task_root = _make_task(
         role="engineering-coordinator",
-        tier="coordinator",
+        node_type="coordinator",
         scope_type="label",
         scope_value="ac-workflow",
         parent_run_id="",  # no parent — it IS the root
@@ -535,12 +606,12 @@ def test_pruned_subtree_root_has_same_fields_as_full_tree_root() -> None:
     # Coordinator as child
     task_child = _make_task(
         role="engineering-coordinator",
-        tier="coordinator",
+        node_type="coordinator",
         scope_type="label",
         scope_value="ac-workflow",
         parent_run_id="label-cto-abc123",
     )
     # Both must have all universal fields
-    for field in ("RUN_ID=", "COGNITIVE_ARCH=", "ROLE_FILE=", "SCOPE_TYPE=", "SCOPE_VALUE="):
+    for field in ("RUN_ID=", "NODE_TYPE=", "COGNITIVE_ARCH=", "ROLE_FILE=", "SCOPE_TYPE=", "SCOPE_VALUE="):
         assert field in task_root
         assert field in task_child

--- a/agentception/tests/test_agentception_templates.py
+++ b/agentception/tests/test_agentception_templates.py
@@ -46,7 +46,7 @@ def _make_repo(tmp_path: Path) -> Path:
     prompts = ac / "prompts"
     prompts.mkdir(parents=True, exist_ok=True)
     (prompts / "parallel-issue-to-pr.md").write_text("# Parallel", encoding="utf-8")
-    (ac / "pipeline-config.json").write_text('{"max_eng_vps": 1}', encoding="utf-8")
+    (ac / "pipeline-config.json").write_text('{"coordinator_limits": {"engineering-coordinator": 1, "qa-coordinator": 1}, "pool_size": 4}', encoding="utf-8")
     (ac / "agent-command-policy.md").write_text("# Policy", encoding="utf-8")
     return tmp_path
 
@@ -186,7 +186,7 @@ def test_import_detects_conflicts(tmp_path: Path) -> None:
     target_ac = target_repo / ".agentception"
     target_ac.mkdir(parents=True)
     existing = target_ac / "pipeline-config.json"
-    existing.write_text('{"max_eng_vps": 99}', encoding="utf-8")
+    existing.write_text('{"coordinator_limits": {"engineering-coordinator": 99, "qa-coordinator": 1}, "pool_size": 4}', encoding="utf-8")
 
     result = import_template(archive_bytes, str(target_repo))
 

--- a/agentception/tests/test_pipeline_panel.py
+++ b/agentception/tests/test_pipeline_panel.py
@@ -89,9 +89,8 @@ def _make_pipeline_cfg(labels: list[str]) -> object:
 
     return _PC.model_validate(
         {
-            "max_eng_vps": 1,
-            "max_qa_vps": 1,
-            "pool_size_per_vp": 4,
+            "coordinator_limits": {"engineering-coordinator": 1, "qa-coordinator": 1},
+            "pool_size": 4,
             "active_labels_order": labels,
         }
     )

--- a/scripts/gen_prompts/role-taxonomy.yaml
+++ b/scripts/gen_prompts/role-taxonomy.yaml
@@ -251,9 +251,9 @@ levels:
           - postgresql
         file_exists: true
 
-      - slug: vp-product
-        label: "VP Product"
-        title: "VP of Product"
+      - slug: product-coordinator
+        label: "Product Coordinator"
+        title: "Product Coordinator"
         category: product
         description: "Drives roadmap execution, product discovery, and user story quality."
         spawnable: false
@@ -271,9 +271,9 @@ levels:
           - htmx
         file_exists: true
 
-      - slug: vp-design
-        label: "VP Design"
-        title: "VP of Design / UX"
+      - slug: design-coordinator
+        label: "Design Coordinator"
+        title: "Design Coordinator"
         category: design
         description: "Leads design systems, interaction design, accessibility, and user research."
         spawnable: false
@@ -291,9 +291,9 @@ levels:
           - jinja2
         file_exists: true
 
-      - slug: vp-data
-        label: "VP Data"
-        title: "VP of Data & Analytics"
+      - slug: data-coordinator
+        label: "Data Coordinator"
+        title: "Data Coordinator"
         category: data
         description: "Leads data pipelines, business intelligence, and experimentation infrastructure."
         spawnable: false
@@ -312,9 +312,9 @@ levels:
           - llm
         file_exists: true
 
-      - slug: vp-security
-        label: "VP Security"
-        title: "VP of Security"
+      - slug: security-coordinator
+        label: "Security Coordinator"
+        title: "Security Coordinator"
         category: security
         description: "Leads application security, infrastructure hardening, and security audits."
         spawnable: false
@@ -334,9 +334,9 @@ levels:
           - postgresql
         file_exists: true
 
-      - slug: vp-infrastructure
-        label: "VP Infrastructure"
-        title: "VP of Infrastructure / DevOps"
+      - slug: infrastructure-coordinator
+        label: "Infrastructure Coordinator"
+        title: "Infrastructure Coordinator"
         category: infrastructure
         description: "Leads platform reliability, CI/CD pipelines, and cloud infrastructure."
         spawnable: false
@@ -354,9 +354,9 @@ levels:
           - postgresql
         file_exists: true
 
-      - slug: vp-mobile
-        label: "VP Mobile"
-        title: "VP of Mobile"
+      - slug: mobile-coordinator
+        label: "Mobile Coordinator"
+        title: "Mobile Coordinator"
         category: mobile
         description: "Leads iOS and Android strategy, mobile architecture, and platform-specific UX."
         spawnable: false
@@ -372,9 +372,9 @@ levels:
           - devops
         file_exists: true
 
-      - slug: vp-platform
-        label: "VP Platform"
-        title: "VP of Platform Engineering"
+      - slug: platform-coordinator
+        label: "Platform Coordinator"
+        title: "Platform Coordinator"
         category: platform
         description: "Leads internal SDK development, API platform, and developer experience."
         spawnable: false
@@ -398,9 +398,9 @@ levels:
           - devops
         file_exists: true
 
-      - slug: vp-ml
-        label: "VP ML/AI"
-        title: "VP of Machine Learning / AI"
+      - slug: ml-coordinator
+        label: "ML Coordinator"
+        title: "ML Coordinator"
         category: ml_ai
         description: "Leads model lifecycle, training infrastructure, inference optimization, and evaluation."
         spawnable: false


### PR DESCRIPTION
## Summary

- **PR 1 — node_type model**: Alembic migration 0008 normalises `logical_tier` values from the 4-level enum to `coordinator`/`leaf`. Removes `_ROLE_TIER` / `tier_for_role()`; callers pass `node_type` explicitly. `.agent-task` files write `NODE_TYPE=`.
- **PR 2 — slug rename**: Eight `vp-*` role slugs renamed to `*-coordinator` everywhere — taxonomy YAML, UI routes, badge CSS, org-chart, and `.agentception/roles/` files. `vp` removed from `_PHASE_ASSIGNABLE_TIERS`.
- **PR 3 — PipelineConfig cleanup**: `max_eng_vps`/`max_qa_vps`/`pool_size_per_vp` → `coordinator_limits: dict[str, int]` and `pool_size: int`. Scaling engine made coordinator-generic. Config UI sliders dynamic. All tests updated.

## Test plan

- [x] `docker compose exec agentception mypy agentception/ tests/` — 0 errors
- [x] `docker compose exec agentception pytest agentception/tests/ -x -v` — 779 passed, 0 failed, ~11s