### PR TITLE
feat: migrate task builders to TOML v2 (#49)

### DIFF
--- a/agentception/routes/api/_shared.py
+++ b/agentception/routes/api/_shared.py
@@ -49,6 +49,7 @@ def _build_agent_task(
     depends_on: list[int] | None = None,
     cognitive_arch: str = "hopper:python",
     wave_id: str = "manual",
+    file_ownership: list[str] | None = None,
 ) -> str:
     """Build the TOML v2 content of a ``.agent-task`` file for an engineer agent.
 
@@ -64,6 +65,7 @@ def _build_agent_task(
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     repo = settings.gh_repo
     dep_list: list[int] = depends_on if depends_on is not None else []
+    ownership: list[str] = file_ownership if file_ownership is not None else []
 
     sections: dict[str, dict[str, _TomlValue]] = {
         "task": {
@@ -100,6 +102,7 @@ def _build_agent_task(
             "phase_label": phase_label,
             "depends_on": dep_list,
             "closes": [issue_number],
+            "file_ownership": ownership,
         },
         "worktree": {
             "path": str(host_worktree),

--- a/agentception/tests/test_agentception_spawn.py
+++ b/agentception/tests/test_agentception_spawn.py
@@ -655,6 +655,40 @@ def test_build_agent_task_depends_on_list(tmp_path: Path) -> None:
     assert parsed["target"]["depends_on"] == [10, 20, 30]
 
 
+def test_build_agent_task_file_ownership_as_toml_array(tmp_path: Path) -> None:
+    """_build_agent_task() writes file_ownership as a TOML string array in [target]."""
+    wt = _fake_worktree(tmp_path, "issue-ownership")
+    output = _build_agent_task(
+        issue_number=60,
+        title="Ownership issue",
+        role="python-developer",
+        worktree=wt,
+        host_worktree=wt,
+        branch="feat/issue-60",
+        file_ownership=["agentception/routes/api/_shared.py", "agentception/services/toml_task.py"],
+    )
+    parsed = tomllib.loads(output)
+    assert parsed["target"]["file_ownership"] == [
+        "agentception/routes/api/_shared.py",
+        "agentception/services/toml_task.py",
+    ]
+
+
+def test_build_agent_task_file_ownership_defaults_to_empty_array(tmp_path: Path) -> None:
+    """_build_agent_task() without file_ownership emits an empty TOML array."""
+    wt = _fake_worktree(tmp_path, "issue-no-ownership")
+    output = _build_agent_task(
+        issue_number=61,
+        title="No ownership",
+        role="python-developer",
+        worktree=wt,
+        host_worktree=wt,
+        branch="feat/issue-61",
+    )
+    parsed = tomllib.loads(output)
+    assert parsed["target"]["file_ownership"] == []
+
+
 # ---------------------------------------------------------------------------
 # _build_child_task — TOML v2 output regression (swim lane fix)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Added `file_ownership` parameter to `_build_agent_task()`, emitting it as a TOML string array in `[target].file_ownership` — completing the final acceptance criterion (all three arrays `depends_on`, `closes`, `file_ownership` now emit as TOML arrays)
- Added `test_build_agent_task_file_ownership_as_toml_array` and `test_build_agent_task_file_ownership_defaults_to_empty_array` covering both the populated and empty-list paths

All three builders (`_build_agent_task`, `_build_coordinator_task`, `_build_conductor_task`) emit valid TOML v2 parseable by `tomllib.loads()`. 28/28 tests pass, mypy clean.

## Acceptance Criteria Satisfied

- [x] `_build_agent_task()` returns valid TOML parseable by `tomllib.loads()`
- [x] `_build_coordinator_task()` returns valid TOML
- [x] `_build_conductor_task()` returns valid TOML
- [x] `depends_on`, `closes`, `file_ownership` written as TOML arrays
- [x] Round-trip: `build → parse_agent_task() → TaskFile` has correct fields
- [x] No K=V strings remain in any builder
- [x] mypy clean, `from __future__ import annotations`

Closes #49