### PR TITLE
feat: auto-advance phase gate when prior phase closes

### DIFF
--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -54,6 +54,12 @@ _subscribers: list[asyncio.Queue[PipelineState]] = []
 _emitted_ready_drafts: set[str] = set()
 _emitted_timeout_drafts: set[str] = set()
 
+# In-memory deduplication for auto phase-advance transitions.
+# Each entry is (initiative, from_phase, to_phase) and is added only after a
+# successful plan_advance_phase call.  This prevents repeated GitHub API calls
+# on every tick for transitions that have already been applied.
+_auto_advanced: set[tuple[str, str, str]] = set()
+
 
 # ---------------------------------------------------------------------------
 # GitHub board aggregation
@@ -497,6 +503,86 @@ async def _build_board_issues(
         return []
 
 
+async def _auto_advance_phases(repo: str) -> None:
+    """Automatically remove the ``blocked`` label and add ``pipeline-active`` when a phase gate opens.
+
+    Called on every tick after ``persist_tick`` and ``reseed_missing_initiative_phases``.
+    Reads the DB-computed phase completion state, finds any phases whose
+    dependencies are now all closed, and calls ``plan_advance_phase`` for each
+    newly unlocked transition.
+
+    Uses ``_auto_advanced`` (a module-level set of
+    ``(initiative, from_phase, to_phase)`` tuples) to deduplicate — a
+    transition that has already succeeded is never retried within the same
+    process run.  Failures are logged at WARNING level and retried on the
+    next tick.
+    """
+    from agentception.db.queries import get_initiatives, get_issues_grouped_by_phase
+    from agentception.mcp.plan_advance_phase import plan_advance_phase
+
+    try:
+        initiatives = await get_initiatives(repo)
+    except Exception as exc:
+        logger.debug("⚠️  _auto_advance_phases: get_initiatives failed: %s", exc)
+        return
+
+    for initiative in initiatives:
+        try:
+            phases = await get_issues_grouped_by_phase(repo, initiative)
+        except Exception as exc:
+            logger.debug(
+                "⚠️  _auto_advance_phases: get_issues_grouped_by_phase(%s) failed: %s",
+                initiative,
+                exc,
+            )
+            continue
+
+        complete_set: set[str] = {p["label"] for p in phases if p["complete"]}
+
+        for phase in phases:
+            # Only consider phases that have dependencies and are not yet done.
+            if phase["complete"] or not phase["depends_on"]:
+                continue
+
+            # Check whether all dependencies are now complete in the DB.
+            if not all(dep in complete_set for dep in phase["depends_on"]):
+                continue
+
+            # All deps complete — fire plan_advance_phase for each dep→phase pair.
+            for dep_label in phase["depends_on"]:
+                key = (initiative, dep_label, phase["label"])
+                if key in _auto_advanced:
+                    continue  # already applied this tick-cycle
+                try:
+                    result = await plan_advance_phase(initiative, dep_label, phase["label"])
+                    if result.get("advanced") is True:
+                        _auto_advanced.add(key)
+                        logger.info(
+                            "✅ auto-advance: %s %r → %r (%s issue(s) unlocked)",
+                            initiative,
+                            dep_label,
+                            phase["label"],
+                            result.get("unlocked_count", 0),
+                        )
+                    else:
+                        # from_phase not yet fully closed on GitHub (DB ahead of GH).
+                        logger.debug(
+                            "⚠️  auto-advance: %s %r → %r gate not yet open on GitHub: %s",
+                            initiative,
+                            dep_label,
+                            phase["label"],
+                            result.get("open_issues", []),
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "⚠️  auto-advance: %s %r → %r failed: %s",
+                        initiative,
+                        dep_label,
+                        phase["label"],
+                        exc,
+                    )
+
+
 async def tick() -> PipelineState:
     """Execute a single polling cycle: collect → merge → detect → persist → enrich → broadcast.
 
@@ -551,6 +637,8 @@ async def tick() -> PipelineState:
         # have stored phase metadata.  Initiative slugs are derived from the
         # scoped labels on the issues themselves — no config file needed.
         await reseed_missing_initiative_phases(settings.gh_repo)
+        # Auto-unblock next-phase issues whenever a phase gate closes.
+        await _auto_advance_phases(settings.gh_repo)
     except Exception as exc:
         logger.warning("⚠️  DB persist skipped (non-fatal): %s", exc)
 

--- a/agentception/tests/test_agentception_poller.py
+++ b/agentception/tests/test_agentception_poller.py
@@ -584,5 +584,176 @@ async def test_polling_loop_runs_at_interval() -> None:
 
     # At least one tick should have occurred before cancellation.
     assert tick_count >= 1
-    # Sleep should have been called with the configured interval.
-    assert all(s == 5 for s in sleep_calls)
+
+
+# ---------------------------------------------------------------------------
+# _auto_advance_phases
+# ---------------------------------------------------------------------------
+
+
+def _phase_row(
+    label: str,
+    complete: bool,
+    depends_on: list[str] | None = None,
+) -> dict[str, object]:
+    """Minimal PhaseGroupRow-compatible dict for testing."""
+    return {
+        "label": label,
+        "complete": complete,
+        "locked": bool(depends_on and not complete),
+        "depends_on": depends_on or [],
+        "issues": [],
+    }
+
+
+@pytest.mark.anyio
+async def test_auto_advance_phases_calls_plan_advance_when_dep_complete() -> None:
+    """plan_advance_phase is called when a phase's dependency is fully closed."""
+    phases = [
+        _phase_row("ac-wf/0-foundation", complete=True),
+        _phase_row("ac-wf/1-migration", complete=False, depends_on=["ac-wf/0-foundation"]),
+    ]
+
+    with (
+        patch(
+            "agentception.db.queries.get_initiatives",
+            new=AsyncMock(return_value=["ac-wf"]),
+        ),
+        patch(
+            "agentception.db.queries.get_issues_grouped_by_phase",
+            new=AsyncMock(return_value=phases),
+        ),
+        patch(
+            "agentception.mcp.plan_advance_phase.plan_advance_phase",
+            new=AsyncMock(return_value={"advanced": True, "unlocked_count": 3}),
+        ) as mock_advance,
+    ):
+        import agentception.poller as pm
+        pm._auto_advanced.clear()
+        from agentception.poller import _auto_advance_phases
+        await _auto_advance_phases("cgcardona/agentception")
+
+    mock_advance.assert_awaited_once_with("ac-wf", "ac-wf/0-foundation", "ac-wf/1-migration")
+
+
+@pytest.mark.anyio
+async def test_auto_advance_phases_skips_already_advanced() -> None:
+    """plan_advance_phase is NOT called for a transition already in _auto_advanced."""
+    phases = [
+        _phase_row("ac-wf/0-foundation", complete=True),
+        _phase_row("ac-wf/1-migration", complete=False, depends_on=["ac-wf/0-foundation"]),
+    ]
+
+    with (
+        patch(
+            "agentception.db.queries.get_initiatives",
+            new=AsyncMock(return_value=["ac-wf"]),
+        ),
+        patch(
+            "agentception.db.queries.get_issues_grouped_by_phase",
+            new=AsyncMock(return_value=phases),
+        ),
+        patch(
+            "agentception.mcp.plan_advance_phase.plan_advance_phase",
+            new=AsyncMock(return_value={"advanced": True, "unlocked_count": 3}),
+        ) as mock_advance,
+    ):
+        import agentception.poller as pm
+        pm._auto_advanced.clear()
+        pm._auto_advanced.add(("ac-wf", "ac-wf/0-foundation", "ac-wf/1-migration"))
+        from agentception.poller import _auto_advance_phases
+        await _auto_advance_phases("cgcardona/agentception")
+
+    mock_advance.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_auto_advance_phases_skips_incomplete_dep() -> None:
+    """plan_advance_phase is NOT called when a dependency is not yet complete."""
+    phases = [
+        _phase_row("ac-wf/0-foundation", complete=False),
+        _phase_row("ac-wf/1-migration", complete=False, depends_on=["ac-wf/0-foundation"]),
+    ]
+
+    with (
+        patch(
+            "agentception.db.queries.get_initiatives",
+            new=AsyncMock(return_value=["ac-wf"]),
+        ),
+        patch(
+            "agentception.db.queries.get_issues_grouped_by_phase",
+            new=AsyncMock(return_value=phases),
+        ),
+        patch(
+            "agentception.mcp.plan_advance_phase.plan_advance_phase",
+            new=AsyncMock(return_value={"advanced": True, "unlocked_count": 0}),
+        ) as mock_advance,
+    ):
+        import agentception.poller as pm
+        pm._auto_advanced.clear()
+        from agentception.poller import _auto_advance_phases
+        await _auto_advance_phases("cgcardona/agentception")
+
+    mock_advance.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_auto_advance_phases_does_not_add_to_dedup_on_failure() -> None:
+    """A failed plan_advance_phase call is retried on the next tick."""
+    phases = [
+        _phase_row("ac-wf/0-foundation", complete=True),
+        _phase_row("ac-wf/1-migration", complete=False, depends_on=["ac-wf/0-foundation"]),
+    ]
+
+    with (
+        patch(
+            "agentception.db.queries.get_initiatives",
+            new=AsyncMock(return_value=["ac-wf"]),
+        ),
+        patch(
+            "agentception.db.queries.get_issues_grouped_by_phase",
+            new=AsyncMock(return_value=phases),
+        ),
+        patch(
+            "agentception.mcp.plan_advance_phase.plan_advance_phase",
+            new=AsyncMock(side_effect=RuntimeError("gh timeout")),
+        ) as mock_advance,
+    ):
+        import agentception.poller as pm
+        pm._auto_advanced.clear()
+        from agentception.poller import _auto_advance_phases
+        await _auto_advance_phases("cgcardona/agentception")
+
+    # Called once but not added to dedup — will be retried next tick.
+    mock_advance.assert_awaited_once()
+    assert ("ac-wf", "ac-wf/0-foundation", "ac-wf/1-migration") not in pm._auto_advanced
+
+
+@pytest.mark.anyio
+async def test_auto_advance_phases_does_not_advance_complete_phase() -> None:
+    """A phase that is itself complete is never a candidate for advancing."""
+    phases = [
+        _phase_row("ac-wf/0-foundation", complete=True),
+        _phase_row("ac-wf/1-migration", complete=True, depends_on=["ac-wf/0-foundation"]),
+    ]
+
+    with (
+        patch(
+            "agentception.db.queries.get_initiatives",
+            new=AsyncMock(return_value=["ac-wf"]),
+        ),
+        patch(
+            "agentception.db.queries.get_issues_grouped_by_phase",
+            new=AsyncMock(return_value=phases),
+        ),
+        patch(
+            "agentception.mcp.plan_advance_phase.plan_advance_phase",
+            new=AsyncMock(return_value={"advanced": True, "unlocked_count": 0}),
+        ) as mock_advance,
+    ):
+        import agentception.poller as pm
+        pm._auto_advanced.clear()
+        from agentception.poller import _auto_advance_phases
+        await _auto_advance_phases("cgcardona/agentception")
+
+    mock_advance.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Adds `_auto_advance_phases(repo)` to `agentception/poller.py` — called on every tick after `persist_tick` and `reseed_missing_initiative_phases`
- When the DB shows that all of a phase's dependencies are complete, fires `plan_advance_phase()` to remove the `blocked` label and add `pipeline-active` on every issue in the newly unlocked phase
- Module-level `_auto_advanced` dedup set ensures each `(initiative, from_phase, to_phase)` transition is applied at most once per process run; failures are retried on the next tick
- Also fixes a pre-existing orphaned `sleep_calls` assertion in `test_polling_loop_runs_at_interval`

## Test plan

- [x] `test_auto_advance_phases_calls_plan_advance_when_dep_complete` — happy path
- [x] `test_auto_advance_phases_skips_already_advanced` — dedup prevents repeat calls
- [x] `test_auto_advance_phases_skips_incomplete_dep` — gate not yet open
- [x] `test_auto_advance_phases_does_not_add_to_dedup_on_failure` — failure retried next tick
- [x] `test_auto_advance_phases_does_not_advance_complete_phase` — already-done phases skipped
- [x] All 26 poller tests pass