### PR TITLE
docs: streamline README + build comprehensive reference library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,27 @@
 # AgentCeption
 
 [![CI](https://github.com/cgcardona/agentception/actions/workflows/ci.yml/badge.svg)](https://github.com/cgcardona/agentception/actions/workflows/ci.yml)
-
-> *The Singularity is here.*
-
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
----
+> *The infinite machine behind the machines.*
 
-## The Idea
-
-For all of recorded history, human progress has been constrained by one thing: the number of hours in a day multiplied by the number of people willing to work. Every civilization, every company, every creative act has bumped against this ceiling. We called it scarcity, and we built entire economic systems around managing it.
-
-Then something changed.
-
-The pace of technological change has been accelerating for decades — we've been saying "the singularity is near" for so long it started to sound like a punchline. Then it became "the singularity is nearer," because anyone paying attention could see the curve bending. But with the arrival of autonomous AI agents that can reason, plan, write code, open pull requests, and report back — the singularity isn't near. **It's here.**
-
-What changes when you can take any piece of drudgery — any repetitive, mechanical, soul-draining work — and hand it to an org chart of agents who will execute it while you sleep? Everything changes. The nature of work changes. The relationship between human creativity and human labor changes. The ceiling lifts.
-
-We are moving from a world of scarcity into a world of **superabundance**. Not just material abundance — abundance of time, of creative capacity, of the ability to pursue what is actually meaningful. Every hour an agent spends filing tickets, writing boilerplate, and opening PRs is an hour a human gets back to think, to create, to be human.
-
-AgentCeption is a bet on that future.
-
----
-
-## What It Does
-
-AgentCeption is a multi-agent orchestration system built on a simple insight: **any body of work can be expressed as an org chart, and any org chart can be staffed by agents.**
-
-You describe what needs to happen. AgentCeption — powered by Claude — translates that into a phase-gated plan: a dependency graph of GitHub issues, organized into waves, sequenced by what must happen before what. Then it dispatches the right agents at the right level of the org tree to execute each wave, autonomously, in parallel, reporting back as they go.
+**AgentCeption** is a multi-agent orchestration system that turns any idea into a phase-gated plan, files the GitHub issues, and dispatches an org chart of AI agents to execute it — autonomously, in parallel, while you sleep.
 
 ```
-Your idea
-    ↓
-Phase 1A — Claude converts your brain dump into a structured PlanSpec YAML
-    ↓
-Phase 1B — You review and approve the plan in the editor
-    ↓
-GitHub issues created, labeled, and phase-gated automatically
-    ↓
-AgentCeption dispatches agents by org tier and label scope:
-  CTO → VP → Engineer
-    ↓
-Agents open PRs → PRs reviewed → merged → next phase unlocks
-    ↓
-Done. While you were thinking about the next big idea.
+Brain dump → Structured plan → GitHub issues → Agent org tree → PRs → Merged
 ```
 
-The org tree is not a metaphor. It's a literal hierarchy:
-
-- A **CTO-tier agent** surveys the board, identifies which phase is unlocked, and decides what to spin up.
-- A **VP-tier agent** receives a label scope, breaks it into individual tickets, and spawns engineers.
-- **Engineer-tier agents** each own a single issue, implement it in an isolated git worktree, and open a PR.
-
-Every agent in this chain has a **cognitive architecture** injected into its context — a composition of figures (historical thinkers and builders), archetypes (thinking styles), skill domains (technical expertise), and atoms (behavioral primitives). You are not deploying generic LLM calls. You are deploying *reasoners*, each shaped for their role.
+One input. Zero boilerplate. The work happens.
 
 ---
 
-## Why It Matters
+## How It Works
 
-Most AI coding tools are power tools. They make individual developers faster. That's good. But they leave the fundamental structure of work untouched — one human, one problem, one context window.
+1. **Plan** — Paste anything. Claude converts it into a `PlanSpec`: phases, issues, dependencies, acceptance criteria.
+2. **Review** — The YAML opens in an editor. Adjust anything. Click **Create Issues** to file everything on GitHub.
+3. **Ship** — The board shows your phases. Click **Launch** on an unlocked phase. A CTO agent surveys the board and cascades work down to coordinators and engineers, each working in an isolated git worktree. PRs appear. Phases unlock. You watch.
 
-AgentCeption is not a power tool. It's a **force multiplier on the organizational unit itself.**
-
-The question it asks is: what would a brilliant 10-person team look like if the team had no size limit? What would you build if you could staff any initiative with the exactly right agents in the exactly right roles, instantly, at no marginal cost?
-
-That question used to be science fiction. It isn't anymore.
-
-We believe this changes what's possible for individual creators, small teams, and anyone who has ever had an idea bigger than their bandwidth. The creative renaissance that has always been one good team away is now one brain dump away.
+Every agent has a **cognitive architecture** — a composed identity (historical thinkers + archetypes + skill domains + behavioral atoms) injected into its context. You are deploying *reasoners*, not LLM calls.
 
 ---
 
@@ -76,7 +30,7 @@ We believe this changes what's possible for individual creators, small teams, an
 ```bash
 git clone https://github.com/cgcardona/agentception
 cd agentception
-cp .env.example .env        # fill in required values (see below)
+cp .env.example .env        # fill in the required values below
 docker compose up -d
 docker compose exec agentception alembic upgrade head
 open http://localhost:10003
@@ -86,99 +40,60 @@ open http://localhost:10003
 
 | Variable | Description |
 |----------|-------------|
-| `DATABASE_URL` | PostgreSQL connection string (see docker-compose.yml for local defaults) |
+| `DATABASE_URL` | PostgreSQL connection string (see `docker-compose.yml` for defaults) |
 | `GITHUB_TOKEN` | GitHub PAT with `repo` + `issues` scope |
-| `GH_REPO` | The repo this instance manages (`owner/repo`) |
+| `GH_REPO` | Repo this instance manages — `owner/repo` |
 | `OPENROUTER_API_KEY` | OpenRouter API key for Phase 1A planning |
 | `HOST_WORKTREES_DIR` | Host path where agent worktrees are created |
 
-See `.env.example` for the full list with descriptions. See [docs/guides/setup.md](docs/guides/setup.md) for detailed setup instructions.
+See [docs/guides/setup.md](docs/guides/setup.md) for the full first-run walkthrough.
 
 ---
 
-## The Planning Workflow
+## MCP Integration (Cursor / Claude)
 
-### Phase 1A — From brain dump to plan
+AgentCeption exposes an MCP server so Cursor and Claude can invoke tools directly:
 
-Open the dashboard at `http://localhost:10003`. Paste anything — a rough idea, a wall of text, a list of tasks, a complaint about what's broken. Click **Plan**.
-
-Claude reads it, reasons about dependencies, and produces a `PlanSpec` YAML: a structured, phase-gated plan with real GitHub issue titles and full structured bodies (context, objective, implementation notes, acceptance criteria, test coverage, documentation, and scope boundaries).
-
-### Phase 1B — Review and approve
-
-The YAML opens in an editor. Read it. Edit it. Add things the LLM missed. Remove things that aren't right. When you're satisfied, click **Create Issues** — AgentCeption files everything on GitHub, creates the phase labels, and wires the dependency graph.
-
-### Dispatch
-
-The Build board shows your phases. Phases that are ready to execute are unlocked. Click **Launch** on any unlocked phase to dispatch the org tree. The CTO agent surveys the board and cascades work down through VPs to engineers, each working in their own isolated git worktree.
-
-You watch the PRs appear.
-
----
-
-## Cognitive Architecture
-
-Every agent dispatched by AgentCeption has a **cognitive architecture** — a composed identity injected into its system prompt that shapes how it reasons.
-
-The architecture has four layers:
-
-| Layer | What it does |
-|-------|-------------|
-| **Figures** | Historical thinkers and builders who model how to think (e.g. Alan Turing for logical rigor, Steve Jobs for taste-driven simplicity) |
-| **Archetypes** | Abstract thinking styles (Architect, Craftsperson, Strategist, etc.) |
-| **Skill domains** | Technical expertise areas (Python, FastAPI, PostgreSQL, DevOps, LLM, etc.) |
-| **Atoms** | Fine-grained behavioral primitives (precision, pragmatism, epistemic humility, etc.) |
-
-You choose a figure, an archetype, and skill domains for each agent role. The `resolve_arch.py` engine composes them into a single, coherent system prompt with governing heuristics, failure modes, and behavioral checkpoints. The result is an agent that doesn't just execute — it reasons in a particular way.
-
-This is the infrastructure for deploying *judgment at scale*.
-
----
-
-## Architecture
-
-```
-agentception/
-  api/routes/      → Thin HTTP handlers
-  readers/         → LLM planner, issue creator, worktree manager, GitHub client
-  services/        → LLM calls, external integrations
-  db/              → SQLAlchemy models, Alembic migrations
-  routes/          → UI (Jinja2/HTMX/Alpine.js) and API (JSON/SSE) routes
-  mcp/             → MCP server (Cursor/Claude tool integration)
-  static/          → Compiled JS/CSS bundles
-  templates/       → Jinja2 HTML templates
-  config.py        → Pydantic Settings (env vars)
-  models.py        → PlanSpec, PlanIssue, PlanPhase, and domain models
-
-scripts/
-  gen_prompts/     → Cognitive architecture engine
-    resolve_arch.py           → Composes figure + archetype + skills into agent prompts
-    cognitive_archetypes/     → YAML definitions for figures, archetypes, skill domains, atoms
-
-.agentception/
-  roles/           → Agent role markdown files (c-suite/, vps/, engineering/)
-  prompts/         → Prompt templates
+```json
+{
+  "mcpServers": {
+    "agentception": {
+      "command": "docker",
+      "args": ["compose", "-f", "/path/to/agentception/docker-compose.yml",
+               "exec", "-T", "agentception", "python", "-m", "agentception.mcp.stdio_server"]
+    }
+  }
+}
 ```
 
-**Stack:** Python 3.11+, FastAPI, Jinja2, HTMX, Alpine.js, SCSS, Pydantic v2, SQLAlchemy (async), Alembic, PostgreSQL.
-
-**Models:** `anthropic/claude-sonnet-4.6` and `anthropic/claude-opus-4.6` via OpenRouter.
+See [docs/guides/mcp.md](docs/guides/mcp.md) for the full tool reference.
 
 ---
 
-## Quick Reference
+## Documentation
 
-| Area | Description |
-|------|-------------|
-| **Developer tools** | [`scripts/dev.sh`](scripts/dev.sh) — Convenience wrapper for mypy / test / cover / build / restart / logs / migrate / shell |
-| **Guides** | [Developer workflow](docs/guides/developer-workflow.md) · [Contributing](docs/guides/contributing.md) — Bind-mount loop, verification order, branch protection, PR & commit conventions |
-| **Changelog** | [`CHANGELOG.md`](CHANGELOG.md) — Release history in Keep a Changelog 1.0.0 format |
+| Guide | What it covers |
+|-------|----------------|
+| [Setup](docs/guides/setup.md) | First-run, Docker, environment variables |
+| [MCP Integration](docs/guides/mcp.md) | Cursor / Claude tool integration |
+| [Developer Workflow](docs/guides/developer-workflow.md) | Bind mounts, mypy, tests, build pipeline |
+| [Contributing](docs/guides/contributing.md) | Branch conventions, PR process, commit style |
+
+| Reference | What it covers |
+|-----------|----------------|
+| [API Routes](docs/reference/api.md) | Every HTTP endpoint — semantic URL taxonomy |
+| [Agent Task Spec](docs/reference/agent-task.md) | `.agent-task` TOML format — all sections and fields |
+| [Type Contracts](docs/reference/type-contracts.md) | Pydantic models, TypedDicts, layer contracts |
+| [Cognitive Architecture](docs/reference/cognitive-arch.md) | Figures, archetypes, skill domains, atoms |
+| [YAML Configuration](docs/reference/yaml-config.md) | `config.yaml`, `team.yaml`, `role-taxonomy.yaml` |
 
 ---
 
-## Related Projects
+## Stack
 
-- **[cgcardona/agentception](https://github.com/cgcardona/agentception)** — AI music composition backend for the Muse client. AgentCeption was originally co-located here and has been extracted into this standalone repository.
+Python 3.11 · FastAPI · Jinja2 · HTMX · Alpine.js · SCSS · Pydantic v2 · SQLAlchemy (async) · Alembic · PostgreSQL · Qdrant
+
+Models: `anthropic/claude-sonnet-4.6` and `anthropic/claude-opus-4.6` via OpenRouter.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,160 @@
+# AgentCeption Documentation
+
+Everything you need to understand, operate, and extend AgentCeption.
+
+---
+
+## Guides
+
+Step-by-step instructions for humans.
+
+| Guide | Summary |
+|-------|---------|
+| [Setup](guides/setup.md) | First-run walkthrough — Docker, environment variables, database migrations |
+| [MCP Integration](guides/mcp.md) | Connect Cursor / Claude to AgentCeption via the MCP server |
+| [Developer Workflow](guides/developer-workflow.md) | Bind-mount loop, mypy → tests → docs verification order, JS/CSS build pipeline |
+| [Contributing](guides/contributing.md) | Branch naming, commit conventions, PR checklist, code review expectations |
+| [CI](guides/ci.md) | GitHub Actions pipeline — what runs, how to reproduce locally |
+
+---
+
+## Reference
+
+Precise specifications for every system component.
+
+| Reference | Summary |
+|-----------|---------|
+| [API Routes](reference/api.md) | Complete HTTP endpoint inventory — semantic URL taxonomy, request/response shapes |
+| [Agent Task Spec](reference/agent-task.md) | `.agent-task` TOML format — every section, every field, with examples |
+| [Type Contracts](reference/type-contracts.md) | Pydantic models, TypedDicts, and the typed layer contracts between DB → service → route |
+| [Cognitive Architecture](reference/cognitive-arch.md) | Figures, archetypes, skill domains, atoms — how agents get their identities |
+| [YAML Configuration](reference/yaml-config.md) | `config.yaml`, `team.yaml`, `role-taxonomy.yaml` — full field reference |
+
+---
+
+## System Overview
+
+### The pipeline in one diagram
+
+```
+User input (brain dump)
+        │
+        ▼
+┌─────────────────────────────────────┐
+│  Phase 1A — LLM Planning            │
+│  POST /api/plan/launch              │
+│  llm_phase_planner.py               │
+│  → PlanSpec YAML (phases + issues)  │
+└─────────────────────────────────────┘
+        │
+        ▼  (human reviews in editor)
+┌─────────────────────────────────────┐
+│  Phase 1B — Issue Filing            │
+│  POST /api/plan/file-issues         │
+│  issue_creator.py                   │
+│  → GitHub issues + phase labels     │
+│  → initiative_phases rows in DB     │
+└─────────────────────────────────────┘
+        │
+        ▼  (human clicks Launch on Ship board)
+┌─────────────────────────────────────┐
+│  Dispatch                           │
+│  POST /api/dispatch/label           │
+│  worktrees.py                       │
+│  → git worktree + .agent-task file  │
+│  → ACAgentRun row in DB             │
+└─────────────────────────────────────┘
+        │
+        ▼  (agent picks up its .agent-task)
+┌─────────────────────────────────────┐
+│  Org tree execution                 │
+│  CTO → Coordinator → Engineer       │
+│  Each agent in its own worktree     │
+│  Reports via POST /api/runs/{id}/*  │
+└─────────────────────────────────────┘
+        │
+        ▼
+┌─────────────────────────────────────┐
+│  Phase gate check                   │
+│  POST /api/ship/{initiative}/advance│
+│  plan_advance_phase MCP tool        │
+│  → Next phase unlocks in DB         │
+└─────────────────────────────────────┘
+```
+
+### Directory structure
+
+```
+agentception/
+  config.py          → Pydantic Settings (all AC_* env vars)
+  models/            → Domain models: PlanSpec, PlanPhase, PlanIssue, TaskFile
+  db/
+    models.py        → SQLAlchemy ORM (ACIssue, ACAgentRun, ACInitiativePhase, …)
+    persist.py       → Write functions (one per resource type)
+    queries.py       → Read functions, returning typed TypedDicts
+  readers/
+    llm_phase_planner.py  → Phase 1A: LLM → PlanSpec YAML
+    issue_creator.py      → Phase 1B: PlanSpec → GitHub issues + DB rows
+    worktrees.py          → Agent dispatch: git worktree + .agent-task + DB row
+  routes/
+    ui/              → Browser-facing pages (Jinja2/HTMX)
+      build_ui.py    → /plan, /ship/{initiative}, /ship/{initiative}/board
+      cognitive_arch.py → /cognitive-arch, /cognitive-arch/{id}
+    api/
+      dispatch.py    → /api/dispatch/* (issue, label, context, prompt)
+      runs.py        → /api/runs/* (pending, acknowledge, children, step, …)
+      ship_api.py    → /api/ship/{initiative}/advance
+  mcp/
+    server.py        → MCP tool definitions (plan_*, build_*, …)
+    stdio_server.py  → stdio transport for Cursor integration
+  static/
+    app.js           → Compiled JS bundle (never edit directly)
+    app.css          → Compiled CSS bundle (never edit directly)
+    js/              → JS source files (build with npm run build:js)
+    scss/            → SCSS source files (build with npm run build:css)
+  templates/         → Jinja2 HTML templates
+  alembic/           → Database migration scripts
+
+scripts/
+  gen_prompts/       → Cognitive architecture engine
+    generate.py      → Renders all .j2 templates into final prompt files
+    resolve_arch.py  → Composes figure + archetype + skills into agent prompts
+    config.yaml      → Pipeline configuration (phases, codebase routing)
+    team.yaml        → Agent team definitions
+    role-taxonomy.yaml → Full org chart (C-Suite → VP → Engineering)
+    cognitive_archetypes/
+      figures/       → Historical thinkers (YAML)
+      archetypes/    → Abstract thinking styles (YAML)
+      skill_domains/ → Technical expertise areas (YAML)
+      atoms/         → Behavioral primitives (YAML)
+    templates/       → Jinja2 prompt templates (.j2)
+      snippets/      → Shared fragments (included, not rendered directly)
+
+.agentception/
+  agent-task-spec.md → Formal .agent-task TOML specification
+  roles/             → Generated agent role markdown files
+  prompts/           → Generated prompt templates
+  pipeline-config.json → Runtime pipeline configuration
+```
+
+### Services
+
+| Service | Container | Port |
+|---------|-----------|------|
+| AgentCeption | `agentception` | 10003 |
+| Postgres | `agentception-postgres` | 5433 |
+| Qdrant | `agentception-qdrant` | 6335 / 6336 |
+
+---
+
+## Key Principles
+
+**Layers never collapse.** Routes are thin (no business logic). Business logic lives in `readers/`. Data shapes live in `db/queries.py` TypedDicts and `models/` Pydantic models.
+
+**Zero `Any`.** The codebase runs `mypy --strict` with a hard ceiling of 0 `Any` patterns. Every type is named. If you know the keys, use a `TypedDict`. If you know the shape, use a `BaseModel`.
+
+**Docker-first.** Never run Python on the host. All commands run inside the container via `docker compose exec agentception <cmd>`. Dev bind mounts mean host edits are instantly visible inside — no rebuild needed for code changes.
+
+**MCP-first.** Agent-to-app communication uses MCP tools. HTTP endpoints exist as the semantic backing for MCP and browser-driven interactions — they are not a secondary transport layer.
+
+**Verification order: mypy → tests → docs.** Always run mypy first. Fix type errors before running tests. Update docs in the same commit as code changes.

--- a/docs/reference/agent-task.md
+++ b/docs/reference/agent-task.md
@@ -1,0 +1,218 @@
+# Agent Task Specification
+
+> **Canonical source:** [`.agentception/agent-task-spec.md`](../../.agentception/agent-task-spec.md) — full field reference, all workflow types, complete examples.
+>
+> **Format:** [TOML 1.0](https://toml.io/en/v1.0.0)  
+> **Parser:** `agentception/readers/worktrees.py` → `TaskFile` Pydantic model  
+> **Version:** 2.0
+
+---
+
+## What is an `.agent-task` file?
+
+Every agent worktree contains exactly one `.agent-task` file at its root. It is the **single source of truth** for that agent's identity, assignment, pipeline position, and execution constraints.
+
+Two consumers read it with different goals:
+
+| Consumer | What it reads | How |
+|----------|--------------|-----|
+| AgentCeption dashboard | Typed scalar fields for monitoring | `tomllib.loads()` → `TaskFile` model |
+| Cursor's LLM (the agent) | Full raw text as natural language context | File read → context window |
+
+Because the LLM reads the entire file, **any valid TOML you add is immediately available to the agent** — even fields AgentCeption doesn't formally parse. This makes the format extensible at zero cost.
+
+---
+
+## Section overview
+
+```toml
+[task]          # Core identity: workflow type, attempt number, required output
+[agent]         # Who runs this task: role, tier, cognitive architecture
+[repo]          # GitHub + git coordinates
+[pipeline]      # Batch/wave lineage for traceability
+[spawn]         # Orchestration: chain, single, or coordinator
+[target]        # What this task acts on (issue, PR, or deliverable)
+[worktree]      # Local filesystem path + branch
+[output]        # Async result rendezvous (for Cursor-driven workflows)
+[domain]        # Non-tech domain context (marketing, legal, ops, etc.)
+
+[plan_draft]        # Payload for plan-spec workflow
+[enriched]          # Pre-enriched coordinator manifest
+
+[[issue_queue]]     # Sub-task list for coordinator agents
+[[pr_queue]]        # PR review list for QA coordinators
+[[deliverable_queue]] # Non-code deliverable list
+```
+
+---
+
+## Quick field reference
+
+### `[task]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | `"2.0"` | Always `"2.0"` for current TOML format |
+| `workflow` | string | One of `issue-to-pr`, `pr-review`, `coordinator`, `conductor`, `bugs-to-issues`, `plan-spec`, `task-to-deliverable` |
+| `id` | UUID v4 | Unique identifier for this task instance |
+| `created_at` | datetime | When this file was written |
+| `attempt_n` | int | Retry counter — agent hard-stops when `> 2` |
+| `required_output` | string | Artifact to produce: `pr_url`, `yaml_file`, `deliverable_path`, etc. |
+| `on_block` | string | `"stop"` or `"escalate"` |
+
+### `[agent]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `role` | string | Role slug: `python-developer`, `cto`, `engineering-coordinator`, etc. |
+| `logical_tier` | string | `executive`, `coordinator`, `engineer`, or `reviewer` |
+| `cognitive_arch` | string | `"figure:skill1:skill2"` — composed by `resolve_arch.py` |
+| `node_type` | string | `coordinator` or `leaf` — drives dispatch behavior |
+
+### `[repo]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `gh_repo` | string | `"owner/repo"` — never derived from local path |
+| `base` | string | Base branch: `"dev"` |
+
+### `[pipeline]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `batch_id` | string | Batch fingerprint: `"label-ac-workflow-20260101T000000Z-abcd"` |
+| `parent_run_id` | string | `run_id` of the spawning agent (empty for CTO root) |
+| `wave` | string | Named phase wave (e.g. `"0-foundation"`) |
+
+### `[spawn]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mode` | string | `"chain"` (auto-spawn reviewer), `"single"` (do and stop), `"coordinator"` (spawn leaf agents from queue) |
+| `sub_agents` | bool | `true` → act as sub-coordinator |
+| `max_concurrent` | int | Safety valve for concurrent leaf agents (default: 4) |
+
+### `[target]`
+
+Fields depend on workflow. Key fields:
+
+| Field | Workflows | Description |
+|-------|-----------|-------------|
+| `issue_number` | `issue-to-pr` | GitHub issue number |
+| `depends_on` | `issue-to-pr` | Issue numbers that must merge first |
+| `closes` | `issue-to-pr` | Issues to close when PR merges |
+| `file_ownership` | `issue-to-pr` | Files this agent owns (conflict prevention) |
+| `pr_number` | `pr-review` | Pull request number |
+| `grade_threshold` | `pr-review` | Minimum grade to merge: `"A"`, `"B"`, `"C"` |
+| `deliverable_type` | `task-to-deliverable` | Type of non-code artifact |
+
+### `[worktree]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | Absolute path to this worktree |
+| `branch` | string | Git branch name |
+| `linked_pr` | int | Written back by agent after PR opens (0 until then) |
+
+### `[output]`
+
+Used when Cursor does LLM work and writes a result to disk.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | Path Cursor writes its output to |
+| `draft_id` | UUID | Correlates to the dashboard request |
+| `format` | string | `"yaml"`, `"json"`, `"markdown"`, `"toml"` |
+| `schema_tool` | string | MCP tool to call for the output schema |
+
+---
+
+## Minimal example (issue-to-PR)
+
+```toml
+[task]
+version = "2.0"
+workflow = "issue-to-pr"
+id = "3f4a9c2e-1b8d-4e7f-a6c5-9d2e8f0b1a3c"
+created_at = 2026-03-03T13:48:21Z
+attempt_n = 0
+required_output = "pr_url"
+on_block = "stop"
+
+[agent]
+role = "python-developer"
+logical_tier = "engineer"
+node_type = "leaf"
+cognitive_arch = "turing:python"
+
+[repo]
+gh_repo = "cgcardona/agentception"
+base = "dev"
+
+[pipeline]
+batch_id = "label-ac-workflow-20260303T134821Z-a7f2"
+parent_run_id = "label-ac-workflow-20260303T134000Z-x9y1"
+wave = "0-foundation"
+
+[spawn]
+mode = "chain"
+sub_agents = false
+
+[target]
+issue_number = 41
+issue_title = "UI: wire plan.js to /api/plan/draft + SSE plan_draft_ready"
+depends_on = []
+closes = [41]
+file_ownership = ["agentception/static/js/plan.js"]
+
+[worktree]
+path = "/tmp/worktrees/issue-41"
+branch = "feat/issue-41"
+linked_pr = 0
+```
+
+---
+
+## How AgentCeption creates task files
+
+The dispatcher (`agentception/readers/worktrees.py`) calls `_build_child_task()` which:
+
+1. Resolves the `cognitive_arch` string from the role config
+2. Creates a git worktree at `$HOST_WORKTREES_DIR/{repo}/{run_id}`
+3. Writes the `.agent-task` TOML file
+4. Inserts an `ACAgentRun` row in the database with `status = "pending_launch"`
+5. The Dispatcher agent reads `/api/runs/pending`, claims runs via `/api/runs/{id}/acknowledge`, then spawns Cursor agents via the Task tool
+
+---
+
+## How agents self-report progress
+
+Every agent reports back using `curl` against the AgentCeption API (or MCP tools):
+
+```bash
+# Report a step
+curl -s -X POST http://localhost:10003/api/runs/$RUN_ID/step \
+  -H "Content-Type: application/json" \
+  -d '{"step_name": "reading issue body", "issue_number": 41}'
+
+# Report done with PR
+curl -s -X POST http://localhost:10003/api/runs/$RUN_ID/done \
+  -H "Content-Type: application/json" \
+  -d '{"issue_number": 41, "pr_number": 99, "summary": "Opened PR #99"}'
+```
+
+`RUN_ID` is written into the `.agent-task` file as a comment and available to the shell environment.
+
+---
+
+## Extension guide
+
+To add a new workflow type:
+
+1. Add a row to the `task.workflow` enum in `agentception/models/__init__.py`
+2. Add any new payload section (`[my_workflow_payload]`) to this spec
+3. Update `.agentception/agent-task-spec.md` with the full field table
+4. Update the coordinator prompt template that writes this workflow's task files
+5. If the workflow produces structured output, add it to `output.format` values
+
+See the [full spec](.agentception/agent-task-spec.md) for exhaustive examples including coordinator manifests, PR queues, and non-tech domain workflows.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,492 @@
+# API Reference
+
+All endpoints are served by the AgentCeption container on port 10003. Every browser page and MCP tool call resolves to one of these routes.
+
+---
+
+## URL Taxonomy
+
+URLs are semantic: each path segment narrows the resource.
+
+```
+/plan                     ← Planning pages
+/ship/{initiative}        ← Ship board for a specific initiative
+/api/plan/*               ← Plan pipeline (draft, file, launch)
+/api/dispatch/*           ← Agent dispatch (issue, label, context, prompt)
+/api/runs/{run_id}/*      ← Agent run lifecycle (step, blocker, done, …)
+/api/ship/{initiative}/*  ← Ship-level actions (advance phase)
+/api/agents/*             ← Agent pipeline state
+/api/health/*             ← System health
+/api/config               ← Runtime configuration
+```
+
+---
+
+## Browser / HTMX Routes (UI)
+
+### Plan
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/` | Redirects to `/plan` |
+| `GET` | `/plan` | Planning page (Phase 1A → 1B flow) |
+| `GET` | `/plan/recent-runs` | Recent plan run list partial |
+
+### Ship
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/ship` | Redirects to `/ship/{first-initiative}` |
+| `GET` | `/ship/{initiative}` | Ship board for the given initiative |
+| `GET` | `/ship/{initiative}/board` | HTMX board partial (polled every 5 s) |
+| `GET` | `/ship/runs/{run_id}/stream` | SSE stream for an agent run's events |
+
+### Agents
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/agents` | Agent list page |
+| `GET` | `/agents/{agent_id}` | Agent detail page (persona, transcript, kill modal) |
+| `GET` | `/agents/spawn` | Spawn wizard |
+| `GET` | `/partials/agents` | HTMX agent list partial |
+| `GET` | `/partials/agents/{agent_id}/transcript` | HTMX transcript partial |
+
+### Cognitive Architecture
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/cognitive-arch` | Catalog of all cognitive architectures |
+| `GET` | `/cognitive-arch/{arch_id}` | Detail view for a specific architecture |
+
+### Issues and PRs
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/issues` | Issue list |
+| `GET` | `/issues/{number}` | Issue detail |
+| `GET` | `/prs` | PR list |
+| `GET` | `/prs/{number}` | PR detail |
+
+### Other Pages
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/org-chart` | Org chart browser |
+| `GET` | `/roles` | Role catalog |
+| `GET` | `/roles/{slug}/detail` | Role detail partial |
+| `GET` | `/worktrees` | Active worktrees list |
+| `GET` | `/worktrees/{slug}/detail` | Worktree detail |
+| `GET` | `/telemetry` | Telemetry dashboard |
+| `GET` | `/config` | Configuration UI |
+| `GET` | `/settings` | Settings page |
+| `GET` | `/transcripts` | Agent transcript list |
+| `GET` | `/transcripts/{uuid}` | Individual transcript |
+| `GET` | `/docs` | In-app documentation index |
+| `GET` | `/docs/{slug}` | In-app documentation page |
+| `GET` | `/dag` | Dependency DAG visualizer |
+| `GET` | `/overview` | Project overview |
+| `GET` | `/api` | Auto-generated API reference |
+
+---
+
+## JSON API Routes
+
+All API routes are prefixed `/api`.
+
+### Plan pipeline — `/api/plan/*`
+
+These drive Phase 1A (brain dump → draft) and Phase 1B (review → file issues).
+
+#### `POST /api/plan/preview`
+
+Generate a plan preview from a brain dump. Streams SSE events as Claude reasons.
+
+**Body:** `application/json`
+```json
+{
+  "brain_dump": "string",
+  "initiative": "string"
+}
+```
+
+**Response:** `text/event-stream` — SSE events with `plan_draft_ready` payload on completion.
+
+---
+
+#### `POST /api/plan/validate`
+
+Validate an edited PlanSpec YAML before filing.
+
+**Body:** `application/json`
+```json
+{ "yaml_text": "string" }
+```
+
+**Response:**
+```json
+{
+  "valid": true,
+  "errors": []
+}
+```
+
+---
+
+#### `POST /api/plan/file-issues`
+
+File all issues from a validated PlanSpec YAML. Creates GitHub issues, phase labels, and `initiative_phases` DB rows.
+
+**Body:** `application/json`
+```json
+{ "yaml_text": "string" }
+```
+
+**Response:** `text/event-stream` — SSE progress events, then a `file_issues_done` event.
+
+---
+
+#### `GET /api/plan/{run_id}/plan-text`
+
+Retrieve the raw plan text for a given plan run.
+
+---
+
+### Dispatch — `/api/dispatch/*`
+
+Endpoints that create and queue agent runs.
+
+#### `GET /api/dispatch/context?label=<label>`
+
+Fetch label context: the list of issues for a label, grouped by phase, plus the dispatcher prompt.
+
+**Query params:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `label` | `string` | GitHub label string (e.g. `ac-workflow`) |
+
+**Response:** `LabelContextResponse`
+```json
+{
+  "label": "ac-workflow",
+  "phases": [
+    {
+      "label": "ac-workflow/0-foundation",
+      "issues": [{"number": 41, "title": "...", "state": "open", "url": "..."}],
+      "locked": false,
+      "complete": false,
+      "depends_on": []
+    }
+  ],
+  "dispatcher_prompt": "..."
+}
+```
+
+---
+
+#### `POST /api/dispatch/issue`
+
+Dispatch an agent for a single issue. Creates a git worktree, writes `.agent-task`, and inserts an `ACAgentRun` row.
+
+**Body:** `DispatchRequest`
+```json
+{
+  "issue_number": 41,
+  "role": "python-developer",
+  "gh_repo": "owner/repo",
+  "batch_id": "label-ac-workflow-20260101T000000Z-abcd"
+}
+```
+
+**Response:** `DispatchResponse`
+```json
+{
+  "run_id": "issue-41-python-developer-abcd",
+  "worktree_path": "/worktrees/...",
+  "branch": "agent/ac-workflow-abcd"
+}
+```
+
+---
+
+#### `POST /api/dispatch/label`
+
+Dispatch a top-of-tree agent (CTO / coordinator) for an entire label scope. Creates the worktree and queues the run.
+
+**Body:** `LabelDispatchRequest`
+```json
+{
+  "label": "ac-workflow",
+  "role": "cto",
+  "gh_repo": "owner/repo"
+}
+```
+
+**Response:** `LabelDispatchResponse`
+```json
+{
+  "run_id": "label-ac-workflow-20260101T000000Z-abcd",
+  "worktree_path": "/worktrees/..."
+}
+```
+
+---
+
+#### `GET /api/dispatch/prompt`
+
+Return the current dispatcher prompt (used by the Dispatcher agent to understand available tools and context).
+
+**Response:** `text/plain`
+
+---
+
+### Run lifecycle — `/api/runs/*`
+
+All run lifecycle endpoints are called by agents via `curl` in their worktree, or by MCP tools.
+
+#### `GET /api/runs/pending`
+
+Return all `ACAgentRun` rows in `pending_launch` state, ready to be claimed and spawned.
+
+**Response:**
+```json
+{
+  "pending": [
+    {
+      "run_id": "label-ac-workflow-abc",
+      "issue_number": 0,
+      "role": "cto",
+      "branch": "agent/ac-workflow-abc",
+      "host_worktree_path": "/home/.agentception/worktrees/...",
+      "batch_id": "label-ac-workflow-20260101T000000Z-abc"
+    }
+  ],
+  "count": 1
+}
+```
+
+---
+
+#### `POST /api/runs/{run_id}/acknowledge`
+
+Atomically claim a pending run. Sets `status = implementing`. Returns `{"ok": false}` if already claimed — safe for concurrent dispatchers.
+
+---
+
+#### `POST /api/runs/{parent_run_id}/children`
+
+Spawn a child agent run under a parent (coordinator spawning an engineer). Creates worktree, writes `.agent-task`, inserts DB row.
+
+**Body:** `SpawnChildRequest`
+```json
+{
+  "role": "python-developer",
+  "node_type": "leaf",
+  "scope_type": "issue",
+  "scope_value": "41",
+  "gh_repo": "owner/repo"
+}
+```
+
+**Response:** `SpawnChildResponse`
+```json
+{
+  "run_id": "issue-41-python-developer-xyz",
+  "worktree_path": "/worktrees/..."
+}
+```
+
+---
+
+#### `POST /api/runs/{run_id}/step`
+
+Report a step completion. Inserts an `ACAgentStep` event visible in the inspector panel.
+
+**Body:** `StepReport`
+```json
+{
+  "step_name": "reading issue body",
+  "issue_number": 41
+}
+```
+
+---
+
+#### `POST /api/runs/{run_id}/blocker`
+
+Report a blocker. Surfaces in the inspector as a blocking event.
+
+**Body:** `BlockerReport`
+```json
+{
+  "description": "Cannot find the module",
+  "issue_number": 41
+}
+```
+
+---
+
+#### `POST /api/runs/{run_id}/decision`
+
+Report a design decision made during execution.
+
+**Body:** `DecisionReport`
+```json
+{
+  "description": "Using SQLAlchemy Core instead of ORM for this query",
+  "issue_number": 41
+}
+```
+
+---
+
+#### `POST /api/runs/{run_id}/done`
+
+Mark a run complete. Triggers worktree cleanup. Optionally links a PR.
+
+**Body:** `DoneReport`
+```json
+{
+  "issue_number": 41,
+  "pr_number": 99,
+  "summary": "Implemented the feature, opened PR #99"
+}
+```
+
+---
+
+#### `POST /api/runs/{run_id}/message`
+
+Send a user message into a running agent's context. The agent's SSE stream picks it up on the next poll cycle.
+
+**Body:**
+```json
+{ "content": "Please focus on the error handling path" }
+```
+
+---
+
+#### `POST /api/runs/{run_id}/stop`
+
+Stop a running agent. Sets `status = DONE`, removes the `agent:wip` label.
+
+---
+
+### Ship — `/api/ship/*`
+
+#### `POST /api/ship/{initiative}/advance`
+
+Advance the phase gate for an initiative. Checks that all issues in `from_phase` are closed, then removes the `locked` label from `to_phase` issues.
+
+**Body:**
+```json
+{
+  "from_phase": "ac-workflow/0-foundation",
+  "to_phase": "ac-workflow/1-generation"
+}
+```
+
+**Response:** `AdvancePhaseOk` on success, `AdvancePhaseBlocked` (422) if open issues remain in `from_phase`.
+
+---
+
+### Agents / Pipeline — `/api/agents/*`, `/api/pipeline`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/pipeline` | Current pipeline state (active runs, phase counts) |
+| `GET` | `/api/agents` | All agent runs |
+| `GET` | `/api/agents/{agent_id}` | Single agent run details |
+| `GET` | `/api/agents/{agent_id}/transcript` | Agent conversation transcript |
+
+---
+
+### Config — `/api/config`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/config` | Current runtime configuration |
+| `PUT` | `/api/config` | Update runtime configuration |
+| `POST` | `/api/config/switch-project` | Switch active codebase/project |
+
+---
+
+### Control — `/api/control/*`
+
+Legacy orchestration control endpoints. Prefer MCP tools for new integrations.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/control/pause` | Pause the pipeline |
+| `POST` | `/api/control/resume` | Resume the pipeline |
+| `GET` | `/api/control/status` | Pipeline pause/resume status |
+| `GET` | `/api/control/active-label` | Currently active label |
+| `PUT` | `/api/control/active-label` | Set active label |
+| `DELETE` | `/api/control/active-label` | Clear active label |
+| `POST` | `/api/control/spawn` | Spawn a single agent |
+| `POST` | `/api/control/spawn-wave` | Spawn a wave of agents |
+| `POST` | `/api/control/sweep` | Sweep stale runs |
+| `POST` | `/api/control/trigger-poll` | Trigger an immediate GitHub poll |
+
+---
+
+### Health — `/api/health/*`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/health/detailed` | Full `HealthSnapshot` (uptime, memory, latency, worktree count) |
+| `GET` | `/ui/health/widget` | HTMX health widget partial |
+
+---
+
+### Worktrees — `/api/worktrees/*`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `DELETE` | `/api/worktrees/{slug}` | Remove a worktree and clean up its DB row |
+
+---
+
+### Issues and PRs — `/api/issues/*`, `/api/prs/*`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/issues/{number}/comments` | GitHub comments for an issue |
+| `GET` | `/api/prs/{number}/checks` | CI checks for a PR |
+| `GET` | `/api/prs/{number}/reviews` | Review decisions for a PR |
+| `GET` | `/api/issues/approval-queue` | Issues awaiting human approval |
+| `POST` | `/api/issues/{number}/approve` | Approve an issue for dispatch |
+
+---
+
+### Intelligence — `/api/intelligence/*`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/dag` | Dependency DAG as JSON |
+| `GET` | `/api/intelligence/pr-violations` | PRs with policy violations |
+| `POST` | `/api/intelligence/pr-violations/{pr_number}/close` | Close a violation |
+| `POST` | `/api/analyze/issue/{number}` | Trigger issue analysis |
+
+---
+
+### Telemetry — `/api/telemetry/*`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/telemetry/waves` | Wave-level telemetry |
+| `GET` | `/api/telemetry/cost` | Cost summary |
+
+---
+
+### Org Chart — `/api/org/*`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/org/tree` | Full org tree as JSON |
+| `POST` | `/api/org/select-preset` | Select an org preset |
+| `GET` | `/api/org/taxonomy` | Role taxonomy |
+| `POST` | `/api/org/roles/add` | Add a role |
+| `DELETE` | `/api/org/roles/{slug}` | Remove a role |
+| `POST` | `/api/org/roles/{slug}/phases` | Assign phases to a role |
+| `POST` | `/api/org/templates` | Create from a template |

--- a/docs/reference/cognitive-arch.md
+++ b/docs/reference/cognitive-arch.md
@@ -1,0 +1,322 @@
+# Cognitive Architecture Reference
+
+Every agent dispatched by AgentCeption has a **cognitive architecture** — a composed identity injected into its system prompt that shapes how it reasons, prioritizes, and produces output. You are deploying reasoners with specific cognitive profiles, not generic LLM calls.
+
+---
+
+## The Four Layers
+
+```
+Layer 3: FIGURES        Turing, von Neumann, Dijkstra, Feynman, Hopper, ...  (77 figures)
+              ↑ extends
+Layer 2: ARCHETYPES     the_architect, the_scholar, the_visionary, ...       (8 archetypes)
+              ↑ composed from
+Layer 1: SKILL DOMAINS  python, fastapi, htmx, postgresql, devops, llm, ... (43 domains)
+              ↑ orthogonal
+Layer 0: ATOMS          epistemic_style, cognitive_rhythm, creativity_level, ...
+```
+
+**Figures extend archetypes.** Archetypes are composed from atoms. Skill domains are orthogonal (they add technical expertise, not personality). The `resolve_arch.py` engine walks the inheritance chain and assembles a single coherent prompt injection.
+
+---
+
+## Layer 0 — Atoms
+
+Atoms are primitive cognitive genes. Each has one active value at a time. Active values contribute `prompt_fragment` text to the final prompt.
+
+**Source:** `scripts/gen_prompts/cognitive_archetypes/atoms/`
+
+### `epistemic_style` — How knowledge is acquired and validated
+
+| Value | Meaning |
+|-------|---------|
+| `deductive` | Proves from axioms. Distrusts conclusions not derived from first principles. |
+| `inductive` | Generalizes from patterns. Builds confidence by accumulating examples. |
+| `abductive` | Seeks the simplest explanation that fits observed evidence. |
+| `analogical` | Thinks by metaphor and structural similarity between domains. |
+| `empirical` | Experiment-first. Runs the test, then believes the result. |
+
+### `cognitive_rhythm` — How work is paced
+
+| Value | Meaning |
+|-------|---------|
+| `deep_focus` | Long uninterrupted blocks. Optimal for complex, load-bearing problems. |
+| `iterative` | Short cycles. Frequent commits. Comfort with incremental progress. |
+| `burst` | Intense, explosive output then synthesis. Prefers full problem in working memory. |
+| `exploratory` | Wide scan before narrow execution. Maps the territory first. |
+
+### `uncertainty_handling` — How the unknown is managed
+
+| Value | Meaning |
+|-------|---------|
+| `probabilistic` | Assigns confidence levels. Acts on expected value, not certainty. |
+| `conservative` | Prefers known-good solutions. Avoids untested territory. |
+| `aggressive` | Ships into uncertainty. Learns from breakage. |
+| `paralytic` | High information requirement before action. Escalates before guessing. |
+
+### `collaboration_posture` — How the agent relates to others
+
+| Value | Meaning |
+|-------|---------|
+| `autonomous` | Figures it out alone. Only asks when fully blocked. |
+| `consultative` | Polls others before committing to direction. |
+| `directive` | Tells others what to do. Comfortable with authority. |
+| `collaborative` | Works alongside. High trust in teammates' judgment. |
+
+### `creativity_level` — How novel solutions are generated
+
+| Value | Meaning |
+|-------|---------|
+| `conservative` | Prefers established patterns. "Don't fix what isn't broken." |
+| `incremental` | Small improvements to existing approaches. |
+| `inventive` | Generates genuinely new approaches. High tolerance for uncertainty. |
+| `radical` | Questions the problem itself. Invents new paradigms. |
+
+### `quality_bar` — What "done" means
+
+| Value | Meaning |
+|-------|---------|
+| `mvp` | Works. Ships fast. Polish later. |
+| `pragmatic` | Correct and maintainable. Practical tradeoffs. |
+| `craftsperson` | Excellence in implementation, not just correctness. |
+| `perfectionist` | Will not ship until it is right. High cost, high output quality. |
+
+### `scope_instinct` — How the agent handles scope
+
+| Value | Meaning |
+|-------|---------|
+| `minimal` | Does exactly what was asked. No scope creep. |
+| `expansive` | Sees the broader context and acts on it. |
+| `focused` | Narrow execution. Ignores peripheral concerns. |
+
+---
+
+## Layer 1 — Skill Domains
+
+Skill domains add technical expertise to any figure or archetype. They are orthogonal — you can combine any skill with any figure.
+
+**Source:** `scripts/gen_prompts/cognitive_archetypes/skill_domains/`
+
+**Available skill domain IDs (43 total):**
+
+```
+alpine        aws           blockchain    cpp           cryptography
+csharp        d3            devops        django        docker
+elasticsearch fastapi       go            graphql       htmx
+java          javascript    jinja2        kafka         kotlin
+kubernetes    llm           llm_engineering  midi       monaco
+nextjs        nodejs        postgresql    python        pytorch
+rag           rails         react         redis         ruby
+rust          security      sql           swift         swift_ui
+terraform     testing       typescript
+```
+
+---
+
+## Layer 2 — Archetypes
+
+Archetypes are abstract thinking styles. They define a coherent atom configuration without being tied to any historical figure.
+
+**Source:** `scripts/gen_prompts/cognitive_archetypes/archetypes/`
+
+| Archetype ID | Character |
+|-------------|-----------|
+| `the_architect` | Systems thinker. Minimal, composable designs. Resists coupling. |
+| `the_scholar` | Deep research orientation. Documents everything. Cites sources. |
+| `the_visionary` | Forward-looking. Comfortable with ambiguity. Shapes culture. |
+| `the_guardian` | Security and correctness first. Never ships what it can't defend. |
+| `the_hacker` | Speed and ingenuity. Finds unexpected solutions. Ships fast. |
+| `the_mentor` | Communicative. Explains reasoning. Thinks about the next person. |
+| `the_operator` | Process and reliability. Operational excellence. Low drama. |
+| `the_pragmatist` | Gets it done. Practical tradeoffs. No perfectionism paralysis. |
+
+---
+
+## Layer 3 — Figures
+
+Historical thinkers and builders. Each figure `extends` an archetype and overrides specific atoms with their unique cognitive profile.
+
+**Source:** `scripts/gen_prompts/cognitive_archetypes/figures/`
+
+**Available figures (77 total):**
+
+```
+anders_hejlsberg   andrej_karpathy    andy_grove         avie_tevanian
+barbara_liskov     bill_gates         bjarne_stroustrup  brendan_eich
+bruce_schneier     carl_sagan         da_vinci           darwin
+david_chaum        demis_hassabis     dhh                dijkstra
+don_norman         einstein           elon_musk          emin_gun_sirer
+fabrice_bellard    fei_fei_li         feynman            gabriel_cardona
+gavin_wood         geoffrey_hinton    graydon_hoare      guido_van_rossum
+hal_finney         hamming            hopper             ilya_sutskever
+james_gosling      jeff_bezos         jeff_dean          joe_armstrong
+john_carmack       ken_thompson       kent_beck          knuth
+leslie_lamport     linus_pauling      linus_torvalds     lovelace
+margaret_hamilton  marie_curie        martin_fowler      matz
+mccarthy           michael_fagan      nassim_taleb       newton
+nick_szabo         nikola_tesla       patrick_collison   paul_graham
+peter_drucker      rich_hickey        ritchie            rob_pike
+ryan_dahl          sam_altman         satoshi_nakamoto   satya_nadella
+scott_forstall     shannon            steve_jobs         sun_tzu
+tim_berners_lee    turing             vint_cerf          vitalik_buterin
+von_neumann        w_edwards_deming   werner_vogels      wozniak
+yann_lecun
+```
+
+### Selected figure profiles
+
+| Figure | Extends | Key traits | Best for |
+|--------|---------|-----------|---------|
+| `turing` | `the_architect` | Deductive, deep_focus, perfectionist, minimal | Core algorithm and type system work |
+| `von_neumann` | `the_architect` | Burst cognitive rhythm, systems mental model | CTO / orchestration roles |
+| `dijkstra` | `the_scholar` | Correctness-obsessed, epistemic precision | Code review, formal verification |
+| `hopper` | `the_pragmatist` | Empirical, collaborative, mvp quality bar | Shipping under constraints |
+| `feynman` | `the_scholar` | Analogical, inventive, deep explanations | Documentation, teaching roles |
+| `knuth` | `the_scholar` | Perfectionist, deep_focus, craftsperson | Algorithm implementation |
+| `steve_jobs` | `the_visionary` | Taste-driven, radical creativity | Product strategy, CEO roles |
+| `don_norman` | `the_architect` | User-centered, design thinking | UX/UI design roles |
+| `bruce_schneier` | `the_guardian` | Threat-model first, conservative | Security roles, CISO |
+| `linus_torvalds` | `the_hacker` | Decisive, high quality bar, direct communication | Systems programming, kernel-style work |
+| `martin_fowler` | `the_mentor` | Refactoring-oriented, patterns, communicative | Architecture review |
+| `kent_beck` | `the_pragmatist` | TDD, iterative, collaborative | Engineering coordination |
+
+---
+
+## Blending figures
+
+You can blend two figures to get a composite cognitive profile:
+
+```
+"lovelace,shannon:htmx:d3:python"
+ ^      ^         ^
+ │      │         └─ skill domains (colon-separated)
+ │      └─ second figure
+ └─ first figure
+```
+
+The resolver walks both figures' inheritance chains, merges their atom overrides (last figure wins on conflicts), and injects a blended prompt.
+
+**Use blends when:**
+- The task spans two cognitive domains (e.g. systems + UX → `turing,don_norman`)
+- You want a figure's domain expertise but a different archetype's posture
+- A single figure's atom profile is too extreme for the task
+
+---
+
+## The `resolve_arch.py` engine
+
+```bash
+# Resolve and print the full prompt injection for a figure + skills
+docker compose exec agentception python3 scripts/gen_prompts/resolve_arch.py turing:python:fastapi
+
+# Print the fingerprint table (atoms + their active values)
+docker compose exec agentception python3 scripts/gen_prompts/resolve_arch.py --fingerprint turing:python
+```
+
+The engine:
+1. Looks up the figure YAML in `cognitive_archetypes/figures/`
+2. Resolves the `extends` chain up to the archetype
+3. Builds the full atom set (archetype defaults → figure overrides → `atom_overrides` in `team.yaml`)
+4. Looks up each skill domain in `cognitive_archetypes/skill_domains/`
+5. Renders a `prompt_injection` Markdown block
+
+This block is injected at the top of every generated role file.
+
+---
+
+## Adding a new figure
+
+1. Create `scripts/gen_prompts/cognitive_archetypes/figures/{your_figure}.yaml`:
+
+```yaml
+id: your_figure
+display_name: "Your Figure"
+layer: figure
+extends: the_architect    # or any other archetype
+
+description: |
+  Who this person was and what they contributed. Be specific about
+  their actual body of work — the LLM uses this to reason in their style.
+
+overrides:
+  epistemic_style: deductive       # Override specific atoms
+  cognitive_rhythm: deep_focus
+  quality_bar: perfectionist
+  creativity_level: inventive
+```
+
+2. Add the figure to the `compatible_figures` list for any role in `role-taxonomy.yaml`.
+
+3. Optionally use it in `team.yaml` for a specific role:
+
+```yaml
+python_developer:
+  figures: [your_figure]
+  skills: [python, fastapi]
+  cognitive_arch: "your_figure:python:fastapi"
+```
+
+4. Re-run `generate.py` to regenerate all role files.
+
+---
+
+## Adding a new skill domain
+
+1. Create `scripts/gen_prompts/cognitive_archetypes/skill_domains/{skill_id}.yaml`:
+
+```yaml
+id: your_skill
+display_name: "Your Technology"
+category: language  # or: framework, platform, discipline, protocol
+
+description: |
+  What this skill domain covers. Be specific about the ecosystem,
+  common patterns, and what expertise in this domain looks like.
+
+key_concepts:
+  - concept_one
+  - concept_two
+
+prompt_fragment: |
+  You are an expert in {skill}. You understand {key_concepts}.
+  When working in this domain, you {key_behaviors}.
+```
+
+2. Use the new skill ID in `team.yaml` for any role that should have it.
+
+---
+
+## Adding a new archetype
+
+1. Create `scripts/gen_prompts/cognitive_archetypes/archetypes/{archetype_id}.yaml`:
+
+```yaml
+id: your_archetype
+display_name: "The Name"
+layer: archetype
+
+description: |
+  What thinking style this archetype represents.
+
+defaults:
+  epistemic_style: empirical
+  cognitive_rhythm: iterative
+  uncertainty_handling: probabilistic
+  collaboration_posture: collaborative
+  creativity_level: incremental
+  quality_bar: pragmatic
+  scope_instinct: focused
+
+prompt_injection: |
+  Core behavioral description injected into the agent's system prompt.
+```
+
+2. Reference it in any figure YAML's `extends:` field.
+
+---
+
+## Viewing cognitive architectures in the UI
+
+- **`/cognitive-arch`** — Catalog of all available architectures (figures + archetypes)
+- **`/cognitive-arch/{arch_id}`** — Detail view for a specific architecture: full atom fingerprint, prompt injection, skill domains, and which roles use it
+- **`/agents/{id}`** — An individual agent's assigned cognitive architecture

--- a/docs/reference/type-contracts.md
+++ b/docs/reference/type-contracts.md
@@ -121,6 +121,161 @@ Pydantic `BaseModel` — Request body for `POST /api/config/switch-project`.
 
 ---
 
+## Dispatch API models
+
+**Path:** `agentception/routes/api/dispatch.py`
+
+### `DispatchRequest` / `DispatchResponse`
+
+Request body and response for `POST /api/dispatch/issue` — dispatch a single-issue agent.
+
+| Model | Field | Type | Description |
+|-------|-------|------|-------------|
+| `DispatchRequest` | `issue_number` | `int` | GitHub issue number |
+| | `role` | `str` | Role slug (e.g. `"python-developer"`) |
+| | `gh_repo` | `str` | `"owner/repo"` |
+| | `batch_id` | `str` | Batch fingerprint |
+| `DispatchResponse` | `run_id` | `str` | Created run ID |
+| | `worktree_path` | `str` | Worktree path inside container |
+| | `branch` | `str` | Git branch name |
+
+---
+
+### `LabelDispatchRequest` / `LabelDispatchResponse`
+
+Request body and response for `POST /api/dispatch/label` — dispatch a top-of-tree agent.
+
+| Model | Field | Type | Description |
+|-------|-------|------|-------------|
+| `LabelDispatchRequest` | `label` | `str` | GitHub label (e.g. `"ac-workflow"`) |
+| | `role` | `str` | Role slug (e.g. `"cto"`) |
+| | `gh_repo` | `str` | `"owner/repo"` |
+| `LabelDispatchResponse` | `run_id` | `str` | Created run ID |
+| | `worktree_path` | `str` | Worktree path inside container |
+
+---
+
+### `LabelContextResponse`
+
+Response for `GET /api/dispatch/context?label=...`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `label` | `str` | The queried label |
+| `phases` | `list[PhaseGroupRow]` | Phase groups with issues (from `get_issues_grouped_by_phase`) |
+| `dispatcher_prompt` | `str` | The current dispatcher prompt text |
+
+---
+
+## Runs API models
+
+**Path:** `agentception/routes/api/runs.py`
+
+### `SpawnChildRequest` / `SpawnChildResponse`
+
+`POST /api/runs/{parent_run_id}/children` — coordinator spawns a leaf agent.
+
+| Model | Field | Type | Description |
+|-------|-------|------|-------------|
+| `SpawnChildRequest` | `role` | `str` | Role slug |
+| | `node_type` | `NodeType` | `"coordinator"` or `"leaf"` |
+| | `scope_type` | `ScopeType` | `"label"`, `"issue"`, or `"pr"` |
+| | `scope_value` | `str` | Issue number, PR number, or label string |
+| | `gh_repo` | `str` | `"owner/repo"` |
+| `SpawnChildResponse` | `run_id` | `str` | Created child run ID |
+| | `worktree_path` | `str` | Worktree path |
+
+---
+
+### `StepReport`, `BlockerReport`, `DecisionReport`
+
+Bodies for `POST /api/runs/{run_id}/step|blocker|decision`.
+
+| Model | Field | Type | Description |
+|-------|-------|------|-------------|
+| `StepReport` | `step_name` | `str` | What step the agent completed |
+| | `issue_number` | `int` | Issue this step relates to |
+| `BlockerReport` | `description` | `str` | What is blocking the agent |
+| | `issue_number` | `int` | Issue being worked |
+| `DecisionReport` | `description` | `str` | Design decision made |
+| | `issue_number` | `int` | Issue being worked |
+
+Note: `run_id` is in the URL path for all three — it was removed from the body in the URL taxonomy refactor.
+
+---
+
+### `DoneReport`
+
+Body for `POST /api/runs/{run_id}/done`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `issue_number` | `int` | Issue completed |
+| `pr_number` | `int \| None` | PR opened (if any) |
+| `summary` | `str` | Completion summary |
+
+---
+
+## Ship API models
+
+**Path:** `agentception/routes/api/ship_api.py`
+
+### `AdvancePhaseBody`
+
+Body for `POST /api/ship/{initiative}/advance`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `from_phase` | `str` | Phase label that must be fully closed (e.g. `"ac-workflow/0-foundation"`) |
+| `to_phase` | `str` | Phase label to unlock (e.g. `"ac-workflow/1-generation"`) |
+
+Note: `initiative` is in the URL path.
+
+---
+
+### `AdvancePhaseOk` / `AdvancePhaseBlocked`
+
+Responses for `POST /api/ship/{initiative}/advance`.
+
+| Model | Field | Type | Description |
+|-------|-------|------|-------------|
+| `AdvancePhaseOk` | `unlocked` | `int` | Number of issues unlocked in `to_phase` |
+| `AdvancePhaseBlocked` | `open_count` | `int` | Number of still-open issues in `from_phase` |
+| | `open_issues` | `list[int]` | Issue numbers that are still open |
+
+`AdvancePhaseBlocked` is returned with HTTP 422.
+
+---
+
+## Board TypedDicts (URL refactor additions)
+
+**Path:** `agentception/db/queries.py`
+
+### `EnrichedIssueRow`
+
+Extended version of `PhasedIssueRow` with dependency information, used by `build_ui.py` to render the ship board.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `number` | `int` | GitHub issue number |
+| `title` | `str` | Issue title |
+| `state` | `str` | `"open"` or `"closed"` |
+| `url` | `str` | GitHub URL |
+| `labels` | `list[str]` | All label names |
+| `depends_on` | `list[int]` | Issue numbers that must merge before this one |
+
+### `InitiativePhaseMeta`
+
+Phase metadata with explicit ordering, used by `get_initiative_phase_meta()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `label` | `str` | Full phase label (e.g. `"ac-workflow/0-foundation"`) |
+| `order` | `int` | 0-based sort index from `initiative_phases.phase_order` |
+| `depends_on` | `list[str]` | Phase labels this phase depends on |
+
+---
+
 ## Readers
 
 ### `switch_project` (function)

--- a/docs/reference/yaml-config.md
+++ b/docs/reference/yaml-config.md
@@ -1,0 +1,306 @@
+# YAML Configuration Reference
+
+AgentCeption's agent prompt system is driven by three YAML files in `scripts/gen_prompts/`. Edit these, then run `generate.py` to regenerate all prompt files.
+
+```
+scripts/gen_prompts/
+  config.yaml        ← Pipeline config: repo, phases, labels, codebases
+  team.yaml          ← Agent org chart: which cognitive arch each role gets
+  role-taxonomy.yaml ← Full role catalog: org hierarchy, spawnable flags
+```
+
+---
+
+## `config.yaml` — Pipeline Configuration
+
+**Source:** `scripts/gen_prompts/config.yaml`
+
+After editing, regenerate:
+```bash
+docker compose exec agentception python3 scripts/gen_prompts/generate.py
+# Then sync labels to GitHub (if labels changed):
+bash scripts/gen_prompts/sync_labels.sh
+```
+
+### `repo`
+
+```yaml
+repo:
+  gh_slug: "cgcardona/agentception"   # GitHub org/repo — never derived from local path
+  name: "agentception"                # used in worktree subfolder names
+```
+
+| Key | Description |
+|-----|-------------|
+| `gh_slug` | GitHub `owner/repo`. This is the canonical repo for all GitHub API calls. **Never derived from local path.** |
+| `name` | Short name used in worktree directory naming. |
+
+---
+
+### `pipeline`
+
+```yaml
+pipeline:
+  claim_label: "agent:wip"
+  max_pool_size: 4
+  phases:
+    - "ac-workflow/0-foundation"
+    - "ac-workflow/1-generation"
+```
+
+| Key | Description |
+|-----|-------------|
+| `claim_label` | GitHub label applied to issues when an agent claims them. Remove to release. Default: `"agent:wip"`. |
+| `max_pool_size` | Max concurrent leaf agents per coordinator run. |
+| `phases` | **Strict phase order** for the active initiative. The CTO and chain-spawn logic iterate this list top-to-bottom. Add/remove phases here, then update the matching `labels.phases` section and re-run `generate.py`. |
+
+> **Phase naming convention:** Use `{initiative}/{N}-{semantic-slug}` where N is the 0-based index. Example: `ac-workflow/0-foundation`, `ac-workflow/1-generation`. The numeric prefix makes lexicographic sort a correct fallback; `phase_order` in the DB is canonical for filed plans.
+
+---
+
+### `codebases`
+
+Defines how agents run mypy and tests for each supported codebase. The `active` key tells AgentCeption which codebase is currently being worked on — this drives the `IS_AC` routing in agent prompts.
+
+```yaml
+codebases:
+  active: "agentception"
+
+  agentception:
+    container: "agentception"
+    mypy: 'docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"'
+    test_dir: "agentception/tests"
+    test_glob: "agentception/tests/test_*.py"
+    label_prefix: "ac-"
+```
+
+| Key | Description |
+|-----|-------------|
+| `active` | Key of the codebase agents are currently working on. |
+| `container` | Docker service name to `exec` into. |
+| `mypy` | Full mypy command. `$WTNAME` is substituted with the worktree slug. |
+| `test_dir` | Directory containing tests. |
+| `test_glob` | Glob pattern for test files. |
+| `label_prefix` | GitHub label prefix for this codebase's phase labels. |
+
+---
+
+### `labels`
+
+Single source of truth for all GitHub labels. Running `sync_labels.sh` creates/updates them.
+
+```yaml
+labels:
+  claim:
+    name: "agent:wip"
+    color: "0075ca"
+    description: "Claimed by a pipeline agent — do not assign manually"
+
+  project:
+    name: "ac-workflow"
+    color: "7c3aed"
+    description: "AgentCeption workflow initiative"
+
+  phases:
+    - name: "ac-workflow/0-foundation"
+      color: "d63939"
+      description: "Phase 0 — foundation work"
+    - name: "ac-workflow/1-generation"
+      color: "6741d9"
+      description: "Phase 1 — generation"
+
+  utility:
+    - name: "bug"
+      color: "d73a4a"
+      description: "Something isn't working"
+    - name: "enhancement"
+      color: "a2eeef"
+      description: "New feature or request"
+```
+
+| Section | Description |
+|---------|-------------|
+| `claim` | The `agent:wip` claim label — applied/removed at runtime by agents. |
+| `project` | Top-level initiative label (e.g. `ac-workflow`). Update when switching projects. |
+| `phases` | Phase labels — must match `pipeline.phases` in name and order. |
+| `utility` | Standard triage/status labels (bug, enhancement, documentation, etc.). |
+
+> **Colors** are 6-digit hex without the leading `#`.
+
+---
+
+## `team.yaml` — Agent Cognitive Architecture
+
+**Source:** `scripts/gen_prompts/team.yaml`
+
+Defines which cognitive architecture is assigned to each role. The `cognitive_arch` field from each role flows directly into `.agent-task` files and the LLM context.
+
+### Structure
+
+```yaml
+org:
+  c_suite:
+    cto:
+      figures: [von_neumann]
+      archetype: the_architect
+      skills: []
+      cognitive_arch: "von_neumann"
+
+  vps:
+    engineering_manager:
+      figures: [dijkstra]
+      archetype: the_scholar
+      skills: [python, fastapi]
+      cognitive_arch: "dijkstra:python:fastapi"
+
+  engineering:
+    python_developer:
+      figures: [turing]
+      archetype: the_pragmatist
+      skills: [python, fastapi, postgresql]
+      cognitive_arch: "turing:python:fastapi:postgresql"
+
+    pr_reviewer:
+      figures: [knuth]
+      archetype: the_scholar
+      skills: [python]
+      cognitive_arch: "knuth:python"
+```
+
+### `cognitive_arch` string format
+
+```
+figures:skill1:skill2:...
+
+figures — comma-separated figure or archetype IDs
+skills  — colon-separated skill domain IDs
+
+Examples:
+  "turing:python"                      — single figure + one skill
+  "dijkstra:python:fastapi"            — single figure + two skills
+  "lovelace,shannon:htmx:d3:python"   — two-figure blend + three skills
+  "the_architect:python:fastapi"       — archetype + two skills
+```
+
+Figure IDs come from `scripts/gen_prompts/cognitive_archetypes/figures/`.
+Skill domain IDs come from `scripts/gen_prompts/cognitive_archetypes/skill_domains/`.
+Archetype IDs come from `scripts/gen_prompts/cognitive_archetypes/archetypes/`.
+
+### `atom_overrides`
+
+Optional. Override default behavioral atoms for a specific role:
+
+```yaml
+cto:
+  figures: [von_neumann]
+  atom_overrides:
+    cognitive_rhythm: burst   # think in bursts, not incrementally
+  cognitive_arch: "von_neumann"
+```
+
+Atom IDs come from `scripts/gen_prompts/cognitive_archetypes/atoms/`.
+
+---
+
+## `role-taxonomy.yaml` — Full Role Catalog
+
+**Source:** `scripts/gen_prompts/role-taxonomy.yaml`
+
+Defines the complete org chart: every role at every tier, spawnable flags, and compatible cognitive architecture figures.
+
+### Structure
+
+```yaml
+levels:
+  - id: c_suite
+    label: "C-Suite"
+    description: "Executive leaders..."
+    roles:
+      - slug: cto
+        label: "CTO"
+        title: "Chief Technology Officer"
+        category: executive
+        description: "..."
+        spawnable: false
+        compatible_figures:
+          - von_neumann
+          - turing
+          - dijkstra
+
+  - id: vps
+    label: "VPs"
+    roles:
+      - slug: engineering-manager
+        label: "Engineering Manager"
+        category: coordinator
+        spawnable: true
+        compatible_figures:
+          - dijkstra
+          - knuth
+
+  - id: engineering
+    label: "Engineering"
+    roles:
+      - slug: python-developer
+        label: "Python Developer"
+        category: leaf
+        spawnable: true
+        compatible_figures:
+          - turing
+          - lovelace
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `slug` | string | Unique identifier — used in `.agent-task` files and API calls |
+| `label` | string | Human display name |
+| `title` | string | Full job title |
+| `category` | string | `executive`, `coordinator`, or `leaf` |
+| `spawnable` | bool | `true` = can be dispatched via the Ship board's Launch button |
+| `compatible_figures` | list | Which cognitive architecture figures can be used for this role |
+
+### How it's used
+
+- The org chart browser at `/org-chart` renders this taxonomy visually
+- `GET /api/org/taxonomy` returns it as JSON for the frontend
+- `GET /api/dispatch/context` filters roles by label scope using this file
+- Agent prompts reference role slugs to resolve their role file (`~/.agentception/roles/{slug}.md`)
+
+---
+
+## Generating prompt files
+
+After editing any of these YAML files:
+
+```bash
+# Regenerate all .agentception/roles/*.md and prompt templates
+docker compose exec agentception python3 scripts/gen_prompts/generate.py
+
+# Sync GitHub labels (only needed after changing labels section)
+bash scripts/gen_prompts/sync_labels.sh
+
+# Verify cognitive arch resolution for a specific role
+docker compose exec agentception python3 scripts/gen_prompts/resolve_arch.py turing:python
+```
+
+The `generate.py` script renders every `.j2` file in `scripts/gen_prompts/templates/` using the YAML context. Files under `templates/snippets/` are skipped (they are included by other templates, not rendered directly).
+
+> **Never edit generated files directly.** The `.agentception/roles/*.md` files are generated — any manual edits will be overwritten on the next `generate.py` run. Edit the source templates instead.
+
+---
+
+## Switching to a new initiative / project
+
+1. Update `config.yaml`:
+   - Change `pipeline.phases` to the new phase list
+   - Update `labels.project` to the new initiative label
+   - Update `labels.phases` to match
+   - Update `codebases.active` if the codebase changed
+
+2. Run `generate.py` to regenerate prompt files.
+
+3. Run `sync_labels.sh` to create the new labels in GitHub.
+
+4. Use the Plan page to generate a PlanSpec for the new initiative, then file issues. The `initiative_phases` rows written at filing time are the canonical phase order for the board — `config.yaml` phases drive the agent prompts, not the board display order.


### PR DESCRIPTION
## Summary

- Trims README to a snappy 60-line marketing page with quick start, MCP snippet, and a clean docs table
- Creates `docs/README.md` as a comprehensive system overview and documentation index
- Adds five new reference documents covering everything agents and developers need to know

## New reference docs

| File | Content |
|------|---------|
| `docs/reference/api.md` | Every HTTP endpoint organized by resource prefix — new semantic URL taxonomy fully documented |
| `docs/reference/agent-task.md` | `.agent-task` TOML format — quick field reference, minimal example, extension guide |
| `docs/reference/yaml-config.md` | `config.yaml`, `team.yaml`, `role-taxonomy.yaml` — full field reference with examples |
| `docs/reference/cognitive-arch.md` | All four layers: 77 figures, 43 skill domains, 8 archetypes, all atoms |
| `docs/reference/type-contracts.md` | Updated with Dispatch/Runs/Ship API models from URL taxonomy refactor |

## Test plan

- [ ] All links in README resolve correctly
- [ ] All links in docs/README.md resolve correctly
- [ ] No broken references between docs files