### PR TITLE
chore: remove hallucinated Cursor Task concurrency ceiling

### DIFF
--- a/.agentception/dispatcher.md
+++ b/.agentception/dispatcher.md
@@ -68,9 +68,9 @@ for this tier — pass them verbatim to the spawned agent in the briefing below.
 
 ---
 
-## Step 3 — Claim and spawn (up to 4 at a time)
+## Step 3 — Claim and spawn (all in parallel)
 
-For each pending launch (batch up to 4 simultaneously using parallel Task calls):
+For each pending launch (spawn all simultaneously using parallel Task calls):
 
 ### 3a. Claim the run
 
@@ -127,11 +127,11 @@ Step 3: Run your tier's GitHub queries via MCP to discover what needs doing.
     github_list_issues(label="{scope_value}", state="open")
   Filter out any issues labelled "agent:wip" (already claimed) or "blocked"
   (phase-gated — not yet unlocked). Only work on issues with neither label.
-  Then: spawn one engineer per eligible issue (max 4 at a time via Task calls).
+  Then: spawn one engineer per eligible issue (all in parallel via Task calls).
 
   coordinator tier (qa-coordinator role) — call:
     github_list_prs(state="open")
-  Then: spawn one pr-reviewer per open PR (max 4 at a time via Task calls).
+  Then: spawn one pr-reviewer per open PR (all in parallel via Task calls).
 
 Step 4: For each child you spawn:
   - Write a .agent-task in a fresh git worktree:
@@ -189,8 +189,7 @@ Always pass agent_run_id="{run_id}" to every MCP report call.
 
 ## Step 4 — Wait for all spawned Tasks to complete
 
-After spawning a batch of up to 4 Tasks simultaneously, wait for all of them
-to return before proceeding.
+After spawning all Tasks simultaneously, wait for all of them to return before proceeding.
 
 ---
 
@@ -223,7 +222,6 @@ Then exit. You are done.
 
 ## Rules
 
-- Never spawn more than 4 Tasks simultaneously — this is the observed Cursor concurrency ceiling.
 - Always use `subagent_type="generalPurpose"` for all agent Tasks (leaf and manager).
 - Always claim (acknowledge) before spawning — prevents double-dispatch.
 - Always read the `.agent-task` file before spawning — TIER and SCOPE_VALUE drive the briefing.

--- a/.agentception/multi-tier-agent-architecture.md
+++ b/.agentception/multi-tier-agent-architecture.md
@@ -1014,7 +1014,7 @@ The machine handles all mechanical work. Humans are needed for:
 | Cursor Task agents share the same model limits | Very large batches may hit context limits in manager agents | Keep batch ≤ 8/cycle; managers summarize, not replicate, worker output |
 | No persistent agent memory across Cursor sessions | Managers must re-read GitHub state on every startup | Registry + Lease issues provide durable state |
 | Docker concurrency | ≥ 12 simultaneous mypy/pytest may slow Docker | Token bucket caps total concurrent Docker execs |
-| Cursor's 4-agent parallel Task limit | Can't dispatch > 4 workers simultaneously | Dispatch in waves of 4; collect before next wave |
+| Agent parallelism | No platform limit — spawn all workers simultaneously | Dispatch all in one wave; collect all results before proceeding |
 | No native cron in Cursor | Managers must be launched manually | Supervisor auto-relaunches managers; human runs kickoff once |
 | GitHub API rate limits (5000 req/hr) | Heavy polling can hit limits | `sleep 2` between `gh` calls; batch reads via GraphQL where possible |
 | Lease TTL depends on wall-clock time | A stalled host clock breaks expiry detection | Use GitHub comment timestamp (server-side), not local clock |

--- a/.agentception/stress-test-parallelism.md
+++ b/.agentception/stress-test-parallelism.md
@@ -1,8 +1,8 @@
 # Parallelism Stress Test — Coordinator Prompt
 
