### PR TITLE
feat: migrate task builders to TOML v2 (#49)

### DIFF
--- a/agentception/routes/api/_shared.py
+++ b/agentception/routes/api/_shared.py
@@ -14,8 +14,10 @@ Contains:
 - ``_issue_is_claimed_api``: checks ``agent:wip`` label presence.
 """
 
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TypeAlias
 
 from agentception.config import settings
 from agentception.services.cognitive_arch import (
@@ -29,6 +31,62 @@ from agentception.services.cognitive_arch import (
 # Writing this file tells CTO and coordinator loops to wait rather than spawn agents.
 _SENTINEL: Path = settings.ac_dir / ".pipeline-pause"
 
+# Type alias for a single TOML scalar/collection value handled by _render_toml_str.
+_TomlValue: TypeAlias = str | int | bool | list[str] | list[int]
+
+
+def _escape_toml_str(s: str) -> str:
+    """Escape special characters for a TOML basic string (double-quoted)."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _toml_val(value: _TomlValue) -> str:
+    """Render a Python value as its TOML inline representation.
+
+    Handles str (with multiline detection), bool (before int, since bool ⊂ int),
+    int, list[str], and list[int].  Multiline strings are emitted as TOML
+    multiline basic strings (triple-double-quote) so plan dumps and long
+    descriptions survive round-trips through tomllib without manual escaping.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        if "\n" in value:
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            return f'"""\n{escaped}\n"""'
+        return f'"{_escape_toml_str(value)}"'
+    # list[str] | list[int] — render as TOML inline array
+    parts: list[str] = []
+    for item in value:
+        if isinstance(item, int):
+            parts.append(str(item))
+        else:
+            parts.append(f'"{_escape_toml_str(item)}"')
+    return "[" + ", ".join(parts) + "]"
+
+
+def _render_toml_str(
+    sections: dict[str, dict[str, _TomlValue]],
+) -> str:
+    """Render a dict of TOML sections into a valid TOML document string.
+
+    Each key in ``sections`` becomes a ``[section]`` header.  Values within
+    each section must be ``str | int | bool | list[str] | list[int]``.
+    Sections are separated by a blank line for readability.
+
+    No external dependency — this is a purpose-built minimal TOML emitter
+    for the fixed schema of ``.agent-task`` files.
+    """
+    lines: list[str] = []
+    for section, fields in sections.items():
+        lines.append(f"[{section}]")
+        for key, value in fields.items():
+            lines.append(f"{key} = {_toml_val(value)}")
+        lines.append("")
+    return "\n".join(lines)
+
 
 def _build_agent_task(
     issue_number: int,
@@ -38,53 +96,68 @@ def _build_agent_task(
     host_worktree: Path,
     branch: str,
     phase_label: str = "",
-    depends_on: str = "none",
+    depends_on: list[int] | None = None,
     cognitive_arch: str = "hopper:python",
     wave_id: str = "manual",
 ) -> str:
-    """Build the raw text content of a ``.agent-task`` file.
+    """Build the TOML v2 content of a ``.agent-task`` file for an engineer agent.
 
-    The format mirrors what the ``parallel-issue-to-pr.md`` coordinator
-    script generates so that agents spawned via the control plane receive
-    the same context as batch-spawned agents.
+    Emits a fully-structured TOML document following the v2.0 spec in
+    ``.agentception/agent-task-spec.md``.  The file is consumed by both the
+    AgentCeption dashboard (via ``parse_agent_task()`` / ``tomllib``) and the
+    Cursor LLM (raw text as context), so every field must be valid TOML.
 
-    ``worktree`` is the container-side path (written to the file for Docker
-    commands).  ``host_worktree`` is the host-side path embedded as
-    ``HOST_WORKTREE`` so the Cursor Task launcher can use the correct path
-    when opening the worktree as a project root.
+    ``worktree`` is the container-side path (retained for backward compat).
+    ``host_worktree`` is the host-side path written to ``[worktree].path`` so
+    the Cursor Task launcher opens the correct directory.
     """
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     repo = settings.gh_repo
-    # ROLE_FILE is metadata only — the kickoff prompt embeds all role content
-    # inline.  The path uses the host repo dir so it is human-readable even
-    # though agents are instructed not to read it from disk.
-    role_file_display = f"<host-repo>/.agentception/roles/{role}.md"
-    return (
-        f"WORKFLOW=issue-to-pr\n"
-        f"GH_REPO={repo}\n"
-        f"ISSUE_NUMBER={issue_number}\n"
-        f"ISSUE_TITLE={title}\n"
-        f"ISSUE_URL=https://github.com/{repo}/issues/{issue_number}\n"
-        f"PHASE_LABEL={phase_label}\n"
-        f"DEPENDS_ON={depends_on}\n"
-        f"BRANCH={branch}\n"
-        f"ROLE={role}\n"
-        f"ROLE_FILE={role_file_display}\n"
-        f"WORKTREE={worktree}\n"
-        f"HOST_WORKTREE={host_worktree}\n"
-        f"BASE=dev\n"
-        f"CLOSES_ISSUES={issue_number}\n"
-        f"BATCH_ID={wave_id}\n"
-        f"WAVE={wave_id}\n"
-        f"COGNITIVE_ARCH={cognitive_arch}\n"
-        f"CREATED_AT={now}\n"
-        f"SPAWN_MODE=chain\n"
-        f"LINKED_PR=none\n"
-        f"SPAWN_SUB_AGENTS=false\n"
-        f"ATTEMPT_N=0\n"
-        f"REQUIRED_OUTPUT=pr_url\n"
-        f"ON_BLOCK=stop\n"
-    )
+    dep_list: list[int] = depends_on if depends_on is not None else []
+
+    sections: dict[str, dict[str, _TomlValue]] = {
+        "task": {
+            "version": "2.0",
+            "workflow": "issue-to-pr",
+            "id": str(uuid.uuid4()),
+            "created_at": now,
+            "attempt_n": 0,
+            "required_output": "pr_url",
+            "on_block": "stop",
+        },
+        "agent": {
+            "role": role,
+            "tier": "engineer",
+            "org_domain": "engineering",
+            "cognitive_arch": cognitive_arch,
+        },
+        "repo": {
+            "gh_repo": repo,
+            "base": "dev",
+        },
+        "pipeline": {
+            "batch_id": wave_id,
+            "wave": wave_id,
+        },
+        "spawn": {
+            "mode": "chain",
+            "sub_agents": False,
+        },
+        "target": {
+            "issue_number": issue_number,
+            "issue_title": title,
+            "issue_url": f"https://github.com/{repo}/issues/{issue_number}",
+            "phase_label": phase_label,
+            "depends_on": dep_list,
+            "closes": [issue_number],
+        },
+        "worktree": {
+            "path": str(host_worktree),
+            "branch": branch,
+            "linked_pr": 0,
+        },
+    }
+    return _render_toml_str(sections)
 
 
 def _build_coordinator_task(
@@ -95,40 +168,60 @@ def _build_coordinator_task(
     host_worktree: Path,
     branch: str,
 ) -> str:
-    """Build the ``.agent-task`` content for a plan coordinator worktree.
+    """Build the TOML v2 ``.agent-task`` content for a plan coordinator worktree.
 
-    The coordinator agent reads ``WORKFLOW=bugs-to-issues`` and follows
-    ``parallel-bugs-to-issues.md``: it runs the Phase Planner, creates GitHub
-    labels, creates worktrees for each batch, writes sub-agent task files, and
-    launches sub-agents.  AgentCeption's only job is to prepare the worktree
-    and this file — the Cursor background agent does all LLM work.
+    The coordinator agent reads ``task.workflow = "bugs-to-issues"`` and runs
+    the Phase Planner, creates GitHub labels, creates worktrees for each batch,
+    and launches sub-agents.  AgentCeption only prepares the worktree and this
+    file — the Cursor background agent does all LLM work.
 
-    The ``PLAN_DUMP`` section is appended as a freeform block after the
-    structured key=value header so the coordinator can read it verbatim.
+    The raw brain dump is stored in ``[plan_draft].dump`` as a TOML multiline
+    basic string so it is available verbatim to the coordinator agent.
     """
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     repo = settings.gh_repo
-    prefix_line = f"LABEL_PREFIX={label_prefix}\n" if label_prefix else ""
-    return (
-        f"WORKFLOW=bugs-to-issues\n"
-        f"GH_REPO={repo}\n"
-        f"ROLE=coordinator\n"
-        f"ROLE_FILE=<host-repo>/.agentception/roles/coordinator.md\n"
-        f"WORKTREE={worktree}\n"
-        f"HOST_WORKTREE={host_worktree}\n"
-        f"BASE=dev\n"
-        f"BATCH_ID={slug}\n"
-        f"WAVE={slug}\n"
-        f"COGNITIVE_ARCH={ROLE_DEFAULT_FIGURE.get('engineering-coordinator', 'von_neumann')}:python\n"
-        f"{prefix_line}"
-        f"CREATED_AT={now}\n"
-        f"SPAWN_MODE=chain\n"
-        f"SPAWN_SUB_AGENTS=true\n"
-        f"ATTEMPT_N=0\n"
-        f"REQUIRED_OUTPUT=phase_plan\n"
-        f"ON_BLOCK=stop\n"
-        f"\nPLAN_DUMP:\n{plan_text}\n"
+    coord_arch = (
+        f"{ROLE_DEFAULT_FIGURE.get('engineering-coordinator', 'von_neumann')}:python"
     )
+
+    plan_draft_fields: dict[str, _TomlValue] = {"dump": plan_text}
+    if label_prefix:
+        plan_draft_fields["label_prefix"] = label_prefix
+
+    sections: dict[str, dict[str, _TomlValue]] = {
+        "task": {
+            "version": "2.0",
+            "workflow": "bugs-to-issues",
+            "id": str(uuid.uuid4()),
+            "created_at": now,
+            "attempt_n": 0,
+            "required_output": "phase_plan",
+            "on_block": "stop",
+        },
+        "agent": {
+            "role": "coordinator",
+            "tier": "coordinator",
+            "cognitive_arch": coord_arch,
+        },
+        "repo": {
+            "gh_repo": repo,
+            "base": "dev",
+        },
+        "pipeline": {
+            "batch_id": slug,
+            "wave": slug,
+        },
+        "spawn": {
+            "mode": "chain",
+            "sub_agents": True,
+        },
+        "worktree": {
+            "path": str(host_worktree),
+            "branch": branch,
+        },
+        "plan_draft": plan_draft_fields,
+    }
+    return _render_toml_str(sections)
 
 
 def _build_conductor_task(
@@ -139,37 +232,58 @@ def _build_conductor_task(
     host_worktree: Path,
     branch: str,
 ) -> str:
-    """Build the ``.agent-task`` content for a conductor worktree.
+    """Build the TOML v2 ``.agent-task`` content for a conductor worktree.
 
-    The conductor agent reads ``WORKFLOW=conductor`` and coordinates across the
-    listed phases, spawning sub-agents for each unclaimed issue.  AgentCeption
-    only prepares the worktree and this file — all LLM work happens inside
-    the Cursor background agent that opens the returned ``host_worktree``.
+    The conductor agent reads ``task.workflow = "conductor"`` and coordinates
+    across the listed phases, spawning sub-agents for each unclaimed issue.
+    AgentCeption only prepares the worktree and this file — all LLM work
+    happens inside the Cursor background agent that opens the returned
+    ``host_worktree``.
     """
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     repo = settings.gh_repo
-    return (
-        f"WORKFLOW=conductor\n"
-        f"GH_REPO={repo}\n"
-        f"ROLE=conductor\n"
-        f"ROLE_FILE=<host-repo>/.agentception/roles/conductor.md\n"
-        f"WAVE_ID={wave_id}\n"
-        f"PHASES={','.join(phases)}\n"
-        f"ORG={org or ''}\n"
-        f"BRANCH={branch}\n"
-        f"WORKTREE={worktree}\n"
-        f"HOST_WORKTREE={host_worktree}\n"
-        f"BASE=dev\n"
-        f"BATCH_ID={wave_id}\n"
-        f"WAVE={wave_id}\n"
-        f"COGNITIVE_ARCH={ROLE_DEFAULT_FIGURE.get('conductor', 'jeff_dean')}:python\n"
-        f"CREATED_AT={now}\n"
-        f"SPAWN_MODE=chain\n"
-        f"SPAWN_SUB_AGENTS=true\n"
-        f"ATTEMPT_N=0\n"
-        f"REQUIRED_OUTPUT=wave_complete\n"
-        f"ON_BLOCK=stop\n"
+    conductor_arch = (
+        f"{ROLE_DEFAULT_FIGURE.get('conductor', 'jeff_dean')}:python"
     )
+
+    target_fields: dict[str, _TomlValue] = {"phases": phases}
+    if org:
+        target_fields["org"] = org
+
+    sections: dict[str, dict[str, _TomlValue]] = {
+        "task": {
+            "version": "2.0",
+            "workflow": "conductor",
+            "id": str(uuid.uuid4()),
+            "created_at": now,
+            "attempt_n": 0,
+            "required_output": "wave_complete",
+            "on_block": "stop",
+        },
+        "agent": {
+            "role": "conductor",
+            "tier": "executive",
+            "cognitive_arch": conductor_arch,
+        },
+        "repo": {
+            "gh_repo": repo,
+            "base": "dev",
+        },
+        "pipeline": {
+            "batch_id": wave_id,
+            "wave": wave_id,
+        },
+        "spawn": {
+            "mode": "chain",
+            "sub_agents": True,
+        },
+        "target": target_fields,
+        "worktree": {
+            "path": str(host_worktree),
+            "branch": branch,
+        },
+    }
+    return _render_toml_str(sections)
 
 
 def _issue_is_claimed_api(iss: dict[str, object]) -> bool:

--- a/agentception/routes/api/control.py
+++ b/agentception/routes/api/control.py
@@ -260,9 +260,9 @@ async def _do_spawn(body: SpawnRequest) -> SpawnResult:
     except Exception:
         issue_body = ""
 
-    # Extract "Depends on #NNN" patterns — comma-separated, or "none" if absent.
+    # Extract "Depends on #NNN" patterns as a list of ints for the TOML builder.
     dep_matches = _re.findall(r"[Dd]epends\s+on\s+#(\d+)", issue_body)
-    depends_on = ",".join(dep_matches) if dep_matches else "none"
+    depends_on: list[int] = [int(m) for m in dep_matches]
 
     # Derive COGNITIVE_ARCH from issue body so the agent gets the right persona.
     cognitive_arch = _resolve_cognitive_arch(issue_body, body.role)

--- a/agentception/tests/test_agentception_spawn.py
+++ b/agentception/tests/test_agentception_spawn.py
@@ -6,11 +6,15 @@ Covers POST /api/control/spawn and GET /agents/spawn.
 All GitHub calls and git operations are mocked — no live network, no
 filesystem side-effects.
 
+Also covers TOML v2 output of _build_agent_task(), _build_coordinator_task(),
+and _build_conductor_task() (AC-49): each builder must emit valid TOML that
+round-trips through tomllib into the correct TaskFile fields.
+
 Run targeted:
     pytest agentception/tests/test_agentception_spawn.py -v
 """
 
-import asyncio
+import tomllib
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -19,7 +23,12 @@ import pytest
 from fastapi.testclient import TestClient
 
 from agentception.app import app
-from agentception.models import SpawnRequest, VALID_ROLES
+from agentception.models import SpawnRequest, TaskFile, VALID_ROLES
+from agentception.routes.api._shared import (
+    _build_agent_task,
+    _build_coordinator_task,
+    _build_conductor_task,
+)
 
 
 @pytest.fixture(scope="module")
@@ -135,14 +144,15 @@ def test_spawn_creates_worktree_and_task_file(
     assert "issue-42" in data["worktree"]
     assert "issue-42" in data["host_worktree"]
     assert data["branch"] == "feat/issue-42"
-    assert "ISSUE_NUMBER=42" in data["agent_task"]
-    assert "BRANCH=feat/issue-42" in data["agent_task"]
-    assert "ROLE=python-developer" in data["agent_task"]
-    assert "COGNITIVE_ARCH=" in data["agent_task"]
+    # TOML v2 output: check key = value format
+    assert "issue_number = 42" in data["agent_task"]
+    assert 'branch = "feat/issue-42"' in data["agent_task"]
+    assert 'role = "python-developer"' in data["agent_task"]
+    assert "cognitive_arch =" in data["agent_task"]
     # Verify the .agent-task file was actually written to disk.
     task_file = expected_worktree / ".agent-task"
     assert task_file.exists()
-    assert "ISSUE_NUMBER=42" in task_file.read_text()
+    assert "issue_number = 42" in task_file.read_text()
 
 
 # ── POST /api/control/spawn — already claimed → 409 ──────────────────────────
@@ -445,3 +455,200 @@ def test_spawn_request_rejects_unknown_role() -> None:
     """SpawnRequest must raise ValueError for an unrecognised role."""
     with pytest.raises(ValueError):
         SpawnRequest(issue_number=1, role="hacker")
+
+
+# ── TOML v2 builder tests (AC-49) ─────────────────────────────────────────────
+
+
+def _fake_worktree(tmp_path: Path, name: str = "issue-99") -> Path:
+    p = tmp_path / name
+    p.mkdir(parents=True)
+    return p
+
+
+def test_build_agent_task_emits_valid_toml(tmp_path: Path) -> None:
+    """_build_agent_task() must produce output that tomllib.loads() accepts."""
+    wt = _fake_worktree(tmp_path)
+    output = _build_agent_task(
+        issue_number=99,
+        title="Test issue",
+        role="python-developer",
+        worktree=wt,
+        host_worktree=wt,
+        branch="feat/issue-99",
+    )
+    parsed = tomllib.loads(output)
+    assert isinstance(parsed, dict)
+    assert parsed["task"]["workflow"] == "issue-to-pr"
+    assert parsed["task"]["version"] == "2.0"
+    assert parsed["target"]["issue_number"] == 99
+    assert parsed["agent"]["role"] == "python-developer"
+    assert parsed["worktree"]["branch"] == "feat/issue-99"
+
+
+def test_build_agent_task_round_trips_to_task_file(tmp_path: Path) -> None:
+    """_build_agent_task() output must round-trip through TaskFile with correct fields."""
+    wt = _fake_worktree(tmp_path)
+    output = _build_agent_task(
+        issue_number=77,
+        title="Round-trip issue",
+        role="python-developer",
+        worktree=wt,
+        host_worktree=wt,
+        branch="feat/issue-77",
+        phase_label="ac-test/0-foundation",
+        depends_on=[10, 11],
+        cognitive_arch="turing:python",
+        wave_id="batch-123",
+    )
+    parsed = tomllib.loads(output)
+    # Manually map TOML sections to TaskFile just as _build_task_file_from_toml does.
+    task_sec = parsed.get("task", {})
+    agent_sec = parsed.get("agent", {})
+    repo_sec = parsed.get("repo", {})
+    pipeline_sec = parsed.get("pipeline", {})
+    spawn_sec = parsed.get("spawn", {})
+    target_sec = parsed.get("target", {})
+    worktree_sec = parsed.get("worktree", {})
+
+    tf = TaskFile(
+        task=task_sec.get("workflow"),
+        id=task_sec.get("id"),
+        attempt_n=task_sec.get("attempt_n", 0),
+        required_output=task_sec.get("required_output"),
+        on_block=task_sec.get("on_block"),
+        role=agent_sec.get("role"),
+        tier=agent_sec.get("tier"),
+        org_domain=agent_sec.get("org_domain"),
+        cognitive_arch=agent_sec.get("cognitive_arch"),
+        gh_repo=repo_sec.get("gh_repo"),
+        base=repo_sec.get("base"),
+        batch_id=pipeline_sec.get("batch_id"),
+        wave=pipeline_sec.get("wave"),
+        spawn_mode=spawn_sec.get("mode"),
+        spawn_sub_agents=spawn_sec.get("sub_agents", False),
+        issue_number=target_sec.get("issue_number"),
+        depends_on=list(target_sec.get("depends_on", [])),
+        closes_issues=list(target_sec.get("closes", [])),
+        worktree=worktree_sec.get("path"),
+        branch=worktree_sec.get("branch"),
+        linked_pr=worktree_sec.get("linked_pr"),
+    )
+    assert tf.task == "issue-to-pr"
+    assert tf.role == "python-developer"
+    assert tf.tier == "engineer"
+    assert tf.cognitive_arch == "turing:python"
+    assert tf.issue_number == 77
+    assert tf.depends_on == [10, 11]
+    assert tf.closes_issues == [77]
+    assert tf.branch == "feat/issue-77"
+    assert tf.batch_id == "batch-123"
+    assert tf.spawn_sub_agents is False
+    assert tf.spawn_mode == "chain"
+    assert tf.attempt_n == 0
+    assert tf.required_output == "pr_url"
+
+
+def test_build_coordinator_task_emits_valid_toml(tmp_path: Path) -> None:
+    """_build_coordinator_task() must produce output that tomllib.loads() accepts."""
+    wt = _fake_worktree(tmp_path, "coord-abc")
+    output = _build_coordinator_task(
+        slug="coord-abc",
+        plan_text="We need to build a billing system.\n- Stripe integration\n- Invoices",
+        label_prefix="q2-billing",
+        worktree=wt,
+        host_worktree=wt,
+        branch="feat/coord-abc",
+    )
+    parsed = tomllib.loads(output)
+    assert isinstance(parsed, dict)
+    assert parsed["task"]["workflow"] == "bugs-to-issues"
+    assert parsed["task"]["version"] == "2.0"
+    assert parsed["agent"]["role"] == "coordinator"
+    assert parsed["spawn"]["sub_agents"] is True
+    assert "Stripe" in parsed["plan_draft"]["dump"]
+    assert parsed["plan_draft"]["label_prefix"] == "q2-billing"
+
+
+def test_build_coordinator_task_without_label_prefix(tmp_path: Path) -> None:
+    """_build_coordinator_task() with empty label_prefix omits label_prefix field."""
+    wt = _fake_worktree(tmp_path, "coord-nolabel")
+    output = _build_coordinator_task(
+        slug="coord-nolabel",
+        plan_text="Simple plan.",
+        label_prefix="",
+        worktree=wt,
+        host_worktree=wt,
+        branch="feat/coord-nolabel",
+    )
+    parsed = tomllib.loads(output)
+    assert "label_prefix" not in parsed.get("plan_draft", {})
+    assert parsed["plan_draft"]["dump"] == "Simple plan."
+
+
+def test_build_conductor_task_emits_valid_toml(tmp_path: Path) -> None:
+    """_build_conductor_task() must produce output that tomllib.loads() accepts."""
+    wt = _fake_worktree(tmp_path, "conductor-wave-1")
+    output = _build_conductor_task(
+        wave_id="wave-2026-001",
+        phases=["ac-build/phase-0", "ac-build/phase-1"],
+        org="engineering",
+        worktree=wt,
+        host_worktree=wt,
+        branch="feat/conductor-wave-1",
+    )
+    parsed = tomllib.loads(output)
+    assert isinstance(parsed, dict)
+    assert parsed["task"]["workflow"] == "conductor"
+    assert parsed["task"]["version"] == "2.0"
+    assert parsed["agent"]["role"] == "conductor"
+    assert parsed["agent"]["tier"] == "executive"
+    assert parsed["spawn"]["sub_agents"] is True
+    assert parsed["target"]["phases"] == ["ac-build/phase-0", "ac-build/phase-1"]
+    assert parsed["target"]["org"] == "engineering"
+
+
+def test_build_conductor_task_without_org(tmp_path: Path) -> None:
+    """_build_conductor_task() with org=None omits the org field from [target]."""
+    wt = _fake_worktree(tmp_path, "conductor-noorg")
+    output = _build_conductor_task(
+        wave_id="wave-noorg",
+        phases=["phase-0"],
+        org=None,
+        worktree=wt,
+        host_worktree=wt,
+        branch="feat/conductor-noorg",
+    )
+    parsed = tomllib.loads(output)
+    assert "org" not in parsed.get("target", {})
+
+
+def test_build_agent_task_depends_on_empty_list(tmp_path: Path) -> None:
+    """_build_agent_task() with no depends_on emits an empty TOML array."""
+    wt = _fake_worktree(tmp_path, "issue-no-deps")
+    output = _build_agent_task(
+        issue_number=5,
+        title="No deps",
+        role="python-developer",
+        worktree=wt,
+        host_worktree=wt,
+        branch="feat/issue-5",
+    )
+    parsed = tomllib.loads(output)
+    assert parsed["target"]["depends_on"] == []
+
+
+def test_build_agent_task_depends_on_list(tmp_path: Path) -> None:
+    """_build_agent_task() passes a list of int deps into TOML target.depends_on."""
+    wt = _fake_worktree(tmp_path, "issue-with-deps")
+    output = _build_agent_task(
+        issue_number=50,
+        title="Has deps",
+        role="python-developer",
+        worktree=wt,
+        host_worktree=wt,
+        branch="feat/issue-50",
+        depends_on=[10, 20, 30],
+    )
+    parsed = tomllib.loads(output)
+    assert parsed["target"]["depends_on"] == [10, 20, 30]


### PR DESCRIPTION
Closing as superseded. The TOML helpers were extracted to `agentception/services/toml_task.py` and `_shared.py` refactored in PR #147. The builders already emit TOML v2. The `depends_on: list[int]` type was also already in place. All work from this PR is covered.