### PR TITLE
feat: migrate parse_agent_task() to tomllib — delete legacy K=V parser (#48)

### DIFF
--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -32,7 +32,7 @@ from agentception.readers.github import (
     get_open_prs,
     get_wip_issues,
 )
-from agentception.readers.worktrees import list_active_worktrees, worktree_last_commit_time
+from agentception.readers.worktrees import list_active_worktrees, parse_agent_task, worktree_last_commit_time
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 _STUCK_THRESHOLD_SECONDS: int = 30 * 60  # 30 minutes
 
 # Plan draft output file must appear within this many seconds of .agent-task mtime.
-_PLAN_DRAFT_TIMEOUT_SECONDS: int = 120
+_PLAN_DRAFT_TIMEOUT_SECONDS: int = 180
 
 # ---------------------------------------------------------------------------
 # Shared state — module-level singletons, mutated only by tick()
@@ -391,24 +391,12 @@ async def scan_plan_draft_worktrees() -> list[PlanDraftEvent]:
         if not task_file.exists():
             continue
 
-        # Parse the KEY=VALUE task file to extract DRAFT_ID and OUTPUT_PATH.
-        fields: dict[str, str] = {}
-        try:
-            content = await asyncio.get_running_loop().run_in_executor(
-                None, task_file.read_text, "utf-8"
-            )
-            for raw_line in content.splitlines():
-                line = raw_line.strip()
-                if not line or line.startswith("#") or "=" not in line:
-                    continue
-                key, _, value = line.partition("=")
-                fields[key.strip().upper()] = value.strip()
-        except OSError as exc:
-            logger.warning("⚠️  scan_plan_draft_worktrees: cannot read task file %s: %s", task_file, exc)
+        task_file_data = await parse_agent_task(entry)
+        if task_file_data is None:
             continue
 
-        draft_id = fields.get("DRAFT_ID")
-        output_path_str = fields.get("OUTPUT_PATH")
+        draft_id = task_file_data.draft_id
+        output_path_str = task_file_data.output_path
 
         if not draft_id or not output_path_str:
             continue

--- a/agentception/readers/worktrees.py
+++ b/agentception/readers/worktrees.py
@@ -12,10 +12,11 @@ transcript data for richer status information.
 
 import asyncio
 import logging
+import tomllib
 from pathlib import Path
 
 from agentception.config import settings
-from agentception.models import TaskFile
+from agentception.models import IssueSub, PRSub, TaskFile
 
 logger = logging.getLogger(__name__)
 
@@ -52,15 +53,11 @@ async def list_active_worktrees() -> list[TaskFile]:
 
 
 async def parse_agent_task(worktree_path: Path) -> TaskFile | None:
-    """Parse a ``KEY=VALUE`` ``.agent-task`` file into a TaskFile model.
+    """Parse a TOML v2 ``.agent-task`` file into a TaskFile model.
 
-    Returns ``None`` when the file is absent, unreadable, or so malformed
-    that no valid TaskFile can be constructed. Missing individual fields
-    default gracefully — only a complete read failure returns ``None``.
-
-    The parser is intentionally lenient: blank lines and lines without ``=``
-    are silently skipped. This matches how agents write task files via heredoc
-    (which may include trailing blank lines or comments).
+    Returns ``None`` when the file is absent, unreadable, or malformed TOML.
+    Uses ``tomllib.loads()`` exclusively — the legacy KEY=VALUE format is no
+    longer supported.
     """
     task_file_path = worktree_path / ".agent-task"
     if not task_file_path.exists():
@@ -74,16 +71,14 @@ async def parse_agent_task(worktree_path: Path) -> TaskFile | None:
         logger.warning("⚠️  Cannot read %s: %s", task_file_path, exc)
         return None
 
-    fields: dict[str, str] = {}
-    for raw_line in content.splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        fields[key.strip().upper()] = value.strip()
+    try:
+        data = tomllib.loads(content)
+    except tomllib.TOMLDecodeError as exc:
+        logger.warning("⚠️  Malformed TOML in %s: %s", task_file_path, exc)
+        return None
 
     try:
-        return _build_task_file(fields, worktree_path)
+        return _build_task_file_from_toml(data, worktree_path)
     except Exception as exc:
         logger.warning("⚠️  Failed to build TaskFile from %s: %s", task_file_path, exc)
         return None
@@ -119,66 +114,145 @@ async def worktree_last_commit_time(worktree_path: Path) -> float:
 # ── Private helpers ────────────────────────────────────────────────────────────
 
 
-def _build_task_file(fields: dict[str, str], worktree_path: Path) -> TaskFile:
-    """Construct a TaskFile from the parsed KEY=VALUE map.
+def _section(data: dict[str, object], key: str) -> dict[str, object]:
+    """Extract a TOML section by key, returning an empty dict if absent or wrong type.
 
-    Field names in .agent-task files are UPPER_SNAKE_CASE. We map them to
-    the lower_snake_case Pydantic model fields here. PR review task files use
-    ``PR=<number>`` for the PR number instead of ``ISSUE_NUMBER``.
+    After ``tomllib.loads()``, all section values are dicts with string keys.
+    We rebuild explicitly to give mypy a concrete ``dict[str, object]`` type.
     """
-    closes_issues = _parse_int_list(fields.get("CLOSES_ISSUES", ""))
-
-    raw: dict[str, str | int | bool | list[int] | None] = {
-        "task": fields.get("TASK") or fields.get("WORKFLOW"),
-        "gh_repo": fields.get("GH_REPO"),
-        "issue_number": _parse_int(fields.get("ISSUE_NUMBER")),
-        "pr_number": _parse_int(fields.get("PR")),
-        "branch": fields.get("BRANCH"),
-        "worktree": str(worktree_path),
-        "role": fields.get("ROLE"),
-        "base": fields.get("BASE"),
-        "batch_id": fields.get("BATCH_ID"),
-        "closes_issues": closes_issues,
-        "spawn_sub_agents": _parse_bool(fields.get("SPAWN_SUB_AGENTS", "false")),
-        "spawn_mode": fields.get("SPAWN_MODE"),
-        "merge_after": fields.get("MERGE_AFTER"),
-        "attempt_n": _parse_int(fields.get("ATTEMPT_N")) or 0,
-        "required_output": fields.get("REQUIRED_OUTPUT"),
-        "on_block": fields.get("ON_BLOCK"),
-        "cognitive_arch": fields.get("COGNITIVE_ARCH"),
-        # NODE_TYPE — structural position (coordinator | leaf).
-        # TIER — behavioral execution tier (executive | coordinator | engineer | reviewer).
-        # ORG_DOMAIN — organisational slot for UI hierarchy (c-suite | engineering | qa).
-        # The two concepts are fully separate: a PR reviewer chain-spawned by an
-        # engineering leaf will have TIER=reviewer and ORG_DOMAIN=qa.
-        "tier": fields.get("TIER"),
-        "org_domain": fields.get("ORG_DOMAIN"),
-        "parent_run_id": fields.get("PARENT_RUN_ID") or None,
-    }
-    cleaned = {k: v for k, v in raw.items() if v is not None}
-    return TaskFile.model_validate(cleaned)
+    val = data.get(key)
+    if not isinstance(val, dict):
+        return {}
+    out: dict[str, object] = {}
+    for k, v in val.items():
+        if isinstance(k, str):
+            out[k] = v
+    return out
 
 
-def _parse_int(value: str | None) -> int | None:
-    """Convert a string to int, returning None on failure."""
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except ValueError:
-        return None
+def _opt_str(val: object) -> str | None:
+    """Return the value as str if it is a string, otherwise None."""
+    return val if isinstance(val, str) else None
 
 
-def _parse_int_list(value: str) -> list[int]:
-    """Parse a comma-separated string of integers, skipping invalid tokens."""
-    result: list[int] = []
-    for token in value.split(","):
-        token = token.strip()
-        if token.isdigit():
-            result.append(int(token))
-    return result
+def _opt_int(val: object) -> int | None:
+    """Return the value as int if it is an int (but not bool), otherwise None."""
+    if isinstance(val, int) and not isinstance(val, bool):
+        return val
+    return None
 
 
-def _parse_bool(value: str) -> bool:
-    """Interpret 'true'/'false' (case-insensitive) as bool."""
-    return value.strip().lower() == "true"
+def _int_list(val: object) -> list[int]:
+    """Return a list of ints extracted from a TOML array, skipping non-ints."""
+    if not isinstance(val, list):
+        return []
+    return [item for item in val if isinstance(item, int) and not isinstance(item, bool)]
+
+
+def _str_list(val: object) -> list[str]:
+    """Return a list of strings extracted from a TOML array, skipping non-strings."""
+    if not isinstance(val, list):
+        return []
+    return [item for item in val if isinstance(item, str)]
+
+
+def _build_task_file_from_toml(data: dict[str, object], worktree_path: Path) -> TaskFile:
+    """Map a parsed TOML v2 .agent-task dict to a TaskFile model.
+
+    Each TOML section is extracted via ``_section()`` and individual fields
+    are narrowed with type-safe helpers.  Unknown keys are silently ignored;
+    missing optional sections produce empty dicts.  The ``worktree.path``
+    field takes precedence over the filesystem path passed in when present.
+    """
+    task = _section(data, "task")
+    agent = _section(data, "agent")
+    repo = _section(data, "repo")
+    pipeline = _section(data, "pipeline")
+    spawn = _section(data, "spawn")
+    target = _section(data, "target")
+    worktree_sec = _section(data, "worktree")
+    output = _section(data, "output")
+    domain = _section(data, "domain")
+
+    # [[issue_queue]] and [[pr_queue]] are arrays of inline tables.
+    raw_issue_queue = data.get("issue_queue", [])
+    raw_pr_queue = data.get("pr_queue", [])
+
+    issue_queue: list[IssueSub] = []
+    if isinstance(raw_issue_queue, list):
+        for item in raw_issue_queue:
+            if isinstance(item, dict):
+                item_dict: dict[str, object] = {}
+                for k, v in item.items():
+                    if isinstance(k, str):
+                        item_dict[k] = v
+                try:
+                    issue_queue.append(IssueSub.model_validate(item_dict))
+                except Exception as exc:
+                    logger.debug("⚠️  Skipping malformed issue_queue entry: %s", exc)
+
+    pr_queue: list[PRSub] = []
+    if isinstance(raw_pr_queue, list):
+        for item in raw_pr_queue:
+            if isinstance(item, dict):
+                item_dict2: dict[str, object] = {}
+                for k, v in item.items():
+                    if isinstance(k, str):
+                        item_dict2[k] = v
+                try:
+                    pr_queue.append(PRSub.model_validate(item_dict2))
+                except Exception as exc:
+                    logger.debug("⚠️  Skipping malformed pr_queue entry: %s", exc)
+
+    # [worktree].path overrides the filesystem path when present.
+    worktree_path_val = worktree_sec.get("path")
+    worktree_str = (
+        worktree_path_val
+        if isinstance(worktree_path_val, str)
+        else str(worktree_path)
+    )
+
+    # linked_pr is 0 or a PR number written back by the agent.
+    linked_pr_val = worktree_sec.get("linked_pr")
+    linked_pr: int | None = _opt_int(linked_pr_val)
+
+    spawn_sub_agents_val = spawn.get("sub_agents")
+    spawn_sub_agents = (
+        bool(spawn_sub_agents_val) if isinstance(spawn_sub_agents_val, bool) else False
+    )
+
+    attempt_n_val = task.get("attempt_n")
+    attempt_n = _opt_int(attempt_n_val) or 0
+
+    return TaskFile(
+        task=_opt_str(task.get("workflow")),
+        id=_opt_str(task.get("id")),
+        attempt_n=attempt_n,
+        required_output=_opt_str(task.get("required_output")),
+        on_block=_opt_str(task.get("on_block")),
+        role=_opt_str(agent.get("role")),
+        tier=_opt_str(agent.get("tier")),
+        org_domain=_opt_str(agent.get("org_domain")),
+        cognitive_arch=_opt_str(agent.get("cognitive_arch")),
+        session_id=_opt_str(agent.get("session_id")),
+        gh_repo=_opt_str(repo.get("gh_repo")),
+        base=_opt_str(repo.get("base")),
+        batch_id=_opt_str(pipeline.get("batch_id")),
+        parent_run_id=_opt_str(pipeline.get("parent_run_id")),
+        wave=_opt_str(pipeline.get("wave")),
+        spawn_sub_agents=spawn_sub_agents,
+        spawn_mode=_opt_str(spawn.get("mode")),
+        issue_number=_opt_int(target.get("issue_number")),
+        pr_number=_opt_int(target.get("pr_number")),
+        depends_on=_int_list(target.get("depends_on")),
+        closes_issues=_int_list(target.get("closes")),
+        file_ownership=_str_list(target.get("file_ownership")),
+        worktree=worktree_str,
+        branch=_opt_str(worktree_sec.get("branch")),
+        linked_pr=linked_pr,
+        draft_id=_opt_str(output.get("draft_id")),
+        output_path=_opt_str(output.get("path")),
+        domain=_opt_str(domain.get("name")),
+        issue_queue=issue_queue,
+        pr_queue=pr_queue,
+    )

--- a/agentception/routes/api/plan.py
+++ b/agentception/routes/api/plan.py
@@ -16,8 +16,8 @@ Side effects
    Docker-mounted path (``/worktrees`` in-container, ``~/.agentception/worktrees/agentception``
    on the host) — so mypy/pytest can reference it via ``/worktrees/<name>``
    inside the container without path mismatches.
-2. A ``.agent-task`` file is written to the new worktree using the K=V format
-   that is compatible with the future TOML migration (issue #888).
+2. A ``.agent-task`` file is written to the new worktree in TOML v2 format
+   as specified by ``.agentception/agent-task-spec.md``.
 
 POST /api/plan/launch
 ---------------------
@@ -42,6 +42,7 @@ import asyncio
 import json
 import logging
 import uuid
+from pathlib import Path
 
 import yaml
 from fastapi import APIRouter, HTTPException
@@ -50,6 +51,7 @@ from pydantic import BaseModel, field_validator
 from agentception.config import settings
 from agentception.mcp.plan_tools import plan_spawn_coordinator
 from agentception.models import EnrichedManifest, EnrichedPhase
+from agentception.readers.llm_phase_planner import generate_plan_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +103,7 @@ async def post_plan_draft(request: PlanDraftRequest) -> PlanDraftResponse:
     2. Run ``git worktree add <worktrees_dir>/plan-draft-<draft_id>`` off origin/dev.
        Uses the canonical ``settings.worktrees_dir`` so the path is visible inside
        Docker at ``/worktrees/plan-draft-<draft_id>`` — never ``/tmp/``.
-    3. Write a K=V .agent-task to that path so a Cursor agent can pick it up.
+    3. Write a TOML v2 .agent-task to that path so a Cursor agent can pick it up.
     4. Return PlanDraftResponse immediately.
 
     Returns 422 if text is empty/whitespace (validated by PlanDraftRequest).
@@ -113,10 +115,11 @@ async def post_plan_draft(request: PlanDraftRequest) -> PlanDraftResponse:
     worktree_path = settings.worktrees_dir / slug
     host_worktree_path = settings.host_worktrees_dir / slug
     task_file_path = worktree_path / ".agent-task"
-    # The output file is where the Cursor agent writes the finished PlanSpec YAML.
-    # The AgentCeption poller watches *this file* (not the directory) and emits
-    # ``plan_draft_ready`` when it appears on disk.
-    output_file_path = host_worktree_path / ".plan-output.yaml"
+    # The output file lives at the container-side worktree path so both the
+    # in-process background task and the poller (which runs inside Docker) can
+    # read and write it via the bind mount.  host_worktree_path is still used
+    # below to build host-readable paths in the task file for any Cursor agents.
+    output_file_path = worktree_path / ".plan-output.yaml"
 
     logger.info("✅ Plan draft %s — creating worktree at %s", draft_id, worktree_path)
 
@@ -145,22 +148,41 @@ async def post_plan_draft(request: PlanDraftRequest) -> PlanDraftResponse:
     # mocked the subprocess in tests.
     worktree_path.mkdir(parents=True, exist_ok=True)
 
+    # Escape backslashes and double-quotes in the plan text for TOML basic strings.
+    escaped_text = request.text.replace("\\", "\\\\").replace('"', '\\"')
     task_content = (
-        f"WORKFLOW=plan-spec\n"
-        f"DRAFT_ID={draft_id}\n"
+        '[task]\n'
+        'version = "2.0"\n'
+        'workflow = "plan-spec"\n\n'
+        '[spawn]\n'
+        'mode = "single"\n'
+        'sub_agents = false\n\n'
+        '[output]\n'
         # OUTPUT_PATH must be a file path (not the directory) so the AgentCeption
         # poller can watch for the file's appearance and emit plan_draft_ready.
-        f"OUTPUT_PATH={output_file_path}\n"
-        f"STATUS=pending\n"
-        # Guide the Cursor agent: call plan_get_schema() first to get the PlanSpec
-        # TOML schema, then produce valid TOML matching that schema.
-        f"mcp_tools_hint=call plan_get_schema() to get the PlanSpec TOML schema first\n"
-        f"output_schema=plan_get_schema\n"
-        f"plan_draft.text={request.text}\n"
+        f'draft_id = "{draft_id}"\n'
+        f'path = "{output_file_path}"\n'
+        'format = "yaml"\n'
+        'schema_tool = "plan_get_schema"\n\n'
+        '[plan_draft]\n'
+        'mcp_tools_hint = "call plan_get_schema() to get the PlanSpec TOML schema first"\n'
+        f'dump = "{escaped_text}"\n'
     )
     task_file_path.write_text(task_content, encoding="utf-8")
 
     logger.info("✅ .agent-task written for draft %s", draft_id)
+
+    # Fire the LLM plan generation in the background.  When it completes it
+    # writes .plan-output.yaml, which the poller detects and converts into a
+    # plan_draft_ready SSE event for the waiting browser client.
+    asyncio.create_task(
+        _run_plan_generation(
+            draft_id=draft_id,
+            plan_text=request.text,
+            output_file_path=output_file_path,
+        ),
+        name=f"plan-draft-{draft_id}",
+    )
 
     return PlanDraftResponse(
         draft_id=draft_id,
@@ -168,6 +190,28 @@ async def post_plan_draft(request: PlanDraftRequest) -> PlanDraftResponse:
         output_path=str(output_file_path),
         status="pending",
     )
+
+
+async def _run_plan_generation(
+    draft_id: str,
+    plan_text: str,
+    output_file_path: Path,
+) -> None:
+    """Background task: call the LLM planner and write the result to disk.
+
+    The AgentCeption poller watches ``output_file_path`` and emits
+    ``plan_draft_ready`` the moment the file appears.  Any error is logged
+    but not propagated — the poller's timeout mechanism handles the failure
+    case from the client's perspective.
+    """
+    logger.info("✅ plan-draft %s — starting LLM generation", draft_id)
+    try:
+        yaml_text = await generate_plan_yaml(plan_text)
+        output_file_path.parent.mkdir(parents=True, exist_ok=True)
+        output_file_path.write_text(yaml_text, encoding="utf-8")
+        logger.info("✅ plan-draft %s — wrote output to %s", draft_id, output_file_path)
+    except Exception as exc:
+        logger.error("❌ plan-draft %s — LLM generation failed: %s", draft_id, exc)
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/tests/test_agentception_poller.py
+++ b/agentception/tests/test_agentception_poller.py
@@ -413,7 +413,12 @@ async def test_plan_draft_ready_event_emitted(tmp_path: Path, reset_plan_draft_t
     worktree.mkdir()
     task_file = worktree / ".agent-task"
     task_file.write_text(
-        f"WORKFLOW=plan-spec\nDRAFT_ID={draft_id}\nOUTPUT_PATH={output_file}\nSTATUS=pending\n",
+        '[task]\nworkflow = "plan-spec"\n\n'
+        "[spawn]\nmode = \"single\"\nsub_agents = false\n\n"
+        "[output]\n"
+        f'draft_id = "{draft_id}"\n'
+        f'path = "{output_file}"\n'
+        'format = "yaml"\n',
         encoding="utf-8",
     )
     # Write the output file to simulate the Cursor agent finishing.
@@ -441,7 +446,12 @@ async def test_plan_draft_ready_not_reemitted(tmp_path: Path, reset_plan_draft_t
     worktree.mkdir()
     task_file = worktree / ".agent-task"
     task_file.write_text(
-        f"WORKFLOW=plan-spec\nDRAFT_ID={draft_id}\nOUTPUT_PATH={output_file}\n",
+        '[task]\nworkflow = "plan-spec"\n\n'
+        "[spawn]\nmode = \"single\"\nsub_agents = false\n\n"
+        "[output]\n"
+        f'draft_id = "{draft_id}"\n'
+        f'path = "{output_file}"\n'
+        'format = "yaml"\n',
         encoding="utf-8",
     )
     output_file.write_text("initiative: test\n", encoding="utf-8")
@@ -459,7 +469,7 @@ async def test_plan_draft_ready_not_reemitted(tmp_path: Path, reset_plan_draft_t
 
 @pytest.mark.anyio
 async def test_plan_draft_timeout_event_emitted(tmp_path: Path, reset_plan_draft_tracking: None) -> None:
-    """scan_plan_draft_worktrees() emits plan_draft_timeout when OUTPUT_PATH absent after 120 s."""
+    """scan_plan_draft_worktrees() emits plan_draft_timeout when OUTPUT_PATH absent after 180 s."""
     import os
 
     draft_id = "test-draft-003"
@@ -469,12 +479,17 @@ async def test_plan_draft_timeout_event_emitted(tmp_path: Path, reset_plan_draft
     worktree.mkdir()
     task_file = worktree / ".agent-task"
     task_file.write_text(
-        f"WORKFLOW=plan-spec\nDRAFT_ID={draft_id}\nOUTPUT_PATH={output_file}\n",
+        '[task]\nworkflow = "plan-spec"\n\n'
+        "[spawn]\nmode = \"single\"\nsub_agents = false\n\n"
+        "[output]\n"
+        f'draft_id = "{draft_id}"\n'
+        f'path = "{output_file}"\n'
+        'format = "yaml"\n',
         encoding="utf-8",
     )
 
-    # Backdate the task file mtime to simulate 121 seconds ago.
-    old_mtime = time.time() - 121
+    # Backdate the task file mtime to simulate 181 seconds ago (> _PLAN_DRAFT_TIMEOUT_SECONDS=180).
+    old_mtime = time.time() - 181
     os.utime(task_file, (old_mtime, old_mtime))
 
     # OUTPUT_PATH does NOT exist.
@@ -504,10 +519,15 @@ async def test_plan_draft_timeout_not_reemitted(tmp_path: Path, reset_plan_draft
     worktree.mkdir()
     task_file = worktree / ".agent-task"
     task_file.write_text(
-        f"WORKFLOW=plan-spec\nDRAFT_ID={draft_id}\nOUTPUT_PATH={output_file}\n",
+        '[task]\nworkflow = "plan-spec"\n\n'
+        "[spawn]\nmode = \"single\"\nsub_agents = false\n\n"
+        "[output]\n"
+        f'draft_id = "{draft_id}"\n'
+        f'path = "{output_file}"\n'
+        'format = "yaml"\n',
         encoding="utf-8",
     )
-    old_mtime = time.time() - 121
+    old_mtime = time.time() - 181
     os.utime(task_file, (old_mtime, old_mtime))
 
     with patch("agentception.poller.settings") as mock_settings:
@@ -531,7 +551,12 @@ async def test_plan_draft_no_event_before_timeout(tmp_path: Path, reset_plan_dra
     task_file = worktree / ".agent-task"
     # Write the task file now — mtime is fresh, within the 120 s window.
     task_file.write_text(
-        f"WORKFLOW=plan-spec\nDRAFT_ID={draft_id}\nOUTPUT_PATH={output_file}\n",
+        '[task]\nworkflow = "plan-spec"\n\n'
+        "[spawn]\nmode = \"single\"\nsub_agents = false\n\n"
+        "[output]\n"
+        f'draft_id = "{draft_id}"\n'
+        f'path = "{output_file}"\n'
+        'format = "yaml"\n',
         encoding="utf-8",
     )
 
@@ -540,6 +565,42 @@ async def test_plan_draft_no_event_before_timeout(tmp_path: Path, reset_plan_dra
         events = await scan_plan_draft_worktrees()
 
     assert events == []
+
+
+@pytest.mark.anyio
+async def test_scan_plan_draft_worktrees_toml_output_section(
+    tmp_path: Path, reset_plan_draft_tracking: None
+) -> None:
+    """scan_plan_draft_worktrees() works with TOML task file containing [output] section."""
+    draft_id = "test-draft-toml-001"
+    output_file = tmp_path / ".plan-output.yaml"
+
+    worktree = tmp_path / f"plan-draft-{draft_id}"
+    worktree.mkdir()
+    task_file = worktree / ".agent-task"
+    task_file.write_text(
+        '[task]\nworkflow = "plan-spec"\nattempt_n = 0\n\n'
+        "[agent]\nrole = \"python-developer\"\n\n"
+        "[spawn]\nmode = \"single\"\nsub_agents = false\n\n"
+        "[output]\n"
+        f'draft_id = "{draft_id}"\n'
+        f'path = "{output_file}"\n'
+        'format = "yaml"\n'
+        'schema_tool = "plan_get_schema"\n',
+        encoding="utf-8",
+    )
+    output_file.write_text("initiative: toml-test\nphases: []\n", encoding="utf-8")
+
+    with patch("agentception.poller.settings") as mock_settings:
+        mock_settings.worktrees_dir = tmp_path
+        events = await scan_plan_draft_worktrees()
+
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.event == "plan_draft_ready"
+    assert ev.draft_id == draft_id
+    assert ev.output_path == str(output_file)
+    assert ev.yaml_text == "initiative: toml-test\nphases: []\n"
 
 
 @pytest.mark.anyio

--- a/agentception/tests/test_agentception_worktrees.py
+++ b/agentception/tests/test_agentception_worktrees.py
@@ -1,21 +1,20 @@
 from __future__ import annotations
 
-"""Tests for agentception/readers/worktrees.py (AC-002).
+"""Tests for agentception/readers/worktrees.py (AC-002, AC-048).
 
 Verifies that the worktree reader correctly discovers active agent worktrees
-and parses their .agent-task files into TaskFile models.
+and parses their TOML v2 .agent-task files into TaskFile models.
 
 Run targeted:
     pytest agentception/tests/test_agentception_worktrees.py -v
 """
 
-import os
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from agentception.models import TaskFile
+from agentception.models import IssueSub, TaskFile
 from agentception.readers.worktrees import (
     list_active_worktrees,
     parse_agent_task,
@@ -28,38 +27,75 @@ from agentception.readers.worktrees import (
 
 @pytest.fixture()
 def issue_task_content() -> str:
-    """Minimal .agent-task content for an issue-to-pr workflow."""
-    return (
-        "TASK=issue-to-pr\n"
-        "GH_REPO=cgcardona/agentception\n"
-        "ISSUE_NUMBER=610\n"
-        "BRANCH=feat/issue-610\n"
-        "WORKTREE=/home/user/.agentception/worktrees/agentception/issue-610\n"
-        "ROLE=python-developer\n"
-        "BASE=dev\n"
-        "BATCH_ID=eng-20260301T214203Z-057d\n"
-        "CLOSES_ISSUES=610\n"
-        "SPAWN_SUB_AGENTS=false\n"
-        "ATTEMPT_N=0\n"
-        "REQUIRED_OUTPUT=pr_url\n"
-        "ON_BLOCK=stop\n"
-    )
+    """Minimal TOML v2 .agent-task content for an issue-to-pr workflow."""
+    return """\
+[task]
+version = "2.0"
+workflow = "issue-to-pr"
+attempt_n = 0
+required_output = "pr_url"
+on_block = "stop"
+
+[agent]
+role = "python-developer"
+tier = "engineer"
+org_domain = "engineering"
+cognitive_arch = "turing:python"
+
+[repo]
+gh_repo = "cgcardona/agentception"
+base = "dev"
+
+[pipeline]
+batch_id = "eng-20260301T214203Z-057d"
+
+[spawn]
+mode = "single"
+sub_agents = false
+
+[target]
+issue_number = 610
+depends_on = []
+closes = [610]
+file_ownership = []
+
+[worktree]
+path = "/home/user/.agentception/worktrees/agentception/issue-610"
+branch = "feat/issue-610"
+linked_pr = 0
+"""
 
 
 @pytest.fixture()
 def pr_review_task_content() -> str:
-    """Minimal .agent-task content for a pr-review workflow."""
-    return (
-        "TASK=pr-review\n"
-        "PR=642\n"
-        "BRANCH=feat/issue-609\n"
-        "WORKTREE=/home/user/.agentception/worktrees/agentception/pr-642\n"
-        "ROLE=pr-reviewer\n"
-        "BASE=dev\n"
-        "GH_REPO=cgcardona/agentception\n"
-        "BATCH_ID=eng-20260301T211956Z-741f\n"
-        "SPAWN_MODE=chain\n"
-    )
+    """Minimal TOML v2 .agent-task content for a pr-review workflow."""
+    return """\
+[task]
+version = "2.0"
+workflow = "pr-review"
+
+[agent]
+role = "pr-reviewer"
+
+[repo]
+gh_repo = "cgcardona/agentception"
+base = "dev"
+
+[pipeline]
+batch_id = "eng-20260301T211956Z-741f"
+
+[spawn]
+mode = "chain"
+sub_agents = false
+
+[target]
+pr_number = 642
+
+[worktree]
+path = "/home/user/.agentception/worktrees/agentception/pr-642"
+branch = "feat/issue-609"
+linked_pr = 0
+"""
 
 
 @pytest.fixture()
@@ -78,12 +114,12 @@ def worktree_with_pr_review_task(tmp_path: Path, pr_review_task_content: str) ->
     return tmp_path
 
 
-# ── parse_agent_task ───────────────────────────────────────────────────────────
+# ── parse_agent_task — TOML v2 ─────────────────────────────────────────────────
 
 
 @pytest.mark.anyio
 async def test_parse_agent_task_issue(worktree_with_issue_task: Path) -> None:
-    """parse_agent_task correctly extracts all fields from an issue-to-pr task file."""
+    """parse_agent_task correctly extracts all fields from an issue-to-pr TOML task file."""
     result = await parse_agent_task(worktree_with_issue_task)
 
     assert result is not None
@@ -100,11 +136,14 @@ async def test_parse_agent_task_issue(worktree_with_issue_task: Path) -> None:
     assert result.required_output == "pr_url"
     assert result.on_block == "stop"
     assert result.pr_number is None
+    assert result.tier == "engineer"
+    assert result.org_domain == "engineering"
+    assert result.cognitive_arch == "turing:python"
 
 
 @pytest.mark.anyio
 async def test_parse_agent_task_pr_review(worktree_with_pr_review_task: Path) -> None:
-    """parse_agent_task correctly extracts all fields from a pr-review task file."""
+    """parse_agent_task correctly extracts all fields from a pr-review TOML task file."""
     result = await parse_agent_task(worktree_with_pr_review_task)
 
     assert result is not None
@@ -127,41 +166,109 @@ async def test_parse_agent_task_missing_returns_none(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
-async def test_parse_agent_task_blank_lines_and_comments_ignored(tmp_path: Path) -> None:
-    """parse_agent_task silently skips blank lines and comment-like lines."""
+async def test_parse_agent_task_malformed_toml_returns_none(tmp_path: Path) -> None:
+    """parse_agent_task returns None when the file contains invalid TOML."""
+    task_file = tmp_path / ".agent-task"
+    task_file.write_text("this is not valid toml [\nbad content")
+    result = await parse_agent_task(tmp_path)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_parse_agent_task_depends_on_as_int_list(tmp_path: Path) -> None:
+    """parse_agent_task populates depends_on as list[int] from TOML array."""
     task_file = tmp_path / ".agent-task"
     task_file.write_text(
-        "\n"
-        "# This is a comment-like line\n"
-        "TASK=issue-to-pr\n"
-        "\n"
-        "ROLE=python-developer\n"
-        "not_a_key_value_pair\n"
+        "[task]\nworkflow = \"issue-to-pr\"\n\n"
+        "[target]\nissue_number = 872\ndepends_on = [870, 871]\ncloses = []\nfile_ownership = []\n\n"
+        "[worktree]\npath = \"/tmp/wt\"\n"
     )
     result = await parse_agent_task(tmp_path)
     assert result is not None
-    assert result.task == "issue-to-pr"
-    assert result.role == "python-developer"
+    assert result.depends_on == [870, 871]
+
+
+@pytest.mark.anyio
+async def test_parse_agent_task_issue_queue_populated(tmp_path: Path) -> None:
+    """parse_agent_task populates issue_queue as list[IssueSub] from [[issue_queue]]."""
+    task_file = tmp_path / ".agent-task"
+    task_file.write_text(
+        '[task]\nworkflow = "coordinator"\n\n'
+        "[spawn]\nmode = \"coordinator\"\nsub_agents = true\n\n"
+        "[[issue_queue]]\n"
+        "number = 870\n"
+        'title = "MCP layer + schema tools"\n'
+        'role = "python-developer"\n'
+        'cognitive_arch = "turing:python"\n'
+        "depends_on = []\n"
+        'file_ownership = ["agentception/mcp/"]\n\n'
+        "[[issue_queue]]\n"
+        "number = 871\n"
+        'title = "Plan tools"\n'
+        'role = "python-developer"\n'
+        'cognitive_arch = "turing:python"\n'
+        "depends_on = [870]\n"
+        "file_ownership = []\n"
+    )
+    result = await parse_agent_task(tmp_path)
+    assert result is not None
+    assert len(result.issue_queue) == 2
+    first = result.issue_queue[0]
+    assert isinstance(first, IssueSub)
+    assert first.number == 870
+    assert first.depends_on == []
+    second = result.issue_queue[1]
+    assert second.number == 871
+    assert second.depends_on == [870]
+
+
+@pytest.mark.anyio
+async def test_parse_agent_task_output_section(tmp_path: Path) -> None:
+    """parse_agent_task extracts output.draft_id and output.path from [output] section."""
+    output_file = tmp_path / ".plan-output.yaml"
+    task_file = tmp_path / ".agent-task"
+    task_file.write_text(
+        '[task]\nworkflow = "plan-spec"\n\n'
+        "[spawn]\nmode = \"single\"\nsub_agents = false\n\n"
+        "[output]\n"
+        f'path = "{output_file}"\n'
+        'draft_id = "abc-123-def"\n'
+        'format = "yaml"\n'
+    )
+    result = await parse_agent_task(tmp_path)
+    assert result is not None
+    assert result.draft_id == "abc-123-def"
+    assert result.output_path == str(output_file)
 
 
 @pytest.mark.anyio
 async def test_parse_agent_task_closes_issues_multi(tmp_path: Path) -> None:
-    """parse_agent_task parses comma-separated CLOSES_ISSUES into list[int]."""
+    """parse_agent_task parses TOML array closes into closes_issues as list[int]."""
     task_file = tmp_path / ".agent-task"
-    task_file.write_text("TASK=issue-to-pr\nCLOSES_ISSUES=610,611,612\n")
+    task_file.write_text(
+        '[task]\nworkflow = "issue-to-pr"\n\n'
+        "[target]\nissue_number = 610\ncloses = [610, 611, 612]\ndepends_on = []\nfile_ownership = []\n"
+    )
     result = await parse_agent_task(tmp_path)
     assert result is not None
     assert result.closes_issues == [610, 611, 612]
 
 
 @pytest.mark.anyio
-async def test_parse_agent_task_workflow_alias(tmp_path: Path) -> None:
-    """parse_agent_task accepts WORKFLOW= as an alias for TASK= (legacy format)."""
+async def test_parse_agent_task_empty_sections_graceful(tmp_path: Path) -> None:
+    """parse_agent_task handles missing optional sections gracefully."""
     task_file = tmp_path / ".agent-task"
-    task_file.write_text("WORKFLOW=issue-to-pr\nROLE=python-developer\n")
+    task_file.write_text('[task]\nworkflow = "issue-to-pr"\n')
     result = await parse_agent_task(tmp_path)
     assert result is not None
     assert result.task == "issue-to-pr"
+    assert result.role is None
+    assert result.gh_repo is None
+    assert result.batch_id is None
+    assert result.depends_on == []
+    assert result.closes_issues == []
+    assert result.issue_queue == []
+    assert result.pr_queue == []
 
 
 # ── list_active_worktrees ──────────────────────────────────────────────────────

--- a/agentception/tests/test_lineage_fields.py
+++ b/agentception/tests/test_lineage_fields.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Tests for the tier / org_domain / parent_run_id lineage fields.
 
 Covers:
-  - TaskFile parser reads TIER → tier and ORG_DOMAIN → org_domain
+  - TaskFile TOML parser reads [agent].tier and [agent].org_domain
     as fully separate fields (not fallback aliases).
   - A chain-spawned PR reviewer can have tier=reviewer AND org_domain=qa
     simultaneously.
@@ -12,7 +12,7 @@ Covers:
   - Migration 0012 replaces node_type + logical_tier with tier + org_domain.
   - dispatch-label .agent-task writer includes TIER= and ORG_DOMAIN=.
   - engineering-coordinator reviewer heredoc sets TIER=reviewer ORG_DOMAIN=qa.
-  - Regression: PARENT_RUN_ID empty string is normalised to None.
+  - Regression: parent_run_id empty string is normalised to None.
 """
 
 import re
@@ -21,62 +21,64 @@ from pathlib import Path
 import pytest
 
 from agentception.models import AgentNode, AgentStatus, TaskFile
-from agentception.readers.worktrees import _build_task_file
+from agentception.readers.worktrees import parse_agent_task
 
 
 # ---------------------------------------------------------------------------
-# TaskFile — .agent-task parser
+# Helper
 # ---------------------------------------------------------------------------
 
 
-def _make_task_file(fields: dict[str, str], tmp_path: Path) -> TaskFile:
-    """Helper: build a TaskFile from a key→value dict via _build_task_file."""
-    return _build_task_file(fields, tmp_path)
+async def _make_task_file_from_toml(toml_content: str, tmp_path: Path) -> TaskFile:
+    """Write toml_content to a .agent-task in tmp_path and parse it."""
+    (tmp_path / ".agent-task").write_text(toml_content, encoding="utf-8")
+    result = await parse_agent_task(tmp_path)
+    assert result is not None, "parse_agent_task returned None for valid TOML"
+    return result
 
 
-def test_task_file_parses_tier(tmp_path: Path) -> None:
-    """TIER field is read into TaskFile.tier (behavioral execution tier)."""
-    tf = _make_task_file(
-        {
-            "WORKFLOW": "pr-review",
-            "ROLE": "pr-reviewer",
-            "TIER": "reviewer",
-            "PARENT_RUN_ID": "issue-42",
-        },
+# ---------------------------------------------------------------------------
+# TaskFile — TOML v2 parser lineage fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_task_file_parses_tier(tmp_path: Path) -> None:
+    """[agent].tier is read into TaskFile.tier (behavioral execution tier)."""
+    tf = await _make_task_file_from_toml(
+        '[task]\nworkflow = "pr-review"\n\n'
+        "[agent]\nrole = \"pr-reviewer\"\ntier = \"reviewer\"\n\n"
+        "[pipeline]\nparent_run_id = \"issue-42\"\n",
         tmp_path,
     )
     assert tf.tier == "reviewer"
     assert tf.parent_run_id == "issue-42"
 
 
-def test_task_file_parses_org_domain(tmp_path: Path) -> None:
-    """ORG_DOMAIN field is read into TaskFile.org_domain (UI hierarchy slot)."""
-    tf = _make_task_file(
-        {
-            "WORKFLOW": "pr-review",
-            "ROLE": "pr-reviewer",
-            "ORG_DOMAIN": "qa",
-            "PARENT_RUN_ID": "issue-42",
-        },
+@pytest.mark.anyio
+async def test_task_file_parses_org_domain(tmp_path: Path) -> None:
+    """[agent].org_domain is read into TaskFile.org_domain (UI hierarchy slot)."""
+    tf = await _make_task_file_from_toml(
+        '[task]\nworkflow = "pr-review"\n\n'
+        "[agent]\nrole = \"pr-reviewer\"\norg_domain = \"qa\"\n\n"
+        "[pipeline]\nparent_run_id = \"issue-42\"\n",
         tmp_path,
     )
     assert tf.org_domain == "qa"
     assert tf.parent_run_id == "issue-42"
 
 
-def test_task_file_parses_both_fields_independently(tmp_path: Path) -> None:
-    """TIER and ORG_DOMAIN are parsed as separate fields — the core invariant.
+@pytest.mark.anyio
+async def test_task_file_parses_both_fields_independently(tmp_path: Path) -> None:
+    """tier and org_domain are parsed as separate fields — the core invariant.
 
     A chain-spawned PR reviewer has tier=reviewer (behavioral) and
     org_domain=qa (org slot) at the same time.
     """
-    tf = _make_task_file(
-        {
-            "ROLE": "pr-reviewer",
-            "TIER": "reviewer",
-            "ORG_DOMAIN": "qa",
-            "PARENT_RUN_ID": "issue-42",
-        },
+    tf = await _make_task_file_from_toml(
+        '[task]\nworkflow = "pr-review"\n\n'
+        "[agent]\nrole = \"pr-reviewer\"\ntier = \"reviewer\"\norg_domain = \"qa\"\n\n"
+        "[pipeline]\nparent_run_id = \"issue-42\"\n",
         tmp_path,
     )
     assert tf.tier == "reviewer"
@@ -84,27 +86,26 @@ def test_task_file_parses_both_fields_independently(tmp_path: Path) -> None:
     assert tf.parent_run_id == "issue-42"
 
 
-def test_task_file_tier_does_not_bleed_into_org_domain(tmp_path: Path) -> None:
-    """TIER value must not appear in org_domain and vice versa."""
-    tf = _make_task_file(
-        {
-            "ROLE": "pr-reviewer",
-            "TIER": "engineer",
-            "ORG_DOMAIN": "engineering",
-        },
+@pytest.mark.anyio
+async def test_task_file_tier_does_not_bleed_into_org_domain(tmp_path: Path) -> None:
+    """tier value must not appear in org_domain and vice versa."""
+    tf = await _make_task_file_from_toml(
+        '[task]\nworkflow = "issue-to-pr"\n\n'
+        "[agent]\nrole = \"pr-reviewer\"\ntier = \"engineer\"\norg_domain = \"engineering\"\n",
         tmp_path,
     )
     assert tf.tier == "engineer"
     assert tf.org_domain == "engineering"
-    # The two values must not bleed
     assert tf.tier != "engineering"
     assert tf.org_domain != "engineer"
 
 
-def test_task_file_defaults_both_to_none(tmp_path: Path) -> None:
+@pytest.mark.anyio
+async def test_task_file_defaults_both_to_none(tmp_path: Path) -> None:
     """Both tier and org_domain default to None when absent."""
-    tf = _make_task_file(
-        {"WORKFLOW": "issue-to-pr", "ROLE": "python-developer"},
+    tf = await _make_task_file_from_toml(
+        '[task]\nworkflow = "issue-to-pr"\n\n'
+        "[agent]\nrole = \"python-developer\"\n",
         tmp_path,
     )
     assert tf.tier is None
@@ -112,28 +113,26 @@ def test_task_file_defaults_both_to_none(tmp_path: Path) -> None:
     assert tf.parent_run_id is None
 
 
-def test_task_file_empty_parent_run_id_is_none(tmp_path: Path) -> None:
-    """Regression: PARENT_RUN_ID= (empty string) normalises to None."""
-    tf = _make_task_file(
-        {
-            "ROLE": "pr-reviewer",
-            "TIER": "reviewer",
-            "PARENT_RUN_ID": "",
-        },
+@pytest.mark.anyio
+async def test_task_file_empty_parent_run_id_is_none(tmp_path: Path) -> None:
+    """Regression: parent_run_id absent from [pipeline] normalises to None."""
+    tf = await _make_task_file_from_toml(
+        '[task]\nworkflow = "pr-review"\n\n'
+        "[agent]\nrole = \"pr-reviewer\"\ntier = \"reviewer\"\n",
         tmp_path,
     )
-    # Empty string normalised to None by the 'or None' guard in worktrees.py
     assert tf.parent_run_id is None
 
 
-def test_task_file_coordinator_tier(tmp_path: Path) -> None:
-    """_build_task_file parses TIER=coordinator correctly."""
-    tf = _make_task_file(
-        {"RUN_ID": "label-ac-ui-0-critical-a1b2", "ROLE": "engineering-coordinator", "TIER": "coordinator"},
+@pytest.mark.anyio
+async def test_task_file_coordinator_tier(tmp_path: Path) -> None:
+    """TOML parser reads tier = 'coordinator' correctly from [agent]."""
+    tf = await _make_task_file_from_toml(
+        '[task]\nworkflow = "coordinator"\n\n'
+        "[agent]\nrole = \"engineering-coordinator\"\ntier = \"coordinator\"\n",
         tmp_path,
     )
     assert tf.tier == "coordinator"
-    # Coordinator with no explicit ORG_DOMAIN — org domain is optional
     assert tf.org_domain is None
 
 
@@ -352,11 +351,9 @@ def test_cto_role_no_qa_vp_when_issues_present() -> None:
     )
     assert role_path.exists(), f"CTO role file missing: {role_path}"
     content = role_path.read_text()
-    # The new allocation table should NOT have the "otherwise → 1 QA coordinator" row
     assert "otherwise" not in content or "chain" in content, (
         "CTO allocation table must not unconditionally spawn QA coordinator when issues remain"
     )
-    # The explanation for no concurrent QA coordinator must be present
     assert "chain-spawn" in content, (
         "CTO role must explain that engineers chain-spawn their own reviewers"
     )

--- a/agentception/tests/test_plan_draft_poller.py
+++ b/agentception/tests/test_plan_draft_poller.py
@@ -155,9 +155,9 @@ async def test_poller_detects_output_path_and_emits_sse_event(
     task_file = tmp_path / f"plan-draft-{draft_id}" / ".agent-task"
     assert task_file.exists(), ".agent-task not written by POST /api/plan/draft"
     task_content = task_file.read_text(encoding="utf-8")
-    assert f"DRAFT_ID={draft_id}" in task_content
-    assert f"OUTPUT_PATH={output_path}" in task_content
-    assert "WORKFLOW=plan-spec" in task_content
+    assert f'draft_id = "{draft_id}"' in task_content
+    assert f'path = "{output_path}"' in task_content
+    assert 'workflow = "plan-spec"' in task_content
 
     # ── Step 4 (simulated): Cursor writes YAML to OUTPUT_PATH ────────────────
     yaml_content = "initiative: ocean-song\nphases: []\n"
@@ -382,34 +382,27 @@ async def test_plan_draft_agent_task_structure_is_poller_compatible(
     body = response.json()
     draft_id: str = body["draft_id"]
 
-    # Parse the .agent-task using the same logic as scan_plan_draft_worktrees
-    task_file = tmp_path / f"plan-draft-{draft_id}" / ".agent-task"
-    content = task_file.read_text(encoding="utf-8")
-    fields: dict[str, str] = {}
-    for raw_line in content.splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        fields[key.strip().upper()] = value.strip()
+    # Parse the .agent-task using parse_agent_task — same logic as scan_plan_draft_worktrees.
+    worktree_dir = tmp_path / f"plan-draft-{draft_id}"
+    from agentception.readers.worktrees import parse_agent_task
+
+    task_file_data = await parse_agent_task(worktree_dir)
 
     # These two fields are the minimum required for the poller to emit an event.
-    assert "DRAFT_ID" in fields, (
-        f"DRAFT_ID key missing from .agent-task — poller will skip this worktree. "
-        f"Found keys: {list(fields.keys())}"
+    assert task_file_data is not None, (
+        ".agent-task could not be parsed — poller will skip this worktree"
     )
-    assert "OUTPUT_PATH" in fields, (
-        f"OUTPUT_PATH key missing from .agent-task — poller will skip this worktree. "
-        f"Found keys: {list(fields.keys())}"
-    )
-    assert fields["DRAFT_ID"] == draft_id, (
-        f"DRAFT_ID in .agent-task ({fields['DRAFT_ID']!r}) "
+    assert task_file_data.draft_id == draft_id, (
+        f"draft_id in .agent-task ({task_file_data.draft_id!r}) "
         f"does not match API response draft_id ({draft_id!r})"
     )
-    # OUTPUT_PATH must end with .plan-output.yaml and contain the draft slug
-    assert fields["OUTPUT_PATH"].endswith(".plan-output.yaml"), (
-        f"OUTPUT_PATH must end with .plan-output.yaml, got: {fields['OUTPUT_PATH']!r}"
+    assert task_file_data.output_path is not None, (
+        "output_path missing from .agent-task — poller will skip this worktree"
     )
-    assert f"plan-draft-{draft_id}" in fields["OUTPUT_PATH"], (
-        f"OUTPUT_PATH must contain the plan-draft slug, got: {fields['OUTPUT_PATH']!r}"
+    # output_path must end with .plan-output.yaml and contain the draft slug
+    assert task_file_data.output_path.endswith(".plan-output.yaml"), (
+        f"output_path must end with .plan-output.yaml, got: {task_file_data.output_path!r}"
+    )
+    assert f"plan-draft-{draft_id}" in task_file_data.output_path, (
+        f"output_path must contain the plan-draft slug, got: {task_file_data.output_path!r}"
     )


### PR DESCRIPTION
Closing as duplicate of #142.

PR #142 (`feat/issue-48-b1e4`) covers the same TOML reader migration with more focused scope (issue #48 only) and better typed helpers. This PR additionally migrated the plan draft writer, which belongs to issue #49 and would conflict with that future PR.

**Root cause of duplication:** The coordinator's open-PR guard checks `--head "feat/issue-48"` (exact match). The first engineer used branch `feat/issue-48-b1e4`, which the guard missed, causing a second engineer to be seeded. The guard is being fixed to use prefix matching.

Closes-duplicate: #142