### PR TITLE
refactor: canonical label architecture — slash separator as invariant, optional project paths

### DIFF
--- a/.agentception/pipeline-config.json
+++ b/.agentception/pipeline-config.json
@@ -11,8 +11,15 @@
     "variant_a_file": null,
     "variant_b_file": null
   },
-  "projects": [],
-  "active_project": null,
+  "projects": [
+    {
+      "name": "agentception",
+      "gh_repo": "cgcardona/agentception",
+      "cursor_project_id": "Users-gabriel-dev-tellurstori-agentception",
+      "initiative_labels": ["ac-*"]
+    }
+  ],
+  "active_project": "agentception",
   "approval_required_labels": [
     "db-schema",
     "security",

--- a/agentception/config.py
+++ b/agentception/config.py
@@ -8,8 +8,11 @@ any env vars set.
 
 When ``pipeline-config.json`` contains a ``projects`` list and an
 ``active_project`` name, the model validator applies the matching project's
-``gh_repo``, ``repo_dir``, and ``worktrees_dir`` values over the env-var
-defaults.  This is the primary mechanism for multi-repo support (AC-601).
+``gh_repo`` over the env-var default.  ``repo_dir`` and ``worktrees_dir`` are
+only overridden when the project entry explicitly provides them (non-null),
+which is only needed for multi-repo setups where the active project lives in a
+different directory than the one the service was started against.  For the
+primary repo, omit those fields and let ``REPO_DIR`` / ``WORKTREES_DIR`` win.
 
 :func:`settings.reload` re-applies the active project on demand.  The poller
 calls it at the top of every tick so a project switch via the GUI takes effect
@@ -27,7 +30,13 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_project(raw: dict[str, object], target: AgentCeptionSettings) -> None:
-    """Apply the active project's path overrides from *raw* onto *target* in-place.
+    """Apply the active project's overrides from *raw* onto *target* in-place.
+
+    Only ``gh_repo`` is always applied from the project entry.  ``repo_dir``
+    and ``worktrees_dir`` are applied only when the project entry explicitly
+    provides a non-null string value — omitting them lets the environment
+    variables (``REPO_DIR``, ``WORKTREES_DIR``) remain authoritative, which is
+    the correct behaviour for the primary (single-repo) use case.
 
     Extracted as a module-level helper so both the Pydantic validator and
     :meth:`AgentCeptionSettings.reload` can share identical logic without

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -1246,7 +1246,11 @@ async def get_initiatives(
             for labels_json_str, state, _phase_label in rows:
                 labels: list[str] = json.loads(labels_json_str or "[]")
                 matched_initiatives = [
-                    lbl for lbl in labels if _label_matches_patterns(lbl, patterns)
+                    lbl
+                    for lbl in labels
+                    # Scoped phase labels (e.g. "ac-build/phase-0") are never
+                    # initiatives — the "/" is the canonical separator.
+                    if "/" not in lbl and _label_matches_patterns(lbl, patterns)
                 ]
                 if not matched_initiatives:
                     continue

--- a/agentception/models/__init__.py
+++ b/agentception/models/__init__.py
@@ -282,17 +282,25 @@ class ProjectConfig(BaseModel):
     The ``active_project`` field in :class:`PipelineConfig` selects which
     project the AgentCeption dashboard currently targets.
 
-    ``worktrees_dir`` supports ``~`` expansion (e.g. ``~/.agentception/worktrees/agentception``).
+    ``repo_dir`` and ``worktrees_dir`` are optional.  When absent, the values
+    from the environment (``REPO_DIR``, ``WORKTREES_DIR``) are used unchanged.
+    Set them only when targeting a *different* repository than the one the
+    service was started against — e.g. in a multi-repo setup.
+    ``worktrees_dir`` supports ``~`` expansion.
+
     ``cursor_project_id`` is the Cursor project slug used to locate transcript files.
-    ``initiative_labels`` is a list of fnmatch-style glob patterns (e.g. ``"ac-*"``,
-    ``"agentception"``) that identify which GitHub labels are treated as initiative
-    tabs on the Build and Ship boards.
+
+    ``initiative_labels`` is a list of fnmatch-style glob patterns (e.g. ``"ac-*"``)
+    that identify which GitHub labels are treated as initiative tabs on the Build
+    and Ship boards.  Patterns are matched only against labels that contain no
+    ``/``, so scoped phase labels (``ac-build/phase-0``) are never surfaced as
+    initiative tabs regardless of the pattern.
     """
 
     name: str
     gh_repo: str
-    repo_dir: str
-    worktrees_dir: str
+    repo_dir: str | None = None
+    worktrees_dir: str | None = None
     cursor_project_id: str | None = None
     initiative_labels: list[str] = []
 

--- a/agentception/tests/test_get_initiatives.py
+++ b/agentception/tests/test_get_initiatives.py
@@ -86,6 +86,22 @@ async def test_get_initiatives_patterns_glob_match() -> None:
 
 
 @pytest.mark.anyio
+async def test_get_initiatives_glob_never_matches_scoped_phase_labels() -> None:
+    """``ac-*`` must not surface scoped phase labels (e.g. ``ac-build/phase-0``) as initiative tabs.
+
+    Python's fnmatch ``*`` matches ``/``, so without the ``"/" not in lbl`` guard
+    the pattern would match ``ac-build/phase-0`` and create a phantom tab.
+    """
+    rows = [
+        _make_row(["ac-build", "ac-build/phase-0"]),
+    ]
+    with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
+        result = await get_initiatives("owner/repo", initiative_patterns=["ac-*"])
+    assert result == ["ac-build"]
+    assert "ac-build/phase-0" not in result
+
+
+@pytest.mark.anyio
 async def test_get_initiatives_patterns_excludes_closed_only() -> None:
     """An initiative only appearing on closed issues is not returned."""
     rows = [


### PR DESCRIPTION
## Summary

- **`ProjectConfig.repo_dir` / `worktrees_dir` made optional** — when absent, `REPO_DIR` / `WORKTREES_DIR` env vars remain authoritative. Hardcoding container-internal paths (e.g. `/app`) in a committed config file is environment-specific and breaks outside Docker. These fields are now reserved for multi-repo cross-mount setups only.
- **`get_initiatives` slash guard** — added `"/" not in lbl` filter before fnmatch matching. Python's `fnmatch *` matches `/`, so `"ac-*"` would otherwise match `ac-build/phase-0` and surface phantom initiative tabs. The slash is now a code-enforced invariant: top-level initiative labels never contain `/`, scoped phase labels always do.
- **`pipeline-config.json` simplified** — `repo_dir`/`worktrees_dir` removed (env wins), `initiative_labels` collapsed from six explicit names to `["ac-*"]`. New initiatives are automatically visible with zero config changes.

## Test plan

- [ ] `test_get_initiatives_glob_never_matches_scoped_phase_labels` — new test that pins the fnmatch footgun and documents the slash invariant
- [ ] All 24 existing tests in `test_get_initiatives.py` and `test_agentception_pipeline_config.py` pass
- [ ] `mypy agentception/ tests/` — clean, zero errors
- [ ] Live service (`GET /build`) still redirects to the correct initiative tab