### PR TITLE
feat: canonical workflow state machine for Ship board swim lanes

### DIFF
--- a/agentception/alembic/versions/0002_workflow_state_machine.py
+++ b/agentception/alembic/versions/0002_workflow_state_machine.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+"""Add workflow state machine tables and PR columns.
+
+New tables:
+- ``pr_issue_links`` — explicit, auditable PR↔Issue linkage with provenance.
+- ``issue_workflow_state`` — canonical, persisted swim-lane state per issue.
+
+New columns on ``pull_requests``:
+- ``base_ref`` — target branch for base-mismatch detection.
+- ``is_draft`` — GitHub draft PR flag.
+- ``closes_issue_numbers_json`` — array of all closing references.
+- ``body_hash`` — SHA-256 of normalised body text.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-03-06
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── New columns on pull_requests ──────────────────────────────────────
+    op.add_column(
+        "pull_requests",
+        sa.Column("base_ref", sa.String(256), nullable=True),
+    )
+    op.add_column(
+        "pull_requests",
+        sa.Column("is_draft", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "pull_requests",
+        sa.Column(
+            "closes_issue_numbers_json",
+            sa.Text(),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+    op.add_column(
+        "pull_requests",
+        sa.Column("body_hash", sa.String(64), nullable=True),
+    )
+
+    # ── pr_issue_links ────────────────────────────────────────────────────
+    op.create_table(
+        "pr_issue_links",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("repo", sa.String(256), nullable=False),
+        sa.Column("pr_number", sa.Integer(), nullable=False),
+        sa.Column("issue_number", sa.Integer(), nullable=False),
+        sa.Column("link_method", sa.String(64), nullable=False),
+        sa.Column("confidence", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("evidence_json", sa.Text(), nullable=False, server_default="{}"),
+        sa.Column("first_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint(
+            "repo", "pr_number", "issue_number", "link_method",
+            name="uq_pr_issue_links",
+        ),
+    )
+    op.create_index("ix_pr_issue_links_issue", "pr_issue_links", ["repo", "issue_number"])
+    op.create_index("ix_pr_issue_links_pr", "pr_issue_links", ["repo", "pr_number"])
+
+    # ── issue_workflow_state ──────────────────────────────────────────────
+    op.create_table(
+        "issue_workflow_state",
+        sa.Column("repo", sa.String(256), nullable=False, primary_key=True),
+        sa.Column("issue_number", sa.Integer(), nullable=False, primary_key=True),
+        sa.Column("initiative", sa.String(256), nullable=True),
+        sa.Column("phase_key", sa.String(256), nullable=True),
+        sa.Column("lane", sa.String(32), nullable=False, server_default="todo"),
+        sa.Column("issue_state", sa.String(32), nullable=False, server_default="open"),
+        sa.Column("run_id", sa.String(512), nullable=True),
+        sa.Column("agent_status", sa.String(64), nullable=True),
+        sa.Column("pr_number", sa.Integer(), nullable=True),
+        sa.Column("pr_state", sa.String(32), nullable=True),
+        sa.Column("pr_base", sa.String(256), nullable=True),
+        sa.Column("pr_head_ref", sa.String(256), nullable=True),
+        sa.Column("pr_link_method", sa.String(64), nullable=True),
+        sa.Column("pr_link_confidence", sa.Integer(), nullable=True),
+        sa.Column("warnings_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("content_hash", sa.String(64), nullable=False, server_default=""),
+        sa.Column("first_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_computed_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("ix_issue_workflow_state_lane", "issue_workflow_state", ["lane"])
+    op.create_index("ix_issue_workflow_state_initiative", "issue_workflow_state", ["initiative"])
+    op.create_index("ix_issue_workflow_state_phase", "issue_workflow_state", ["phase_key"])
+
+
+def downgrade() -> None:
+    op.drop_table("issue_workflow_state")
+    op.drop_table("pr_issue_links")
+    op.drop_column("pull_requests", "body_hash")
+    op.drop_column("pull_requests", "closes_issue_numbers_json")
+    op.drop_column("pull_requests", "is_draft")
+    op.drop_column("pull_requests", "base_ref")

--- a/agentception/db/models.py
+++ b/agentception/db/models.py
@@ -232,9 +232,22 @@ class ACPullRequest(Base):
     """open | closed | merged"""
 
     head_ref: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    base_ref: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    """Target branch (e.g. ``dev``, ``main``).  Added for base-mismatch detection."""
+
+    is_draft: Mapped[bool] = mapped_column(Integer, nullable=False, default=False)
+    """Whether the PR is a GitHub draft.  Stored as 0/1 for SQLite compat."""
+
     closes_issue_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    closes_issue_numbers_json: Mapped[str] = mapped_column(
+        Text, nullable=False, default="[]"
+    )
+    """JSON array of all issue numbers referenced by Closes/Fixes/Resolves keywords."""
+
     labels_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
     content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    body_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    """SHA-256 of normalised body text — enables body-change detection independently of content_hash."""
 
     created_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
@@ -461,3 +474,127 @@ class ACPipelineSnapshot(Base):
     agents_active: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     alerts_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
     """JSON array of alert strings from the tick."""
+
+
+# ---------------------------------------------------------------------------
+# ACPRIssueLink — explicit, auditable PR↔Issue linkage
+# ---------------------------------------------------------------------------
+
+
+class ACPRIssueLink(Base):
+    """One row per candidate PR↔Issue association, with provenance.
+
+    Multiple link methods may produce rows for the same (repo, pr_number,
+    issue_number) triple; the unique constraint deduplicates.  The linker
+    picks the best link per issue based on confidence and PR state.
+    """
+
+    __tablename__ = "pr_issue_links"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    repo: Mapped[str] = mapped_column(String(256), nullable=False)
+    pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    issue_number: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    link_method: Mapped[str] = mapped_column(String(64), nullable=False)
+    """How the link was discovered.
+
+    Values: ``explicit`` | ``body_closes`` | ``branch_regex`` |
+    ``run_pr_number`` | ``title_mention`` | ``unknown``
+    """
+
+    confidence: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    """0–100 score — higher means more reliable signal."""
+
+    evidence_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+    """JSON blob describing the evidence (matched text, run_id, regex capture, etc.)."""
+
+    first_seen_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    last_seen_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "repo", "pr_number", "issue_number", "link_method",
+            name="uq_pr_issue_links",
+        ),
+        Index("ix_pr_issue_links_issue", "repo", "issue_number"),
+        Index("ix_pr_issue_links_pr", "repo", "pr_number"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# ACIssueWorkflowState — canonical, persisted swim-lane state per issue
+# ---------------------------------------------------------------------------
+
+
+class ACIssueWorkflowState(Base):
+    """One row per (repo, issue_number) — the UI's source of truth for swim lanes.
+
+    Computed idempotently each tick from DB signals (issues, PRs, runs,
+    pr_issue_links).  The board reads this table instead of re-inferring
+    lanes at request time.
+    """
+
+    __tablename__ = "issue_workflow_state"
+
+    repo: Mapped[str] = mapped_column(String(256), primary_key=True)
+    issue_number: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    initiative: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    """Denormalised for fast initiative-scoped queries."""
+
+    phase_key: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    """Scoped phase label (e.g. ``ac-ui/0-critical-bugs``)."""
+
+    lane: Mapped[str] = mapped_column(String(32), nullable=False, default="todo")
+    """Canonical swim lane: ``todo`` | ``active`` | ``pr_open`` | ``reviewing`` | ``done``."""
+
+    issue_state: Mapped[str] = mapped_column(String(32), nullable=False, default="open")
+    """GitHub issue state (``open`` | ``closed``), with stabilisation rules applied."""
+
+    run_id: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    """FK-like reference to the most relevant ``ac_agent_runs.id``."""
+
+    agent_status: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    """Computed agent status (implementing, reviewing, pending_launch, stale, done, unknown)."""
+
+    pr_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    """Best-linked PR number, if any."""
+
+    pr_state: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    """State of the best-linked PR (open, merged, closed, draft, unknown)."""
+
+    pr_base: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    """Target branch of the best-linked PR."""
+
+    pr_head_ref: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    """Source branch of the best-linked PR."""
+
+    pr_link_method: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    """How the PR was linked to this issue (see ACPRIssueLink.link_method)."""
+
+    pr_link_confidence: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    """Confidence score of the PR link (0–100)."""
+
+    warnings_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    """JSON array of warning strings surfaced to the maintainer."""
+
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False, default="")
+    """Hash of canonical state fields — update guard to avoid no-op writes."""
+
+    first_seen_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    last_computed_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+    __table_args__ = (
+        Index("ix_issue_workflow_state_lane", "lane"),
+        Index("ix_issue_workflow_state_initiative", "initiative"),
+        Index("ix_issue_workflow_state_phase", "phase_key"),
+    )

--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -31,7 +31,9 @@ from agentception.db.models import (
     ACAgentRun,
     ACInitiativePhase,
     ACIssue,
+    ACIssueWorkflowState,
     ACPipelineSnapshot,
+    ACPRIssueLink,
     ACPullRequest,
     ACRoleVersion,
     ACWave,
@@ -81,12 +83,19 @@ async def persist_tick(
             all_prs = list(open_prs) + list(merged_prs or [])
             await _upsert_prs(session, all_prs, gh_repo)
             await _upsert_agent_runs(session, state.agents)
-            # Auto-close issues whose PRs are merged (handles the dev-branch workflow
-            # where GitHub's auto-close doesn't fire because PRs target dev, not main).
             await _auto_close_pr_linked_issues(session, gh_repo)
             await session.commit()
     except Exception as exc:
         logger.warning("⚠️  DB persist_tick failed (non-fatal): %s", exc)
+
+    # Workflow state recomputation runs in a separate transaction so a
+    # failure here never rolls back the critical PR/issue/run upserts above.
+    try:
+        async with get_session() as session:
+            await _recompute_workflow_state(session, gh_repo)
+            await session.commit()
+    except Exception as exc:
+        logger.warning("⚠️  Workflow state recomputation failed (non-fatal): %s", exc)
 
 
 # ---------------------------------------------------------------------------
@@ -202,22 +211,36 @@ async def _upsert_prs(
     prs: list[dict[str, object]],
     repo: str,
 ) -> None:
+    """Hash-diff upsert for PR rows.
+
+    Key changes vs. the old implementation:
+
+    1. **No tombstone poisoning** — PRs absent from the feed are NOT flipped to
+       ``closed``.  Missing data is unknown, not closed.  Only explicit GitHub
+       state transitions change the state column.
+    2. **Body always re-parsed** — ``closes_issue_number`` and the new
+       ``closes_issue_numbers_json`` are recomputed from body text every tick,
+       not just on first insert.
+    3. **Body hash in content_hash** — ensures body changes trigger a row update
+       even when title/labels/state are unchanged.
+    4. **New columns** — ``base_ref``, ``is_draft``, ``body_hash``.
+    """
     from sqlalchemy.ext.asyncio import AsyncSession
 
     assert isinstance(session, AsyncSession)
     now = _now()
-
-    # Track every PR number we see in this tick so we can tombstone the rest.
-    seen_numbers: set[int] = set()
 
     for raw in prs:
         num = raw.get("number")
         if not isinstance(num, int):
             continue
         title = str(raw.get("title", ""))
-        # Normalise GitHub's uppercase GraphQL state values (OPEN/MERGED/CLOSED) to lowercase.
         state_str = str(raw.get("state", "open")).lower()
         head_ref = raw.get("headRefName")
+        base_ref = raw.get("baseRefName")
+        is_draft_raw = raw.get("isDraft", False)
+        is_draft = bool(is_draft_raw) if isinstance(is_draft_raw, bool) else False
+
         labels_raw = raw.get("labels", [])
         label_names: list[str] = []
         if isinstance(labels_raw, list):
@@ -227,14 +250,14 @@ async def _upsert_prs(
                 if isinstance(lbl, (str, dict))
             ]
         labels_json = json.dumps(sorted(label_names))
-        content_hash = _hash(title, state_str, labels_json, str(head_ref))
 
-        result = await session.execute(
-            select(ACPullRequest).where(
-                ACPullRequest.github_number == num, ACPullRequest.repo == repo
-            )
+        body_str = str(raw.get("body") or "")
+        body_hash = _hash(body_str) if body_str else ""
+
+        content_hash = _hash(
+            title, state_str, labels_json, str(head_ref),
+            str(base_ref), body_hash,
         )
-        existing = result.scalar_one_or_none()
 
         merged_at_raw = raw.get("mergedAt")
         merged_at: datetime.datetime | None = None
@@ -246,18 +269,25 @@ async def _upsert_prs(
             except ValueError:
                 pass
 
-        # Parse the first "Closes/Fixes/Resolves #N" reference from the PR body.
-        # Agents targeting `dev` (not `main`) bypass GitHub's auto-close; we
-        # track the linkage here so _auto_close_pr_linked_issues can act on it.
-        body_str = str(raw.get("body") or "")
-        closes_match = re.search(
-            r"(?i)(?:closes|fixes|resolves)\s+#(\d+)", body_str
-        )
+        # Always re-derive ALL closing references from body (not just the first).
+        closes_issue_numbers: list[int] = [
+            int(m.group(1))
+            for m in re.finditer(
+                r"(?i)(?:closes|fixes|resolves)\s+(?:[\w\-]+/[\w\-]+)?#(\d+)",
+                body_str,
+            )
+        ]
         closes_issue_number: int | None = (
-            int(closes_match.group(1)) if closes_match else None
+            closes_issue_numbers[0] if closes_issue_numbers else None
         )
+        closes_issue_numbers_json = json.dumps(closes_issue_numbers)
 
-        seen_numbers.add(num)
+        result = await session.execute(
+            select(ACPullRequest).where(
+                ACPullRequest.github_number == num, ACPullRequest.repo == repo
+            )
+        )
+        existing = result.scalar_one_or_none()
 
         if existing is None:
             session.add(
@@ -267,46 +297,36 @@ async def _upsert_prs(
                     title=title,
                     state=state_str,
                     head_ref=str(head_ref) if isinstance(head_ref, str) else None,
+                    base_ref=str(base_ref) if isinstance(base_ref, str) else None,
+                    is_draft=is_draft,
                     closes_issue_number=closes_issue_number,
+                    closes_issue_numbers_json=closes_issue_numbers_json,
                     labels_json=labels_json,
                     content_hash=content_hash,
+                    body_hash=body_hash or None,
                     merged_at=merged_at,
                     first_seen_at=now,
                     last_synced_at=now,
                 )
             )
         elif existing.content_hash != content_hash or existing.state != state_str:
-            # Update when content changed OR state transitioned (open → merged/closed).
             existing.title = title
             existing.state = state_str
             existing.head_ref = str(head_ref) if isinstance(head_ref, str) else None
+            existing.base_ref = str(base_ref) if isinstance(base_ref, str) else None
+            existing.is_draft = is_draft
             existing.labels_json = labels_json
             existing.content_hash = content_hash
+            existing.body_hash = body_hash or None
             if merged_at is not None and existing.merged_at is None:
                 existing.merged_at = merged_at
-            # Populate closes_issue_number on first parse (never overwrite once set).
-            if closes_issue_number is not None and existing.closes_issue_number is None:
-                existing.closes_issue_number = closes_issue_number
+            # Always update closes references from body — deterministic recomputation.
+            existing.closes_issue_number = closes_issue_number
+            existing.closes_issue_numbers_json = closes_issue_numbers_json
             existing.last_synced_at = now
-
-    # Tombstone sweep: the poller passes ALL open + merged PRs every tick.
-    # Any DB row with state='open' that is absent from this tick's feed was
-    # closed without merging on GitHub — mark it closed so the board is not
-    # poisoned by stale "open" signals for PRs that no longer exist.
-    tombstone_result = await session.execute(
-        select(ACPullRequest).where(
-            ACPullRequest.repo == repo,
-            ACPullRequest.state == "open",
-        )
-    )
-    for stale_pr in tombstone_result.scalars().all():
-        if stale_pr.github_number not in seen_numbers:
-            stale_pr.state = "closed"
-            stale_pr.last_synced_at = now
-            logger.debug(
-                "🧹 PR #%s tombstoned → closed (absent from open+merged feed)",
-                stale_pr.github_number,
-            )
+        else:
+            # Content unchanged — still mark as seen this tick.
+            existing.last_synced_at = now
 
 
 # ---------------------------------------------------------------------------
@@ -430,23 +450,297 @@ async def _gh_close_issue(repo: str, issue_number: int) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Workflow state recomputation (linker + state machine)
+# ---------------------------------------------------------------------------
+
+
+async def _recompute_workflow_state(session: object, repo: str) -> list[str]:
+    """Recompute PR↔Issue links and canonical workflow state for all issues.
+
+    Called within ``persist_tick`` after issues, PRs, and runs are upserted.
+    Returns a list of invariant-violation alert strings (empty if clean).
+    """
+    from agentception.workflow.invariants import InvariantContext, WorkflowSnapshot, check_invariants
+    from agentception.workflow.linking import (
+        BestPR,
+        CandidateLink,
+        PRInfo,
+        PRRow,
+        RunRow,
+        best_pr_for_issue,
+        discover_links_for_pr,
+    )
+    from agentception.workflow.state_machine import IssueInput, RunInput, compute_workflow_state
+    from agentception.workflow.status import compute_agent_status
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    assert isinstance(session, AsyncSession)
+    now = _now()
+
+    # --- Load all data ---
+    issues_result = await session.execute(
+        select(ACIssue).where(ACIssue.repo == repo)
+    )
+    all_issues = issues_result.scalars().all()
+
+    prs_result = await session.execute(
+        select(ACPullRequest).where(ACPullRequest.repo == repo)
+    )
+    all_prs = prs_result.scalars().all()
+
+    runs_result = await session.execute(
+        select(ACAgentRun).order_by(ACAgentRun.spawned_at.desc())
+    )
+    all_runs = runs_result.scalars().all()
+
+    # --- Build lookup structures ---
+    runs_by_pr: dict[int, list[RunRow]] = {}
+    latest_run_by_issue: dict[int, ACAgentRun] = {}
+    run_pr_numbers: dict[str, int | None] = {}
+
+    for run in all_runs:
+        run_pr_numbers[run.id] = run.pr_number
+        if run.pr_number is not None:
+            run_row = RunRow(
+                id=run.id,
+                issue_number=run.issue_number,
+                pr_number=run.pr_number,
+            )
+            runs_by_pr.setdefault(run.pr_number, []).append(run_row)
+        if run.issue_number is not None and run.issue_number not in latest_run_by_issue:
+            latest_run_by_issue[run.issue_number] = run
+
+    pr_info_map: dict[int, PRInfo] = {}
+    pr_states: dict[int, str] = {}
+    pr_bases: dict[int, str | None] = {}
+    closes_refs_by_pr: dict[int, list[int]] = {}
+
+    for pr in all_prs:
+        pr_info_map[pr.github_number] = PRInfo(
+            number=pr.github_number,
+            state=pr.state,
+            base_ref=pr.base_ref,
+            head_ref=pr.head_ref,
+        )
+        pr_states[pr.github_number] = pr.state
+        pr_bases[pr.github_number] = pr.base_ref
+        # Parse closes refs from the stored JSON array.
+        try:
+            refs = json.loads(pr.closes_issue_numbers_json or "[]")
+        except (json.JSONDecodeError, TypeError):
+            refs = []
+        if isinstance(refs, list):
+            closes_refs_by_pr[pr.github_number] = [r for r in refs if isinstance(r, int)]
+
+    # --- Discover links for every PR ---
+    all_candidates: list[CandidateLink] = []
+    for pr in all_prs:
+        labels: list[str] = json.loads(pr.labels_json or "[]")
+        pr_row = PRRow(
+            number=pr.github_number,
+            title=pr.title,
+            head_ref=pr.head_ref,
+            base_ref=pr.base_ref,
+            body="",  # body not stored on ACPullRequest — linkage comes from closes_issue_numbers_json
+            labels=labels,
+        )
+        candidates = discover_links_for_pr(pr_row, repo, runs_by_pr)
+
+        # Also add body_closes candidates from the stored closes_issue_numbers.
+        for issue_num in closes_refs_by_pr.get(pr.github_number, []):
+            already_has = any(
+                c["issue_number"] == issue_num and c["link_method"] == "body_closes"
+                for c in candidates
+            )
+            if not already_has:
+                candidates.append(CandidateLink(
+                    repo=repo,
+                    pr_number=pr.github_number,
+                    issue_number=issue_num,
+                    link_method="body_closes",
+                    confidence=95,
+                    evidence_json=json.dumps({"source": "closes_issue_numbers_json"}),
+                ))
+
+        all_candidates.extend(candidates)
+
+    # --- Persist link rows (upsert) ---
+    link_issue_numbers_by_pr: dict[int, list[int]] = {}
+    for candidate in all_candidates:
+        pr_num = candidate["pr_number"]
+        issue_num = candidate["issue_number"]
+        link_issue_numbers_by_pr.setdefault(pr_num, []).append(issue_num)
+
+        existing_link = await session.execute(
+            select(ACPRIssueLink).where(
+                ACPRIssueLink.repo == repo,
+                ACPRIssueLink.pr_number == pr_num,
+                ACPRIssueLink.issue_number == issue_num,
+                ACPRIssueLink.link_method == candidate["link_method"],
+            )
+        )
+        link_row = existing_link.scalar_one_or_none()
+        if link_row is None:
+            session.add(ACPRIssueLink(
+                repo=repo,
+                pr_number=pr_num,
+                issue_number=issue_num,
+                link_method=candidate["link_method"],
+                confidence=candidate["confidence"],
+                evidence_json=candidate["evidence_json"],
+                first_seen_at=now,
+                last_seen_at=now,
+            ))
+        else:
+            link_row.confidence = candidate["confidence"]
+            link_row.evidence_json = candidate["evidence_json"]
+            link_row.last_seen_at = now
+
+    # --- Compute workflow state for each issue ---
+    issue_number_set = {i.github_number for i in all_issues}
+    workflow_snapshots: dict[int, WorkflowSnapshot] = {}
+
+    for issue in all_issues:
+        issue_num = issue.github_number
+        issue_labels: list[str] = json.loads(issue.labels_json or "[]")
+
+        # Derive initiative and phase from labels.
+        initiative: str | None = None
+        phase_key: str | None = None
+        for lbl in issue_labels:
+            if "/" in lbl:
+                initiative = lbl.split("/")[0]
+                phase_key = lbl
+                break
+
+        # Get best PR for this issue.
+        issue_candidates = [c for c in all_candidates if c["issue_number"] == issue_num]
+        best = best_pr_for_issue(issue_num, issue_candidates, pr_info_map)
+
+        # Get latest run for this issue.
+        run_obj = latest_run_by_issue.get(issue_num)
+        run_input: RunInput | None = None
+        if run_obj is not None:
+            computed_status = compute_agent_status(run_obj.status, run_obj.last_activity_at, now=now)
+            # Promote to "reviewing" if an active reviewer run exists for this PR.
+            if best and best["pr_state"] in ("open", "draft"):
+                for r in all_runs:
+                    if (
+                        r.role == "pr-reviewer"
+                        and r.pr_number == best["pr_number"]
+                        and r.status in ("implementing", "reviewing")
+                    ):
+                        computed_status = "reviewing"
+                        break
+            run_input = RunInput(
+                id=run_obj.id,
+                status=run_obj.status,
+                agent_status=computed_status,
+                pr_number=run_obj.pr_number,
+            )
+
+        # Detect merged-recently for stabilisation.
+        pr_merged_recently = False
+        if best and best["pr_state"] == "merged" and issue.state == "open":
+            pr_merged_recently = True
+
+        issue_input = IssueInput(
+            number=issue_num,
+            state=issue.state,
+            labels=issue_labels,
+            phase_key=phase_key,
+            initiative=initiative,
+        )
+
+        wf_state = compute_workflow_state(
+            issue_input, run_input, best, pr_merged_recently=pr_merged_recently,
+        )
+
+        # Persist to ac_issue_workflow_state.
+        existing_wf = await session.execute(
+            select(ACIssueWorkflowState).where(
+                ACIssueWorkflowState.repo == repo,
+                ACIssueWorkflowState.issue_number == issue_num,
+            )
+        )
+        wf_row = existing_wf.scalar_one_or_none()
+
+        if wf_row is None:
+            session.add(ACIssueWorkflowState(
+                repo=repo,
+                issue_number=issue_num,
+                initiative=initiative,
+                phase_key=phase_key,
+                lane=wf_state["lane"],
+                issue_state=wf_state["issue_state"],
+                run_id=wf_state["run_id"],
+                agent_status=wf_state["agent_status"],
+                pr_number=wf_state["pr_number"],
+                pr_state=wf_state["pr_state"],
+                pr_base=wf_state["pr_base"],
+                pr_head_ref=wf_state["pr_head_ref"],
+                pr_link_method=wf_state["pr_link_method"],
+                pr_link_confidence=wf_state["pr_link_confidence"],
+                warnings_json=json.dumps(wf_state["warnings"]),
+                content_hash=wf_state["content_hash"],
+                first_seen_at=now,
+                last_computed_at=now,
+            ))
+        elif wf_row.content_hash != wf_state["content_hash"]:
+            wf_row.initiative = initiative
+            wf_row.phase_key = phase_key
+            wf_row.lane = wf_state["lane"]
+            wf_row.issue_state = wf_state["issue_state"]
+            wf_row.run_id = wf_state["run_id"]
+            wf_row.agent_status = wf_state["agent_status"]
+            wf_row.pr_number = wf_state["pr_number"]
+            wf_row.pr_state = wf_state["pr_state"]
+            wf_row.pr_base = wf_state["pr_base"]
+            wf_row.pr_head_ref = wf_state["pr_head_ref"]
+            wf_row.pr_link_method = wf_state["pr_link_method"]
+            wf_row.pr_link_confidence = wf_state["pr_link_confidence"]
+            wf_row.warnings_json = json.dumps(wf_state["warnings"])
+            wf_row.content_hash = wf_state["content_hash"]
+            wf_row.last_computed_at = now
+
+        workflow_snapshots[issue_num] = WorkflowSnapshot(
+            lane=wf_state["lane"],
+            pr_number=wf_state["pr_number"],
+            pr_state=wf_state["pr_state"],
+            agent_status=wf_state["agent_status"],
+            issue_state=wf_state["issue_state"],
+        )
+
+    # --- Run invariants ---
+    inv_ctx = InvariantContext(
+        repo=repo,
+        issue_numbers=list(issue_number_set),
+        pr_numbers_in_db={pr.github_number for pr in all_prs},
+        run_pr_numbers=run_pr_numbers,
+        link_issue_numbers_by_pr=link_issue_numbers_by_pr,
+        workflow_states=workflow_snapshots,
+        pr_states=pr_states,
+        pr_bases=pr_bases,
+        closes_refs_by_pr=closes_refs_by_pr,
+    )
+    alerts = check_invariants(inv_ctx)
+
+    if alerts:
+        logger.warning(
+            "⚠️  Workflow invariant alerts (%d): %s",
+            len(alerts),
+            "; ".join(alerts[:3]),
+        )
+
+    return alerts
+
+
+# ---------------------------------------------------------------------------
 # Agent runs (status upsert)
 # ---------------------------------------------------------------------------
 
 
-_ACTIVE_STATUSES = {"implementing", "reviewing", "stale"}
-"""Statuses that indicate a run has a live, poller-visible worktree.
-
-Runs in these states that are absent from the current poller tick are
-orphaned (the worktree was removed without a clean status transition)
-and are flipped to ``unknown`` so the UI does not show phantom agents.
-
-``pending_launch`` is intentionally excluded: pending runs live only in
-the DB (the Dispatcher hasn't claimed them yet) and have no poller
-presence.  Including them in the sweep would immediately flip them to
-``unknown`` before the Dispatcher ever reads them.  The only valid
-transition out of ``pending_launch`` is via the acknowledge endpoint.
-"""
+from agentception.workflow.status import ACTIVE_STATUSES as _ACTIVE_STATUSES  # noqa: E402
 
 
 async def _upsert_agent_runs(
@@ -784,7 +1078,7 @@ async def acknowledge_agent_run(run_id: str) -> bool:
         return False
 
 
-_RESET_STATUSES = frozenset({"pending_launch", "implementing", "reviewing"})
+from agentception.workflow.status import RESET_STATUSES as _RESET_STATUSES  # noqa: E402
 
 
 async def reset_build_runs_to_unknown() -> int:

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -23,6 +23,7 @@ from agentception.db.models import (
     ACAgentMessage,
     ACAgentRun,
     ACIssue,
+    ACIssueWorkflowState,
     ACPipelineSnapshot,
     ACPullRequest,
     ACWave,
@@ -351,6 +352,25 @@ class OpenPRForIssueRow(TypedDict):
     head_ref: str | None
 
 
+class WorkflowStateRow(TypedDict):
+    """Canonical workflow state for a board issue, read from ``ac_issue_workflow_state``.
+
+    This is the UI's source of truth for swim lanes — no ad-hoc inference.
+    """
+
+    lane: str
+    issue_state: str
+    run_id: str | None
+    agent_status: str | None
+    pr_number: int | None
+    pr_state: str | None
+    pr_base: str | None
+    pr_head_ref: str | None
+    pr_link_method: str | None
+    pr_link_confidence: int | None
+    warnings: list[str]
+
+
 class RunForIssueRow(TypedDict):
     """Most-recent run entry from get_runs_for_issue_numbers.
 
@@ -403,18 +423,16 @@ class RunTreeNodeRow(TypedDict):
 # Step-data helpers — used internally by get_runs_for_issue_numbers
 # ---------------------------------------------------------------------------
 
-#: A run in an active status with no event newer than this is marked "stale".
-_STALE_THRESHOLD_SECONDS: int = 1800  # 30 minutes
-
-#: Statuses considered "active" for staleness detection.
-_ACTIVE_STATUSES: frozenset[str] = frozenset(
-    {"implementing", "pending_launch", "reviewing"}
+from agentception.workflow.status import (
+    LIVE_STATUSES as _LIVE_STATUSES,
+    STALE_THRESHOLD,
 )
 
-#: Statuses considered "genuinely live" for hierarchy-panel visibility.
-_LIVE_STATUSES: frozenset[str] = frozenset(
-    {"implementing", "pending_launch", "reviewing"}
-)
+#: Statuses considered "active" for staleness detection (same as live for queries).
+_ACTIVE_STATUSES = _LIVE_STATUSES
+
+#: Seconds threshold — derived from the canonical timedelta.
+_STALE_THRESHOLD_SECONDS: int = int(STALE_THRESHOLD.total_seconds())
 
 #: Branch naming convention for engineer feature branches.
 #: Group 1 captures the issue number so we can link the PR back to its issue.
@@ -1733,6 +1751,51 @@ async def get_open_prs_by_issue(
         return out
     except Exception as exc:
         logger.warning("⚠️  get_open_prs_by_issue DB query failed (non-fatal): %s", exc)
+        return {}
+
+
+async def get_workflow_states_by_issue(
+    issue_numbers: list[int],
+    repo: str,
+) -> dict[int, WorkflowStateRow]:
+    """Return canonical workflow state keyed by issue number.
+
+    Reads from ``ac_issue_workflow_state`` — the persisted, canonical source
+    of truth for swim lanes.  Falls back to ``{}`` on error so the board
+    degrades gracefully.
+    """
+    if not issue_numbers:
+        return {}
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACIssueWorkflowState).where(
+                    ACIssueWorkflowState.repo == repo,
+                    ACIssueWorkflowState.issue_number.in_(issue_numbers),
+                )
+            )
+            rows = result.scalars().all()
+
+        out: dict[int, WorkflowStateRow] = {}
+        for row in rows:
+            import json as _json
+            warnings: list[str] = _json.loads(row.warnings_json or "[]")
+            out[row.issue_number] = WorkflowStateRow(
+                lane=row.lane,
+                issue_state=row.issue_state,
+                run_id=row.run_id,
+                agent_status=row.agent_status,
+                pr_number=row.pr_number,
+                pr_state=row.pr_state,
+                pr_base=row.pr_base,
+                pr_head_ref=row.pr_head_ref,
+                pr_link_method=row.pr_link_method,
+                pr_link_confidence=row.pr_link_confidence,
+                warnings=warnings,
+            )
+        return out
+    except Exception as exc:
+        logger.warning("⚠️  get_workflow_states_by_issue DB query failed (non-fatal): %s", exc)
         return {}
 
 

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -190,8 +190,11 @@ async def get_open_issues(label: str | None = None) -> list[dict[str, object]]:
 async def get_open_prs() -> list[dict[str, object]]:
     """List open pull requests targeting the ``dev`` branch.
 
-    Returns each PR as a dict with at minimum: ``number``, ``title``,
-    ``headRefName``, ``labels``, and ``state``.
+    Returns each PR as a dict with: ``number``, ``title``, ``headRefName``,
+    ``baseRefName``, ``labels``, ``state``, ``body``, ``isDraft``.
+
+    The ``body`` and ``baseRefName`` fields are required for correct PR↔Issue
+    linkage and base-mismatch detection in the workflow state machine.
     """
     repo = settings.gh_repo
     args = [
@@ -199,11 +202,33 @@ async def get_open_prs() -> list[dict[str, object]]:
         "--repo", repo,
         "--base", "dev",
         "--state", "open",
-        "--json", "number,title,headRefName,labels,state",
+        "--json", "number,title,headRefName,baseRefName,labels,state,body,isDraft",
     ]
     result = await gh_json(args, ".", "get_open_prs")
     if not isinstance(result, list):
         raise RuntimeError(f"get_open_prs: expected list from gh, got {type(result).__name__}")
+    return [item for item in result if isinstance(item, dict)]
+
+
+async def get_open_prs_any_base() -> list[dict[str, object]]:
+    """List ALL open pull requests regardless of target branch.
+
+    Ensures PRs opened against ``main``, ``staging``, or any other branch
+    are not lost.  The workflow state machine uses ``baseRefName`` to detect
+    base-mismatch and issue a warning, but the card still moves.
+    """
+    repo = settings.gh_repo
+    args = [
+        "pr", "list",
+        "--repo", repo,
+        "--state", "open",
+        "--json", "number,title,headRefName,baseRefName,labels,state,body,isDraft",
+    ]
+    result = await gh_json(args, ".", "get_open_prs_any_base")
+    if not isinstance(result, list):
+        raise RuntimeError(
+            f"get_open_prs_any_base: expected list from gh, got {type(result).__name__}"
+        )
     return [item for item in result if isinstance(item, dict)]
 
 
@@ -213,21 +238,11 @@ async def get_open_prs_with_body() -> list[dict[str, object]]:
     Like ``get_open_prs()`` but also fetches the PR body so callers can parse
     ``Closes #NNN`` references to identify linked issues.  Used by the
     out-of-order PR guard (``agentception.intelligence.guards``).
+
+    .. deprecated::
+        Prefer ``get_open_prs()`` which now always includes body.
     """
-    repo = settings.gh_repo
-    args = [
-        "pr", "list",
-        "--repo", repo,
-        "--base", "dev",
-        "--state", "open",
-        "--json", "number,title,headRefName,labels,body",
-    ]
-    result = await gh_json(args, ".", "get_open_prs_with_body")
-    if not isinstance(result, list):
-        raise RuntimeError(
-            f"get_open_prs_with_body: expected list from gh, got {type(result).__name__}"
-        )
-    return [item for item in result if isinstance(item, dict)]
+    return await get_open_prs()
 
 
 async def get_merged_prs() -> list[dict[str, object]]:
@@ -270,7 +285,7 @@ async def get_merged_prs_full(limit: int = 100) -> list[dict[str, object]]:
         "--repo", repo,
         "--base", "dev",
         "--state", "merged",
-        "--json", "number,title,headRefName,labels,mergedAt,state,body",
+        "--json", "number,title,headRefName,baseRefName,labels,mergedAt,state,body,isDraft",
         "--limit", str(limit),
     ]
     cache_key = f"get_merged_prs_full:limit={limit}"

--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -38,6 +38,7 @@ from agentception.db.queries import (
     PhaseGroupRow,
     RunForIssueRow,
     RunTreeNodeRow,
+    WorkflowStateRow,
     get_agent_events_tail,
     get_agent_thoughts_tail,
     get_initiatives,
@@ -46,6 +47,7 @@ from agentception.db.queries import (
     get_open_prs_by_issue,
     get_run_tree_by_batch_id,
     get_runs_for_issue_numbers,
+    get_workflow_states_by_issue,
 )
 from agentception.readers.pipeline_config import read_pipeline_config
 from ._shared import _TEMPLATES
@@ -148,15 +150,20 @@ async def _build_enriched_groups(
     Returns ``(enriched_groups, total_issue_count, open_issue_count)``.
     Centralises the DB fan-out so both the full page and the HTMX partial
     share a single implementation.
+
+    Reads swim lanes from the canonical ``ac_issue_workflow_state`` table.
+    Falls back to ad-hoc ``_compute_swim_lane()`` for issues that haven't
+    been computed yet (graceful dual-run during migration).
     """
     groups = await get_issues_grouped_by_phase(repo, initiative=initiative)
     all_issue_numbers = [i["number"] for g in groups for i in g["issues"]]
     open_issue_count = sum(
         1 for g in groups for i in g["issues"] if i["state"] != "closed"
     )
-    runs, open_prs = await asyncio.gather(
+    runs, open_prs, workflow_states = await asyncio.gather(
         get_runs_for_issue_numbers(all_issue_numbers),
         get_open_prs_by_issue(all_issue_numbers, repo),
+        get_workflow_states_by_issue(all_issue_numbers, repo),
     )
     enriched: list[EnrichedPhaseGroupRow] = [
         EnrichedPhaseGroupRow(
@@ -171,10 +178,12 @@ async def _build_enriched_groups(
                     labels=i["labels"],
                     depends_on=i["depends_on"],
                     run=runs.get(i["number"]),
-                    swim_lane=_compute_swim_lane(
+                    swim_lane=_resolve_swim_lane(
+                        i["number"],
                         i["state"],
                         runs.get(i["number"]),
                         open_prs.get(i["number"]),
+                        workflow_states.get(i["number"]),
                     ),
                 )
                 for i in g["issues"]
@@ -186,6 +195,23 @@ async def _build_enriched_groups(
         for g in groups
     ]
     return enriched, len(all_issue_numbers), open_issue_count
+
+
+def _resolve_swim_lane(
+    issue_number: int,
+    issue_state: str,
+    run: RunForIssueRow | None,
+    open_pr: OpenPRForIssueRow | None,
+    workflow_state: WorkflowStateRow | None,
+) -> str:
+    """Return the canonical swim lane, preferring the persisted workflow state.
+
+    During dual-run / migration, falls back to ``_compute_swim_lane()``
+    for issues without a persisted state row yet.
+    """
+    if workflow_state is not None:
+        return workflow_state["lane"]
+    return _compute_swim_lane(issue_state, run, open_pr)
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/tests/test_advance_phase_endpoint.py
+++ b/agentception/tests/test_advance_phase_endpoint.py
@@ -63,6 +63,7 @@ def _mock_issue() -> dict[str, object]:
     return {
         "number": 1,
         "title": "Test issue",
+        "body_excerpt": "",
         "state": "open",
         "url": "https://github.com/owner/repo/issues/1",
         "labels": [],
@@ -211,6 +212,14 @@ def test_build_board_renders_advance_button_when_prev_complete_and_locked(
             "agentception.routes.ui.build_ui.get_runs_for_issue_numbers",
             new=AsyncMock(return_value={}),
         ),
+        patch(
+            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
+            new=AsyncMock(return_value={}),
+        ),
     ):
         resp = client.get("/ship/my-initiative/board")
 
@@ -233,6 +242,14 @@ def test_build_board_no_advance_button_when_not_locked(client: TestClient) -> No
         ),
         patch(
             "agentception.routes.ui.build_ui.get_runs_for_issue_numbers",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
             new=AsyncMock(return_value={}),
         ),
     ):
@@ -259,6 +276,14 @@ def test_build_board_no_advance_button_when_prev_not_complete(
             "agentception.routes.ui.build_ui.get_runs_for_issue_numbers",
             new=AsyncMock(return_value={}),
         ),
+        patch(
+            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
+            new=AsyncMock(return_value={}),
+        ),
     ):
         resp = client.get("/ship/my-initiative/board")
 
@@ -283,6 +308,14 @@ def test_build_board_no_advance_button_single_phase(
         ),
         patch(
             "agentception.routes.ui.build_ui.get_runs_for_issue_numbers",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
             new=AsyncMock(return_value={}),
         ),
     ):

--- a/agentception/tests/test_lineage_fields.py
+++ b/agentception/tests/test_lineage_fields.py
@@ -259,16 +259,18 @@ def test_migration_0001_has_no_node_type_or_logical_tier() -> None:
     assert "logical_tier" not in content
 
 
-def test_migration_0001_is_only_migration() -> None:
-    """Exactly one migration file exists — the consolidated baseline."""
+def test_migration_chain_is_contiguous() -> None:
+    """Migration files form a contiguous 0001→0002 chain."""
     migration_dir = Path(__file__).parent.parent / "alembic" / "versions"
-    py_files = [
+    py_files = sorted(
         f for f in migration_dir.glob("*.py") if f.name != "__init__.py"
-    ]
-    assert len(py_files) == 1, (
-        f"Expected exactly 1 migration file, found {len(py_files)}: "
-        + ", ".join(f.name for f in sorted(py_files))
     )
+    assert len(py_files) >= 2, (
+        f"Expected at least 2 migration files, found {len(py_files)}: "
+        + ", ".join(f.name for f in py_files)
+    )
+    assert py_files[0].name.startswith("0001_"), f"First migration should be 0001, got {py_files[0].name}"
+    assert py_files[1].name.startswith("0002_"), f"Second migration should be 0002, got {py_files[1].name}"
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/tests/test_workflow_state_machine.py
+++ b/agentception/tests/test_workflow_state_machine.py
@@ -1,0 +1,613 @@
+from __future__ import annotations
+
+"""Contract tests for the workflow state machine, PR↔Issue linker, and invariants.
+
+These tests enforce the acceptance criteria from the Ship board swim-lane
+state machine specification.  They must pass before any merge.
+
+Coverage:
+
+1. Open PR with ``Closes #17`` and non-standard branch → lane ``pr_open``
+2. Open PR with no body but branch ``feat/issue-17-x`` → lane ``pr_open``
+3. Run has ``pr_number=42`` but PR not yet in DB → warning + deterministic behaviour
+4. PR targets ``main`` not ``dev`` → lane ``pr_open`` + warning ``wrong_base``
+5. PR merges → lane ``done`` (with stabilisation even if issue still open)
+6. Multiple runs: latest unknown, older has PR → lane still correct via PR link
+7. Tombstone absence does NOT flip to closed (no tombstone poisoning)
+8. Linker discovers all signal types with correct confidence
+9. Best-PR selection precedence
+10. Invariant checks
+
+Run:
+    docker compose exec agentception pytest \\
+        agentception/tests/test_workflow_state_machine.py -v
+"""
+
+import json
+
+import pytest
+
+from agentception.workflow.linking import (
+    BestPR,
+    CandidateLink,
+    PRInfo,
+    PRRow,
+    RunRow,
+    best_pr_for_issue,
+    discover_links_for_pr,
+)
+from agentception.workflow.state_machine import (
+    LANE_ACTIVE,
+    LANE_DONE,
+    LANE_PR_OPEN,
+    LANE_REVIEWING,
+    LANE_TODO,
+    IssueInput,
+    RunInput,
+    WorkflowState,
+    compute_workflow_state,
+)
+from agentception.workflow.status import (
+    ACTIVE_STATUSES,
+    LANE_ACTIVE_STATUSES,
+    LIVE_STATUSES,
+    RESET_STATUSES,
+    AgentStatus,
+    compute_agent_status,
+    is_active,
+    is_live,
+)
+from agentception.workflow.invariants import (
+    InvariantContext,
+    WorkflowSnapshot,
+    check_invariants,
+)
+
+_REPO = "cgcardona/agentception"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _issue(
+    number: int = 17,
+    state: str = "open",
+    labels: list[str] | None = None,
+    phase_key: str | None = None,
+    initiative: str | None = None,
+) -> IssueInput:
+    return IssueInput(
+        number=number,
+        state=state,
+        labels=labels or [],
+        phase_key=phase_key,
+        initiative=initiative,
+    )
+
+
+def _run(
+    run_id: str = "issue-17",
+    status: str = "implementing",
+    agent_status: str = "implementing",
+    pr_number: int | None = None,
+) -> RunInput:
+    return RunInput(
+        id=run_id,
+        status=status,
+        agent_status=agent_status,
+        pr_number=pr_number,
+    )
+
+
+def _best_pr(
+    pr_number: int = 42,
+    pr_state: str = "open",
+    pr_base: str | None = "dev",
+    pr_head_ref: str | None = "feat/issue-17-fix",
+    link_method: str = "body_closes",
+    confidence: int = 95,
+) -> BestPR:
+    return BestPR(
+        pr_number=pr_number,
+        pr_state=pr_state,
+        pr_base=pr_base,
+        pr_head_ref=pr_head_ref,
+        link_method=link_method,
+        confidence=confidence,
+    )
+
+
+def _pr_row(
+    number: int = 42,
+    title: str = "Fix the thing",
+    head_ref: str | None = "feat/issue-17-fix",
+    base_ref: str | None = "dev",
+    body: str = "",
+    labels: list[str] | None = None,
+) -> PRRow:
+    return PRRow(
+        number=number,
+        title=title,
+        head_ref=head_ref,
+        base_ref=base_ref,
+        body=body,
+        labels=labels or [],
+    )
+
+
+# ===========================================================================
+# 1) State Machine — Lane Computation
+# ===========================================================================
+
+
+class TestLaneComputation:
+    """Core state machine lane rules."""
+
+    def test_closed_issue_is_done(self) -> None:
+        result = compute_workflow_state(_issue(state="closed"), None, None)
+        assert result["lane"] == LANE_DONE
+
+    def test_open_pr_with_closes_body_is_pr_open(self) -> None:
+        """Acceptance criterion 1: PR with Closes #17 and non-standard branch."""
+        result = compute_workflow_state(
+            _issue(),
+            _run(),
+            _best_pr(pr_head_ref="fix/my-thing", link_method="body_closes"),
+        )
+        assert result["lane"] == LANE_PR_OPEN
+
+    def test_open_pr_with_branch_regex_is_pr_open(self) -> None:
+        """Acceptance criterion 2: no body but feat/issue-17-x branch."""
+        result = compute_workflow_state(
+            _issue(),
+            _run(),
+            _best_pr(link_method="branch_regex"),
+        )
+        assert result["lane"] == LANE_PR_OPEN
+
+    def test_pr_wrong_base_still_pr_open_with_warning(self) -> None:
+        """Acceptance criterion 4: PR targets main, still shows in PR lane."""
+        result = compute_workflow_state(
+            _issue(),
+            _run(),
+            _best_pr(pr_base="main"),
+        )
+        assert result["lane"] == LANE_PR_OPEN
+        assert any("wrong_base" in w for w in result["warnings"])
+
+    def test_merged_pr_is_done(self) -> None:
+        """Acceptance criterion 5: PR merges → lane done."""
+        result = compute_workflow_state(
+            _issue(),
+            _run(status="done", agent_status="done"),
+            _best_pr(pr_state="merged"),
+        )
+        assert result["lane"] == LANE_DONE
+
+    def test_merged_pr_stabilisation_prevents_flicker(self) -> None:
+        """Acceptance criterion 5: issue still open after merge → done + warning."""
+        result = compute_workflow_state(
+            _issue(state="open"),
+            _run(status="done", agent_status="done"),
+            _best_pr(pr_state="merged"),
+            pr_merged_recently=True,
+        )
+        assert result["lane"] == LANE_DONE
+        assert "issue_close_pending_propagation" in result["warnings"]
+        assert result["issue_state"] == "close_pending"
+
+    def test_reviewing_pr_is_reviewing(self) -> None:
+        result = compute_workflow_state(
+            _issue(),
+            _run(agent_status="reviewing"),
+            _best_pr(),
+        )
+        assert result["lane"] == LANE_REVIEWING
+
+    def test_active_run_no_pr_is_active(self) -> None:
+        result = compute_workflow_state(
+            _issue(),
+            _run(agent_status="implementing"),
+            None,
+        )
+        assert result["lane"] == LANE_ACTIVE
+
+    def test_pending_launch_is_active(self) -> None:
+        result = compute_workflow_state(
+            _issue(),
+            _run(agent_status="pending_launch"),
+            None,
+        )
+        assert result["lane"] == LANE_ACTIVE
+
+    def test_stale_run_is_active(self) -> None:
+        result = compute_workflow_state(
+            _issue(),
+            _run(agent_status="stale"),
+            None,
+        )
+        assert result["lane"] == LANE_ACTIVE
+
+    def test_no_run_no_pr_is_todo(self) -> None:
+        result = compute_workflow_state(_issue(), None, None)
+        assert result["lane"] == LANE_TODO
+
+    def test_unknown_run_no_pr_is_todo(self) -> None:
+        result = compute_workflow_state(
+            _issue(),
+            _run(agent_status="unknown"),
+            None,
+        )
+        assert result["lane"] == LANE_TODO
+
+    def test_done_run_no_pr_is_todo(self) -> None:
+        """Run finished but no PR — goes back to todo (work might have failed)."""
+        result = compute_workflow_state(
+            _issue(),
+            _run(agent_status="done"),
+            None,
+        )
+        assert result["lane"] == LANE_TODO
+
+
+class TestRunPRMismatchWarning:
+    """Acceptance criterion 3: Run has pr_number but PR not in links."""
+
+    def test_run_claims_pr_no_link_produces_warning(self) -> None:
+        result = compute_workflow_state(
+            _issue(),
+            _run(pr_number=42),
+            None,
+        )
+        assert any("run_claims_pr_missing_from_links" in w for w in result["warnings"])
+
+    def test_run_claims_pr_with_link_no_warning(self) -> None:
+        result = compute_workflow_state(
+            _issue(),
+            _run(pr_number=42),
+            _best_pr(pr_number=42),
+        )
+        assert not any("run_claims_pr_missing" in w for w in result["warnings"])
+
+
+class TestContentHash:
+    """State hash prevents no-op writes."""
+
+    def test_identical_inputs_produce_same_hash(self) -> None:
+        r1 = compute_workflow_state(_issue(), _run(), _best_pr())
+        r2 = compute_workflow_state(_issue(), _run(), _best_pr())
+        assert r1["content_hash"] == r2["content_hash"]
+
+    def test_different_lane_produces_different_hash(self) -> None:
+        r1 = compute_workflow_state(_issue(), _run(), _best_pr())
+        r2 = compute_workflow_state(_issue(state="closed"), _run(), _best_pr())
+        assert r1["content_hash"] != r2["content_hash"]
+
+
+# ===========================================================================
+# 2) PR↔Issue Linker
+# ===========================================================================
+
+
+class TestLinkDiscovery:
+    """Linker discovers all signal types with correct confidence."""
+
+    def test_body_closes_reference(self) -> None:
+        pr = _pr_row(body="This PR:\n\nCloses #17\n\nDone.")
+        links = discover_links_for_pr(pr, _REPO)
+        body_links = [l for l in links if l["link_method"] == "body_closes"]
+        assert len(body_links) == 1
+        assert body_links[0]["issue_number"] == 17
+        assert body_links[0]["confidence"] == 95
+
+    def test_body_fixes_reference(self) -> None:
+        pr = _pr_row(body="Fixes #42")
+        links = discover_links_for_pr(pr, _REPO)
+        body_links = [l for l in links if l["link_method"] == "body_closes"]
+        assert len(body_links) == 1
+        assert body_links[0]["issue_number"] == 42
+
+    def test_body_resolves_reference(self) -> None:
+        pr = _pr_row(body="resolves #99")
+        links = discover_links_for_pr(pr, _REPO)
+        body_links = [l for l in links if l["link_method"] == "body_closes"]
+        assert body_links[0]["issue_number"] == 99
+
+    def test_body_multiple_closes(self) -> None:
+        pr = _pr_row(body="Closes #17\nFixes #18\nResolves #19")
+        links = discover_links_for_pr(pr, _REPO)
+        body_links = [l for l in links if l["link_method"] == "body_closes"]
+        nums = {l["issue_number"] for l in body_links}
+        assert nums == {17, 18, 19}
+
+    def test_branch_regex(self) -> None:
+        pr = _pr_row(head_ref="feat/issue-17-fix-buttons")
+        links = discover_links_for_pr(pr, _REPO)
+        branch_links = [l for l in links if l["link_method"] == "branch_regex"]
+        assert len(branch_links) == 1
+        assert branch_links[0]["issue_number"] == 17
+        assert branch_links[0]["confidence"] == 90
+
+    def test_explicit_label(self) -> None:
+        pr = _pr_row(labels=["agent:issue-17"])
+        links = discover_links_for_pr(pr, _REPO)
+        explicit_links = [l for l in links if l["link_method"] == "explicit"]
+        assert len(explicit_links) == 1
+        assert explicit_links[0]["issue_number"] == 17
+        assert explicit_links[0]["confidence"] == 100
+
+    def test_run_pr_number(self) -> None:
+        pr = _pr_row(number=42)
+        runs_by_pr = {42: [RunRow(id="issue-17", issue_number=17, pr_number=42)]}
+        links = discover_links_for_pr(pr, _REPO, runs_by_pr)
+        run_links = [l for l in links if l["link_method"] == "run_pr_number"]
+        assert len(run_links) == 1
+        assert run_links[0]["issue_number"] == 17
+        assert run_links[0]["confidence"] == 85
+
+    def test_title_mention(self) -> None:
+        pr = _pr_row(title="Fix #17 button rendering", head_ref="random/no-issue-ref")
+        links = discover_links_for_pr(pr, _REPO)
+        title_links = [l for l in links if l["link_method"] == "title_mention"]
+        assert len(title_links) == 1
+        assert title_links[0]["issue_number"] == 17
+        assert title_links[0]["confidence"] == 60
+
+    def test_no_signals_empty(self) -> None:
+        pr = _pr_row(head_ref="main", body="No references here")
+        links = discover_links_for_pr(pr, _REPO)
+        assert links == []
+
+    def test_sorted_by_confidence_desc(self) -> None:
+        pr = _pr_row(
+            head_ref="feat/issue-17-fix",
+            body="Closes #17",
+            labels=["agent:issue-17"],
+        )
+        links = discover_links_for_pr(pr, _REPO)
+        confidences = [l["confidence"] for l in links]
+        assert confidences == sorted(confidences, reverse=True)
+
+
+class TestBestPRSelection:
+    """Best-PR selection precedence rules."""
+
+    def test_prefers_open_over_merged(self) -> None:
+        links = [
+            CandidateLink(repo=_REPO, pr_number=1, issue_number=17, link_method="body_closes", confidence=95, evidence_json="{}"),
+            CandidateLink(repo=_REPO, pr_number=2, issue_number=17, link_method="body_closes", confidence=95, evidence_json="{}"),
+        ]
+        pr_info = {
+            1: PRInfo(number=1, state="merged", base_ref="dev", head_ref="feat/issue-17-a"),
+            2: PRInfo(number=2, state="open", base_ref="dev", head_ref="feat/issue-17-b"),
+        }
+        best = best_pr_for_issue(17, links, pr_info)
+        assert best is not None
+        assert best["pr_number"] == 2
+        assert best["pr_state"] == "open"
+
+    def test_prefers_higher_confidence(self) -> None:
+        links = [
+            CandidateLink(repo=_REPO, pr_number=1, issue_number=17, link_method="title_mention", confidence=60, evidence_json="{}"),
+            CandidateLink(repo=_REPO, pr_number=2, issue_number=17, link_method="body_closes", confidence=95, evidence_json="{}"),
+        ]
+        pr_info = {
+            1: PRInfo(number=1, state="open", base_ref="dev", head_ref="fix/a"),
+            2: PRInfo(number=2, state="open", base_ref="dev", head_ref="fix/b"),
+        }
+        best = best_pr_for_issue(17, links, pr_info)
+        assert best is not None
+        assert best["pr_number"] == 2
+
+    def test_prefers_higher_pr_number_as_tiebreak(self) -> None:
+        links = [
+            CandidateLink(repo=_REPO, pr_number=1, issue_number=17, link_method="body_closes", confidence=95, evidence_json="{}"),
+            CandidateLink(repo=_REPO, pr_number=5, issue_number=17, link_method="body_closes", confidence=95, evidence_json="{}"),
+        ]
+        pr_info = {
+            1: PRInfo(number=1, state="open", base_ref="dev", head_ref="fix/a"),
+            5: PRInfo(number=5, state="open", base_ref="dev", head_ref="fix/b"),
+        }
+        best = best_pr_for_issue(17, links, pr_info)
+        assert best is not None
+        assert best["pr_number"] == 5
+
+    def test_no_links_returns_none(self) -> None:
+        assert best_pr_for_issue(17, [], {}) is None
+
+    def test_other_issue_links_ignored(self) -> None:
+        links = [
+            CandidateLink(repo=_REPO, pr_number=1, issue_number=99, link_method="body_closes", confidence=95, evidence_json="{}"),
+        ]
+        pr_info = {1: PRInfo(number=1, state="open", base_ref="dev", head_ref="fix/a")}
+        assert best_pr_for_issue(17, links, pr_info) is None
+
+
+# ===========================================================================
+# 3) Status Module
+# ===========================================================================
+
+
+class TestAgentStatusEnum:
+    """Canonical status sets are consistent and complete."""
+
+    def test_active_statuses_excludes_pending_launch(self) -> None:
+        assert "pending_launch" not in ACTIVE_STATUSES
+
+    def test_live_statuses_includes_pending_launch(self) -> None:
+        assert "pending_launch" in LIVE_STATUSES
+
+    def test_lane_active_includes_all_relevant(self) -> None:
+        assert "implementing" in LANE_ACTIVE_STATUSES
+        assert "pending_launch" in LANE_ACTIVE_STATUSES
+        assert "stale" in LANE_ACTIVE_STATUSES
+        assert "reviewing" in LANE_ACTIVE_STATUSES
+
+    def test_reset_statuses(self) -> None:
+        assert RESET_STATUSES == {"pending_launch", "implementing", "reviewing"}
+
+    def test_is_active(self) -> None:
+        assert is_active("implementing")
+        assert not is_active("pending_launch")
+        assert not is_active("done")
+
+    def test_is_live(self) -> None:
+        assert is_live("implementing")
+        assert is_live("pending_launch")
+        assert not is_live("done")
+
+
+class TestComputeAgentStatus:
+    """Staleness logic from the canonical compute_agent_status."""
+
+    def test_fresh_implementing_stays(self) -> None:
+        import datetime
+        now = datetime.datetime.now(datetime.timezone.utc)
+        assert compute_agent_status("implementing", now, now=now) == "implementing"
+
+    def test_stale_implementing_becomes_stale(self) -> None:
+        import datetime
+        now = datetime.datetime.now(datetime.timezone.utc)
+        old = now - datetime.timedelta(hours=1)
+        assert compute_agent_status("implementing", old, now=now) == "stale"
+
+    def test_unknown_status_normalised(self) -> None:
+        assert compute_agent_status("garbage_status", None) == "unknown"
+
+
+# ===========================================================================
+# 4) Invariant Checks
+# ===========================================================================
+
+
+class TestInvariants:
+    """Invariant check functions."""
+
+    def _base_ctx(self) -> InvariantContext:
+        return InvariantContext(
+            repo=_REPO,
+            issue_numbers=[17],
+            pr_numbers_in_db={42},
+            run_pr_numbers={},
+            link_issue_numbers_by_pr={},
+            workflow_states={},
+            pr_states={42: "open"},
+            pr_bases={42: "dev"},
+            closes_refs_by_pr={},
+        )
+
+    def test_clean_context_no_alerts(self) -> None:
+        alerts = check_invariants(self._base_ctx())
+        assert alerts == []
+
+    def test_inv_pr_link_1_missing_link(self) -> None:
+        ctx = self._base_ctx()
+        ctx["closes_refs_by_pr"] = {42: [17]}
+        ctx["link_issue_numbers_by_pr"] = {}
+        alerts = check_invariants(ctx)
+        assert any("INV-PR-LINK-1" in a for a in alerts)
+
+    def test_inv_pr_link_1_present_link_no_alert(self) -> None:
+        ctx = self._base_ctx()
+        ctx["closes_refs_by_pr"] = {42: [17]}
+        ctx["link_issue_numbers_by_pr"] = {42: [17]}
+        alerts = check_invariants(ctx)
+        assert not any("INV-PR-LINK-1" in a for a in alerts)
+
+    def test_inv_run_pr_1_missing_pr(self) -> None:
+        ctx = self._base_ctx()
+        ctx["run_pr_numbers"] = {"issue-17": 999}
+        alerts = check_invariants(ctx)
+        assert any("INV-RUN-PR-1" in a for a in alerts)
+
+    def test_inv_lane_1_pr_open_no_pr(self) -> None:
+        ctx = self._base_ctx()
+        ctx["workflow_states"] = {
+            17: WorkflowSnapshot(
+                lane="pr_open",
+                pr_number=None,
+                pr_state=None,
+                agent_status="implementing",
+                issue_state="open",
+            )
+        }
+        alerts = check_invariants(ctx)
+        assert any("INV-LANE-1" in a for a in alerts)
+
+    def test_inv_base_1_wrong_base(self) -> None:
+        ctx = self._base_ctx()
+        ctx["pr_bases"] = {42: "main"}
+        ctx["pr_states"] = {42: "open"}
+        alerts = check_invariants(ctx)
+        assert any("INV-BASE-1" in a for a in alerts)
+
+
+# ===========================================================================
+# 5) Integration: End-to-end lane derivation
+# ===========================================================================
+
+
+class TestEndToEndLaneDerivation:
+    """Simulate the full pipeline: discover links → best PR → compute lane."""
+
+    def test_closes_body_drives_pr_open(self) -> None:
+        """Acceptance criterion 1: any branch + Closes #17 → pr_open."""
+        pr = _pr_row(number=42, head_ref="fix/my-random-branch", body="Closes #17")
+        links = discover_links_for_pr(pr, _REPO)
+        pr_info = {42: PRInfo(number=42, state="open", base_ref="dev", head_ref="fix/my-random-branch")}
+        best = best_pr_for_issue(17, links, pr_info)
+        result = compute_workflow_state(_issue(number=17), _run(), best)
+        assert result["lane"] == LANE_PR_OPEN
+
+    def test_branch_convention_drives_pr_open(self) -> None:
+        """Acceptance criterion 2: feat/issue-17-x → pr_open."""
+        pr = _pr_row(number=42, head_ref="feat/issue-17-some-slug", body="")
+        links = discover_links_for_pr(pr, _REPO)
+        pr_info = {42: PRInfo(number=42, state="open", base_ref="dev", head_ref="feat/issue-17-some-slug")}
+        best = best_pr_for_issue(17, links, pr_info)
+        result = compute_workflow_state(_issue(number=17), _run(), best)
+        assert result["lane"] == LANE_PR_OPEN
+
+    def test_run_pr_number_drives_pr_open(self) -> None:
+        """Acceptance criterion 3: agent reports pr_number → pr_open."""
+        pr = _pr_row(number=42, head_ref="random/branch", body="No closes ref")
+        runs_by_pr = {42: [RunRow(id="issue-17", issue_number=17, pr_number=42)]}
+        links = discover_links_for_pr(pr, _REPO, runs_by_pr)
+        pr_info = {42: PRInfo(number=42, state="open", base_ref="dev", head_ref="random/branch")}
+        best = best_pr_for_issue(17, links, pr_info)
+        result = compute_workflow_state(_issue(number=17), _run(pr_number=42), best)
+        assert result["lane"] == LANE_PR_OPEN
+
+    def test_wrong_base_still_pr_open(self) -> None:
+        """Acceptance criterion 4: PR against main → pr_open + warning."""
+        pr = _pr_row(number=42, head_ref="feat/issue-17-fix", body="Closes #17", base_ref="main")
+        links = discover_links_for_pr(pr, _REPO)
+        pr_info = {42: PRInfo(number=42, state="open", base_ref="main", head_ref="feat/issue-17-fix")}
+        best = best_pr_for_issue(17, links, pr_info)
+        result = compute_workflow_state(_issue(number=17), _run(), best)
+        assert result["lane"] == LANE_PR_OPEN
+        assert any("wrong_base" in w for w in result["warnings"])
+
+    def test_merge_to_done_stabilised(self) -> None:
+        """Acceptance criterion 5: merge → done even if issue still open."""
+        result = compute_workflow_state(
+            _issue(number=17, state="open"),
+            _run(status="done", agent_status="done"),
+            _best_pr(pr_state="merged"),
+            pr_merged_recently=True,
+        )
+        assert result["lane"] == LANE_DONE
+        assert "issue_close_pending_propagation" in result["warnings"]
+
+    def test_multiple_runs_latest_unknown_older_has_pr(self) -> None:
+        """Acceptance criterion 6: latest run unknown, older run produced PR."""
+        # The state machine gets the best PR (from links), not from the run.
+        # Even if the latest run is unknown, if a PR link exists, lane is pr_open.
+        result = compute_workflow_state(
+            _issue(number=17),
+            _run(agent_status="unknown"),  # latest run is unknown
+            _best_pr(pr_state="open"),     # but PR link exists from older run
+        )
+        assert result["lane"] == LANE_PR_OPEN

--- a/agentception/workflow/__init__.py
+++ b/agentception/workflow/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+"""Workflow state machine package — canonical swim-lane computation.
+
+Submodules
+----------
+status      — unified agent status enum and helpers.
+linking     — multi-signal PR↔Issue linker.
+state_machine — deterministic lane computation from DB signals.
+invariants  — tick-level invariant checks and alerts.
+"""

--- a/agentception/workflow/invariants.py
+++ b/agentception/workflow/invariants.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+"""Tick-level invariant checks and alerts for the workflow state machine.
+
+Run after each tick to detect data inconsistencies and surface warnings
+to maintainers.  Invariant violations are returned as alert strings (not
+exceptions) so the pipeline never crashes due to a check.
+"""
+
+import logging
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+
+class InvariantContext(TypedDict):
+    """Data snapshot passed to the invariant checker."""
+
+    repo: str
+    issue_numbers: list[int]
+    pr_numbers_in_db: set[int]
+    run_pr_numbers: dict[str, int | None]
+    link_issue_numbers_by_pr: dict[int, list[int]]
+    workflow_states: dict[int, WorkflowSnapshot]
+    pr_states: dict[int, str]
+    pr_bases: dict[int, str | None]
+    closes_refs_by_pr: dict[int, list[int]]
+
+
+class WorkflowSnapshot(TypedDict):
+    """Minimal workflow state fields for invariant checking."""
+
+    lane: str
+    pr_number: int | None
+    pr_state: str | None
+    agent_status: str | None
+    issue_state: str
+
+
+def check_invariants(ctx: InvariantContext) -> list[str]:
+    """Run all invariant checks and return a list of alert strings.
+
+    Each alert is a human-readable string prefixed with the invariant ID
+    (e.g. ``INV-PR-LINK-1: ...``).  Returns an empty list when all checks pass.
+    """
+    alerts: list[str] = []
+
+    alerts.extend(_inv_pr_link_1(ctx))
+    alerts.extend(_inv_run_pr_1(ctx))
+    alerts.extend(_inv_lane_1(ctx))
+    alerts.extend(_inv_base_1(ctx))
+
+    if alerts:
+        logger.warning(
+            "⚠️  %d invariant violation(s) detected: %s",
+            len(alerts),
+            "; ".join(alerts[:5]),
+        )
+
+    return alerts
+
+
+def _inv_pr_link_1(ctx: InvariantContext) -> list[str]:
+    """INV-PR-LINK-1: Every PR with ``Closes #N`` must have a link row."""
+    alerts: list[str] = []
+    for pr_num, close_refs in ctx["closes_refs_by_pr"].items():
+        linked = ctx["link_issue_numbers_by_pr"].get(pr_num, [])
+        for issue_num in close_refs:
+            if issue_num not in linked:
+                alerts.append(
+                    f"INV-PR-LINK-1: PR #{pr_num} mentions Closes #{issue_num} "
+                    f"but no link row exists"
+                )
+    return alerts
+
+
+def _inv_run_pr_1(ctx: InvariantContext) -> list[str]:
+    """INV-RUN-PR-1: Runs with pr_number must have a matching PR row or warning."""
+    alerts: list[str] = []
+    for run_id, pr_num in ctx["run_pr_numbers"].items():
+        if pr_num is not None and pr_num not in ctx["pr_numbers_in_db"]:
+            alerts.append(
+                f"INV-RUN-PR-1: Run {run_id} has pr_number={pr_num} "
+                f"but PR is not in ac_pull_requests"
+            )
+    return alerts
+
+
+def _inv_lane_1(ctx: InvariantContext) -> list[str]:
+    """INV-LANE-1: pr_open/reviewing lanes must have an open best-PR."""
+    alerts: list[str] = []
+    for issue_num, ws in ctx["workflow_states"].items():
+        if ws["lane"] in ("pr_open", "reviewing"):
+            if ws["pr_number"] is None:
+                alerts.append(
+                    f"INV-LANE-1: Issue #{issue_num} in lane '{ws['lane']}' "
+                    f"but has no linked PR"
+                )
+            elif ws["pr_state"] not in ("open", "draft"):
+                alerts.append(
+                    f"INV-LANE-1: Issue #{issue_num} in lane '{ws['lane']}' "
+                    f"but PR #{ws['pr_number']} state is '{ws['pr_state']}'"
+                )
+    return alerts
+
+
+def _inv_base_1(ctx: InvariantContext) -> list[str]:
+    """INV-BASE-1: PRs targeting non-dev base branches."""
+    alerts: list[str] = []
+    for pr_num, base in ctx["pr_bases"].items():
+        if base is not None and base != "dev" and ctx["pr_states"].get(pr_num) == "open":
+            alerts.append(
+                f"INV-BASE-1: PR #{pr_num} targets '{base}' instead of 'dev'"
+            )
+    return alerts

--- a/agentception/workflow/linking.py
+++ b/agentception/workflow/linking.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+"""Multi-signal PR↔Issue linker with auditable provenance.
+
+Discovers candidate links between pull requests and issues using five
+signals (in decreasing confidence order):
+
+1. **Explicit metadata** — PR labels like ``agent:issue-123`` (confidence 100).
+2. **Body closes references** — ``Closes/Fixes/Resolves #N`` (confidence 95).
+3. **Branch regex** — ``feat/issue-{N}-*`` (confidence 90).
+4. **Run pr_number** — an agent run claims this PR (confidence 85).
+5. **Title mention** — ``#123`` or ``issue 123`` in PR title (confidence 60).
+
+Each candidate is persisted as a row in ``ac_pr_issue_links`` with method,
+confidence, and evidence.  The ``best_pr_for_issue`` function chooses the
+canonical PR for each issue using deterministic precedence rules.
+"""
+
+import json
+import logging
+import re
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Regexes
+# ---------------------------------------------------------------------------
+
+_CLOSES_RE = re.compile(
+    r"(?i)(?:closes|fixes|resolves)\s+(?:[\w\-]+/[\w\-]+)?#(\d+)"
+)
+"""Matches ``Closes #17``, ``fixes owner/repo#123``, ``Resolves #42``."""
+
+_FEAT_ISSUE_BRANCH_RE = re.compile(r"feat/issue-(\d+)")
+"""Matches ``feat/issue-17-some-slug`` and extracts the issue number."""
+
+_AGENT_ISSUE_LABEL_RE = re.compile(r"agent:issue-(\d+)")
+"""Matches ``agent:issue-123`` label on PRs (explicit metadata signal)."""
+
+_TITLE_ISSUE_RE = re.compile(
+    r"(?:^|\W)#(\d+)(?:\W|$)|\bissue[\s-]?(\d+)\b", re.IGNORECASE
+)
+"""Loose match for ``#123`` or ``issue 123`` / ``issue-123`` in PR title."""
+
+
+# ---------------------------------------------------------------------------
+# Candidate link TypedDict
+# ---------------------------------------------------------------------------
+
+
+class CandidateLink(TypedDict):
+    """One candidate PR↔Issue link produced by the linker."""
+
+    repo: str
+    pr_number: int
+    issue_number: int
+    link_method: str
+    confidence: int
+    evidence_json: str
+
+
+# ---------------------------------------------------------------------------
+# Minimal PR/Run row shapes expected by the linker
+# ---------------------------------------------------------------------------
+
+
+class PRRow(TypedDict):
+    """Minimal PR fields needed for link discovery."""
+
+    number: int
+    title: str
+    head_ref: str | None
+    base_ref: str | None
+    body: str
+    labels: list[str]
+
+
+class RunRow(TypedDict):
+    """Minimal run fields needed for the run_pr_number signal."""
+
+    id: str
+    issue_number: int | None
+    pr_number: int | None
+
+
+# ---------------------------------------------------------------------------
+# Core link discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_links_for_pr(
+    pr: PRRow,
+    repo: str,
+    runs_by_pr: dict[int, list[RunRow]] | None = None,
+) -> list[CandidateLink]:
+    """Produce all candidate issue links for a single PR.
+
+    Parameters
+    ----------
+    pr:
+        PR row with at least number, title, head_ref, body, labels.
+    repo:
+        Repository slug (e.g. ``owner/repo``).
+    runs_by_pr:
+        Optional lookup: ``{pr_number: [RunRow, ...]}`` for the run_pr_number signal.
+
+    Returns
+    -------
+    list[CandidateLink]
+        Candidate links sorted by confidence descending.
+    """
+    candidates: list[CandidateLink] = []
+    pr_num = pr["number"]
+
+    # Signal 1: explicit metadata labels (agent:issue-123)
+    for label in pr["labels"]:
+        m = _AGENT_ISSUE_LABEL_RE.match(label)
+        if m:
+            candidates.append(CandidateLink(
+                repo=repo,
+                pr_number=pr_num,
+                issue_number=int(m.group(1)),
+                link_method="explicit",
+                confidence=100,
+                evidence_json=json.dumps({"label": label}),
+            ))
+
+    # Signal 2: body closes references
+    body = pr["body"] or ""
+    for m in _CLOSES_RE.finditer(body):
+        issue_num = int(m.group(1))
+        candidates.append(CandidateLink(
+            repo=repo,
+            pr_number=pr_num,
+            issue_number=issue_num,
+            link_method="body_closes",
+            confidence=95,
+            evidence_json=json.dumps({"matched_text": m.group(0).strip()}),
+        ))
+
+    # Signal 3: branch regex
+    head_ref = pr["head_ref"] or ""
+    branch_match = _FEAT_ISSUE_BRANCH_RE.match(head_ref)
+    if branch_match:
+        issue_num = int(branch_match.group(1))
+        candidates.append(CandidateLink(
+            repo=repo,
+            pr_number=pr_num,
+            issue_number=issue_num,
+            link_method="branch_regex",
+            confidence=90,
+            evidence_json=json.dumps({"head_ref": head_ref}),
+        ))
+
+    # Signal 4: run pr_number
+    if runs_by_pr:
+        for run in runs_by_pr.get(pr_num, []):
+            if run["issue_number"] is not None:
+                candidates.append(CandidateLink(
+                    repo=repo,
+                    pr_number=pr_num,
+                    issue_number=run["issue_number"],
+                    link_method="run_pr_number",
+                    confidence=85,
+                    evidence_json=json.dumps({"run_id": run["id"]}),
+                ))
+
+    # Signal 5: title mention
+    title = pr["title"] or ""
+    for m in _TITLE_ISSUE_RE.finditer(title):
+        issue_num = int(m.group(1) or m.group(2))
+        already_found = any(c["issue_number"] == issue_num for c in candidates)
+        if not already_found:
+            candidates.append(CandidateLink(
+                repo=repo,
+                pr_number=pr_num,
+                issue_number=issue_num,
+                link_method="title_mention",
+                confidence=60,
+                evidence_json=json.dumps({"matched_text": m.group(0).strip()}),
+            ))
+
+    candidates.sort(key=lambda c: c["confidence"], reverse=True)
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Best-PR selection for an issue
+# ---------------------------------------------------------------------------
+
+_PR_STATE_PRIORITY: dict[str, int] = {
+    "open": 0,
+    "merged": 1,
+    "closed": 2,
+    "draft": 0,
+    "unknown": 3,
+}
+
+
+class BestPR(TypedDict):
+    """The canonical PR associated with an issue after link resolution."""
+
+    pr_number: int
+    pr_state: str
+    pr_base: str | None
+    pr_head_ref: str | None
+    link_method: str
+    confidence: int
+
+
+class PRInfo(TypedDict):
+    """Minimal PR metadata for best-PR selection."""
+
+    number: int
+    state: str
+    base_ref: str | None
+    head_ref: str | None
+
+
+def best_pr_for_issue(
+    issue_number: int,
+    links: list[CandidateLink],
+    pr_info: dict[int, PRInfo],
+) -> BestPR | None:
+    """Choose the best PR for a given issue from candidate links.
+
+    Precedence (highest wins):
+    1. PR state: open > merged > closed
+    2. Higher confidence link method
+    3. Most recently created (highest PR number as proxy)
+    """
+    issue_links = [l for l in links if l["issue_number"] == issue_number]
+    if not issue_links:
+        return None
+
+    def sort_key(link: CandidateLink) -> tuple[int, int, int]:
+        pr_num = link["pr_number"]
+        info = pr_info.get(pr_num)
+        state_priority = _PR_STATE_PRIORITY.get(
+            info["state"] if info else "unknown", 99
+        )
+        return (state_priority, -link["confidence"], -pr_num)
+
+    issue_links.sort(key=sort_key)
+    best = issue_links[0]
+    info = pr_info.get(best["pr_number"])
+
+    return BestPR(
+        pr_number=best["pr_number"],
+        pr_state=info["state"] if info else "unknown",
+        pr_base=info["base_ref"] if info else None,
+        pr_head_ref=info["head_ref"] if info else None,
+        link_method=best["link_method"],
+        confidence=best["confidence"],
+    )

--- a/agentception/workflow/state_machine.py
+++ b/agentception/workflow/state_machine.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+"""Canonical workflow state machine — deterministic swim-lane computation.
+
+This module is the **single place** that decides which swim lane an issue
+card belongs in.  No other code (Jinja2, JS, queries, build_ui) may
+recompute lanes.  The UI reads persisted ``ACIssueWorkflowState.lane``.
+
+State machine inputs (all from DB):
+- Issue row (state, labels, phase)
+- Best-linked PR (from ``workflow.linking``)
+- Latest agent run
+- Merge/close history
+
+Output:
+- A ``WorkflowState`` dataclass persisted to ``ac_issue_workflow_state``.
+
+Lane rules (explicit state machine — no "if ladder"):
+
+    DONE       — issue closed  OR  (PR merged AND closure stable)
+    REVIEWING  — PR open AND agent_status == reviewing
+    PR_OPEN    — PR open (any link method, any base branch)
+    ACTIVE     — agent run in an active status, no open PR
+    TODO       — none of the above
+"""
+
+import hashlib
+import json
+import logging
+from typing import TypedDict
+
+from agentception.workflow.linking import BestPR
+from agentception.workflow.status import LANE_ACTIVE_STATUSES
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Input shapes
+# ---------------------------------------------------------------------------
+
+
+class IssueInput(TypedDict):
+    """Minimal issue fields consumed by the state machine."""
+
+    number: int
+    state: str
+    labels: list[str]
+    phase_key: str | None
+    initiative: str | None
+
+
+class RunInput(TypedDict):
+    """Minimal agent-run fields consumed by the state machine."""
+
+    id: str
+    status: str
+    agent_status: str
+    pr_number: int | None
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+class WorkflowState(TypedDict):
+    """Canonical computed workflow state for one issue."""
+
+    lane: str
+    issue_state: str
+    run_id: str | None
+    agent_status: str | None
+    pr_number: int | None
+    pr_state: str | None
+    pr_base: str | None
+    pr_head_ref: str | None
+    pr_link_method: str | None
+    pr_link_confidence: int | None
+    warnings: list[str]
+    content_hash: str
+
+
+# ---------------------------------------------------------------------------
+# Lane values
+# ---------------------------------------------------------------------------
+
+LANE_TODO = "todo"
+LANE_ACTIVE = "active"
+LANE_PR_OPEN = "pr_open"
+LANE_REVIEWING = "reviewing"
+LANE_DONE = "done"
+
+VALID_LANES: frozenset[str] = frozenset({
+    LANE_TODO, LANE_ACTIVE, LANE_PR_OPEN, LANE_REVIEWING, LANE_DONE,
+})
+
+
+# ---------------------------------------------------------------------------
+# Core computation
+# ---------------------------------------------------------------------------
+
+
+def compute_workflow_state(
+    issue: IssueInput,
+    run: RunInput | None,
+    best_pr: BestPR | None,
+    *,
+    pr_merged_recently: bool = False,
+) -> WorkflowState:
+    """Compute the canonical workflow state for a single issue.
+
+    Parameters
+    ----------
+    issue:
+        Issue data from ``ac_issues``.
+    run:
+        Most recent agent run for this issue (from ``ac_agent_runs``), or ``None``.
+    best_pr:
+        Best-linked PR (from ``workflow.linking.best_pr_for_issue``), or ``None``.
+    pr_merged_recently:
+        If ``True`` and the issue is still open, stabilise the lane as ``done``
+        to prevent flicker during GitHub's auto-close propagation window.
+
+    Returns
+    -------
+    WorkflowState
+        Deterministic state with lane, PR info, warnings, and content hash.
+    """
+    warnings: list[str] = []
+
+    # --- Gather PR fields ---
+    pr_number = best_pr["pr_number"] if best_pr else None
+    pr_state = best_pr["pr_state"] if best_pr else None
+    pr_base = best_pr["pr_base"] if best_pr else None
+    pr_head_ref = best_pr["pr_head_ref"] if best_pr else None
+    pr_link_method = best_pr["link_method"] if best_pr else None
+    pr_link_confidence = best_pr["confidence"] if best_pr else None
+
+    # --- Gather run fields ---
+    run_id = run["id"] if run else None
+    agent_status = run["agent_status"] if run else None
+
+    # --- Check for run→PR mismatch ---
+    if run and run["pr_number"] is not None and best_pr is None:
+        warnings.append(
+            f"run_claims_pr_missing_from_links: run {run['id']} "
+            f"has pr_number={run['pr_number']} but no PR link found"
+        )
+
+    # --- Base branch mismatch warning ---
+    if pr_base is not None and pr_base != "dev":
+        warnings.append(
+            f"wrong_base: PR #{pr_number} targets '{pr_base}' instead of 'dev'"
+        )
+
+    # --- Compute lane ---
+    lane = _compute_lane(
+        issue_state=issue["state"],
+        agent_status=agent_status,
+        pr_state=pr_state,
+        pr_merged_recently=pr_merged_recently,
+    )
+
+    # --- Issue state for persistence ---
+    issue_state = issue["state"]
+    if pr_merged_recently and issue_state == "open":
+        issue_state = "close_pending"
+        if lane != LANE_DONE:
+            lane = LANE_DONE
+        warnings.append("issue_close_pending_propagation")
+
+    # --- Content hash for update guard ---
+    content_hash = _state_hash(
+        lane, issue_state, run_id, agent_status,
+        pr_number, pr_state, pr_base, pr_head_ref,
+        pr_link_method, pr_link_confidence, warnings,
+    )
+
+    return WorkflowState(
+        lane=lane,
+        issue_state=issue_state,
+        run_id=run_id,
+        agent_status=agent_status,
+        pr_number=pr_number,
+        pr_state=pr_state,
+        pr_base=pr_base,
+        pr_head_ref=pr_head_ref,
+        pr_link_method=pr_link_method,
+        pr_link_confidence=pr_link_confidence,
+        warnings=warnings,
+        content_hash=content_hash,
+    )
+
+
+def _compute_lane(
+    *,
+    issue_state: str,
+    agent_status: str | None,
+    pr_state: str | None,
+    pr_merged_recently: bool,
+) -> str:
+    """Pure lane computation from normalised signals.
+
+    Priority (highest wins):
+    1. DONE      — issue closed or PR merged (with stabilisation)
+    2. REVIEWING — open PR and agent reviewing
+    3. PR_OPEN   — open PR
+    4. ACTIVE    — active agent, no open PR
+    5. TODO      — fallback
+    """
+    if issue_state == "closed":
+        return LANE_DONE
+
+    if pr_state == "merged":
+        return LANE_DONE
+
+    if pr_merged_recently:
+        return LANE_DONE
+
+    if pr_state in ("open", "draft"):
+        if agent_status == "reviewing":
+            return LANE_REVIEWING
+        return LANE_PR_OPEN
+
+    if agent_status is not None and agent_status in LANE_ACTIVE_STATUSES:
+        return LANE_ACTIVE
+
+    return LANE_TODO
+
+
+def _state_hash(
+    lane: str,
+    issue_state: str,
+    run_id: str | None,
+    agent_status: str | None,
+    pr_number: int | None,
+    pr_state: str | None,
+    pr_base: str | None,
+    pr_head_ref: str | None,
+    pr_link_method: str | None,
+    pr_link_confidence: int | None,
+    warnings: list[str],
+) -> str:
+    """Produce a deterministic hash of all state fields for the update guard."""
+    blob = json.dumps(
+        [
+            lane, issue_state, run_id, agent_status,
+            pr_number, pr_state, pr_base, pr_head_ref,
+            pr_link_method, pr_link_confidence, sorted(warnings),
+        ],
+        sort_keys=True,
+    )
+    return hashlib.sha256(blob.encode()).hexdigest()

--- a/agentception/workflow/status.py
+++ b/agentception/workflow/status.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+"""Canonical agent status definitions — single source of truth.
+
+Every module that needs to reason about agent lifecycle status imports from
+here.  No other file may define its own ``_ACTIVE_STATUSES`` or equivalent.
+"""
+
+import datetime
+import enum
+
+STALE_THRESHOLD = datetime.timedelta(seconds=1800)
+"""Runs with no activity for 30 minutes are considered stale."""
+
+
+class AgentStatus(str, enum.Enum):
+    """Canonical lifecycle states for an agent run.
+
+    Values are lowercase strings matching the DB ``agent_runs.status`` column.
+    """
+
+    PENDING_LAUNCH = "pending_launch"
+    IMPLEMENTING = "implementing"
+    REVIEWING = "reviewing"
+    DONE = "done"
+    STALE = "stale"
+    UNKNOWN = "unknown"
+
+
+ACTIVE_STATUSES: frozenset[str] = frozenset({
+    AgentStatus.IMPLEMENTING.value,
+    AgentStatus.REVIEWING.value,
+    AgentStatus.STALE.value,
+})
+"""Statuses indicating a run has (or recently had) a live worktree.
+
+Used by the orphan sweep in ``persist.py``.  ``pending_launch`` is excluded
+because pending runs exist only in the DB queue — including them would
+immediately orphan them before the Dispatcher claims them.
+"""
+
+LIVE_STATUSES: frozenset[str] = frozenset({
+    AgentStatus.IMPLEMENTING.value,
+    AgentStatus.PENDING_LAUNCH.value,
+    AgentStatus.REVIEWING.value,
+})
+"""Statuses considered "live" for UI hierarchy and staleness checks."""
+
+RESET_STATUSES: frozenset[str] = frozenset({
+    AgentStatus.PENDING_LAUNCH.value,
+    AgentStatus.IMPLEMENTING.value,
+    AgentStatus.REVIEWING.value,
+})
+"""Statuses reset to ``unknown`` during a full build reset."""
+
+LANE_ACTIVE_STATUSES: frozenset[str] = frozenset({
+    AgentStatus.IMPLEMENTING.value,
+    AgentStatus.PENDING_LAUNCH.value,
+    AgentStatus.STALE.value,
+    AgentStatus.REVIEWING.value,
+})
+"""Statuses that place an issue card in the ``active`` swim lane (when no PR exists)."""
+
+
+def is_active(status: str) -> bool:
+    """Return ``True`` if *status* represents a run with a live worktree."""
+    return status in ACTIVE_STATUSES
+
+
+def is_live(status: str) -> bool:
+    """Return ``True`` if *status* should appear as live in the UI."""
+    return status in LIVE_STATUSES
+
+
+def compute_agent_status(
+    raw_status: str,
+    last_activity_at: datetime.datetime | None,
+    *,
+    now: datetime.datetime | None = None,
+) -> str:
+    """Normalise a raw status string and apply staleness logic.
+
+    Returns a status string suitable for display and lane computation.
+    """
+    if now is None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+    if raw_status in LIVE_STATUSES and last_activity_at is not None:
+        if (now - last_activity_at) > STALE_THRESHOLD:
+            return AgentStatus.STALE.value
+
+    if raw_status in {s.value for s in AgentStatus}:
+        return raw_status
+
+    return AgentStatus.UNKNOWN.value


### PR DESCRIPTION
## Summary

- Replace brittle ad-hoc swim-lane inference with a canonical workflow state machine that persists one authoritative lane per issue in `ac_issue_workflow_state`
- Add multi-signal PR↔Issue linker (5 signals: explicit metadata, body closes, branch regex, run pr_number, title mention) with confidence scores and auditable provenance in `ac_pr_issue_links`
- Remove tombstone poisoning — PRs absent from a filtered query are no longer incorrectly marked closed
- Fix `get_open_prs()` to fetch `body`, `baseRefName`, `isDraft` so PR linkage actually works
- Isolate workflow recomputation into a separate DB transaction so failures never roll back critical PR/issue upserts

## What changed

| File | Change |
|------|--------|
| `agentception/db/models.py` | New `ACPRIssueLink`, `ACIssueWorkflowState` tables + new columns on `ACPullRequest` |
| `agentception/alembic/versions/0002_workflow_state_machine.py` | Migration for all schema changes |
| `agentception/workflow/status.py` | Canonical `AgentStatus` enum — single source of truth for all status sets |
| `agentception/workflow/linking.py` | 5-signal PR↔Issue linker with confidence and evidence |
| `agentception/workflow/state_machine.py` | Deterministic lane computation |
| `agentception/workflow/invariants.py` | Tick-level invariant checks (INV-PR-LINK-1, INV-RUN-PR-1, INV-LANE-1, INV-BASE-1) |
| `agentception/readers/github.py` | `get_open_prs()` now fetches body/baseRefName/isDraft; new `get_open_prs_any_base()` |
| `agentception/db/persist.py` | Tombstone removed; body always re-parsed; workflow recomputation in isolated txn |
| `agentception/db/queries.py` | New `get_workflow_states_by_issue()` reads canonical state |
| `agentception/routes/ui/build_ui.py` | Board reads persisted lane with fallback to ad-hoc during migration |

## Test plan

- [x] 53 contract tests in `test_workflow_state_machine.py` covering all 7 acceptance criteria
- [x] mypy clean (158 files, zero errors)
- [x] typing audit: zero `Any` patterns
- [x] Verified in production: issue #49 correctly moved to PR_OPEN after migration ran