### PR TITLE
fix: run alembic upgrade head at container startup to prevent UndefinedColumnError

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - ${HOME}/.agentception/worktrees/agentception:/worktrees
     networks:
       - agentception-net
+    command: >
+      sh -c "cd /app && alembic -c agentception/alembic.ini upgrade head && exec uvicorn agentception.app:app --host 0.0.0.0 --port 10003"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -92,6 +92,11 @@ All three should show `running` (postgres and agentception will also show `healt
 
 ## Step 5 — Run database migrations
 
+> **Automatic:** `docker compose up` now runs `alembic upgrade head` before
+> starting the server, so migrations are applied automatically on every
+> container start.  You only need to run this manually when working outside
+> Compose (e.g. in CI or a bare Python environment).
+
 ```bash
 docker compose exec agentception alembic -c agentception/alembic.ini upgrade head
 ```


### PR DESCRIPTION
## Root cause

Migrations 0008 and 0009 (added in PRs #119–#120) were never applied to the live DB. Every query against `agent_runs` was silently failing with:

```
UndefinedColumnError: column agent_runs.node_type does not exist
```

`persist_agent_run_dispatch()` swallows exceptions (best-effort design), so the UI showed "Queued for launch" but nothing was written to the DB. `build_get_pending_launches` always returned `count: 0`, causing the Dispatcher to print "Queue is empty — nothing to dispatch."

## Fix

Prepend `alembic -c agentception/alembic.ini upgrade head` to the container `command` in `docker-compose.yml`. This runs before uvicorn starts on every `docker compose up` and is idempotent when the schema is already current.

Also manually applied migrations 0008 and 0009 to the live DB so the existing container is immediately healthy.

## Test plan
- [ ] `docker compose up` — logs show `alembic.runtime.migration` lines followed by `Application startup complete.`
- [ ] Launch from the new scope-based modal → Dispatcher sees the run in `build_get_pending_launches`
- [ ] New migration added in future PR → automatically applied on next `docker compose up` with no manual step