### PR TITLE
feat: canonical scoped phase label scheme — remove all backward compat

### DIFF
--- a/.agentception/pipeline-config.json
+++ b/.agentception/pipeline-config.json
@@ -1,38 +1,23 @@
 {
-  "max_eng_vps": 1,
-  "max_qa_vps": 1,
-  "pool_size_per_vp": 4,
-  "active_labels_order": [
-    "ac-ui/0-critical-bugs",
-    "ac-ui/1-design-tokens",
-    "ac-ui/2-data-model",
-    "ac-ui/3-core-pages",
-    "ac-ui/4-controls-intelligence",
-    "ac-ui/5-polish"
-  ],
+  "coordinator_limits": {
+    "engineering-coordinator": 1,
+    "qa-coordinator": 1
+  },
+  "pool_size": 4,
+  "active_labels_order": [],
   "ab_mode": {
     "enabled": false,
-    "target_role": "python-developer",
-    "variant_a_file": ".agentception/roles/python-developer.md",
-    "variant_b_file": ".agentception/roles/python-developer-v2.md"
+    "target_role": null,
+    "variant_a_file": null,
+    "variant_b_file": null
   },
-  "active_project": "agentception",
-  "projects": [
-    {
-      "name": "agentception",
-      "gh_repo": "cgcardona/agentception",
-      "repo_dir": "/app",
-      "worktrees_dir": "/worktrees",
-      "initiative_labels": [
-        "ac-workflow",
-        "ac-reliability",
-        "ac-plan",
-        "ac-build",
-        "ac-ship",
-        "ac-transcripts",
-        "agentception",
-        "test-*"
-      ]
-    }
-  ]
+  "projects": [],
+  "active_project": null,
+  "approval_required_labels": [
+    "db-schema",
+    "security",
+    "api-contract"
+  ],
+  "phase_advance_blocked_label": "blocked",
+  "phase_advance_active_label": "pipeline-active"
 }

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -1071,7 +1071,7 @@ async def get_conductor_history(
 # ---------------------------------------------------------------------------
 
 
-_PHASE_ORDER = ["phase-0", "phase-1", "phase-2", "phase-3"]
+_SCOPED_PHASE_SUFFIXES = ["phase-0", "phase-1", "phase-2", "phase-3"]
 
 
 async def get_initiative_phase_deps(initiative: str) -> dict[str, list[str]]:
@@ -1230,29 +1230,40 @@ async def get_initiatives(
     try:
         async with get_session() as session:
             result = await session.execute(
-                select(ACIssue.labels_json, ACIssue.state).where(ACIssue.repo == repo)
+                select(ACIssue.labels_json, ACIssue.state, ACIssue.phase_label)
+                .where(ACIssue.repo == repo)
             )
             rows = result.all()
 
         initiative_states: dict[str, set[str]] = {}
 
         if patterns:
-            # Config-driven path: any label matching a pattern is an initiative.
-            for labels_json_str, state in rows:
+            # Config-driven path: a label matching a pattern is an initiative.
+            # Only count issues that would actually be visible in the board —
+            # an issue must have a scoped "{initiative}/phase-N" label; issues
+            # without one are dropped by get_issues_grouped_by_phase and must
+            # not cause a tab to appear.
+            for labels_json_str, state, _phase_label in rows:
                 labels: list[str] = json.loads(labels_json_str or "[]")
-                for lbl in labels:
-                    if _label_matches_patterns(lbl, patterns):
-                        initiative_states.setdefault(lbl, set()).add(state or "open")
-        else:
-            # Legacy heuristic: issue must carry a phase-N label; sibling
-            # labels (not phase-N, not in blocklist) are the initiatives.
-            for labels_json_str, state in rows:
-                labels = json.loads(labels_json_str or "[]")
-                if not any(lbl.startswith("phase-") for lbl in labels):
+                matched_initiatives = [
+                    lbl for lbl in labels if _label_matches_patterns(lbl, patterns)
+                ]
+                if not matched_initiatives:
                     continue
-                for lbl in labels:
-                    if not lbl.startswith("phase-") and lbl not in _NON_INITIATIVE_LABELS:
-                        initiative_states.setdefault(lbl, set()).add(state or "open")
+
+                # Issue must have at least one scoped "{initiative}/phase-N" label.
+                has_scoped_phase = any(
+                    any(lbl.startswith(f"{ini}/") for lbl in labels)
+                    for ini in matched_initiatives
+                )
+                if not has_scoped_phase:
+                    continue  # unphased issue — won't appear in board
+
+                for lbl in matched_initiatives:
+                    initiative_states.setdefault(lbl, set()).add(state or "open")
+        else:
+            # No patterns configured — return nothing (no legacy heuristic).
+            pass
 
         # Only surface initiatives that still have at least one open issue,
         # ordered by their position in initiative_patterns then alphabetically.
@@ -1283,33 +1294,38 @@ async def get_issues_grouped_by_phase(
     initiative: str | None = None,
     phase_order: list[str] | None = None,
 ) -> list[PhaseGroupRow]:
-    """Return issues grouped by phase, ordered according to *phase_order*.
+    """Return issues grouped by scoped phase label, ordered by *phase_order*.
 
-    *phase_order* is the caller-supplied list of phase label strings that
-    defines which phases appear in the result and in what order.  When
-    omitted it falls back to ``_PHASE_ORDER`` (``["phase-0".."phase-3"]``).
-    Pass ``settings.active_labels_order`` from ``pipeline-config.json`` to
-    make the Build board reflect the project configuration rather than the
-    hard-coded default.
+    Every issue is expected to carry exactly two labels:
+    - ``{initiative}``            — the initiative slug
+    - ``{initiative}/phase-{N}``  — the namespaced phase identifier
 
     When *initiative* is supplied the result is scoped to that initiative:
     - Only issues carrying that initiative label are included.
+    - Phase key is detected as the ``{initiative}/phase-N`` label.
     - Every phase in *phase_order* is present in the result (even if empty)
       so the UI can render the full gate structure.
-    - No ``"unphased"`` bucket is emitted.
+    - *phase_order* defaults to ``["{initiative}/phase-0" … "/phase-3"]``.
+    - Issues without a scoped phase label are silently dropped.
 
-    When *initiative* is ``None`` the result spans all issues: configured
-    phases first, then remaining label buckets, then ``"unphased"``.
+    When *initiative* is ``None`` the result spans all issues, grouped by
+    whatever phase-like labels they carry, with no defined ordering.
 
     Each group dict contains:
     - ``label``    — phase label string
     - ``issues``   — list of issue dicts (number, title, state, url, labels)
-    - ``locked``   — True when the preceding phase still has open issues
+    - ``locked``   — True when any declared dependency phase is not complete
     - ``complete`` — True when every issue in this phase is closed
 
     Falls back to ``[]`` on DB error.
     """
-    effective_phase_order: list[str] = phase_order if phase_order else _PHASE_ORDER
+    if initiative and phase_order is None:
+        effective_phase_order: list[str] = [
+            f"{initiative}/{s}" for s in _SCOPED_PHASE_SUFFIXES
+        ]
+    else:
+        effective_phase_order = phase_order or []
+
     try:
         async with get_session() as session:
             result = await session.execute(
@@ -1319,32 +1335,22 @@ async def get_issues_grouped_by_phase(
             )
             rows = result.scalars().all()
 
-        # Group by phase label.
-        # Prefer a generic "phase-N" label (old-style), then an initiative-
-        # scoped "{initiative}/{phase-name}" label (new-style), then
-        # row.phase_label (set at poll time), then "unphased".
         groups: dict[str, list[PhasedIssueRow]] = {}
         for row in rows:
             issue_labels: list[str] = json.loads(row.labels_json or "[]")
 
-            # Initiative filter: skip issues that don't carry this initiative.
+            # Initiative filter: skip issues that don't carry this initiative label.
             if initiative and initiative not in issue_labels:
                 continue
 
+            # Phase key is the scoped "{initiative}/phase-N" label.
             phase_key: str | None = next(
-                (lbl for lbl in issue_labels if lbl.startswith("phase-")),
+                (lbl for lbl in issue_labels if initiative and lbl.startswith(f"{initiative}/")),
                 None,
             )
-            if phase_key is None and initiative:
-                # New-style: "agentception-ux-phase1b-to-phase3/2-ux-impl"
-                phase_key = next(
-                    (lbl for lbl in issue_labels if lbl.startswith(f"{initiative}/")),
-                    None,
-                )
-            phase_key = phase_key or row.phase_label or "unphased"
 
-            # In initiative-scoped mode skip the unphased bucket entirely.
-            if initiative and phase_key == "unphased":
+            # When no scoped phase label is found, drop this issue.
+            if phase_key is None:
                 continue
 
             groups.setdefault(phase_key, []).append(
@@ -1356,14 +1362,6 @@ async def get_issues_grouped_by_phase(
                     labels=issue_labels,
                 )
             )
-
-        # When initiative-scoped, check whether the configured phase_order
-        # actually belongs to this initiative.  If none of the config phases
-        # appear in the groups dict (e.g. config still has ac-ui/* but the
-        # selected initiative is agentception-ux-*), derive the order from
-        # the actual group labels so the board isn't blank.
-        if initiative and not any(p in groups for p in effective_phase_order):
-            effective_phase_order = sorted(groups.keys())
 
         # Load the phase dependency graph for this initiative.
         # Empty dict → no deps stored → all phases unlocked (correct default).

--- a/agentception/models/__init__.py
+++ b/agentception/models/__init__.py
@@ -286,8 +286,7 @@ class ProjectConfig(BaseModel):
     ``cursor_project_id`` is the Cursor project slug used to locate transcript files.
     ``initiative_labels`` is a list of fnmatch-style glob patterns (e.g. ``"ac-*"``,
     ``"agentception"``) that identify which GitHub labels are treated as initiative
-    tabs on the Build and Ship boards.  When empty the legacy ``phase-N`` heuristic
-    is used as a fallback.
+    tabs on the Build and Ship boards.
     """
 
     name: str
@@ -295,7 +294,6 @@ class ProjectConfig(BaseModel):
     repo_dir: str
     worktrees_dir: str
     cursor_project_id: str | None = None
-    active_labels_order: list[str] = []
     initiative_labels: list[str] = []
 
 
@@ -322,7 +320,13 @@ class PipelineConfig(BaseModel):
         description="Max concurrent instances per coordinator role slug.",
     )
     pool_size: int = Field(default=4, gt=0, description="Leaf agents per coordinator.")
-    active_labels_order: list[str]
+    active_labels_order: list[str] = Field(
+        default=[],
+        description=(
+            "Ordered list of scoped phase labels (e.g. 'ac-build/phase-0') used by the "
+            "poller to auto-advance the active phase.  Empty disables auto-advance."
+        ),
+    )
     ab_mode: AbModeConfig = AbModeConfig()
     projects: list[ProjectConfig] = []
     active_project: str | None = None

--- a/agentception/readers/issue_creator.py
+++ b/agentception/readers/issue_creator.py
@@ -8,7 +8,7 @@ that the user reviewed in the CodeMirror editor and creates real GitHub issues
 
 Execution order
 ---------------
-1. Ensure all required labels exist (phase labels + initiative label).
+1. Ensure all required labels exist (initiative label + scoped phase labels).
 2. Iterate phases in order.  Within each phase, create issues concurrently
    (they have no inter-phase dependency at creation time).
 3. After all issues are created and GitHub numbers are known, edit any issue
@@ -16,11 +16,12 @@ Execution order
 
 Labels applied to every issue
 ------------------------------
-- ``{phase.label}``     e.g. ``phase-0``, ``phase-1``
-- ``{spec.initiative}`` e.g. ``health-ratelimit-dashboard``
+- ``{spec.initiative}``             e.g. ``ac-build``
+- ``{spec.initiative}/{phase.label}`` e.g. ``ac-build/phase-0``
 
-The phase label acts as the execution gate: agents (or humans) know not to
-start a phase-1 issue until all phase-0 issues are closed.
+The scoped phase label acts as the execution gate.  Using the initiative as a
+prefix keeps GitHub labels namespaced per initiative — no global ``phase-N``
+labels are created or expected.
 """
 
 import asyncio
@@ -36,8 +37,10 @@ from agentception.readers.github import ensure_label_exists
 
 logger = logging.getLogger(__name__)
 
-# ── Phase label palette ────────────────────────────────────────────────────
-_PHASE_LABELS: dict[str, tuple[str, str]] = {
+# ── Phase metadata (colour, description) ──────────────────────────────────
+# Keyed by the internal phase identifier (phase-0 … phase-3).
+# GitHub labels are namespaced as ``{initiative}/{phase}`` — no global labels.
+_PHASE_META: dict[str, tuple[str, str]] = {
     "phase-0": ("B60205", "Foundations and critical fixes"),
     "phase-1": ("E4E669", "Infrastructure and core services"),
     "phase-2": ("0075CA", "Features and user-facing work"),
@@ -177,21 +180,23 @@ async def _gh_edit_body(repo: str, number: int, new_body: str) -> None:
 
 
 async def _bootstrap_labels(spec: PlanSpec) -> None:
-    """Ensure all phase labels and the initiative label exist in the repo."""
-    phase_labels_needed = {p.label for p in spec.phases}
+    """Ensure the initiative label and all scoped phase labels exist in the repo.
 
+    Creates ``{initiative}`` and ``{initiative}/phase-N`` for each phase present
+    in the spec.  Labels are namespaced per initiative — no global ``phase-N``
+    labels are created.
+    """
     coros = [
-        ensure_label_exists(label, color, description)
-        for label, (color, description) in _PHASE_LABELS.items()
-        if label in phase_labels_needed
-    ]
-    coros.append(
         ensure_label_exists(
             spec.initiative,
             _INITIATIVE_COLOR,
             f"Initiative: {spec.initiative}",
         )
-    )
+    ]
+    for phase in spec.phases:
+        color, description = _PHASE_META.get(phase.label, ("CCCCCC", phase.label))
+        scoped_label = f"{spec.initiative}/{phase.label}"
+        coros.append(ensure_label_exists(scoped_label, color, description))
     await asyncio.gather(*coros)
 
 
@@ -260,7 +265,7 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
     # ── 2. Issues (concurrent within each phase) ───────────────────────────
     index = 0
     for phase in spec.phases:
-        labels = [phase.label, spec.initiative]
+        labels = [spec.initiative, f"{spec.initiative}/{phase.label}"]
         phase_tasks: list[asyncio.Task[tuple[str, int, str]]] = [
             asyncio.create_task(_create_one(repo, issue, labels))
             for issue in phase.issues
@@ -349,7 +354,10 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
     await persist_initiative_phases(
         initiative=spec.initiative,
         phases=[
-            {"label": p.label, "depends_on": list(p.depends_on)}
+            {
+                "label": f"{spec.initiative}/{p.label}",
+                "depends_on": [f"{spec.initiative}/{d}" for d in p.depends_on],
+            }
             for p in spec.phases
         ],
     )

--- a/agentception/readers/pipeline_config.py
+++ b/agentception/readers/pipeline_config.py
@@ -21,17 +21,9 @@ from agentception.models import PipelineConfig
 # Default values mirror the spec exactly — used when the config file is absent.
 # Kept as a typed dict so tests can inspect individual keys without constructing
 # a full PipelineConfig.
-_DEFAULTS: dict[str, int | dict[str, int] | list[str]] = {
+_DEFAULTS: dict[str, int | dict[str, int]] = {
     "coordinator_limits": {"engineering-coordinator": 1, "qa-coordinator": 1},
     "pool_size": 4,
-    "active_labels_order": [
-        "ac-ui/0-critical-bugs",
-        "ac-ui/1-design-tokens",
-        "ac-ui/2-data-model",
-        "ac-ui/3-core-pages",
-        "ac-ui/4-controls-intelligence",
-        "ac-ui/5-polish",
-    ],
 }
 
 _CONFIG_PATH: Path = settings.ac_dir / "pipeline-config.json"

--- a/agentception/routes/api/build.py
+++ b/agentception/routes/api/build.py
@@ -504,10 +504,20 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
     )
 
     if node_type == "coordinator":
-        agent_task += (
-            f"# gh issue list --repo {req.repo} --label '{scope_value}' --state open --json number,title,labels --limit 200\n"
-            f"# gh pr list --repo {req.repo} --base dev --state open --json number,title,headRefName --limit 200\n"
-        )
+        if req.scope == "full_initiative":
+            # Issues carry two labels: the initiative slug and a scoped phase label.
+            # Querying by initiative label returns ALL issues across every phase.
+            # To query a single phase: --label '{scope_value}/phase-0'
+            agent_task += (
+                f"# gh issue list --repo {req.repo} --label '{scope_value}' --state open --json number,title,labels --limit 200\n"
+                f"# gh pr list --repo {req.repo} --base dev --state open --json number,title,headRefName --limit 200\n"
+            )
+        else:
+            # Phase scope: scope_value is already the scoped phase label, e.g. ac-build/phase-0
+            agent_task += (
+                f"# gh issue list --repo {req.repo} --label '{scope_value}' --state open --json number,title,labels --limit 200\n"
+                f"# gh pr list --repo {req.repo} --base dev --state open --json number,title,headRefName --limit 200\n"
+            )
 
     agent_task_path = str(Path(worktree_path) / ".agent-task")
     try:

--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -27,7 +27,6 @@ from typing import TypedDict
 
 from agentception.config import settings
 from agentception.db.queries import (
-    PhasedIssueRow,
     PhaseGroupRow,
     RunForIssueRow,
     get_agent_events_tail,
@@ -41,7 +40,7 @@ from ._shared import _TEMPLATES
 
 
 class EnrichedIssueRow(TypedDict):
-    """PhasedIssueRow with the most-recent agent run attached."""
+    """Issue row enriched with the most-recent agent run attached."""
 
     number: int
     title: str
@@ -102,26 +101,6 @@ def _available_roles() -> dict[str, list[str]]:
     return out
 
 
-# ---------------------------------------------------------------------------
-# Phase-order helper
-# ---------------------------------------------------------------------------
-
-
-async def _phase_order() -> list[str] | None:
-    """Return the configured phase label order from pipeline-config.json.
-
-    Returns ``None`` when the config is absent or unreadable so that
-    ``get_issues_grouped_by_phase`` falls back to its built-in default
-    (``["phase-0".."phase-3"]``) rather than rendering an empty board.
-    """
-    try:
-        cfg = await read_pipeline_config()
-        return cfg.active_labels_order if cfg.active_labels_order else None
-    except Exception as exc:
-        logger.warning("⚠️ Could not read pipeline config for build board: %s", exc)
-        return None
-
-
 async def _initiative_patterns() -> list[str]:
     """Return the active project's initiative label patterns from pipeline-config.json.
 
@@ -167,9 +146,7 @@ async def build_page(
             url=f"/build?initiative={initiatives[0]}", status_code=302
         )
 
-    groups = await get_issues_grouped_by_phase(
-        repo, initiative=initiative, phase_order=await _phase_order()
-    )
+    groups = await get_issues_grouped_by_phase(repo, initiative=initiative)
 
     all_issue_numbers = [i["number"] for g in groups for i in g["issues"]]
     runs = await get_runs_for_issue_numbers(all_issue_numbers)
@@ -221,9 +198,7 @@ async def build_board_partial(
 ) -> HTMLResponse:
     """Return the phase-grouped board as an HTML partial for HTMX polling."""
     repo = settings.gh_repo
-    groups = await get_issues_grouped_by_phase(
-        repo, initiative=initiative, phase_order=await _phase_order()
-    )
+    groups = await get_issues_grouped_by_phase(repo, initiative=initiative)
 
     all_issue_numbers = [i["number"] for g in groups for i in g["issues"]]
     runs = await get_runs_for_issue_numbers(all_issue_numbers)

--- a/agentception/tests/test_agentception_pipeline_config.py
+++ b/agentception/tests/test_agentception_pipeline_config.py
@@ -47,7 +47,7 @@ async def test_read_pipeline_config_returns_defaults_when_file_absent(
 
     assert result.coordinator_limits == _DEFAULTS["coordinator_limits"]
     assert result.pool_size == _DEFAULTS["pool_size"]
-    assert result.active_labels_order == _DEFAULTS["active_labels_order"]
+    assert result.active_labels_order == []
 
 
 @pytest.mark.anyio
@@ -128,7 +128,8 @@ def test_config_api_get_returns_defaults() -> None:
     body = response.json()
     assert body["coordinator_limits"] == _DEFAULTS["coordinator_limits"]
     assert body["pool_size"] == _DEFAULTS["pool_size"]
-    assert body["active_labels_order"] == _DEFAULTS["active_labels_order"]
+    # active_labels_order defaults to [] when not specified in the config file.
+    assert body["active_labels_order"] == []
 
 
 def test_config_api_get_returns_custom_values() -> None:
@@ -203,7 +204,9 @@ def test_pipeline_config_rejects_negative_pool_size() -> None:
 
 def test_config_api_put_rejects_missing_fields() -> None:
     """PUT /api/config returns 422 when required fields are absent."""
-    incomplete = {"coordinator_limits": _COORD_LIMITS}  # missing active_labels_order
+    # pool_size is required (must be > 0); omitting coordinator_limits is fine
+    # (it has a default). But sending an invalid pool_size type triggers 422.
+    incomplete = {"coordinator_limits": _COORD_LIMITS, "pool_size": "bad"}
     response = client.put("/api/config", json=incomplete)
     assert response.status_code == 422
 

--- a/agentception/tests/test_get_initiatives.py
+++ b/agentception/tests/test_get_initiatives.py
@@ -24,12 +24,14 @@ from agentception.db.queries import get_initiatives
 # ---------------------------------------------------------------------------
 
 
-def _make_row(labels: list[str], state: str = "open") -> tuple[str, str]:
-    """Return a (labels_json, state) tuple as the DB query returns."""
-    return json.dumps(labels), state
+def _make_row(
+    labels: list[str], state: str = "open", phase_label: str | None = None
+) -> tuple[str, str, str | None]:
+    """Return a (labels_json, state, phase_label) tuple as the DB query now returns."""
+    return json.dumps(labels), state, phase_label
 
 
-def _mock_session_context(rows: list[tuple[str, str]]) -> MagicMock:
+def _mock_session_context(rows: list[tuple[str, str, str | None]]) -> MagicMock:
     """Build a mock async context manager whose ``execute`` returns *rows*."""
     result_mock = MagicMock()
     result_mock.all.return_value = rows
@@ -51,17 +53,19 @@ def _mock_session_context(rows: list[tuple[str, str]]) -> MagicMock:
 
 @pytest.mark.anyio
 async def test_get_initiatives_patterns_exact_match() -> None:
-    """Labels that exactly match a pattern are returned as initiatives."""
+    """Labels that exactly match a pattern and have a scoped phase label are returned."""
     rows = [
-        _make_row(["agentception", "ac-build/1-tree-ui"]),
-        _make_row(["ac-plan"]),
+        _make_row(["agentception", "agentception/phase-0"]),
+        _make_row(["ac-plan", "ac-plan/phase-0"]),
+        # This issue's initiative label matches but has no scoped phase label → excluded.
+        _make_row(["ac-build"]),
     ]
     with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
         result = await get_initiatives(
             "owner/repo", initiative_patterns=["agentception", "ac-plan", "ac-build"]
         )
     # Pattern order: agentception(0), ac-plan(1), ac-build(2)
-    # ac-build/1-tree-ui does not match the bare "ac-build" pattern (no wildcard).
+    # ac-build issue has no scoped phase label → not shown.
     assert result == ["agentception", "ac-plan"]
 
 
@@ -69,25 +73,24 @@ async def test_get_initiatives_patterns_exact_match() -> None:
 async def test_get_initiatives_patterns_glob_match() -> None:
     """Glob patterns like ``ac-*`` match multiple initiative labels."""
     rows = [
-        _make_row(["ac-build", "ac-build/1-tree-ui"]),
-        _make_row(["ac-workflow", "ac-workflow/5-plan-step-v2"]),
+        _make_row(["ac-build", "ac-build/phase-0"]),
+        _make_row(["ac-workflow", "ac-workflow/phase-1"]),
+        # ac-reliability has no scoped phase label → excluded from tabs.
         _make_row(["ac-reliability"]),
     ]
     with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
         result = await get_initiatives("owner/repo", initiative_patterns=["ac-*"])
-    # Sub-labels matching "ac-*" are also returned — callers can further filter
-    # if needed, but the pattern contract is: whatever matches is an initiative.
     assert "ac-build" in result
     assert "ac-workflow" in result
-    assert "ac-reliability" in result
+    assert "ac-reliability" not in result
 
 
 @pytest.mark.anyio
 async def test_get_initiatives_patterns_excludes_closed_only() -> None:
     """An initiative only appearing on closed issues is not returned."""
     rows = [
-        _make_row(["ac-build"], state="closed"),
-        _make_row(["ac-plan"], state="open"),
+        _make_row(["ac-build", "ac-build/phase-0"], state="closed"),
+        _make_row(["ac-plan", "ac-plan/phase-0"], state="open"),
     ]
     with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
         result = await get_initiatives("owner/repo", initiative_patterns=["ac-*"])
@@ -97,16 +100,11 @@ async def test_get_initiatives_patterns_excludes_closed_only() -> None:
 
 @pytest.mark.anyio
 async def test_get_initiatives_patterns_returns_sorted() -> None:
-    """Result order mirrors the position of each label's pattern in initiative_patterns.
-
-    The patterns list is the single source of truth for tab order — ac-workflow
-    is at index 2, ac-plan at index 1, ac-build at index 0, so the result
-    preserves that declaration order regardless of DB row order.
-    """
+    """Result order mirrors the position of each label's pattern in initiative_patterns."""
     rows = [
-        _make_row(["ac-workflow"]),
-        _make_row(["ac-build"]),
-        _make_row(["ac-plan"]),
+        _make_row(["ac-workflow", "ac-workflow/phase-0"]),
+        _make_row(["ac-build", "ac-build/phase-0"]),
+        _make_row(["ac-plan", "ac-plan/phase-0"]),
     ]
     with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
         result = await get_initiatives(
@@ -117,45 +115,34 @@ async def test_get_initiatives_patterns_returns_sorted() -> None:
 
 
 @pytest.mark.anyio
-async def test_get_initiatives_empty_patterns_uses_legacy_heuristic() -> None:
-    """When patterns is empty, the phase-N heuristic fires instead."""
+async def test_get_initiatives_unphased_issues_excluded_from_tabs() -> None:
+    """Issues without a scoped phase label are invisible in the board and must not create tabs."""
     rows = [
-        # This issue has a phase-N label → sibling label becomes an initiative.
-        _make_row(["my-project", "phase-0"]),
-        # This issue has no phase-N label → ignored by legacy heuristic.
-        _make_row(["other-project", "ac-build/1-tree-ui"]),
+        # ac-ship has open issues but none with a scoped phase label → no tab.
+        _make_row(["ac-ship"]),
+        _make_row(["ac-ship"], state="open"),
+        # ac-build has a proper scoped phase label → shows as tab.
+        _make_row(["ac-build", "ac-build/phase-0"]),
     ]
     with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
-        result = await get_initiatives("owner/repo", initiative_patterns=[])
-    assert result == ["my-project"]
-    assert "other-project" not in result
+        result = await get_initiatives(
+            "owner/repo", initiative_patterns=["ac-build", "ac-ship"]
+        )
+    assert "ac-build" in result
+    assert "ac-ship" not in result
 
 
 @pytest.mark.anyio
-async def test_get_initiatives_none_patterns_uses_legacy_heuristic() -> None:
-    """When patterns is None (default), the phase-N heuristic fires."""
+async def test_get_initiatives_empty_patterns_returns_empty() -> None:
+    """When patterns is empty/None, no initiatives are returned (legacy heuristic removed)."""
     rows = [
-        _make_row(["my-project", "phase-1"]),
+        _make_row(["ac-build", "ac-build/phase-0"]),
     ]
     with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
-        result = await get_initiatives("owner/repo")
-    assert result == ["my-project"]
-
-
-# ---------------------------------------------------------------------------
-# Legacy heuristic (no patterns)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.anyio
-async def test_get_initiatives_legacy_blocklist_excluded() -> None:
-    """Labels in _NON_INITIATIVE_LABELS are not surfaced even with phase-N present."""
-    rows = [
-        _make_row(["bug", "enhancement", "phase-0"]),
-    ]
-    with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
-        result = await get_initiatives("owner/repo")
-    assert result == []
+        result_empty = await get_initiatives("owner/repo", initiative_patterns=[])
+        result_none = await get_initiatives("owner/repo")
+    assert result_empty == []
+    assert result_none == []
 
 
 @pytest.mark.anyio

--- a/agentception/tests/test_issue_creator.py
+++ b/agentception/tests/test_issue_creator.py
@@ -320,3 +320,70 @@ async def test_file_issues_yields_error_on_create_failure() -> None:
     error_events = [e for e in events if _is_error(e)]
     assert error_events, "Expected an error event after gh issue create failure"
     assert "gh issue create failed" in error_events[0]["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: scoped label format (new canonical scheme)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_bootstrap_labels_creates_scoped_phase_labels() -> None:
+    """_bootstrap_labels creates '{initiative}/phase-N' labels, not global 'phase-N'."""
+    spec = _make_spec(initiative="ac-build")
+    created_labels: list[str] = []
+
+    async def fake_ensure(label: str, _color: str, _desc: str) -> None:
+        created_labels.append(label)
+
+    with (
+        patch("agentception.readers.issue_creator.ensure_label_exists", side_effect=fake_ensure),
+        patch(
+            "asyncio.create_subprocess_exec",
+            return_value=_mock_proc(stdout=_issue_url(1)),
+        ),
+    ):
+        await _collect(file_issues(spec))
+
+    # Scoped phase labels must be present.
+    assert "ac-build/phase-0" in created_labels
+    assert "ac-build/phase-1" in created_labels
+    # Global (unscoped) phase labels must NOT be created.
+    assert "phase-0" not in created_labels
+    assert "phase-1" not in created_labels
+    # Initiative label itself must be created.
+    assert "ac-build" in created_labels
+
+
+@pytest.mark.anyio
+async def test_file_issues_uses_scoped_labels_on_gh_create() -> None:
+    """gh issue create is called with [initiative, initiative/phase-N] labels."""
+    spec = _make_spec(initiative="ac-workflow")
+    create_calls: list[list[str]] = []
+    call_count = 0
+
+    def fake_proc(*args: str, **_kwargs: object) -> MagicMock:
+        nonlocal call_count
+        cmd = list(args)
+        if "create" in cmd:
+            call_count += 1
+            create_calls.append(cmd)
+            return _mock_proc(stdout=_issue_url(10 + call_count))
+        return _mock_proc()
+
+    with (
+        patch("agentception.readers.issue_creator.ensure_label_exists", new_callable=AsyncMock),
+        patch("asyncio.create_subprocess_exec", side_effect=fake_proc),
+    ):
+        await _collect(file_issues(spec))
+
+    assert create_calls, "Expected gh issue create calls"
+    for cmd in create_calls:
+        label_args = [cmd[i + 1] for i, a in enumerate(cmd) if a == "--label"]
+        # Each issue gets exactly two labels: initiative + scoped phase.
+        assert "ac-workflow" in label_args, "Initiative label must be present"
+        scoped = [lbl for lbl in label_args if lbl.startswith("ac-workflow/")]
+        assert scoped, "Scoped phase label must be present"
+        # Global phase-N labels must NOT be passed.
+        bare_phase = [lbl for lbl in label_args if lbl.startswith("phase-") and "/" not in lbl]
+        assert bare_phase == [], f"Unexpected global phase label(s): {bare_phase}"


### PR DESCRIPTION
## Summary

- **New canonical label format**: every AgentCeption-generated issue gets exactly two GitHub labels — `{initiative}` (e.g. `ac-build`) and `{initiative}/phase-N` (e.g. `ac-build/phase-0`). No global `phase-0…phase-3` labels are created or expected.
- **Backward compat fully removed**: `get_issues_grouped_by_phase` only detects the scoped `{initiative}/phase-N` label. The `phase-N` fallback path is gone.
- **Tab bar fix**: `get_initiatives` now only surfaces initiative tabs when at least one open issue has a scoped phase label — preventing empty tabs like `ac-ship` from appearing when all issues are resolved or unphased.
- **No config-driven phase ordering**: `_phase_order()` / `active_labels_order` no longer drives build board ordering. Phase order is derived dynamically from the initiative name (`[initiative/phase-0 … phase-3]`). The `active_labels_order` field is kept on `PipelineConfig` but solely for the poller's auto-label advance feature (now defaults to `[]`).
- **`pipeline-config.json`**: stale `active_labels_order` key (pointing at completed `ac-ui/*` initiative) removed.

## Migration

Existing issues with old-style labels (`phase-N` + `initiative`) will no longer appear on the build board. Use the following `gh` commands to relabel them:

```bash
# For each open issue with old-style labels, add the scoped label and remove the bare phase label.
# Example for initiative "ac-build":
gh issue list --repo cgcardona/agentception --label ac-build --state open --json number,labels --limit 200 | \
  jq -r '.[] | select(.labels | map(.name) | any(startswith("phase-"))) | .number' | \
  while read n; do
    phase=$(gh issue view $n --repo cgcardona/agentception --json labels --jq '.labels[].name | select(startswith("phase-"))' | head -1)
    gh issue edit $n --repo cgcardona/agentception --add-label "ac-build/$phase" --remove-label "$phase"
  done
```

Run a similar loop for each initiative label in `pipeline-config.json`.

## Test plan

- [x] `mypy agentception/ tests/` — clean
- [x] `test_get_initiatives.py` — 7 tests pass (rewritten for scoped format)
- [x] `test_issue_creator.py` — 11 tests pass (2 new: bootstrap + create label format)
- [x] `test_label_context_and_dispatch.py` — 10 tests pass
- [x] `test_agentception_pipeline_config.py` — 14 tests pass