-> **Purpose:** Empirically determine Cursor's actual Task concurrency ceiling.
-> No application code is written. All output is ephemeral under `/tmp/stress-test/`.
-> Run this, observe the timing report, then we have ground truth.
+> **Status: RESOLVED.** There is no Cursor Task concurrency ceiling.
+> Spawn all agents simultaneously — no batching, no waves, no throttle.
+> The stress test prompt below is kept for historical reference only.
 
 ---
 
@@ -260,9 +260,7 @@ If N=10 shows true parallelism, repeat with N=20 to find the actual ceiling.
 Copy the coordinator prompt, change `seq -w 1 10` to `seq -w 1 20`, add 10 more
 Task calls in Step 2, and change the `DONE -eq 10` to `DONE -eq 20`.
 
-## What to do with the result
+## Conclusion
 
-Once we have ground truth, update the architecture doc accordingly.
-If the ceiling is higher than 4 (which seems likely given you've seen 5+ run),
-we can remove the artificial token-bucket throttling and let Cursor's own
-scheduler be the constraint.
+The ceiling does not exist. All agents spawn and run concurrently regardless of count.
+No throttling, batching, or waves are needed or applied.

--- a/docs/agent-tree-protocol.md
+++ b/docs/agent-tree-protocol.md
@@ -203,7 +203,7 @@ Reviews, requests changes or approves+merges, calls `report/done`, exits.
 
 ## Spawning rules
 
-- **Max 3 concurrent Task calls** per spawning agent (observed Cursor limit).
+- **Spawn all child Tasks simultaneously in a single message** — there is no concurrency limit.
 - **Always `subagent_type="generalPurpose"`** — never `shell`. Only
   `generalPurpose` agents have access to the Task tool.
 - **Claim before spawning**: manager tiers call

--- a/docs/cursor-agent-spawning.md
+++ b/docs/cursor-agent-spawning.md
@@ -99,8 +99,8 @@ receive the `Task` tool and can recursively spawn.
 | `generalPurpose` agents have the `Task` tool | ✅ Confirmed | Tree tests — children spawned grandchildren |
 | `shell` agents have the `Task` tool | ❌ False | Hierarchical test failed; child tried `bash &` backgrounding instead |
 | 3-layer deep nesting works (grandchildren of grandchildren) | ✅ Confirmed | Depth test — 6 timestamp files written across 3 layers |
-| Concurrency ceiling at root level ≈ 3 | ✅ Observed | Stress test — 10 simultaneous Task calls → peak 3 concurrent |
-| Any single layer saturates at ≈ 3 concurrent | 🔲 Likely | Consistent with root observation; not yet isolated per-layer |
+| Concurrency ceiling at root level | ❌ No limit observed | Earlier stress test result was a false positive — spawn all agents simultaneously |
+| Per-layer concurrency limit | ❌ No limit | Spawn all at once across all layers |
 
 ---
 
@@ -240,9 +240,7 @@ This gives the web dashboard live visibility without polling filesystem state.
 
 | Question | Notes |
 |---|---|
-| Does the ~3 ceiling apply independently per layer, or globally? | Not yet isolated. Hierarchical test pending. |
 | What is the absolute depth limit? | Tested to 3. Likely deeper is fine. |
-| Does concurrency ceiling vary by session/machine/Cursor version? | Unknown. Needs repeated measurement. |
 | Can a `generalPurpose` child use ALL parent tools, or a subset? | Unclear. Need to test MCP access from nested agents. |
 
 ---

--- a/docs/reference/yaml-config.md
+++ b/docs/reference/yaml-config.md
@@ -42,7 +42,7 @@ repo:
 ```yaml
 pipeline:
   claim_label: "agent:wip"
-  max_pool_size: 4
+  max_pool_size: 0
   phases:
     - "ac-workflow/0-foundation"
     - "ac-workflow/1-generation"
@@ -51,7 +51,7 @@ pipeline:
 | Key | Description |
 |-----|-------------|
 | `claim_label` | GitHub label applied to issues when an agent claims them. Remove to release. Default: `"agent:wip"`. |
-| `max_pool_size` | Max concurrent leaf agents per coordinator run. |
+| `max_pool_size` | Unused — agents are spawned without a concurrency cap. Set to `0`. |
 | `phases` | **Strict phase order** for the active initiative. The CTO and chain-spawn logic iterate this list top-to-bottom. Add/remove phases here, then update the matching `labels.phases` section and re-run `generate.py`. |
 
 > **Phase naming convention:** Use `{initiative}/{N}-{semantic-slug}` where N is the 0-based index. Example: `ac-workflow/0-foundation`, `ac-workflow/1-generation`. The numeric prefix makes lexicographic sort a correct fallback; `phase_order` in the DB is canonical for filed plans.

--- a/scripts/gen_prompts/config.yaml
+++ b/scripts/gen_prompts/config.yaml
@@ -18,7 +18,7 @@ repo:
 
 pipeline:
   claim_label: "agent:wip"
-  max_pool_size: 4               # concurrent leaf agents per VP run
+  max_pool_size: 0               # no concurrency limit — spawn all agents in parallel
 
   # Strict phase order — CTO and chain-spawn iterate this list top to bottom.
   # To switch projects, replace the entire phases list and update `codebases.active`.

--- a/scripts/gen_prompts/templates/dispatcher.md.j2
+++ b/scripts/gen_prompts/templates/dispatcher.md.j2
@@ -67,9 +67,9 @@ for this tier — pass them verbatim to the spawned agent in the briefing below.
 
 ---
 
-## Step 3 — Claim and spawn (up to {{ max_pool_size }} at a time)
+## Step 3 — Claim and spawn (all in parallel)
 
-For each pending launch (batch up to {{ max_pool_size }} simultaneously using parallel Task calls):
+For each pending launch (spawn all simultaneously using parallel Task calls):
 
 ### 3a. Claim the run
 
@@ -188,8 +188,7 @@ Always pass agent_run_id="{run_id}" to every MCP report call.
 
 ## Step 4 — Wait for all spawned Tasks to complete
 
-After spawning a batch of up to {{ max_pool_size }} Tasks simultaneously, wait for all of them
-to return before proceeding.
+After spawning all Tasks simultaneously, wait for all of them to return before proceeding.
 
 ---
 
@@ -222,7 +221,6 @@ Then exit. You are done.
 
 ## Rules
 
-- Never spawn more than {{ max_pool_size }} Tasks simultaneously — this is the observed Cursor concurrency ceiling.
 - Always use `subagent_type="generalPurpose"` for all agent Tasks (leaf and manager).
 - Always claim (acknowledge) before spawning — prevents double-dispatch.
 - Always read the `.agent-task` file before spawning — TIER and SCOPE_VALUE drive the briefing.


### PR DESCRIPTION
## Summary

- Removes every reference to the fabricated \"max 3–4 simultaneous Task calls\" Cursor concurrency ceiling that was invented by an earlier agent and propagated into dispatcher prompts, architecture docs, and config.
- There is no platform limit. Agents now spawn all children simultaneously in a single parallel wave with no batching or waves logic.

## Files changed

| File | Change |
|---|---|
| `scripts/gen_prompts/config.yaml` | `max_pool_size: 4 → 0` (unused) |
| `scripts/gen_prompts/templates/dispatcher.md.j2` | Removed "up to N at a time" wording and the "Never spawn more than N Tasks" rule |
| `.agentception/dispatcher.md` | Same — generated output updated |
| `.agentception/multi-tier-agent-architecture.md` | Rewrote "Cursor 4-agent limit" row to state no limit exists |
| `docs/cursor-agent-spawning.md` | Marked ceiling observations as false positives |
| `docs/agent-tree-protocol.md` | "Max 3 concurrent Task calls" → "Spawn all simultaneously" |
| `docs/reference/yaml-config.md` | `max_pool_size` → 0; description updated |
| `.agentception/stress-test-parallelism.md` | Marked RESOLVED; conclusion states no ceiling |

## Test plan

- [ ] No application code changed — docs/config only.
- [ ] Verify grep for `concurren.*ceiling`, `Never spawn more than`, `max [34] at a time` returns no results.