### PR TITLE
chore: prefer GitHub MCP server over gh CLI in agent rules

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -22,6 +22,27 @@ When uncertain: (1) preserve existing patterns, (2) prefer smaller changes over 
 - **Org tree dispatch:** CTO → VP → Engineer. Each tier receives the correct label scope and cognitive-architecture context.
 - **No deprecated APIs:** Remove dead code on sight. No fallbacks for old API shapes.
 
+## GitHub interactions — MCP first
+
+The `user-github` MCP server (officially maintained by GitHub) is available in every Cursor session. **Always prefer MCP tools over `gh` CLI for GitHub operations.** MCP calls are typed, structured, and composable; `gh` is a last resort for operations not yet covered by the server.
+
+| Operation | MCP tool |
+|-----------|----------|
+| Read an issue | `issue_read` |
+| Create / edit an issue | `issue_write` |
+| Add an issue comment | `add_issue_comment` |
+| List issues | `list_issues` |
+| Search issues / PRs | `search_issues`, `search_pull_requests` |
+| Read a PR | `pull_request_read` |
+| Create a PR | `create_pull_request` |
+| Update / merge a PR | `update_pull_request`, `merge_pull_request` |
+| Create / submit a review | `pull_request_review_write` |
+| List / create branches | `list_branches`, `create_branch` |
+| Get current user | `get_me` |
+| Search code | `search_code` |
+
+Only fall back to `gh` CLI when the MCP server does not cover the required operation (e.g. `gh worktree`, `gh auth`).
+
 ## Execution
 
 - **Docker-first:** Never run Python on the host. `docker compose exec agentception <cmd>`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,29 @@ When your changes affect another agent's domain, produce a **handoff prompt** de
 
 ---
 
+## GitHub interactions — MCP first
+
+The `user-github` MCP server (officially maintained by GitHub) is available in every Cursor session. **Always prefer MCP tools over `gh` CLI for GitHub operations.** MCP calls are typed, structured, and composable; `gh` is a last resort for operations not yet covered by the server.
+
+| Operation | MCP tool |
+|-----------|----------|
+| Read an issue | `issue_read` |
+| Create / edit an issue | `issue_write` |
+| Add an issue comment | `add_issue_comment` |
+| List issues | `list_issues` |
+| Search issues / PRs | `search_issues`, `search_pull_requests` |
+| Read a PR | `pull_request_read` |
+| Create a PR | `create_pull_request` |
+| Update / merge a PR | `update_pull_request`, `merge_pull_request` |
+| Create / submit a review | `pull_request_review_write` |
+| List / create branches | `list_branches`, `create_branch` |
+| Get current user | `get_me` |
+| Search code | `search_code` |
+
+Only fall back to `gh` CLI when the MCP server does not cover the required operation (e.g. `gh worktree`, `gh auth`).
+
+---
+
 ## Architecture Boundaries
 
 ```


### PR DESCRIPTION
## Summary

- Adds a **GitHub interactions — MCP first** section to both `.cursorrules` and `AGENTS.md`
- Instructs all Cursor agents to use the `user-github` MCP server (officially maintained by GitHub) instead of shelling out to `gh` for GitHub interactions
- Includes a quick-reference table mapping common operations to their MCP tool names
- Narrow fallback allowance: only use `gh` CLI for operations the MCP server doesn't cover (e.g. `gh worktree`, `gh auth`)

## Test plan

- [x] Rule is present and identical in both `.cursorrules` and `AGENTS.md`
- [x] No code changes — doc/rule only