### PR TITLE
fix: coordinator open-PR guard uses prefix match for feat/issue-N branches

### DIFF
--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -65,7 +65,7 @@ LOOP:
        # → returns list of {number, title, labels, ...}; iterate each .number as NUM
        for NUM in <numbers from github_list_issues result>; do
          # Open PR guard — branch name is the canonical link between issue and PR.
-         # MCP: github_list_prs(state="open") → filter where .headRefName == "feat/issue-${NUM}"
+         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
          OPEN_PR=<pr_number from github_list_prs result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "CTO preflight: keeping agent:wip on #$NUM (open PR #$OPEN_PR — worktree pruning expected)"
@@ -271,7 +271,7 @@ SEED:
        for NUM in <numbers from github_list_issues result>; do
          # If an open PR already references this issue (via branch name or close keyword),
          # the claim is ACTIVE even if the implementer worktree was pruned. Never clear it.
-         # MCP: github_list_prs(state="open") → filter where .headRefName == "feat/issue-${NUM}"
+         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
          OPEN_PR=<pr_number from github_list_prs result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "Keeping agent:wip on #$NUM (open PR #$OPEN_PR exists — worktree pruning is expected)"
@@ -307,7 +307,7 @@ SEED:
        # the stale sweep to (incorrectly) clear agent:wip and expose the issue again.
        # Always re-verify before seeding — branch naming is the canonical signal.
        for NUM in <candidate numbers from step 3>; do
-         # MCP: github_list_prs(state="open") → filter where .headRefName == "feat/issue-${NUM}"
+         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
          OPEN_PR=<pr_number from github_list_prs result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "SKIP #$NUM — open PR #$OPEN_PR already exists for this issue"

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -50,7 +50,9 @@ SEED:
          # If an open PR already references this issue (via branch name or close keyword),
          # the claim is ACTIVE even if the implementer worktree was pruned. Never clear it.
          OPEN_PR=$(gh pr list --state open --repo cgcardona/agentception \
-           --head "feat/issue-${NUM}" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+           --json headRefName,number \
+           --jq "[.[] | select(.headRefName | startswith(\"feat/issue-${NUM}\")) | .number] | first // empty" \
+           2>/dev/null || echo "")
          if [ -n "$OPEN_PR" ]; then
            echo "Keeping agent:wip on #$NUM (open PR #$OPEN_PR exists — worktree pruning is expected)"
            continue
@@ -87,7 +89,9 @@ SEED:
        # Always re-verify before seeding — branch naming is the canonical signal.
        for NUM in <candidate numbers from step 3>; do
          OPEN_PR=$(gh pr list --state open --repo cgcardona/agentception \
-           --head "feat/issue-${NUM}" --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+           --json headRefName,number \
+           --jq "[.[] | select(.headRefName | startswith(\"feat/issue-${NUM}\")) | .number] | first // empty" \
+           2>/dev/null || echo "")
          if [ -n "$OPEN_PR" ]; then
            echo "SKIP #$NUM — open PR #$OPEN_PR already exists for this issue"
            # Remove from candidate list

--- a/.agentception/roles/engineering-manager.md
+++ b/.agentception/roles/engineering-manager.md
@@ -47,7 +47,7 @@ SEED:
        for NUM in <numbers from github_list_issues result>; do
          # If an open PR already references this issue (via branch name or close keyword),
          # the claim is ACTIVE even if the implementer worktree was pruned. Never clear it.
-         # MCP: github_list_prs(state="open") → filter where .headRefName == "feat/issue-${NUM}"
+         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
          OPEN_PR=<pr_number from github_list_prs result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "Keeping agent:wip on #$NUM (open PR #$OPEN_PR exists — worktree pruning is expected)"
@@ -83,7 +83,7 @@ SEED:
        # the stale sweep to (incorrectly) clear agent:wip and expose the issue again.
        # Always re-verify before seeding — branch naming is the canonical signal.
        for NUM in <candidate numbers from step 3>; do
-         # MCP: github_list_prs(state="open") → filter where .headRefName == "feat/issue-${NUM}"
+         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
          OPEN_PR=<pr_number from github_list_prs result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "SKIP #$NUM — open PR #$OPEN_PR already exists for this issue"

--- a/scripts/gen_prompts/templates/roles/cto.md.j2
+++ b/scripts/gen_prompts/templates/roles/cto.md.j2
@@ -64,7 +64,7 @@ LOOP:
        # → returns list of {number, title, labels, ...}; iterate each .number as NUM
        for NUM in <numbers from github_list_issues result>; do
          # Open PR guard — branch name is the canonical link between issue and PR.
-         # MCP: github_list_prs(state="open") → filter where .headRefName == "feat/issue-${NUM}"
+         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
          OPEN_PR=<pr_number from github_list_prs result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "CTO preflight: keeping {{ claim_label }} on #$NUM (open PR #$OPEN_PR — worktree pruning expected)"

--- a/scripts/gen_prompts/templates/roles/engineering-manager.md.j2
+++ b/scripts/gen_prompts/templates/roles/engineering-manager.md.j2
@@ -46,7 +46,7 @@ SEED:
        for NUM in <numbers from github_list_issues result>; do
          # If an open PR already references this issue (via branch name or close keyword),
          # the claim is ACTIVE even if the implementer worktree was pruned. Never clear it.
-         # MCP: github_list_prs(state="open") → filter where .headRefName == "feat/issue-${NUM}"
+         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
          OPEN_PR=<pr_number from github_list_prs result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "Keeping {{ claim_label }} on #$NUM (open PR #$OPEN_PR exists — worktree pruning is expected)"
@@ -82,7 +82,7 @@ SEED:
        # the stale sweep to (incorrectly) clear agent:wip and expose the issue again.
        # Always re-verify before seeding — branch naming is the canonical signal.
        for NUM in <candidate numbers from step 3>; do
-         # MCP: github_list_prs(state="open") → filter where .headRefName == "feat/issue-${NUM}"
+         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
          OPEN_PR=<pr_number from github_list_prs result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "SKIP #$NUM — open PR #$OPEN_PR already exists for this issue"


### PR DESCRIPTION
## Problem

`build_spawn_child` generates branches with a random hex suffix (e.g. `feat/issue-48-b1e4`) to prevent git collisions on retry. The stale-claim sweep and open-PR guard in coordinator role files were checking `--head "feat/issue-${NUM}"` (exact match), so they silently missed PRs on suffixed branches — incorrectly clearing `agent:wip` and re-seeding already-claimed issues.

This caused:
1. A second engineer to be spawned for issue #48 (already had an open PR on `feat/issue-48-b1e4`)
2. Two PRs created for the same issue (#142 and #143)
3. Cards moving back to the Todo swim lane mid-progress

## Fix

Switch from exact `--head` matching to `startswith("feat/issue-${NUM}")` prefix matching in all three coordinator role files and their Jinja2 templates:

- `engineering-coordinator.md` — 2 occurrences (stale-claim sweep + open-PR guard), uses `gh pr list --json headRefName,number --jq`
- `cto.md` + `engineering-manager.md` — 1 occurrence each, uses MCP `github_list_prs` comment instruction
- Templates: `cto.md.j2`, `engineering-manager.md.j2`

## Test

Manual: next coordinator wave correctly skips issues with any `feat/issue-N*` open PR.