### PR TITLE
chore: replace gh CLI with MCP in all agent-facing prompts

### DIFF
--- a/.agentception/agent-command-policy.md
+++ b/.agentception/agent-command-policy.md
@@ -279,17 +279,18 @@ git branch -D <feature-branch>            ← delete LOCAL branch ref after PR s
 ```
 gh auth status
 gh repo view
-gh pr view <N> [--json <fields>]
-gh pr list [--state <state>] [--json <fields>]
-gh pr diff <N>
-gh issue view <N>
-gh issue list [--search "..."] [--state ...] [--label ...]
-gh label list [--limit N]         ← enumerate valid repo labels before gh issue edit
+# ⚠️  PREFER MCP for these — use gh only when MCP is unavailable in this context:
+# pull_request_read(pullNumber=N)           replaces: gh pr view <N>
+# list_pull_requests(state=...)             replaces: gh pr list
+gh pr diff <N>                              ← keep as gh — no MCP equivalent (diff content)
+# issue_read(issue_number=N)               replaces: gh issue view <N>
+# list_issues(label=..., state=...)        replaces: gh issue list
+gh label list [--limit N]                  ← keep as gh — no MCP equivalent
 gh run list
 gh run view <id>
 gh release list
 gh release view [<tag>]
-gh api <GET-endpoint>              ← read-only API calls only
+gh api <GET-endpoint>                       ← read-only API calls only
 ```
 
 ### GitHub CLI — Label Management (Label Pre-flight scripts)
@@ -301,28 +302,18 @@ gh label edit <name> --color <hex> --description "..."    ← updates existing l
 #    Without it, gh issue edit --add-label fails silently and issues are mislabeled.
 ```
 
-### GitHub CLI — Safe Writes
+### GitHub CLI — Allowed Writes (prefer MCP equivalents instead)
 ```
-gh pr checkout <N>                 ← checkout into own worktree
-gh pr create --title "..." --body "..."
-gh pr edit <N> [--base <branch>] [--title "..."] [--body "..."] [--add-label "..."]
-                                   ← safe write; needed to retarget base branch or update PR metadata
-                                   ← must be on allowlist: runs a GraphQL mutation (POST api.github.com/graphql)
-                                   ← which the sandbox blocks for non-allowlisted commands
-gh pr comment <N> --body "..."
-
-# ⚠️  PREFER MCP OVER GH CLI for these operations:
-#   merge_pull_request(owner, repo, pullNumber, merge_method="squash")  ← replaces gh pr merge
-#   issue_write(owner, repo, title, body)                               ← replaces gh issue create
-#   issue_write(owner, repo, issue_number, state="closed")              ← replaces gh issue close
-#   add_issue_comment(owner, repo, issue_number, body)                  ← replaces gh issue comment
-#   github_add_label(issue_number, label)                               ← replaces gh issue edit --add-label
-#   github_remove_label(issue_number, label)                            ← replaces gh issue edit --remove-label
-# Only use gh CLI for operations with no MCP equivalent (gh pr checkout, gh pr diff).
-# ⚠️  LABEL RULE: a single missing label causes gh issue create to fail entirely.
-#    Always create the issue first, then apply labels with gh issue edit || true.
-#    Valid labels: bug enhancement documentation performance ai-pipeline agentception mypy
-#                 cli testing multimodal help-wanted good-first-issue weekend-mvp
+gh pr checkout <N>                 ← ONLY allowed write with no MCP equivalent; use for branch checkout
+# All other writes — use MCP tools instead:
+# create_pull_request(base, head, title, body)     replaces: gh pr create
+# update_pull_request(pullNumber, ...)             replaces: gh pr edit
+# add_issue_comment(issue_number, body)            replaces: gh pr comment / gh issue comment
+# merge_pull_request(pullNumber, merge_method="squash")  replaces: gh pr merge
+# issue_write(title, body)                         replaces: gh issue create
+# issue_write(issue_number, state="closed")        replaces: gh issue close
+# github_add_label(issue_number, label)            replaces: gh issue edit --add-label
+# github_remove_label(issue_number, label)         replaces: gh issue edit --remove-label
 ```
 
 ### Docker — Inspection
@@ -591,14 +582,14 @@ gh pr close <N>   ← FORBIDDEN unless gh pr comment with the exact reason runs 
 6. **When in doubt, stop and ask.** Explain exactly what you need and why.
    A paused agent is infinitely better than a destructive one.
 
-7. **Never use `while read` in pipelines for issue/PR data.** Use `xargs` instead — it is on
-   the allowlist and avoids the sandbox prompt that `read` (a shell builtin) triggers.
+7. **Never use `while read` or `xargs gh issue close` in pipelines for issue/PR data.** Use MCP
+   instead — `issue_write` and `add_issue_comment` are direct tool calls with no subprocess overhead
+   and no sandbox prompt risk.
    ```bash
-   # ✅ Correct — uses xargs (allowlisted, no prompt):
-   gh pr view <N> --json body --jq '.body' \
-     | grep -oE '[Cc]loses?\s+#[0-9]+' \
-     | grep -oE '[0-9]+' \
-     | xargs -I{} gh issue close {} --comment "Fixed by PR #<N>." --repo "$GH_REPO"
+   # ✅ Correct — use MCP to close linked issues (no shell subprocesses needed):
+   # For each issue number in the "Closes #N" list from the PR body:
+   # MCP: issue_write(issue_number=N, state="closed")
+   #      add_issue_comment(issue_number=N, body="✅ Closed by PR #<N> (merged).")
 
    # ❌ Wrong — while read triggers a sandbox prompt:
    | while read ISSUE_NUM; do gh issue close "$ISSUE_NUM" ...; done

--- a/.agentception/parallel-bugs-to-issues.md
+++ b/.agentception/parallel-bugs-to-issues.md
@@ -15,7 +15,7 @@
 >
 > **You do NOT:**
 > - Create any GitHub issues yourself.
-> - Run `gh issue create` yourself.
+> - Create GitHub issues via the shell — use MCP `issue_write()` instead.
 > - Apply labels yourself.
 > - Skip the Phase Planner — it is mandatory even if issues seem obvious.
 >
@@ -404,7 +404,7 @@ export GH_REPO=${GH_REPO:-cgcardona/agentception}
 | GitHub repo slug | read from `.agent-task` GH_REPO field — always `cgcardona/agentception` |
 | GitHub CLI | `gh` — already authenticated |
 
-**No Docker needed.** Issues are created via `gh issue create` — no code
+**No Docker needed.** Issues are created via MCP `issue_write()` — no code
 changes, no mypy, no tests.
 
 ---
@@ -463,9 +463,8 @@ STEP 2 — RESOLVE UPSTREAM ISSUE NUMBERS:
   IFS=',' read -ra UPSTREAM <<< "$PHASE_DEPENDS_ON_ISSUES"
   for issue_title in "${UPSTREAM[@]}"; do
     [ -z "$issue_title" ] && continue
-    NUM=$(gh issue list --repo "$GH_REPO" \
-      --search "\"$issue_title\" in:title" --state open \
-      --json number --jq '.[0].number // empty' 2>/dev/null)
+    # MCP: search_issues(owner="cgcardona", repo="agentception", query="\"$issue_title\" in:title", state="open")
+    # Use the first result's number as NUM.
     [ -n "$NUM" ] && UPSTREAM_MAP+=("$issue_title → #$NUM")
     echo "  Upstream: $issue_title → #${NUM:-NOT FOUND}"
   done
@@ -493,24 +492,18 @@ STEP 3 — CREATE ISSUES:
        `<PHASE_LABEL>` — <phase description from task file>
 
   Idempotency check first:
-    gh issue list --repo "$GH_REPO" --search "<title>" --state all \
-      --json number,title,url | head -3
+    # MCP: search_issues(owner="cgcardona", repo="agentception", query="<title> in:title")
+    # If any result matches the exact title → skip, record URL.
     If matching issue exists → skip, record URL.
 
   Create WITHOUT --label (two-step pattern):
-    ISSUE_URL=$(gh issue create \
-      --repo "$GH_REPO" \
-      --title "<TITLE>" \
-      --body "$(cat <<'EOF'
-<full constructed body with Dependencies + Phase sections>
-EOF
-)")
+    # MCP: issue_write(owner="cgcardona", repo="agentception", title="<TITLE>", body="<full constructed body with Dependencies + Phase sections>")
+    # Returns: issue number and URL — record as ISSUE_URL.
 
   Apply labels individually (|| true = non-fatal):
     IFS=',' read -ra ISSUE_LABELS <<< "<LABELS field>"
-    for label in "${ISSUE_LABELS[@]}"; do
-      gh issue edit "$ISSUE_URL" --repo "$GH_REPO" --add-label "$label" 2>/dev/null || true
-    done
+    # For each label in ISSUE_LABELS:
+    # MCP: github_add_label(issue_number=<N>, label=label)
 
   Fingerprint the created issue immediately — every issue must show which agent created it:
     ISSUE_CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -544,7 +537,7 @@ EOF
     #   body="🏷️ **Created by agent**\n\n$ISSUE_FINGERPRINT")
 
   Record the created URL.
-  ⚠️  If gh issue create fails twice for the same issue, skip and report — no loops.
+  ⚠️  If MCP issue_write() fails twice for the same issue, skip and report — no loops.
 
   ── LABEL REFERENCE ──────────────────────────────────────────────────────────
   │ Standard: bug  enhancement  documentation  testing  mypy                    │
@@ -561,12 +554,13 @@ STEP 4 — CROSS-LINK DOWNSTREAM ISSUES:
   For each created issue that had DEPENDS_ON_PHASES set:
     # Find the upstream issue numbers (already resolved in STEP 2)
     # Append to the body:
-    CURRENT_BODY=$(gh issue view "$ISSUE_NUM" --repo "$GH_REPO" --json body --jq '.body')
+    # MCP: issue_read(owner="cgcardona", repo="agentception", issue_number=ISSUE_NUM)
+    # CURRENT_BODY = result.body
     UPDATED_BODY="$CURRENT_BODY
 
 ---
 **Depends on:** $(join the real "#N — title" strings for upstream issues)"
-    gh issue edit "$ISSUE_NUM" --repo "$GH_REPO" --body "$UPDATED_BODY" 2>/dev/null || true
+    # MCP: issue_write(owner="cgcardona", repo="agentception", issue_number=ISSUE_NUM, body=UPDATED_BODY)
     echo "✅ Cross-linked #$ISSUE_NUM"
 
 STEP 5 — SELF-DESTRUCT:
@@ -587,13 +581,12 @@ and the resolved upstream #N cross-links written. An empty URL list is a failure
 
 ```bash
 # 1. Verify every issue has correct labels
-gh issue list --repo cgcardona/agentception --label "ac-ui/0-foundation" \
-  --json number,title,labels --jq '.[] | "#\(.number) \(.title)"'
+# MCP: list_issues(owner="cgcardona", repo="agentception", labels="ac-ui/0-foundation", state="open")
+# Check each result's labels list for the expected labels.
 
 # 2. Verify dependency text in issue bodies
-gh issue list --repo cgcardona/agentception --state open \
-  --json number,title,body \
-  --jq '.[] | select(.body | contains("Depends on")) | "#\(.number) \(.title)"'
+# MCP: list_issues(owner="cgcardona", repo="agentception", state="open")
+# Filter results: select issues where body contains "Depends on".
 
 # 3. Clean up worktrees
 git worktree prune
@@ -601,8 +594,7 @@ git worktree list  # should show only main repo
 
 # 4. Issues are immediately available for parallel-issue-to-pr.md
 # Dispatch by phase label (foundational phases first):
-gh issue list --repo cgcardona/agentception --label "ac-ui/0-foundation" \
-  --state open --json number,title,url
+# MCP: list_issues(owner="cgcardona", repo="agentception", labels="ac-ui/0-foundation", state="open")
 ```
 
 ---

--- a/.agentception/parallel-conductor.md
+++ b/.agentception/parallel-conductor.md
@@ -153,29 +153,23 @@ STEP 0 — READ YOUR TASK FILE:
     Something is systematically wrong (label misconfiguration, GitHub API failure,
     all remaining issues blocked on human-gated dependencies, etc.).
     Create a GitHub issue:
-      gh issue create --repo "$GH_REPO" \
-        --title "⚠️ Conductor stuck: ATTEMPT_N=$ATTEMPT_N — needs human intervention" \
-        --body "The pipeline conductor has run $(( ATTEMPT_N )) times without advancing.
-  Possible causes:
-  - All remaining batches have unresolved DEPENDS_ON dependencies
-  - All remaining PRs are in D/F grade rejection state
-  - Label misconfiguration (phase/batch labels missing or wrong)
-  - GitHub API failures
-  
-  Run: gh issue list --repo $GH_REPO --label 'conductor-reminder' --state open
-  "
+      # MCP: issue_write(owner="cgcardona", repo="agentception",
+      #   title="⚠️ Conductor stuck: ATTEMPT_N=$ATTEMPT_N — needs human intervention",
+      #   body="The pipeline conductor has run $ATTEMPT_N times without advancing.\n\nPossible causes:\n- All remaining batches have unresolved DEPENDS_ON dependencies\n- All remaining PRs are in D/F grade rejection state\n- Label misconfiguration (phase/batch labels missing or wrong)\n- GitHub API failures\n\nUse MCP: list_issues(owner='cgcardona', repo='agentception', labels=['conductor-reminder'], state='open')")
+      # Returns: created issue URL/number
     Then self-destruct and escalate to the user.
 
 STEP 1 — STALE STATE CLEANUP (always run first):
   # 1a. Close stale conductor-reminder issues (they're outdated by this new run)
-  STALE_REMINDERS=$(gh issue list --repo "$GH_REPO" \
-    --label "conductor-reminder" --state open --json number --jq '.[].number' 2>/dev/null)
-  if [ -n "$STALE_REMINDERS" ]; then
-    echo "$STALE_REMINDERS" | tr ',' '\n' | xargs -I{} gh issue close {} \
-      --comment "Superseded by new conductor run. New reminder will be created if pipeline is still incomplete." \
-      --repo "$GH_REPO" 2>/dev/null || true
-    echo "✅ Closed stale reminder issues: $STALE_REMINDERS"
-  fi
+  # MCP: list_issues(owner="cgcardona", repo="agentception",
+  #   labels=["conductor-reminder"], state="open")
+  # Returns: STALE_REMINDERS — list of open conductor-reminder issues with their numbers
+  # For each issue N in STALE_REMINDERS:
+  #   MCP: issue_write(owner="cgcardona", repo="agentception",
+  #     issue_number=N, state="closed")
+  #   MCP: add_issue_comment(owner="cgcardona", repo="agentception",
+  #     issue_number=N, body="Superseded by new conductor run. New reminder will be created if pipeline is still incomplete.")
+  echo "✅ Closed stale reminder issues"
 
   # 1b. Clean up orphaned worktrees from crashed previous runs
   REPO=$(git worktree list | head -1 | awk '{print $1}')
@@ -199,30 +193,27 @@ STEP 2 — QUERY GITHUB PIPELINE STATE:
 
   echo "=== OPEN ISSUES BY PHASE/BATCH ==="
   if [ -n "$PHASE_FILTER" ]; then
-    gh issue list --repo "$GH_REPO" --label "$PHASE_FILTER" --state open \
-      --json number,title,labels --limit 100
+    # MCP: list_issues(owner="cgcardona", repo="agentception",
+    #   labels=[PHASE_FILTER], state="open")
+    # Returns: list of open issues with number, title, labels (up to 100)
   else
     # Query all phase labels in priority order
     for phase in "phase-1/db-schema" "phase-2/core-api" "phase-3/api-extensions" \
                  "phase-4/new-ui-pages" "phase-5/ui-enhancements" \
                  "phase-6/seed-data" "phase-7/machine-access"; do
-      COUNT=$(gh issue list --repo "$GH_REPO" --label "$phase" --state open \
-        --json number --jq 'length' 2>/dev/null || echo 0)
-      if [ "$COUNT" -gt 0 ]; then
-        echo ""
-        echo "── $phase ($COUNT open issues) ──"
-        gh issue list --repo "$GH_REPO" --label "$phase" --state open \
-          --json number,title,labels --jq \
-          '.[] | "\(.number) | \(.title) | \(.labels | map(.name) | join(","))"'
-      fi
+      # MCP: list_issues(owner="cgcardona", repo="agentception",
+      #   labels=[phase], state="open")
+      # Returns: list — set COUNT to length; for each item print "number | title | labels"
+      echo ""
+      echo "── $phase (COUNT open issues) ──"
     done
   fi
 
   echo ""
   echo "=== OPEN PRs ==="
-  gh pr list --repo "$GH_REPO" --state open --limit 50 \
-    --json number,title,headRefName,labels --jq \
-    '.[] | "#\(.number) | \(.title) | \(.headRefName)"'
+  # MCP: list_pull_requests(owner="cgcardona", repo="agentception",
+  #   state="open")
+  # Returns: list of open PRs — for each print "#number | title | headRefName"
 
 STEP 3 — RESOLVE DEPENDENCY GRAPH:
   # Determine which phases are fully merged (all issues closed) and which have work.
@@ -233,8 +224,10 @@ STEP 3 — RESOLVE DEPENDENCY GRAPH:
   for phase in "phase-1/db-schema" "phase-2/core-api" "phase-3/api-extensions" \
                "phase-4/new-ui-pages" "phase-5/ui-enhancements" \
                "phase-6/seed-data" "phase-7/machine-access"; do
-    COUNT=$(gh issue list --repo "$GH_REPO" --label "$phase" --state open \
-      --json number --jq 'length' 2>/dev/null || echo 0)
+    # MCP: list_issues(owner="cgcardona", repo="agentception",
+    #   labels=[phase], state="open")
+    # Returns: list — set COUNT to length of result
+    COUNT=0  # set to MCP result length
     PHASE_OPEN[$phase]=$COUNT
     echo "  $phase: $COUNT open issues"
   done
@@ -277,27 +270,24 @@ STEP 3 — RESOLVE DEPENDENCY GRAPH:
   READY_PRS=()
   for phase in "${ACTIVE_PHASES[@]}"; do
     # Issues with no associated PR → ready for ISSUE_TO_PR
-    PHASE_ISSUES=$(gh issue list --repo "$GH_REPO" --label "$phase" --state open \
-      --json number,title --jq '.[] | "\(.number)|\(.title)"' 2>/dev/null)
-    while IFS= read -r issue_entry; do
-      [ -z "$issue_entry" ] && continue
-      ISSUE_NUM="${issue_entry%%|*}"
+    # MCP: list_issues(owner="cgcardona", repo="agentception",
+    #   labels=[phase], state="open")
+    # Returns: PHASE_ISSUES — list of {number, title}
+    for each issue_entry in PHASE_ISSUES:
+      ISSUE_NUM = issue_entry.number
       # Check if a PR already exists for this issue
-      EXISTING_PR=$(gh pr list --repo "$GH_REPO" --state open \
-        --search "closes #$ISSUE_NUM" --json number --jq '.[0].number' 2>/dev/null)
+      # MCP: search_pull_requests(owner="cgcardona", repo="agentception",
+      #   query="closes #$ISSUE_NUM is:open")
+      # Returns: EXISTING_PR — first result's number (empty list means no PR exists)
       if [ -z "$EXISTING_PR" ]; then
         READY_ISSUES+=("$issue_entry")
       fi
-    done <<< "$PHASE_ISSUES"
 
     # PRs linked to this phase's issues → ready for PR_REVIEW
-    PHASE_PRS=$(gh pr list --repo "$GH_REPO" --state open --limit 50 \
-      --json number,title,labels --jq \
-      ".[] | select(.labels | map(.name) | any(. == \"$phase\")) | \"\(.number)|\(.title)\"" 2>/dev/null)
-    while IFS= read -r pr_entry; do
-      [ -z "$pr_entry" ] && continue
-      READY_PRS+=("$pr_entry")
-    done <<< "$PHASE_PRS"
+    # MCP: list_pull_requests(owner="cgcardona", repo="agentception",
+    #   state="open")
+    # Returns: all open PRs — filter client-side: select those whose labels include $phase
+    # Append matching "$number|$title" strings to READY_PRS
   done
 
   echo ""
@@ -316,8 +306,9 @@ STEP 4 — HUMAN APPROVAL GATE:
   # Check for phase-1 (DB schema / Alembic migrations)
   for issue_entry in "${READY_ISSUES[@]}"; do
     ISSUE_NUM="${issue_entry%%|*}"
-    LABELS=$(gh issue view "$ISSUE_NUM" --repo "$GH_REPO" --json labels \
-      --jq '.labels | map(.name) | join(",")' 2>/dev/null)
+    # MCP: issue_read(owner="cgcardona", repo="agentception",
+    #   issue_number=ISSUE_NUM)
+    # Returns: issue object — extract .labels | map(.name) | join(",") as LABELS
     if echo "$LABELS" | grep -q "phase-1/db-schema"; then
       echo "⚠️  HUMAN GATE: Issue #$ISSUE_NUM is in phase-1/db-schema (Alembic migration)."
       echo "   Verify MERGE_AFTER chain before dispatching. Requires human sign-off."
@@ -349,7 +340,8 @@ STEP 5 — DISPATCH COORDINATORS:
     echo "Target issues (pre-screened for file isolation within their phase):"
     for i in "${READY_ISSUES[@]}"; do echo "  #${i%%|*}: ${i##*|}"; done
     echo ""
-    echo "The coordinator query: gh issue list --repo $GH_REPO --label <active_phase> --state open"
+    echo "The coordinator confirmation query:"
+    echo "  MCP: list_issues(owner='cgcardona', repo='agentception', labels=[<active_phase>], state='open')"
     echo "Match these issue numbers to confirm the set before creating worktrees."
     echo ""
     echo "Coordinator constraint: MAX_ISSUES_PER_DISPATCH=$(grep "^MAX_ISSUES_PER_DISPATCH=" .agent-task | cut -d= -f2)"
@@ -398,11 +390,15 @@ STEP 6 — COLLECT COORDINATOR REPORTS:
 STEP 7 — REMINDER GATE:
   # After collecting all reports, determine if work remains.
 
-  REMAINING_ISSUES=$(gh issue list --repo "$GH_REPO" --state open \
-    --json labels --jq '[.[] | select(.labels | map(.name) | any(startswith("phase-")))] | length' \
-    2>/dev/null || echo 0)
-  REMAINING_PRS=$(gh pr list --repo "$GH_REPO" --state open --limit 100 \
-    --json number --jq 'length' 2>/dev/null || echo 0)
+  # MCP: list_issues(owner="cgcardona", repo="agentception",
+  #   state="open")
+  # Returns: all open issues — filter client-side: select those with any label starting with "phase-"
+  # Set REMAINING_ISSUES to filtered count
+  REMAINING_ISSUES=0  # set to MCP filtered count
+  # MCP: list_pull_requests(owner="cgcardona", repo="agentception",
+  #   state="open")
+  # Returns: all open PRs — set REMAINING_PRS to length
+  REMAINING_PRS=0  # set to MCP result length
 
   if [ "$REMAINING_ISSUES" -gt 0 ] || [ "$REMAINING_PRS" -gt 0 ]; then
     echo ""
@@ -423,25 +419,28 @@ into a new Cursor composer window rooted in the conductor worktree.
 $(for phase in "phase-1/db-schema" "phase-2/core-api" "phase-3/api-extensions" \
      "phase-4/new-ui-pages" "phase-5/ui-enhancements" \
      "phase-6/seed-data" "phase-7/machine-access"; do
-  COUNT=$(gh issue list --repo "$GH_REPO" --label "$phase" --state open \
-    --json number --jq 'length' 2>/dev/null || echo 0)
-  [ "$COUNT" -gt 0 ] && echo "- $phase: $COUNT open issues"
+  # MCP: list_issues(owner="cgcardona", repo="agentception",
+  #   labels=[phase], state="open")
+  # Returns: list — set COUNT to length; if COUNT > 0, emit "- $phase: $COUNT open issues"
+  echo "- $phase: COUNT open issues"
 done)
 
 ### Gated items (require human sign-off before conductor can proceed)
-$(gh issue list --repo "$GH_REPO" --label "phase-1/db-schema" --state open \
-  --json number,title --jq '.[] | "- Issue #\(.number): \(.title)"' 2>/dev/null || true)
+# MCP: list_issues(owner="cgcardona", repo="agentception",
+#   labels=["phase-1/db-schema"], state="open")
+# Returns: list — for each item emit "- Issue #number: title"
 
 ### Failed PRs (D/F grade — not merged, needs human review)
-$(gh pr list --repo "$GH_REPO" --state open \
-  --json number,title --jq '.[] | "- PR #\(.number): \(.title)"' 2>/dev/null | head -5 || true)
+# MCP: list_pull_requests(owner="cgcardona", repo="agentception",
+#   state="open")
+# Returns: list — for each item (up to 5) emit "- PR #number: title"
 "
 
-    REMINDER_URL=$(gh issue create \
-      --repo "$GH_REPO" \
-      --title "⏰ Conductor reminder — pipeline incomplete ($(date -u '+%Y-%m-%d'))" \
-      --body "$STATUS_BODY")
-    gh issue edit "$REMINDER_URL" --add-label "conductor-reminder" 2>/dev/null || true
+    # MCP: issue_write(owner="cgcardona", repo="agentception",
+    #   title="⏰ Conductor reminder — pipeline incomplete ($(date -u '+%Y-%m-%d'))",
+    #   body=STATUS_BODY)
+    # Returns: created issue object — capture .number as REMINDER_NUM
+    # MCP: github_add_label(issue_number=REMINDER_NUM, label="conductor-reminder")
 
     # Fingerprint the reminder issue so every conductor run is traceable.
     CONDUCTOR_CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -491,7 +490,10 @@ STEP 7.5 — POST-WAVE STALE BRANCH CLEANUP:
   git fetch --prune
   STALE_BRANCHES=$(git branch -r 2>/dev/null | grep -v "origin/main\|origin/dev\|HEAD" | sed 's|  origin/||' | tr -d ' ')
   for br in $STALE_BRANCHES; do
-    MERGED=$(gh pr list --head "$br" --state merged --json number --jq '.[0].number' --repo "$GH_REPO" 2>/dev/null)
+    # MCP: search_pull_requests(owner="cgcardona", repo="agentception",
+    #   query="head:$br is:merged")
+    # Returns: MERGED — first result's number (empty list means no merged PR for this branch)
+    MERGED=""  # set to first result's number from MCP response
     if [ -n "$MERGED" ]; then
       git push origin --delete "$br" 2>/dev/null \
         && echo "🧹 Deleted $br (PR #$MERGED merged)" \
@@ -560,5 +562,6 @@ These are patterns from real multi-agent systems. The conductor addresses each:
 REPO=$(git rev-parse --show-toplevel)
 git -C "$REPO" fetch origin && git -C "$REPO" merge origin/dev
 git worktree list
-gh issue list --repo cgcardona/agentception --label "conductor-reminder" --state open
+# MCP: list_issues(owner="cgcardona", repo="agentception",
+#   labels=["conductor-reminder"], state="open")
 ```

--- a/.agentception/parallel-issue-to-pr.md
+++ b/.agentception/parallel-issue-to-pr.md
@@ -71,14 +71,14 @@ Kickoff (coordinator)
 
 Agent (per worktree)
   └─ cat .agent-task                        ← knows exactly what to do
-  └─ gh pr list --search "closes #<N>"     ← CHECK FIRST: existing PR or branch?
+  └─ search_pull_requests(q="closes #<N> repo:cgcardona/agentception")  ← CHECK FIRST: existing PR or branch?
      if merged PR found → close issue + self-destruct
      if open PR found   → stop + self-destruct
   └─ git checkout -b feat/<description>     ← creates feature branch (only if new)
   └─ implement → mypy → tests → commit      ← build the fix
   └─ git fetch origin && git merge origin/dev  ← sync dev before pushing
   └─ resolve conflicts if any → re-run mypy + tests
-  └─ git push → gh pr create
+  └─ git push → MCP: create_pull_request(...)
   └─ git worktree remove --force <path>     ← self-destructs when done
   └─ git worktree prune
 ```
@@ -138,7 +138,8 @@ Before finalising your four, confirm each pair is independent:
 
 ```bash
 # For each candidate issue, list the files it is expected to touch:
-gh issue view <N> --json body   # check "Files / modules" section
+# MCP: issue_read(owner="cgcardona", repo="agentception", issue_number=N)
+# check "Files / modules" section in result.body
 
 # Confirm no pair shares a file before assigning the batch.
 ```
@@ -181,13 +182,11 @@ BATCH_LABEL="batch-01"
 
 # ── DERIVE ISSUES FROM GITHUB — never hardcode issue numbers ─────────────────
 echo "📋 Querying GitHub for open '$BATCH_LABEL' issues..."
+# MCP: list_issues(owner="cgcardona", repo="agentception", labels=[BATCH_LABEL], state="open")
+# Iterate results as RAW_ISSUES
 mapfile -t RAW_ISSUES < <(
-  gh issue list \
-    --repo "$GH_REPO" \
-    --label "$BATCH_LABEL" \
-    --state open \
-    --json number,title,labels \
-    --jq '.[] | "\(.number)|\(.title)|\(.labels | map(.name) | join(","))"'
+  # MCP result: each item has .number, .title, .labels[].name
+  # Format each as: "NUMBER|TITLE|label1,label2,..."
 )
 
 if [ ${#RAW_ISSUES[@]} -eq 0 ]; then
@@ -238,7 +237,9 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   # Assign ROLE based on issue labels:
   #   phase-1/db-schema, alembic, migration labels → database-architect
   #   all others → python-developer
-  ISSUE_LABELS=$(gh issue view "$NUM" --repo "$GH_REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+  # MCP: issue_read(owner="cgcardona", repo="agentception", issue_number=NUM)
+  # ISSUE_LABELS = result.labels[].name joined with ","
+  # ISSUE_BODY = result.body
   AGENT_ROLE="python-developer"
   if echo "$ISSUE_LABELS" | grep -qE "db-schema|alembic|migration"; then
     AGENT_ROLE="database-architect"
@@ -246,7 +247,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
 
   # Write rich .agent-task — agent reads ALL context from this file
   # Extract DEPENDS_ON from issue body (looks for "Depends on #NNN" patterns)
-  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  # (ISSUE_BODY already set from MCP issue_read above)
   DEPENDS_ON=$(echo "$ISSUE_BODY" | grep -oE 'Depends on[^.]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   [ -z "$DEPENDS_ON" ] && DEPENDS_ON=none
 
@@ -256,7 +257,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   FILE_OWNERSHIP_VALUE="${FILE_OWNERSHIP:-tbd}"
 
   # Resolve COGNITIVE_ARCH for this issue's tech stack
-  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  # (ISSUE_BODY already set from MCP issue_read above)
   if echo "$ISSUE_BODY" | grep -qiE "d3\.js|force-directed|d3\.force|d3\.select"; then
     SKILLS="d3:javascript"
   elif echo "$ISSUE_BODY" | grep -qiE "monaco|vs/loader|editor.*cdn"; then
@@ -1048,8 +1049,8 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
 
   # Discover the PR number for the branch you just pushed.
   MY_BRANCH=$(git -C "$WORKTREE" rev-parse --abbrev-ref HEAD)
-  MY_PR=$(gh pr list --repo "$GH_REPO" --head "$MY_BRANCH" --state open \
-    --json number --jq '.[0].number // empty')
+  # MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open", head=MY_BRANCH)
+  # MY_PR = first result's number
 
   if [ -n "$MY_PR" ] && [ "$MY_PR" != "null" ]; then
     # Create a fresh review worktree at the PR branch tip.
@@ -1175,10 +1176,9 @@ REPO=$(git rev-parse --show-toplevel)
 cd "$REPO"
 
 echo "=== Files touched by currently open PRs ==="
-# MCP: github_list_prs(state="open") → for each PR:
-#   - .number, .title  (from github_list_prs result)
-#   - files: gh pr diff NUM --name-only (no MCP equivalent for diff content)
-for num in $(gh pr list --state open --json number --jq '.[].number'); do
+# MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open")
+# Iterate over result.number for overlap check
+for num in <result from MCP list_pull_requests>; do
   files=$(gh pr diff "$num" --name-only 2>/dev/null)
   if [ -n "$files" ]; then
     # MCP: github_get_pr(pr_number=num) → .title
@@ -1246,21 +1246,13 @@ PHASE_LABEL="phase-1"   # match the label used in Setup
 
 GH_REPO=cgcardona/agentception   # ← single place to change if the repo slug ever changes
 
-REMAINING=$(gh issue list \
-  --repo "$GH_REPO" \
-  --label "$PHASE_LABEL" \
-  --state open \
-  --json number \
-  --jq 'length')
+# MCP: list_issues(owner="cgcardona", repo="agentception", labels=[PHASE_LABEL], state="open")
+# REMAINING = count of results
+REMAINING=<count from MCP response>
 
 if [ "$REMAINING" -gt 0 ]; then
   echo "⚠️  $REMAINING open issue(s) still labeled '$PHASE_LABEL':"
-  gh issue list \
-    --repo "$GH_REPO" \
-    --label "$PHASE_LABEL" \
-    --state open \
-    --json number,title,url \
-    --jq '.[] | "#\(.number)  \(.title)\n  \(.url)"'
+  # MCP result already fetched above — iterate each: "#NUM  TITLE\n  URL"
   echo ""
   echo "→ These need implementation, review, or explicit closure before moving to the next phase."
   echo "→ Common causes:"
@@ -1278,7 +1270,7 @@ fi
 
 ```bash
 GH_REPO=cgcardona/agentception   # ← single place to change if the repo slug ever changes
-gh pr list --repo "$GH_REPO" --state open
+# MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open")
 ```
 
 All PRs from this batch should be open (awaiting review) or merged. None should be closed/rejected without a corresponding issue closure.
@@ -1309,8 +1301,9 @@ git -C "$REPO" status
 1. Check whether the work is already merged:
    ```bash
    # For each dirty file, find the PR that contains it:
-   gh pr list --state merged --json number,title --jq '.[].number' | \
-     xargs -I{} gh pr diff {} --name-only 2>/dev/null | grep <filename>
+   # MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="merged")
+   # For each result: use gh pr diff <number> --name-only to get changed files
+   # gh pr diff <number> --name-only 2>/dev/null | grep <filename>
    ```
 2. **If already merged** → the dirty files are stale copies. Discard them:
    ```bash
@@ -1325,7 +1318,7 @@ git -C "$REPO" status
    git -C "$REPO" add -A
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
-   gh pr create --base dev --head fix/<description> ...
+   # MCP: create_pull_request(owner="cgcardona", repo="agentception", title="...", body="...", head="fix/<description>", base="dev")
    ```
 
 ### 5 — Hand off to PR review

--- a/.agentception/parallel-pr-review.md
+++ b/.agentception/parallel-pr-review.md
@@ -141,9 +141,10 @@ for entry in "${PRS[@]}"; do
   REVIEW_ROLE="pr-reviewer"
 
   # Fetch PR metadata for the task file
-  PR_BRANCH=$(gh pr view "$NUM" --repo "$GH_REPO" --json headRefName --jq '.headRefName' 2>/dev/null || echo "unknown")
+  # MCP: pull_request_read(owner="cgcardona", repo="agentception", pullNumber=NUM)
+  # PR_BRANCH = result.headRefName
+  # PR_BODY = result.body
   PR_FILES=$(gh pr diff "$NUM" --repo "$GH_REPO" --name-only 2>/dev/null | tr '\n' ',' | sed 's/,$//')
-  PR_BODY=$(gh pr view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null || echo "")
   CLOSES_ISSUE=$(echo "$PR_BODY" | grep -oE '[Cc]loses?\s+#[0-9]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   # MERGE_AFTER: PR number that must be merged before this one (for Alembic chain safety).
   # Set automatically if the PR body contains "Merges after #NNN" or "Depends on PR #NNN".
@@ -1506,8 +1507,12 @@ git -C "$REPO" status
 
 1. Check whether the work is already merged:
    ```bash
-   gh pr list --state merged --json number,title --jq '.[].number' | \
-     xargs -I{} gh pr diff {} --name-only 2>/dev/null | grep <filename>
+   # MCP: list_pull_requests(owner="cgcardona", repo="agentception",
+   #       state="merged") → for each result, extract .number into MERGED_NUMS
+   # Then for each merged PR number, check if its diff contains the dirty file:
+   for num in $MERGED_NUMS; do
+     gh pr diff "$num" --repo "$GH_REPO" --name-only 2>/dev/null | grep <filename>
+   done
    ```
 2. **If already merged** → stale copies. Discard:
    ```bash
@@ -1521,7 +1526,9 @@ git -C "$REPO" status
    git -C "$REPO" add -A
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
-   gh pr create --base dev --head fix/<description> ...
+   # MCP: create_pull_request(owner="cgcardona", repo="agentception",
+   #       title="feat: <description> (rescued from main repo dirty state)",
+   #       base="dev", head="fix/<description>", body="Rescued dirty-state work.")
    ```
 
 ---
@@ -1584,16 +1591,14 @@ N=$(grep "^PR_NUMBER=" .agent-task | cut -d= -f2)
 GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
 GH_REPO=${GH_REPO:-cgcardona/agentception}
 WTNAME=$(basename "$(pwd)")
-# Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
-IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "ac-ui/" || true)
-if [ "$IS_AC" -gt 0 ]; then
-  docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
-else
-  REPO=$(git worktree list | head -1 | awk '{print $1}')
-  cd "$REPO" && docker compose exec agentception sh -c \
-    "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
-fi
+# Determine if this PR is an AgentCeption PR:
+# Call pull_request_read(owner="cgcardona", repo="agentception", pullNumber=N)
+# If any label name contains "ac-ui/", run:
+#   docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
+# Otherwise (generic PR — no "ac-ui/" labels), run:
+REPO=$(git worktree list | head -1 | awk '{print $1}')
+cd "$REPO" && docker compose exec agentception sh -c \
+  "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
 ```
 Your job is to ensure the PR does not *introduce* new errors. But if you touch a file with pre-existing errors, you own them.
 

--- a/.agentception/pipeline-howto.md
+++ b/.agentception/pipeline-howto.md
@@ -147,7 +147,7 @@ Lets you answer: *"Which specific agent opened this PR / merged this PR?"*
 git log --all --grep="AgentCeption-Batch: eng-20260301T053412Z-a7f2"
 
 # Find the PR opened by a specific agent session:
-gh pr list --repo cgcardona/agentception --state all --search "eng-20260301T053412Z-a7f2"
+search_pull_requests(q="eng-20260301T053412Z-a7f2 repo:cgcardona/agentception", state="all")
 
 # Find which batch a commit came from:
 git show <sha> | grep "AgentCeption-"
@@ -161,8 +161,8 @@ git show <sha> | grep "AgentCeption-"
 
 ```bash
 # What's open?
-gh issue list --state open --label "batch-NN" --repo cgcardona/agentception
-gh pr list --base dev --state open --repo cgcardona/agentception
+list_issues(label="batch-NN", state="open")   # GitHub MCP
+list_pull_requests(state="open", base="dev")  # GitHub MCP
 
 # What's in flight?
 git worktree list
@@ -175,7 +175,8 @@ git worktree list
 git worktree add -b feat/issue-{N} ~/.agentception/worktrees/agentception/issue-{N} origin/dev
 
 # For each PR to review (checkout the PR's branch):
-BRANCH=$(gh pr view {N} --json headRefName --jq '.headRefName')
+# Call pull_request_read(pullNumber=N) and read the headRefName field
+BRANCH=<headRefName from pull_request_read result>
 git worktree add ~/.agentception/worktrees/agentception/pr-{N} origin/$BRANCH
 ```
 
@@ -221,10 +222,10 @@ Use this when you want the pipeline to run end-to-end without manual interventio
 ```
 You are the CTO. Read <repo-root>/.agentception/roles/cto.md.
 
-Survey the pipeline state with gh issue list and gh pr list.
+Survey the pipeline state using MCP: list_issues(state="open") and list_pull_requests(state="open").
 Dispatch the Engineering Coordinator and QA Coordinator simultaneously using the Task tool.
 Each coordinator launches leaf agents pointing at the canonical prompts — not inline instructions.
-Continue until gh issue list --state open returns 0 results and gh pr list --state open returns 0 results.
+Continue until list_issues(state="open") returns 0 results and list_pull_requests(state="open") returns 0 results.
 GH_REPO=cgcardona/agentception
 Repo: <repo-root>
 ```
@@ -316,10 +317,10 @@ That is the complete prompt. The canonical file has everything else.
 
 ```bash
 # Check open PRs
-gh pr list --base dev --state open --repo cgcardona/agentception
+list_pull_requests(state="open", base="dev")  # GitHub MCP
 
 # Check open issues remaining in a batch
-gh issue list --label "batch-07" --state open --repo cgcardona/agentception
+list_issues(label="batch-07", state="open")   # GitHub MCP
 
 # Check worktrees in flight
 git worktree list
@@ -331,7 +332,7 @@ git worktree list
 
 If an agent crashes mid-task:
 
-1. Check if its PR was opened: `gh pr list --state open --repo cgcardona/agentception`
+1. Check if its PR was opened: `list_pull_requests(state="open")`  *(GitHub MCP)*
 2. Check if its worktree still exists: `git worktree list`
 3. If worktree exists + no PR: re-launch the leaf agent with the same prompt
 4. If worktree missing + PR open: create a review worktree and assign a reviewer

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -484,14 +484,14 @@ Kickoff (coordinator)
 
 Agent (per worktree)
   └─ cat .agent-task                        ← knows exactly what to do
-  └─ gh pr list --search "closes #<N>"     ← CHECK FIRST: existing PR or branch?
+  └─ search_pull_requests(q="closes #<N> repo:cgcardona/agentception")  ← CHECK FIRST: existing PR or branch?
      if merged PR found → close issue + self-destruct
      if open PR found   → stop + self-destruct
   └─ git checkout -b feat/<description>     ← creates feature branch (only if new)
   └─ implement → mypy → tests → commit      ← build the fix
   └─ git fetch origin && git merge origin/dev  ← sync dev before pushing
   └─ resolve conflicts if any → re-run mypy + tests
-  └─ git push → gh pr create
+  └─ git push → MCP: create_pull_request(...)
   └─ git worktree remove --force <path>     ← self-destructs when done
   └─ git worktree prune
 ```
@@ -551,7 +551,8 @@ Before finalising your four, confirm each pair is independent:
 
 ```bash
 # For each candidate issue, list the files it is expected to touch:
-gh issue view <N> --json body   # check "Files / modules" section
+# MCP: issue_read(owner="cgcardona", repo="agentception", issue_number=N)
+# check "Files / modules" section in result.body
 
 # Confirm no pair shares a file before assigning the batch.
 ```
@@ -594,13 +595,11 @@ BATCH_LABEL="batch-01"
 
 # ── DERIVE ISSUES FROM GITHUB — never hardcode issue numbers ─────────────────
 echo "📋 Querying GitHub for open '$BATCH_LABEL' issues..."
+# MCP: list_issues(owner="cgcardona", repo="agentception", labels=[BATCH_LABEL], state="open")
+# Iterate results as RAW_ISSUES
 mapfile -t RAW_ISSUES < <(
-  gh issue list \
-    --repo "$GH_REPO" \
-    --label "$BATCH_LABEL" \
-    --state open \
-    --json number,title,labels \
-    --jq '.[] | "\(.number)|\(.title)|\(.labels | map(.name) | join(","))"'
+  # MCP result: each item has .number, .title, .labels[].name
+  # Format each as: "NUMBER|TITLE|label1,label2,..."
 )
 
 if [ ${#RAW_ISSUES[@]} -eq 0 ]; then
@@ -651,7 +650,9 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   # Assign ROLE based on issue labels:
   #   phase-1/db-schema, alembic, migration labels → database-architect
   #   all others → python-developer
-  ISSUE_LABELS=$(gh issue view "$NUM" --repo "$GH_REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+  # MCP: issue_read(owner="cgcardona", repo="agentception", issue_number=NUM)
+  # ISSUE_LABELS = result.labels[].name joined with ","
+  # ISSUE_BODY = result.body
   AGENT_ROLE="python-developer"
   if echo "$ISSUE_LABELS" | grep -qE "db-schema|alembic|migration"; then
     AGENT_ROLE="database-architect"
@@ -659,7 +660,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
 
   # Write rich .agent-task — agent reads ALL context from this file
   # Extract DEPENDS_ON from issue body (looks for "Depends on #NNN" patterns)
-  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  # (ISSUE_BODY already set from MCP issue_read above)
   DEPENDS_ON=$(echo "$ISSUE_BODY" | grep -oE 'Depends on[^.]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   [ -z "$DEPENDS_ON" ] && DEPENDS_ON=none
 
@@ -669,7 +670,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   FILE_OWNERSHIP_VALUE="${FILE_OWNERSHIP:-tbd}"
 
   # Resolve COGNITIVE_ARCH for this issue's tech stack
-  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  # (ISSUE_BODY already set from MCP issue_read above)
   if echo "$ISSUE_BODY" | grep -qiE "d3\.js|force-directed|d3\.force|d3\.select"; then
     SKILLS="d3:javascript"
   elif echo "$ISSUE_BODY" | grep -qiE "monaco|vs/loader|editor.*cdn"; then
@@ -1461,8 +1462,8 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
 
   # Discover the PR number for the branch you just pushed.
   MY_BRANCH=$(git -C "$WORKTREE" rev-parse --abbrev-ref HEAD)
-  MY_PR=$(gh pr list --repo "$GH_REPO" --head "$MY_BRANCH" --state open \
-    --json number --jq '.[0].number // empty')
+  # MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open", head=MY_BRANCH)
+  # MY_PR = first result's number
 
   if [ -n "$MY_PR" ] && [ "$MY_PR" != "null" ]; then
     # Create a fresh review worktree at the PR branch tip.
@@ -1588,10 +1589,9 @@ REPO=$(git rev-parse --show-toplevel)
 cd "$REPO"
 
 echo "=== Files touched by currently open PRs ==="
-# MCP: github_list_prs(state="open") → for each PR:
-#   - .number, .title  (from github_list_prs result)
-#   - files: gh pr diff NUM --name-only (no MCP equivalent for diff content)
-for num in $(gh pr list --state open --json number --jq '.[].number'); do
+# MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open")
+# Iterate over result.number for overlap check
+for num in <result from MCP list_pull_requests>; do
   files=$(gh pr diff "$num" --name-only 2>/dev/null)
   if [ -n "$files" ]; then
     # MCP: github_get_pr(pr_number=num) → .title
@@ -1659,21 +1659,13 @@ PHASE_LABEL="phase-1"   # match the label used in Setup
 
 GH_REPO=cgcardona/agentception   # ← single place to change if the repo slug ever changes
 
-REMAINING=$(gh issue list \
-  --repo "$GH_REPO" \
-  --label "$PHASE_LABEL" \
-  --state open \
-  --json number \
-  --jq 'length')
+# MCP: list_issues(owner="cgcardona", repo="agentception", labels=[PHASE_LABEL], state="open")
+# REMAINING = count of results
+REMAINING=<count from MCP response>
 
 if [ "$REMAINING" -gt 0 ]; then
   echo "⚠️  $REMAINING open issue(s) still labeled '$PHASE_LABEL':"
-  gh issue list \
-    --repo "$GH_REPO" \
-    --label "$PHASE_LABEL" \
-    --state open \
-    --json number,title,url \
-    --jq '.[] | "#\(.number)  \(.title)\n  \(.url)"'
+  # MCP result already fetched above — iterate each: "#NUM  TITLE\n  URL"
   echo ""
   echo "→ These need implementation, review, or explicit closure before moving to the next phase."
   echo "→ Common causes:"
@@ -1691,7 +1683,7 @@ fi
 
 ```bash
 GH_REPO=cgcardona/agentception   # ← single place to change if the repo slug ever changes
-gh pr list --repo "$GH_REPO" --state open
+# MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open")
 ```
 
 All PRs from this batch should be open (awaiting review) or merged. None should be closed/rejected without a corresponding issue closure.
@@ -1722,8 +1714,9 @@ git -C "$REPO" status
 1. Check whether the work is already merged:
    ```bash
    # For each dirty file, find the PR that contains it:
-   gh pr list --state merged --json number,title --jq '.[].number' | \
-     xargs -I{} gh pr diff {} --name-only 2>/dev/null | grep <filename>
+   # MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="merged")
+   # For each result: use gh pr diff <number> --name-only to get changed files
+   # gh pr diff <number> --name-only 2>/dev/null | grep <filename>
    ```
 2. **If already merged** → the dirty files are stale copies. Discard them:
    ```bash
@@ -1738,7 +1731,7 @@ git -C "$REPO" status
    git -C "$REPO" add -A
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
-   gh pr create --base dev --head fix/<description> ...
+   # MCP: create_pull_request(owner="cgcardona", repo="agentception", title="...", body="...", head="fix/<description>", base="dev")
    ```
 
 ### 5 — Hand off to PR review
@@ -2123,9 +2116,10 @@ for entry in "${PRS[@]}"; do
   REVIEW_ROLE="pr-reviewer"
 
   # Fetch PR metadata for the task file
-  PR_BRANCH=$(gh pr view "$NUM" --repo "$GH_REPO" --json headRefName --jq '.headRefName' 2>/dev/null || echo "unknown")
+  # MCP: pull_request_read(owner="cgcardona", repo="agentception", pullNumber=NUM)
+  # PR_BRANCH = result.headRefName
+  # PR_BODY = result.body
   PR_FILES=$(gh pr diff "$NUM" --repo "$GH_REPO" --name-only 2>/dev/null | tr '\n' ',' | sed 's/,$//')
-  PR_BODY=$(gh pr view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null || echo "")
   CLOSES_ISSUE=$(echo "$PR_BODY" | grep -oE '[Cc]loses?\s+#[0-9]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   # MERGE_AFTER: PR number that must be merged before this one (for Alembic chain safety).
   # Set automatically if the PR body contains "Merges after #NNN" or "Depends on PR #NNN".
@@ -3488,8 +3482,12 @@ git -C "$REPO" status
 
 1. Check whether the work is already merged:
    ```bash
-   gh pr list --state merged --json number,title --jq '.[].number' | \
-     xargs -I{} gh pr diff {} --name-only 2>/dev/null | grep <filename>
+   # MCP: list_pull_requests(owner="cgcardona", repo="agentception",
+   #       state="merged") → for each result, extract .number into MERGED_NUMS
+   # Then for each merged PR number, check if its diff contains the dirty file:
+   for num in $MERGED_NUMS; do
+     gh pr diff "$num" --repo "$GH_REPO" --name-only 2>/dev/null | grep <filename>
+   done
    ```
 2. **If already merged** → stale copies. Discard:
    ```bash
@@ -3503,7 +3501,9 @@ git -C "$REPO" status
    git -C "$REPO" add -A
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
-   gh pr create --base dev --head fix/<description> ...
+   # MCP: create_pull_request(owner="cgcardona", repo="agentception",
+   #       title="feat: <description> (rescued from main repo dirty state)",
+   #       base="dev", head="fix/<description>", body="Rescued dirty-state work.")
    ```
 
 ---
@@ -3566,16 +3566,14 @@ N=$(grep "^PR_NUMBER=" .agent-task | cut -d= -f2)
 GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
 GH_REPO=${GH_REPO:-cgcardona/agentception}
 WTNAME=$(basename "$(pwd)")
-# Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
-IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "ac-ui/" || true)
-if [ "$IS_AC" -gt 0 ]; then
-  docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
-else
-  REPO=$(git worktree list | head -1 | awk '{print $1}')
-  cd "$REPO" && docker compose exec agentception sh -c \
-    "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
-fi
+# Determine if this PR is an AgentCeption PR:
+# Call pull_request_read(owner="cgcardona", repo="agentception", pullNumber=N)
+# If any label name contains "ac-ui/", run:
+#   docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
+# Otherwise (generic PR — no "ac-ui/" labels), run:
+REPO=$(git worktree list | head -1 | awk '{print $1}')
+cd "$REPO" && docker compose exec agentception sh -c \
+  "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
 ```
 Your job is to ensure the PR does not *introduce* new errors. But if you touch a file with pre-existing errors, you own them.
 
@@ -3895,9 +3893,10 @@ for entry in "${PRS[@]}"; do
   REVIEW_ROLE="pr-reviewer"
 
   # Fetch PR metadata for the task file
-  PR_BRANCH=$(gh pr view "$NUM" --repo "$GH_REPO" --json headRefName --jq '.headRefName' 2>/dev/null || echo "unknown")
+  # MCP: pull_request_read(owner="cgcardona", repo="agentception", pullNumber=NUM)
+  # PR_BRANCH = result.headRefName
+  # PR_BODY = result.body
   PR_FILES=$(gh pr diff "$NUM" --repo "$GH_REPO" --name-only 2>/dev/null | tr '\n' ',' | sed 's/,$//')
-  PR_BODY=$(gh pr view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null || echo "")
   CLOSES_ISSUE=$(echo "$PR_BODY" | grep -oE '[Cc]loses?\s+#[0-9]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   # MERGE_AFTER: PR number that must be merged before this one (for Alembic chain safety).
   # Set automatically if the PR body contains "Merges after #NNN" or "Depends on PR #NNN".
@@ -5260,8 +5259,12 @@ git -C "$REPO" status
 
 1. Check whether the work is already merged:
    ```bash
-   gh pr list --state merged --json number,title --jq '.[].number' | \
-     xargs -I{} gh pr diff {} --name-only 2>/dev/null | grep <filename>
+   # MCP: list_pull_requests(owner="cgcardona", repo="agentception",
+   #       state="merged") → for each result, extract .number into MERGED_NUMS
+   # Then for each merged PR number, check if its diff contains the dirty file:
+   for num in $MERGED_NUMS; do
+     gh pr diff "$num" --repo "$GH_REPO" --name-only 2>/dev/null | grep <filename>
+   done
    ```
 2. **If already merged** → stale copies. Discard:
    ```bash
@@ -5275,7 +5278,9 @@ git -C "$REPO" status
    git -C "$REPO" add -A
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
-   gh pr create --base dev --head fix/<description> ...
+   # MCP: create_pull_request(owner="cgcardona", repo="agentception",
+   #       title="feat: <description> (rescued from main repo dirty state)",
+   #       base="dev", head="fix/<description>", body="Rescued dirty-state work.")
    ```
 
 ---
@@ -5338,16 +5343,14 @@ N=$(grep "^PR_NUMBER=" .agent-task | cut -d= -f2)
 GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
 GH_REPO=${GH_REPO:-cgcardona/agentception}
 WTNAME=$(basename "$(pwd)")
-# Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
-IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "ac-ui/" || true)
-if [ "$IS_AC" -gt 0 ]; then
-  docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
-else
-  REPO=$(git worktree list | head -1 | awk '{print $1}')
-  cd "$REPO" && docker compose exec agentception sh -c \
-    "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
-fi
+# Determine if this PR is an AgentCeption PR:
+# Call pull_request_read(owner="cgcardona", repo="agentception", pullNumber=N)
+# If any label name contains "ac-ui/", run:
+#   docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
+# Otherwise (generic PR — no "ac-ui/" labels), run:
+REPO=$(git worktree list | head -1 | awk '{print $1}')
+cd "$REPO" && docker compose exec agentception sh -c \
+  "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
 ```
 Your job is to ensure the PR does not *introduce* new errors. But if you touch a file with pre-existing errors, you own them.
 
@@ -5451,14 +5454,14 @@ Kickoff (coordinator)
 
 Agent (per worktree)
   └─ cat .agent-task                        ← knows exactly what to do
-  └─ gh pr list --search "closes #<N>"     ← CHECK FIRST: existing PR or branch?
+  └─ search_pull_requests(q="closes #<N> repo:cgcardona/agentception")  ← CHECK FIRST: existing PR or branch?
      if merged PR found → close issue + self-destruct
      if open PR found   → stop + self-destruct
   └─ git checkout -b feat/<description>     ← creates feature branch (only if new)
   └─ implement → mypy → tests → commit      ← build the fix
   └─ git fetch origin && git merge origin/dev  ← sync dev before pushing
   └─ resolve conflicts if any → re-run mypy + tests
-  └─ git push → gh pr create
+  └─ git push → MCP: create_pull_request(...)
   └─ git worktree remove --force <path>     ← self-destructs when done
   └─ git worktree prune
 ```
@@ -5518,7 +5521,8 @@ Before finalising your four, confirm each pair is independent:
 
 ```bash
 # For each candidate issue, list the files it is expected to touch:
-gh issue view <N> --json body   # check "Files / modules" section
+# MCP: issue_read(owner="cgcardona", repo="agentception", issue_number=N)
+# check "Files / modules" section in result.body
 
 # Confirm no pair shares a file before assigning the batch.
 ```
@@ -5561,13 +5565,11 @@ BATCH_LABEL="batch-01"
 
 # ── DERIVE ISSUES FROM GITHUB — never hardcode issue numbers ─────────────────
 echo "📋 Querying GitHub for open '$BATCH_LABEL' issues..."
+# MCP: list_issues(owner="cgcardona", repo="agentception", labels=[BATCH_LABEL], state="open")
+# Iterate results as RAW_ISSUES
 mapfile -t RAW_ISSUES < <(
-  gh issue list \
-    --repo "$GH_REPO" \
-    --label "$BATCH_LABEL" \
-    --state open \
-    --json number,title,labels \
-    --jq '.[] | "\(.number)|\(.title)|\(.labels | map(.name) | join(","))"'
+  # MCP result: each item has .number, .title, .labels[].name
+  # Format each as: "NUMBER|TITLE|label1,label2,..."
 )
 
 if [ ${#RAW_ISSUES[@]} -eq 0 ]; then
@@ -5618,7 +5620,9 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   # Assign ROLE based on issue labels:
   #   phase-1/db-schema, alembic, migration labels → database-architect
   #   all others → python-developer
-  ISSUE_LABELS=$(gh issue view "$NUM" --repo "$GH_REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+  # MCP: issue_read(owner="cgcardona", repo="agentception", issue_number=NUM)
+  # ISSUE_LABELS = result.labels[].name joined with ","
+  # ISSUE_BODY = result.body
   AGENT_ROLE="python-developer"
   if echo "$ISSUE_LABELS" | grep -qE "db-schema|alembic|migration"; then
     AGENT_ROLE="database-architect"
@@ -5626,7 +5630,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
 
   # Write rich .agent-task — agent reads ALL context from this file
   # Extract DEPENDS_ON from issue body (looks for "Depends on #NNN" patterns)
-  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  # (ISSUE_BODY already set from MCP issue_read above)
   DEPENDS_ON=$(echo "$ISSUE_BODY" | grep -oE 'Depends on[^.]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   [ -z "$DEPENDS_ON" ] && DEPENDS_ON=none
 
@@ -5636,7 +5640,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   FILE_OWNERSHIP_VALUE="${FILE_OWNERSHIP:-tbd}"
 
   # Resolve COGNITIVE_ARCH for this issue's tech stack
-  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  # (ISSUE_BODY already set from MCP issue_read above)
   if echo "$ISSUE_BODY" | grep -qiE "d3\.js|force-directed|d3\.force|d3\.select"; then
     SKILLS="d3:javascript"
   elif echo "$ISSUE_BODY" | grep -qiE "monaco|vs/loader|editor.*cdn"; then
@@ -6428,8 +6432,8 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
 
   # Discover the PR number for the branch you just pushed.
   MY_BRANCH=$(git -C "$WORKTREE" rev-parse --abbrev-ref HEAD)
-  MY_PR=$(gh pr list --repo "$GH_REPO" --head "$MY_BRANCH" --state open \
-    --json number --jq '.[0].number // empty')
+  # MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open", head=MY_BRANCH)
+  # MY_PR = first result's number
 
   if [ -n "$MY_PR" ] && [ "$MY_PR" != "null" ]; then
     # Create a fresh review worktree at the PR branch tip.
@@ -6555,10 +6559,9 @@ REPO=$(git rev-parse --show-toplevel)
 cd "$REPO"
 
 echo "=== Files touched by currently open PRs ==="
-# MCP: github_list_prs(state="open") → for each PR:
-#   - .number, .title  (from github_list_prs result)
-#   - files: gh pr diff NUM --name-only (no MCP equivalent for diff content)
-for num in $(gh pr list --state open --json number --jq '.[].number'); do
+# MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open")
+# Iterate over result.number for overlap check
+for num in <result from MCP list_pull_requests>; do
   files=$(gh pr diff "$num" --name-only 2>/dev/null)
   if [ -n "$files" ]; then
     # MCP: github_get_pr(pr_number=num) → .title
@@ -6626,21 +6629,13 @@ PHASE_LABEL="phase-1"   # match the label used in Setup
 
 GH_REPO=cgcardona/agentception   # ← single place to change if the repo slug ever changes
 
-REMAINING=$(gh issue list \
-  --repo "$GH_REPO" \
-  --label "$PHASE_LABEL" \
-  --state open \
-  --json number \
-  --jq 'length')
+# MCP: list_issues(owner="cgcardona", repo="agentception", labels=[PHASE_LABEL], state="open")
+# REMAINING = count of results
+REMAINING=<count from MCP response>
 
 if [ "$REMAINING" -gt 0 ]; then
   echo "⚠️  $REMAINING open issue(s) still labeled '$PHASE_LABEL':"
-  gh issue list \
-    --repo "$GH_REPO" \
-    --label "$PHASE_LABEL" \
-    --state open \
-    --json number,title,url \
-    --jq '.[] | "#\(.number)  \(.title)\n  \(.url)"'
+  # MCP result already fetched above — iterate each: "#NUM  TITLE\n  URL"
   echo ""
   echo "→ These need implementation, review, or explicit closure before moving to the next phase."
   echo "→ Common causes:"
@@ -6658,7 +6653,7 @@ fi
 
 ```bash
 GH_REPO=cgcardona/agentception   # ← single place to change if the repo slug ever changes
-gh pr list --repo "$GH_REPO" --state open
+# MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open")
 ```
 
 All PRs from this batch should be open (awaiting review) or merged. None should be closed/rejected without a corresponding issue closure.
@@ -6689,8 +6684,9 @@ git -C "$REPO" status
 1. Check whether the work is already merged:
    ```bash
    # For each dirty file, find the PR that contains it:
-   gh pr list --state merged --json number,title --jq '.[].number' | \
-     xargs -I{} gh pr diff {} --name-only 2>/dev/null | grep <filename>
+   # MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="merged")
+   # For each result: use gh pr diff <number> --name-only to get changed files
+   # gh pr diff <number> --name-only 2>/dev/null | grep <filename>
    ```
 2. **If already merged** → the dirty files are stale copies. Discard them:
    ```bash
@@ -6705,7 +6701,7 @@ git -C "$REPO" status
    git -C "$REPO" add -A
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
-   gh pr create --base dev --head fix/<description> ...
+   # MCP: create_pull_request(owner="cgcardona", repo="agentception", title="...", body="...", head="fix/<description>", base="dev")
    ```
 
 ### 5 — Hand off to PR review

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -261,14 +261,14 @@ Kickoff (coordinator)
 
 Agent (per worktree)
   └─ cat .agent-task                        ← knows exactly what to do
-  └─ gh pr list --search "closes #<N>"     ← CHECK FIRST: existing PR or branch?
+  └─ search_pull_requests(q="closes #<N> repo:cgcardona/agentception")  ← CHECK FIRST: existing PR or branch?
      if merged PR found → close issue + self-destruct
      if open PR found   → stop + self-destruct
   └─ git checkout -b feat/<description>     ← creates feature branch (only if new)
   └─ implement → mypy → tests → commit      ← build the fix
   └─ git fetch origin && git merge origin/dev  ← sync dev before pushing
   └─ resolve conflicts if any → re-run mypy + tests
-  └─ git push → gh pr create
+  └─ git push → MCP: create_pull_request(...)
   └─ git worktree remove --force <path>     ← self-destructs when done
   └─ git worktree prune
 ```
@@ -328,7 +328,8 @@ Before finalising your four, confirm each pair is independent:
 
 ```bash
 # For each candidate issue, list the files it is expected to touch:
-gh issue view <N> --json body   # check "Files / modules" section
+# MCP: issue_read(owner="cgcardona", repo="agentception", issue_number=N)
+# check "Files / modules" section in result.body
 
 # Confirm no pair shares a file before assigning the batch.
 ```
@@ -371,13 +372,11 @@ BATCH_LABEL="batch-01"
 
 # ── DERIVE ISSUES FROM GITHUB — never hardcode issue numbers ─────────────────
 echo "📋 Querying GitHub for open '$BATCH_LABEL' issues..."
+# MCP: list_issues(owner="cgcardona", repo="agentception", labels=[BATCH_LABEL], state="open")
+# Iterate results as RAW_ISSUES
 mapfile -t RAW_ISSUES < <(
-  gh issue list \
-    --repo "$GH_REPO" \
-    --label "$BATCH_LABEL" \
-    --state open \
-    --json number,title,labels \
-    --jq '.[] | "\(.number)|\(.title)|\(.labels | map(.name) | join(","))"'
+  # MCP result: each item has .number, .title, .labels[].name
+  # Format each as: "NUMBER|TITLE|label1,label2,..."
 )
 
 if [ ${#RAW_ISSUES[@]} -eq 0 ]; then
@@ -428,7 +427,9 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   # Assign ROLE based on issue labels:
   #   phase-1/db-schema, alembic, migration labels → database-architect
   #   all others → python-developer
-  ISSUE_LABELS=$(gh issue view "$NUM" --repo "$GH_REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+  # MCP: issue_read(owner="cgcardona", repo="agentception", issue_number=NUM)
+  # ISSUE_LABELS = result.labels[].name joined with ","
+  # ISSUE_BODY = result.body
   AGENT_ROLE="python-developer"
   if echo "$ISSUE_LABELS" | grep -qE "db-schema|alembic|migration"; then
     AGENT_ROLE="database-architect"
@@ -436,7 +437,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
 
   # Write rich .agent-task — agent reads ALL context from this file
   # Extract DEPENDS_ON from issue body (looks for "Depends on #NNN" patterns)
-  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  # (ISSUE_BODY already set from MCP issue_read above)
   DEPENDS_ON=$(echo "$ISSUE_BODY" | grep -oE 'Depends on[^.]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   [ -z "$DEPENDS_ON" ] && DEPENDS_ON=none
 
@@ -446,7 +447,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   FILE_OWNERSHIP_VALUE="${FILE_OWNERSHIP:-tbd}"
 
   # Resolve COGNITIVE_ARCH for this issue's tech stack
-  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  # (ISSUE_BODY already set from MCP issue_read above)
   if echo "$ISSUE_BODY" | grep -qiE "d3\.js|force-directed|d3\.force|d3\.select"; then
     SKILLS="d3:javascript"
   elif echo "$ISSUE_BODY" | grep -qiE "monaco|vs/loader|editor.*cdn"; then
@@ -1238,8 +1239,8 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
 
   # Discover the PR number for the branch you just pushed.
   MY_BRANCH=$(git -C "$WORKTREE" rev-parse --abbrev-ref HEAD)
-  MY_PR=$(gh pr list --repo "$GH_REPO" --head "$MY_BRANCH" --state open \
-    --json number --jq '.[0].number // empty')
+  # MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open", head=MY_BRANCH)
+  # MY_PR = first result's number
 
   if [ -n "$MY_PR" ] && [ "$MY_PR" != "null" ]; then
     # Create a fresh review worktree at the PR branch tip.
@@ -1365,10 +1366,9 @@ REPO=$(git rev-parse --show-toplevel)
 cd "$REPO"
 
 echo "=== Files touched by currently open PRs ==="
-# MCP: github_list_prs(state="open") → for each PR:
-#   - .number, .title  (from github_list_prs result)
-#   - files: gh pr diff NUM --name-only (no MCP equivalent for diff content)
-for num in $(gh pr list --state open --json number --jq '.[].number'); do
+# MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open")
+# Iterate over result.number for overlap check
+for num in <result from MCP list_pull_requests>; do
   files=$(gh pr diff "$num" --name-only 2>/dev/null)
   if [ -n "$files" ]; then
     # MCP: github_get_pr(pr_number=num) → .title
@@ -1436,21 +1436,13 @@ PHASE_LABEL="phase-1"   # match the label used in Setup
 
 GH_REPO=cgcardona/agentception   # ← single place to change if the repo slug ever changes
 
-REMAINING=$(gh issue list \
-  --repo "$GH_REPO" \
-  --label "$PHASE_LABEL" \
-  --state open \
-  --json number \
-  --jq 'length')
+# MCP: list_issues(owner="cgcardona", repo="agentception", labels=[PHASE_LABEL], state="open")
+# REMAINING = count of results
+REMAINING=<count from MCP response>
 
 if [ "$REMAINING" -gt 0 ]; then
   echo "⚠️  $REMAINING open issue(s) still labeled '$PHASE_LABEL':"
-  gh issue list \
-    --repo "$GH_REPO" \
-    --label "$PHASE_LABEL" \
-    --state open \
-    --json number,title,url \
-    --jq '.[] | "#\(.number)  \(.title)\n  \(.url)"'
+  # MCP result already fetched above — iterate each: "#NUM  TITLE\n  URL"
   echo ""
   echo "→ These need implementation, review, or explicit closure before moving to the next phase."
   echo "→ Common causes:"
@@ -1468,7 +1460,7 @@ fi
 
 ```bash
 GH_REPO=cgcardona/agentception   # ← single place to change if the repo slug ever changes
-gh pr list --repo "$GH_REPO" --state open
+# MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open")
 ```
 
 All PRs from this batch should be open (awaiting review) or merged. None should be closed/rejected without a corresponding issue closure.
@@ -1499,8 +1491,9 @@ git -C "$REPO" status
 1. Check whether the work is already merged:
    ```bash
    # For each dirty file, find the PR that contains it:
-   gh pr list --state merged --json number,title --jq '.[].number' | \
-     xargs -I{} gh pr diff {} --name-only 2>/dev/null | grep <filename>
+   # MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="merged")
+   # For each result: use gh pr diff <number> --name-only to get changed files
+   # gh pr diff <number> --name-only 2>/dev/null | grep <filename>
    ```
 2. **If already merged** → the dirty files are stale copies. Discard them:
    ```bash
@@ -1515,7 +1508,7 @@ git -C "$REPO" status
    git -C "$REPO" add -A
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
-   gh pr create --base dev --head fix/<description> ...
+   # MCP: create_pull_request(owner="cgcardona", repo="agentception", title="...", body="...", head="fix/<description>", base="dev")
    ```
 
 ### 5 — Hand off to PR review
@@ -1900,9 +1893,10 @@ for entry in "${PRS[@]}"; do
   REVIEW_ROLE="pr-reviewer"
 
   # Fetch PR metadata for the task file
-  PR_BRANCH=$(gh pr view "$NUM" --repo "$GH_REPO" --json headRefName --jq '.headRefName' 2>/dev/null || echo "unknown")
+  # MCP: pull_request_read(owner="cgcardona", repo="agentception", pullNumber=NUM)
+  # PR_BRANCH = result.headRefName
+  # PR_BODY = result.body
   PR_FILES=$(gh pr diff "$NUM" --repo "$GH_REPO" --name-only 2>/dev/null | tr '\n' ',' | sed 's/,$//')
-  PR_BODY=$(gh pr view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null || echo "")
   CLOSES_ISSUE=$(echo "$PR_BODY" | grep -oE '[Cc]loses?\s+#[0-9]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   # MERGE_AFTER: PR number that must be merged before this one (for Alembic chain safety).
   # Set automatically if the PR body contains "Merges after #NNN" or "Depends on PR #NNN".
@@ -3265,8 +3259,12 @@ git -C "$REPO" status
 
 1. Check whether the work is already merged:
    ```bash
-   gh pr list --state merged --json number,title --jq '.[].number' | \
-     xargs -I{} gh pr diff {} --name-only 2>/dev/null | grep <filename>
+   # MCP: list_pull_requests(owner="cgcardona", repo="agentception",
+   #       state="merged") → for each result, extract .number into MERGED_NUMS
+   # Then for each merged PR number, check if its diff contains the dirty file:
+   for num in $MERGED_NUMS; do
+     gh pr diff "$num" --repo "$GH_REPO" --name-only 2>/dev/null | grep <filename>
+   done
    ```
 2. **If already merged** → stale copies. Discard:
    ```bash
@@ -3280,7 +3278,9 @@ git -C "$REPO" status
    git -C "$REPO" add -A
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
-   gh pr create --base dev --head fix/<description> ...
+   # MCP: create_pull_request(owner="cgcardona", repo="agentception",
+   #       title="feat: <description> (rescued from main repo dirty state)",
+   #       base="dev", head="fix/<description>", body="Rescued dirty-state work.")
    ```
 
 ---
@@ -3343,16 +3343,14 @@ N=$(grep "^PR_NUMBER=" .agent-task | cut -d= -f2)
 GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
 GH_REPO=${GH_REPO:-cgcardona/agentception}
 WTNAME=$(basename "$(pwd)")
-# Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
-IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "ac-ui/" || true)
-if [ "$IS_AC" -gt 0 ]; then
-  docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
-else
-  REPO=$(git worktree list | head -1 | awk '{print $1}')
-  cd "$REPO" && docker compose exec agentception sh -c \
-    "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
-fi
+# Determine if this PR is an AgentCeption PR:
+# Call pull_request_read(owner="cgcardona", repo="agentception", pullNumber=N)
+# If any label name contains "ac-ui/", run:
+#   docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
+# Otherwise (generic PR — no "ac-ui/" labels), run:
+REPO=$(git worktree list | head -1 | awk '{print $1}')
+cd "$REPO" && docker compose exec agentception sh -c \
+  "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
 ```
 Your job is to ensure the PR does not *introduce* new errors. But if you touch a file with pre-existing errors, you own them.
 

--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -50,16 +50,14 @@ N=$(grep "^PR_NUMBER=" .agent-task | cut -d= -f2)
 GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
 GH_REPO=${GH_REPO:-cgcardona/agentception}
 WTNAME=$(basename "$(pwd)")
-# Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
-IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "ac-ui/" || true)
-if [ "$IS_AC" -gt 0 ]; then
-  docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
-else
-  REPO=$(git worktree list | head -1 | awk '{print $1}')
-  cd "$REPO" && docker compose exec agentception sh -c \
-    "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
-fi
+# Determine if this PR is an AgentCeption PR:
+# Call pull_request_read(owner="cgcardona", repo="agentception", pullNumber=N)
+# If any label name contains "ac-ui/", run:
+#   docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
+# Otherwise (generic PR — no "ac-ui/" labels), run:
+REPO=$(git worktree list | head -1 | awk '{print $1}')
+cd "$REPO" && docker compose exec agentception sh -c \
+  "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
 ```
 Your job is to ensure the PR does not *introduce* new errors. But if you touch a file with pre-existing errors, you own them.
 

--- a/.agentception/roles/qa-coordinator.md
+++ b/.agentception/roles/qa-coordinator.md
@@ -286,9 +286,10 @@ for entry in "${PRS[@]}"; do
   REVIEW_ROLE="pr-reviewer"
 
   # Fetch PR metadata for the task file
-  PR_BRANCH=$(gh pr view "$NUM" --repo "$GH_REPO" --json headRefName --jq '.headRefName' 2>/dev/null || echo "unknown")
+  # MCP: pull_request_read(owner="cgcardona", repo="agentception", pullNumber=NUM)
+  # PR_BRANCH = result.headRefName
+  # PR_BODY = result.body
   PR_FILES=$(gh pr diff "$NUM" --repo "$GH_REPO" --name-only 2>/dev/null | tr '\n' ',' | sed 's/,$//')
-  PR_BODY=$(gh pr view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null || echo "")
   CLOSES_ISSUE=$(echo "$PR_BODY" | grep -oE '[Cc]loses?\s+#[0-9]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   # MERGE_AFTER: PR number that must be merged before this one (for Alembic chain safety).
   # Set automatically if the PR body contains "Merges after #NNN" or "Depends on PR #NNN".
@@ -1651,8 +1652,12 @@ git -C "$REPO" status
 
 1. Check whether the work is already merged:
    ```bash
-   gh pr list --state merged --json number,title --jq '.[].number' | \
-     xargs -I{} gh pr diff {} --name-only 2>/dev/null | grep <filename>
+   # MCP: list_pull_requests(owner="cgcardona", repo="agentception",
+   #       state="merged") → for each result, extract .number into MERGED_NUMS
+   # Then for each merged PR number, check if its diff contains the dirty file:
+   for num in $MERGED_NUMS; do
+     gh pr diff "$num" --repo "$GH_REPO" --name-only 2>/dev/null | grep <filename>
+   done
    ```
 2. **If already merged** → stale copies. Discard:
    ```bash
@@ -1666,7 +1671,9 @@ git -C "$REPO" status
    git -C "$REPO" add -A
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
-   gh pr create --base dev --head fix/<description> ...
+   # MCP: create_pull_request(owner="cgcardona", repo="agentception",
+   #       title="feat: <description> (rescued from main repo dirty state)",
+   #       base="dev", head="fix/<description>", body="Rescued dirty-state work.")
    ```
 
 ---
@@ -1729,16 +1736,14 @@ N=$(grep "^PR_NUMBER=" .agent-task | cut -d= -f2)
 GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
 GH_REPO=${GH_REPO:-cgcardona/agentception}
 WTNAME=$(basename "$(pwd)")
-# Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
-IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "ac-ui/" || true)
-if [ "$IS_AC" -gt 0 ]; then
-  docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
-else
-  REPO=$(git worktree list | head -1 | awk '{print $1}')
-  cd "$REPO" && docker compose exec agentception sh -c \
-    "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
-fi
+# Determine if this PR is an AgentCeption PR:
+# Call pull_request_read(owner="cgcardona", repo="agentception", pullNumber=N)
+# If any label name contains "ac-ui/", run:
+#   docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
+# Otherwise (generic PR — no "ac-ui/" labels), run:
+REPO=$(git worktree list | head -1 | awk '{print $1}')
+cd "$REPO" && docker compose exec agentception sh -c \
+  "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
 ```
 Your job is to ensure the PR does not *introduce* new errors. But if you touch a file with pre-existing errors, you own them.
 
@@ -1842,14 +1847,14 @@ Kickoff (coordinator)
 
 Agent (per worktree)
   └─ cat .agent-task                        ← knows exactly what to do
-  └─ gh pr list --search "closes #<N>"     ← CHECK FIRST: existing PR or branch?
+  └─ search_pull_requests(q="closes #<N> repo:cgcardona/agentception")  ← CHECK FIRST: existing PR or branch?
      if merged PR found → close issue + self-destruct
      if open PR found   → stop + self-destruct
   └─ git checkout -b feat/<description>     ← creates feature branch (only if new)
   └─ implement → mypy → tests → commit      ← build the fix
   └─ git fetch origin && git merge origin/dev  ← sync dev before pushing
   └─ resolve conflicts if any → re-run mypy + tests
-  └─ git push → gh pr create
+  └─ git push → MCP: create_pull_request(...)
   └─ git worktree remove --force <path>     ← self-destructs when done
   └─ git worktree prune
 ```
@@ -1909,7 +1914,8 @@ Before finalising your four, confirm each pair is independent:
 
 ```bash
 # For each candidate issue, list the files it is expected to touch:
-gh issue view <N> --json body   # check "Files / modules" section
+# MCP: issue_read(owner="cgcardona", repo="agentception", issue_number=N)
+# check "Files / modules" section in result.body
 
 # Confirm no pair shares a file before assigning the batch.
 ```
@@ -1952,13 +1958,11 @@ BATCH_LABEL="batch-01"
 
 # ── DERIVE ISSUES FROM GITHUB — never hardcode issue numbers ─────────────────
 echo "📋 Querying GitHub for open '$BATCH_LABEL' issues..."
+# MCP: list_issues(owner="cgcardona", repo="agentception", labels=[BATCH_LABEL], state="open")
+# Iterate results as RAW_ISSUES
 mapfile -t RAW_ISSUES < <(
-  gh issue list \
-    --repo "$GH_REPO" \
-    --label "$BATCH_LABEL" \
-    --state open \
-    --json number,title,labels \
-    --jq '.[] | "\(.number)|\(.title)|\(.labels | map(.name) | join(","))"'
+  # MCP result: each item has .number, .title, .labels[].name
+  # Format each as: "NUMBER|TITLE|label1,label2,..."
 )
 
 if [ ${#RAW_ISSUES[@]} -eq 0 ]; then
@@ -2009,7 +2013,9 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   # Assign ROLE based on issue labels:
   #   phase-1/db-schema, alembic, migration labels → database-architect
   #   all others → python-developer
-  ISSUE_LABELS=$(gh issue view "$NUM" --repo "$GH_REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+  # MCP: issue_read(owner="cgcardona", repo="agentception", issue_number=NUM)
+  # ISSUE_LABELS = result.labels[].name joined with ","
+  # ISSUE_BODY = result.body
   AGENT_ROLE="python-developer"
   if echo "$ISSUE_LABELS" | grep -qE "db-schema|alembic|migration"; then
     AGENT_ROLE="database-architect"
@@ -2017,7 +2023,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
 
   # Write rich .agent-task — agent reads ALL context from this file
   # Extract DEPENDS_ON from issue body (looks for "Depends on #NNN" patterns)
-  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  # (ISSUE_BODY already set from MCP issue_read above)
   DEPENDS_ON=$(echo "$ISSUE_BODY" | grep -oE 'Depends on[^.]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   [ -z "$DEPENDS_ON" ] && DEPENDS_ON=none
 
@@ -2027,7 +2033,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   FILE_OWNERSHIP_VALUE="${FILE_OWNERSHIP:-tbd}"
 
   # Resolve COGNITIVE_ARCH for this issue's tech stack
-  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  # (ISSUE_BODY already set from MCP issue_read above)
   if echo "$ISSUE_BODY" | grep -qiE "d3\.js|force-directed|d3\.force|d3\.select"; then
     SKILLS="d3:javascript"
   elif echo "$ISSUE_BODY" | grep -qiE "monaco|vs/loader|editor.*cdn"; then
@@ -2819,8 +2825,8 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
 
   # Discover the PR number for the branch you just pushed.
   MY_BRANCH=$(git -C "$WORKTREE" rev-parse --abbrev-ref HEAD)
-  MY_PR=$(gh pr list --repo "$GH_REPO" --head "$MY_BRANCH" --state open \
-    --json number --jq '.[0].number // empty')
+  # MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open", head=MY_BRANCH)
+  # MY_PR = first result's number
 
   if [ -n "$MY_PR" ] && [ "$MY_PR" != "null" ]; then
     # Create a fresh review worktree at the PR branch tip.
@@ -2946,10 +2952,9 @@ REPO=$(git rev-parse --show-toplevel)
 cd "$REPO"
 
 echo "=== Files touched by currently open PRs ==="
-# MCP: github_list_prs(state="open") → for each PR:
-#   - .number, .title  (from github_list_prs result)
-#   - files: gh pr diff NUM --name-only (no MCP equivalent for diff content)
-for num in $(gh pr list --state open --json number --jq '.[].number'); do
+# MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open")
+# Iterate over result.number for overlap check
+for num in <result from MCP list_pull_requests>; do
   files=$(gh pr diff "$num" --name-only 2>/dev/null)
   if [ -n "$files" ]; then
     # MCP: github_get_pr(pr_number=num) → .title
@@ -3017,21 +3022,13 @@ PHASE_LABEL="phase-1"   # match the label used in Setup
 
 GH_REPO=cgcardona/agentception   # ← single place to change if the repo slug ever changes
 
-REMAINING=$(gh issue list \
-  --repo "$GH_REPO" \
-  --label "$PHASE_LABEL" \
-  --state open \
-  --json number \
-  --jq 'length')
+# MCP: list_issues(owner="cgcardona", repo="agentception", labels=[PHASE_LABEL], state="open")
+# REMAINING = count of results
+REMAINING=<count from MCP response>
 
 if [ "$REMAINING" -gt 0 ]; then
   echo "⚠️  $REMAINING open issue(s) still labeled '$PHASE_LABEL':"
-  gh issue list \
-    --repo "$GH_REPO" \
-    --label "$PHASE_LABEL" \
-    --state open \
-    --json number,title,url \
-    --jq '.[] | "#\(.number)  \(.title)\n  \(.url)"'
+  # MCP result already fetched above — iterate each: "#NUM  TITLE\n  URL"
   echo ""
   echo "→ These need implementation, review, or explicit closure before moving to the next phase."
   echo "→ Common causes:"
@@ -3049,7 +3046,7 @@ fi
 
 ```bash
 GH_REPO=cgcardona/agentception   # ← single place to change if the repo slug ever changes
-gh pr list --repo "$GH_REPO" --state open
+# MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="open")
 ```
 
 All PRs from this batch should be open (awaiting review) or merged. None should be closed/rejected without a corresponding issue closure.
@@ -3080,8 +3077,9 @@ git -C "$REPO" status
 1. Check whether the work is already merged:
    ```bash
    # For each dirty file, find the PR that contains it:
-   gh pr list --state merged --json number,title --jq '.[].number' | \
-     xargs -I{} gh pr diff {} --name-only 2>/dev/null | grep <filename>
+   # MCP: list_pull_requests(owner="cgcardona", repo="agentception", state="merged")
+   # For each result: use gh pr diff <number> --name-only to get changed files
+   # gh pr diff <number> --name-only 2>/dev/null | grep <filename>
    ```
 2. **If already merged** → the dirty files are stale copies. Discard them:
    ```bash
@@ -3096,7 +3094,7 @@ git -C "$REPO" status
    git -C "$REPO" add -A
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
-   gh pr create --base dev --head fix/<description> ...
+   # MCP: create_pull_request(owner="cgcardona", repo="agentception", title="...", body="...", head="fix/<description>", base="dev")
    ```
 
 ### 5 — Hand off to PR review

--- a/scripts/gen_prompts/templates/parallel-bugs-to-issues.md.j2
+++ b/scripts/gen_prompts/templates/parallel-bugs-to-issues.md.j2
@@ -15,7 +15,7 @@
 >
 > **You do NOT:**
 > - Create any GitHub issues yourself.
-> - Run `gh issue create` yourself.
+> - Create GitHub issues via the shell — use MCP `issue_write()` instead.
 > - Apply labels yourself.
 > - Skip the Phase Planner — it is mandatory even if issues seem obvious.
 >
@@ -404,7 +404,7 @@ export GH_REPO=${GH_REPO:-{{ gh_repo }}}
 | GitHub repo slug | read from `.agent-task` GH_REPO field — always `{{ gh_repo }}` |
 | GitHub CLI | `gh` — already authenticated |
 
-**No Docker needed.** Issues are created via `gh issue create` — no code
+**No Docker needed.** Issues are created via MCP `issue_write()` — no code
 changes, no mypy, no tests.
 
 ---
@@ -463,9 +463,8 @@ STEP 2 — RESOLVE UPSTREAM ISSUE NUMBERS:
   IFS=',' read -ra UPSTREAM <<< "$PHASE_DEPENDS_ON_ISSUES"
   for issue_title in "${UPSTREAM[@]}"; do
     [ -z "$issue_title" ] && continue
-    NUM=$(gh issue list --repo "$GH_REPO" \
-      --search "\"$issue_title\" in:title" --state open \
-      --json number --jq '.[0].number // empty' 2>/dev/null)
+    # MCP: search_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", query="\"$issue_title\" in:title", state="open")
+    # Use the first result's number as NUM.
     [ -n "$NUM" ] && UPSTREAM_MAP+=("$issue_title → #$NUM")
     echo "  Upstream: $issue_title → #${NUM:-NOT FOUND}"
   done
@@ -493,24 +492,18 @@ STEP 3 — CREATE ISSUES:
        `<PHASE_LABEL>` — <phase description from task file>
 
   Idempotency check first:
-    gh issue list --repo "$GH_REPO" --search "<title>" --state all \
-      --json number,title,url | head -3
+    # MCP: search_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", query="<title> in:title")
+    # If any result matches the exact title → skip, record URL.
     If matching issue exists → skip, record URL.
 
   Create WITHOUT --label (two-step pattern):
-    ISSUE_URL=$(gh issue create \
-      --repo "$GH_REPO" \
-      --title "<TITLE>" \
-      --body "$(cat <<'EOF'
-<full constructed body with Dependencies + Phase sections>
-EOF
-)")
+    # MCP: issue_write(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", title="<TITLE>", body="<full constructed body with Dependencies + Phase sections>")
+    # Returns: issue number and URL — record as ISSUE_URL.
 
   Apply labels individually (|| true = non-fatal):
     IFS=',' read -ra ISSUE_LABELS <<< "<LABELS field>"
-    for label in "${ISSUE_LABELS[@]}"; do
-      gh issue edit "$ISSUE_URL" --repo "$GH_REPO" --add-label "$label" 2>/dev/null || true
-    done
+    # For each label in ISSUE_LABELS:
+    # MCP: github_add_label(issue_number=<N>, label=label)
 
   Fingerprint the created issue immediately — every issue must show which agent created it:
     ISSUE_CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -519,7 +512,7 @@ EOF
     #   body="🏷️ **Created by agent**\n\n$ISSUE_FINGERPRINT")
 
   Record the created URL.
-  ⚠️  If gh issue create fails twice for the same issue, skip and report — no loops.
+  ⚠️  If MCP issue_write() fails twice for the same issue, skip and report — no loops.
 
   ── LABEL REFERENCE ──────────────────────────────────────────────────────────
   │ Standard: bug  enhancement  documentation  testing  mypy                    │
@@ -536,12 +529,13 @@ STEP 4 — CROSS-LINK DOWNSTREAM ISSUES:
   For each created issue that had DEPENDS_ON_PHASES set:
     # Find the upstream issue numbers (already resolved in STEP 2)
     # Append to the body:
-    CURRENT_BODY=$(gh issue view "$ISSUE_NUM" --repo "$GH_REPO" --json body --jq '.body')
+    # MCP: issue_read(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", issue_number=ISSUE_NUM)
+    # CURRENT_BODY = result.body
     UPDATED_BODY="$CURRENT_BODY
 
 ---
 **Depends on:** $(join the real "#N — title" strings for upstream issues)"
-    gh issue edit "$ISSUE_NUM" --repo "$GH_REPO" --body "$UPDATED_BODY" 2>/dev/null || true
+    # MCP: issue_write(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", issue_number=ISSUE_NUM, body=UPDATED_BODY)
     echo "✅ Cross-linked #$ISSUE_NUM"
 
 STEP 5 — SELF-DESTRUCT:
@@ -558,13 +552,12 @@ and the resolved upstream #N cross-links written. An empty URL list is a failure
 
 ```bash
 # 1. Verify every issue has correct labels
-gh issue list --repo {{ gh_repo }} --label "{{ label_prefix }}0-foundation" \
-  --json number,title,labels --jq '.[] | "#\(.number) \(.title)"'
+# MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", labels="{{ label_prefix }}0-foundation", state="open")
+# Check each result's labels list for the expected labels.
 
 # 2. Verify dependency text in issue bodies
-gh issue list --repo {{ gh_repo }} --state open \
-  --json number,title,body \
-  --jq '.[] | select(.body | contains("Depends on")) | "#\(.number) \(.title)"'
+# MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", state="open")
+# Filter results: select issues where body contains "Depends on".
 
 # 3. Clean up worktrees
 git worktree prune
@@ -572,8 +565,7 @@ git worktree list  # should show only main repo
 
 # 4. Issues are immediately available for parallel-issue-to-pr.md
 # Dispatch by phase label (foundational phases first):
-gh issue list --repo {{ gh_repo }} --label "{{ label_prefix }}0-foundation" \
-  --state open --json number,title,url
+# MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", labels="{{ label_prefix }}0-foundation", state="open")
 ```
 
 ---

--- a/scripts/gen_prompts/templates/parallel-conductor.md.j2
+++ b/scripts/gen_prompts/templates/parallel-conductor.md.j2
@@ -153,29 +153,23 @@ STEP 0 — READ YOUR TASK FILE:
     Something is systematically wrong (label misconfiguration, GitHub API failure,
     all remaining issues blocked on human-gated dependencies, etc.).
     Create a GitHub issue:
-      gh issue create --repo "$GH_REPO" \
-        --title "⚠️ Conductor stuck: ATTEMPT_N=$ATTEMPT_N — needs human intervention" \
-        --body "The pipeline conductor has run $(( ATTEMPT_N )) times without advancing.
-  Possible causes:
-  - All remaining batches have unresolved DEPENDS_ON dependencies
-  - All remaining PRs are in D/F grade rejection state
-  - Label misconfiguration (phase/batch labels missing or wrong)
-  - GitHub API failures
-  
-  Run: gh issue list --repo $GH_REPO --label 'conductor-reminder' --state open
-  "
+      # MCP: issue_write(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+      #   title="⚠️ Conductor stuck: ATTEMPT_N=$ATTEMPT_N — needs human intervention",
+      #   body="The pipeline conductor has run $ATTEMPT_N times without advancing.\n\nPossible causes:\n- All remaining batches have unresolved DEPENDS_ON dependencies\n- All remaining PRs are in D/F grade rejection state\n- Label misconfiguration (phase/batch labels missing or wrong)\n- GitHub API failures\n\nUse MCP: list_issues(owner='{{ gh_repo.split('/')[0] }}', repo='{{ gh_repo.split('/')[1] }}', labels=['conductor-reminder'], state='open')")
+      # Returns: created issue URL/number
     Then self-destruct and escalate to the user.
 
 STEP 1 — STALE STATE CLEANUP (always run first):
   # 1a. Close stale conductor-reminder issues (they're outdated by this new run)
-  STALE_REMINDERS=$(gh issue list --repo "$GH_REPO" \
-    --label "conductor-reminder" --state open --json number --jq '.[].number' 2>/dev/null)
-  if [ -n "$STALE_REMINDERS" ]; then
-    echo "$STALE_REMINDERS" | tr ',' '\n' | xargs -I{} gh issue close {} \
-      --comment "Superseded by new conductor run. New reminder will be created if pipeline is still incomplete." \
-      --repo "$GH_REPO" 2>/dev/null || true
-    echo "✅ Closed stale reminder issues: $STALE_REMINDERS"
-  fi
+  # MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+  #   labels=["conductor-reminder"], state="open")
+  # Returns: STALE_REMINDERS — list of open conductor-reminder issues with their numbers
+  # For each issue N in STALE_REMINDERS:
+  #   MCP: issue_write(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+  #     issue_number=N, state="closed")
+  #   MCP: add_issue_comment(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+  #     issue_number=N, body="Superseded by new conductor run. New reminder will be created if pipeline is still incomplete.")
+  echo "✅ Closed stale reminder issues"
 
   # 1b. Clean up orphaned worktrees from crashed previous runs
   REPO=$(git worktree list | head -1 | awk '{print $1}')
@@ -199,30 +193,27 @@ STEP 2 — QUERY GITHUB PIPELINE STATE:
 
   echo "=== OPEN ISSUES BY PHASE/BATCH ==="
   if [ -n "$PHASE_FILTER" ]; then
-    gh issue list --repo "$GH_REPO" --label "$PHASE_FILTER" --state open \
-      --json number,title,labels --limit 100
+    # MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+    #   labels=[PHASE_FILTER], state="open")
+    # Returns: list of open issues with number, title, labels (up to 100)
   else
     # Query all phase labels in priority order
     for phase in "phase-1/db-schema" "phase-2/core-api" "phase-3/api-extensions" \
                  "phase-4/new-ui-pages" "phase-5/ui-enhancements" \
                  "phase-6/seed-data" "phase-7/machine-access"; do
-      COUNT=$(gh issue list --repo "$GH_REPO" --label "$phase" --state open \
-        --json number --jq 'length' 2>/dev/null || echo 0)
-      if [ "$COUNT" -gt 0 ]; then
-        echo ""
-        echo "── $phase ($COUNT open issues) ──"
-        gh issue list --repo "$GH_REPO" --label "$phase" --state open \
-          --json number,title,labels --jq \
-          '.[] | "\(.number) | \(.title) | \(.labels | map(.name) | join(","))"'
-      fi
+      # MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+      #   labels=[phase], state="open")
+      # Returns: list — set COUNT to length; for each item print "number | title | labels"
+      echo ""
+      echo "── $phase (COUNT open issues) ──"
     done
   fi
 
   echo ""
   echo "=== OPEN PRs ==="
-  gh pr list --repo "$GH_REPO" --state open --limit 50 \
-    --json number,title,headRefName,labels --jq \
-    '.[] | "#\(.number) | \(.title) | \(.headRefName)"'
+  # MCP: list_pull_requests(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+  #   state="open")
+  # Returns: list of open PRs — for each print "#number | title | headRefName"
 
 STEP 3 — RESOLVE DEPENDENCY GRAPH:
   # Determine which phases are fully merged (all issues closed) and which have work.
@@ -233,8 +224,10 @@ STEP 3 — RESOLVE DEPENDENCY GRAPH:
   for phase in "phase-1/db-schema" "phase-2/core-api" "phase-3/api-extensions" \
                "phase-4/new-ui-pages" "phase-5/ui-enhancements" \
                "phase-6/seed-data" "phase-7/machine-access"; do
-    COUNT=$(gh issue list --repo "$GH_REPO" --label "$phase" --state open \
-      --json number --jq 'length' 2>/dev/null || echo 0)
+    # MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+    #   labels=[phase], state="open")
+    # Returns: list — set COUNT to length of result
+    COUNT=0  # set to MCP result length
     PHASE_OPEN[$phase]=$COUNT
     echo "  $phase: $COUNT open issues"
   done
@@ -277,27 +270,24 @@ STEP 3 — RESOLVE DEPENDENCY GRAPH:
   READY_PRS=()
   for phase in "${ACTIVE_PHASES[@]}"; do
     # Issues with no associated PR → ready for ISSUE_TO_PR
-    PHASE_ISSUES=$(gh issue list --repo "$GH_REPO" --label "$phase" --state open \
-      --json number,title --jq '.[] | "\(.number)|\(.title)"' 2>/dev/null)
-    while IFS= read -r issue_entry; do
-      [ -z "$issue_entry" ] && continue
-      ISSUE_NUM="${issue_entry%%|*}"
+    # MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+    #   labels=[phase], state="open")
+    # Returns: PHASE_ISSUES — list of {number, title}
+    for each issue_entry in PHASE_ISSUES:
+      ISSUE_NUM = issue_entry.number
       # Check if a PR already exists for this issue
-      EXISTING_PR=$(gh pr list --repo "$GH_REPO" --state open \
-        --search "closes #$ISSUE_NUM" --json number --jq '.[0].number' 2>/dev/null)
+      # MCP: search_pull_requests(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+      #   query="closes #$ISSUE_NUM is:open")
+      # Returns: EXISTING_PR — first result's number (empty list means no PR exists)
       if [ -z "$EXISTING_PR" ]; then
         READY_ISSUES+=("$issue_entry")
       fi
-    done <<< "$PHASE_ISSUES"
 
     # PRs linked to this phase's issues → ready for PR_REVIEW
-    PHASE_PRS=$(gh pr list --repo "$GH_REPO" --state open --limit 50 \
-      --json number,title,labels --jq \
-      ".[] | select(.labels | map(.name) | any(. == \"$phase\")) | \"\(.number)|\(.title)\"" 2>/dev/null)
-    while IFS= read -r pr_entry; do
-      [ -z "$pr_entry" ] && continue
-      READY_PRS+=("$pr_entry")
-    done <<< "$PHASE_PRS"
+    # MCP: list_pull_requests(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+    #   state="open")
+    # Returns: all open PRs — filter client-side: select those whose labels include $phase
+    # Append matching "$number|$title" strings to READY_PRS
   done
 
   echo ""
@@ -316,8 +306,9 @@ STEP 4 — HUMAN APPROVAL GATE:
   # Check for phase-1 (DB schema / Alembic migrations)
   for issue_entry in "${READY_ISSUES[@]}"; do
     ISSUE_NUM="${issue_entry%%|*}"
-    LABELS=$(gh issue view "$ISSUE_NUM" --repo "$GH_REPO" --json labels \
-      --jq '.labels | map(.name) | join(",")' 2>/dev/null)
+    # MCP: issue_read(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+    #   issue_number=ISSUE_NUM)
+    # Returns: issue object — extract .labels | map(.name) | join(",") as LABELS
     if echo "$LABELS" | grep -q "phase-1/db-schema"; then
       echo "⚠️  HUMAN GATE: Issue #$ISSUE_NUM is in phase-1/db-schema (Alembic migration)."
       echo "   Verify MERGE_AFTER chain before dispatching. Requires human sign-off."
@@ -349,7 +340,8 @@ STEP 5 — DISPATCH COORDINATORS:
     echo "Target issues (pre-screened for file isolation within their phase):"
     for i in "${READY_ISSUES[@]}"; do echo "  #${i%%|*}: ${i##*|}"; done
     echo ""
-    echo "The coordinator query: gh issue list --repo $GH_REPO --label <active_phase> --state open"
+    echo "The coordinator confirmation query:"
+    echo "  MCP: list_issues(owner='{{ gh_repo.split('/')[0] }}', repo='{{ gh_repo.split('/')[1] }}', labels=[<active_phase>], state='open')"
     echo "Match these issue numbers to confirm the set before creating worktrees."
     echo ""
     echo "Coordinator constraint: MAX_ISSUES_PER_DISPATCH=$(grep "^MAX_ISSUES_PER_DISPATCH=" .agent-task | cut -d= -f2)"
@@ -398,11 +390,15 @@ STEP 6 — COLLECT COORDINATOR REPORTS:
 STEP 7 — REMINDER GATE:
   # After collecting all reports, determine if work remains.
 
-  REMAINING_ISSUES=$(gh issue list --repo "$GH_REPO" --state open \
-    --json labels --jq '[.[] | select(.labels | map(.name) | any(startswith("phase-")))] | length' \
-    2>/dev/null || echo 0)
-  REMAINING_PRS=$(gh pr list --repo "$GH_REPO" --state open --limit 100 \
-    --json number --jq 'length' 2>/dev/null || echo 0)
+  # MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+  #   state="open")
+  # Returns: all open issues — filter client-side: select those with any label starting with "phase-"
+  # Set REMAINING_ISSUES to filtered count
+  REMAINING_ISSUES=0  # set to MCP filtered count
+  # MCP: list_pull_requests(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+  #   state="open")
+  # Returns: all open PRs — set REMAINING_PRS to length
+  REMAINING_PRS=0  # set to MCP result length
 
   if [ "$REMAINING_ISSUES" -gt 0 ] || [ "$REMAINING_PRS" -gt 0 ]; then
     echo ""
@@ -423,25 +419,28 @@ into a new Cursor composer window rooted in the conductor worktree.
 $(for phase in "phase-1/db-schema" "phase-2/core-api" "phase-3/api-extensions" \
      "phase-4/new-ui-pages" "phase-5/ui-enhancements" \
      "phase-6/seed-data" "phase-7/machine-access"; do
-  COUNT=$(gh issue list --repo "$GH_REPO" --label "$phase" --state open \
-    --json number --jq 'length' 2>/dev/null || echo 0)
-  [ "$COUNT" -gt 0 ] && echo "- $phase: $COUNT open issues"
+  # MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+  #   labels=[phase], state="open")
+  # Returns: list — set COUNT to length; if COUNT > 0, emit "- $phase: $COUNT open issues"
+  echo "- $phase: COUNT open issues"
 done)
 
 ### Gated items (require human sign-off before conductor can proceed)
-$(gh issue list --repo "$GH_REPO" --label "phase-1/db-schema" --state open \
-  --json number,title --jq '.[] | "- Issue #\(.number): \(.title)"' 2>/dev/null || true)
+# MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+#   labels=["phase-1/db-schema"], state="open")
+# Returns: list — for each item emit "- Issue #number: title"
 
 ### Failed PRs (D/F grade — not merged, needs human review)
-$(gh pr list --repo "$GH_REPO" --state open \
-  --json number,title --jq '.[] | "- PR #\(.number): \(.title)"' 2>/dev/null | head -5 || true)
+# MCP: list_pull_requests(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+#   state="open")
+# Returns: list — for each item (up to 5) emit "- PR #number: title"
 "
 
-    REMINDER_URL=$(gh issue create \
-      --repo "$GH_REPO" \
-      --title "⏰ Conductor reminder — pipeline incomplete ($(date -u '+%Y-%m-%d'))" \
-      --body "$STATUS_BODY")
-    gh issue edit "$REMINDER_URL" --add-label "conductor-reminder" 2>/dev/null || true
+    # MCP: issue_write(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+    #   title="⏰ Conductor reminder — pipeline incomplete ($(date -u '+%Y-%m-%d'))",
+    #   body=STATUS_BODY)
+    # Returns: created issue object — capture .number as REMINDER_NUM
+    # MCP: github_add_label(issue_number=REMINDER_NUM, label="conductor-reminder")
 
     # Fingerprint the reminder issue so every conductor run is traceable.
     CONDUCTOR_CREATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -466,7 +465,10 @@ STEP 7.5 — POST-WAVE STALE BRANCH CLEANUP:
   git fetch --prune
   STALE_BRANCHES=$(git branch -r 2>/dev/null | grep -v "origin/main\|origin/dev\|HEAD" | sed 's|  origin/||' | tr -d ' ')
   for br in $STALE_BRANCHES; do
-    MERGED=$(gh pr list --head "$br" --state merged --json number --jq '.[0].number' --repo "$GH_REPO" 2>/dev/null)
+    # MCP: search_pull_requests(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+    #   query="head:$br is:merged")
+    # Returns: MERGED — first result's number (empty list means no merged PR for this branch)
+    MERGED=""  # set to first result's number from MCP response
     if [ -n "$MERGED" ]; then
       git push origin --delete "$br" 2>/dev/null \
         && echo "🧹 Deleted $br (PR #$MERGED merged)" \
@@ -531,5 +533,6 @@ These are patterns from real multi-agent systems. The conductor addresses each:
 REPO=$(git rev-parse --show-toplevel)
 git -C "$REPO" fetch origin && git -C "$REPO" merge origin/dev
 git worktree list
-gh issue list --repo {{ gh_repo }} --label "conductor-reminder" --state open
+# MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+#   labels=["conductor-reminder"], state="open")
 ```

--- a/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
+++ b/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
@@ -40,14 +40,14 @@ Kickoff (coordinator)
 
 Agent (per worktree)
   └─ cat .agent-task                        ← knows exactly what to do
-  └─ gh pr list --search "closes #<N>"     ← CHECK FIRST: existing PR or branch?
+  └─ search_pull_requests(q="closes #<N> repo:{{ gh_repo }}")  ← CHECK FIRST: existing PR or branch?
      if merged PR found → close issue + self-destruct
      if open PR found   → stop + self-destruct
   └─ git checkout -b feat/<description>     ← creates feature branch (only if new)
   └─ implement → mypy → tests → commit      ← build the fix
   └─ git fetch origin && git merge origin/dev  ← sync dev before pushing
   └─ resolve conflicts if any → re-run mypy + tests
-  └─ git push → gh pr create
+  └─ git push → MCP: create_pull_request(...)
   └─ git worktree remove --force <path>     ← self-destructs when done
   └─ git worktree prune
 ```
@@ -107,7 +107,8 @@ Before finalising your four, confirm each pair is independent:
 
 ```bash
 # For each candidate issue, list the files it is expected to touch:
-gh issue view <N> --json body   # check "Files / modules" section
+# MCP: issue_read(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", issue_number=N)
+# check "Files / modules" section in result.body
 
 # Confirm no pair shares a file before assigning the batch.
 ```
@@ -150,13 +151,11 @@ BATCH_LABEL="batch-01"
 
 # ── DERIVE ISSUES FROM GITHUB — never hardcode issue numbers ─────────────────
 echo "📋 Querying GitHub for open '$BATCH_LABEL' issues..."
+# MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", labels=[BATCH_LABEL], state="open")
+# Iterate results as RAW_ISSUES
 mapfile -t RAW_ISSUES < <(
-  gh issue list \
-    --repo "$GH_REPO" \
-    --label "$BATCH_LABEL" \
-    --state open \
-    --json number,title,labels \
-    --jq '.[] | "\(.number)|\(.title)|\(.labels | map(.name) | join(","))"'
+  # MCP result: each item has .number, .title, .labels[].name
+  # Format each as: "NUMBER|TITLE|label1,label2,..."
 )
 
 if [ ${#RAW_ISSUES[@]} -eq 0 ]; then
@@ -207,7 +206,9 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   # Assign ROLE based on issue labels:
   #   phase-1/db-schema, alembic, migration labels → database-architect
   #   all others → python-developer
-  ISSUE_LABELS=$(gh issue view "$NUM" --repo "$GH_REPO" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+  # MCP: issue_read(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", issue_number=NUM)
+  # ISSUE_LABELS = result.labels[].name joined with ","
+  # ISSUE_BODY = result.body
   AGENT_ROLE="python-developer"
   if echo "$ISSUE_LABELS" | grep -qE "db-schema|alembic|migration"; then
     AGENT_ROLE="database-architect"
@@ -215,7 +216,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
 
   # Write rich .agent-task — agent reads ALL context from this file
   # Extract DEPENDS_ON from issue body (looks for "Depends on #NNN" patterns)
-  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  # (ISSUE_BODY already set from MCP issue_read above)
   DEPENDS_ON=$(echo "$ISSUE_BODY" | grep -oE 'Depends on[^.]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   [ -z "$DEPENDS_ON" ] && DEPENDS_ON=none
 
@@ -225,7 +226,7 @@ for entry in "${SELECTED_ISSUES[@]}"; do
   FILE_OWNERSHIP_VALUE="${FILE_OWNERSHIP:-tbd}"
 
   # Resolve COGNITIVE_ARCH for this issue's tech stack
-  ISSUE_BODY=$(gh issue view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null)
+  # (ISSUE_BODY already set from MCP issue_read above)
   if echo "$ISSUE_BODY" | grep -qiE "d3\.js|force-directed|d3\.force|d3\.select"; then
     SKILLS="d3:javascript"
   elif echo "$ISSUE_BODY" | grep -qiE "monaco|vs/loader|editor.*cdn"; then
@@ -714,8 +715,8 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
 
   # Discover the PR number for the branch you just pushed.
   MY_BRANCH=$(git -C "$WORKTREE" rev-parse --abbrev-ref HEAD)
-  MY_PR=$(gh pr list --repo "$GH_REPO" --head "$MY_BRANCH" --state open \
-    --json number --jq '.[0].number // empty')
+  # MCP: list_pull_requests(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", state="open", head=MY_BRANCH)
+  # MY_PR = first result's number
 
   if [ -n "$MY_PR" ] && [ "$MY_PR" != "null" ]; then
     # Create a fresh review worktree at the PR branch tip.
@@ -837,10 +838,9 @@ REPO=$(git rev-parse --show-toplevel)
 cd "$REPO"
 
 echo "=== Files touched by currently open PRs ==="
-# MCP: github_list_prs(state="open") → for each PR:
-#   - .number, .title  (from github_list_prs result)
-#   - files: gh pr diff NUM --name-only (no MCP equivalent for diff content)
-for num in $(gh pr list --state open --json number --jq '.[].number'); do
+# MCP: list_pull_requests(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", state="open")
+# Iterate over result.number for overlap check
+for num in <result from MCP list_pull_requests>; do
   files=$(gh pr diff "$num" --name-only 2>/dev/null)
   if [ -n "$files" ]; then
     # MCP: github_get_pr(pr_number=num) → .title
@@ -908,21 +908,13 @@ PHASE_LABEL="phase-1"   # match the label used in Setup
 
 GH_REPO={{ gh_repo }}   # ← single place to change if the repo slug ever changes
 
-REMAINING=$(gh issue list \
-  --repo "$GH_REPO" \
-  --label "$PHASE_LABEL" \
-  --state open \
-  --json number \
-  --jq 'length')
+# MCP: list_issues(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", labels=[PHASE_LABEL], state="open")
+# REMAINING = count of results
+REMAINING=<count from MCP response>
 
 if [ "$REMAINING" -gt 0 ]; then
   echo "⚠️  $REMAINING open issue(s) still labeled '$PHASE_LABEL':"
-  gh issue list \
-    --repo "$GH_REPO" \
-    --label "$PHASE_LABEL" \
-    --state open \
-    --json number,title,url \
-    --jq '.[] | "#\(.number)  \(.title)\n  \(.url)"'
+  # MCP result already fetched above — iterate each: "#NUM  TITLE\n  URL"
   echo ""
   echo "→ These need implementation, review, or explicit closure before moving to the next phase."
   echo "→ Common causes:"
@@ -940,7 +932,7 @@ fi
 
 ```bash
 GH_REPO={{ gh_repo }}   # ← single place to change if the repo slug ever changes
-gh pr list --repo "$GH_REPO" --state open
+# MCP: list_pull_requests(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", state="open")
 ```
 
 All PRs from this batch should be open (awaiting review) or merged. None should be closed/rejected without a corresponding issue closure.
@@ -971,8 +963,9 @@ git -C "$REPO" status
 1. Check whether the work is already merged:
    ```bash
    # For each dirty file, find the PR that contains it:
-   gh pr list --state merged --json number,title --jq '.[].number' | \
-     xargs -I{} gh pr diff {} --name-only 2>/dev/null | grep <filename>
+   # MCP: list_pull_requests(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", state="merged")
+   # For each result: use gh pr diff <number> --name-only to get changed files
+   # gh pr diff <number> --name-only 2>/dev/null | grep <filename>
    ```
 2. **If already merged** → the dirty files are stale copies. Discard them:
    ```bash
@@ -987,7 +980,7 @@ git -C "$REPO" status
    git -C "$REPO" add -A
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
-   gh pr create --base dev --head fix/<description> ...
+   # MCP: create_pull_request(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", title="...", body="...", head="fix/<description>", base="dev")
    ```
 
 ### 5 — Hand off to PR review

--- a/scripts/gen_prompts/templates/parallel-pr-review.md.j2
+++ b/scripts/gen_prompts/templates/parallel-pr-review.md.j2
@@ -141,9 +141,10 @@ for entry in "${PRS[@]}"; do
   REVIEW_ROLE="pr-reviewer"
 
   # Fetch PR metadata for the task file
-  PR_BRANCH=$(gh pr view "$NUM" --repo "$GH_REPO" --json headRefName --jq '.headRefName' 2>/dev/null || echo "unknown")
+  # MCP: pull_request_read(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", pullNumber=NUM)
+  # PR_BRANCH = result.headRefName
+  # PR_BODY = result.body
   PR_FILES=$(gh pr diff "$NUM" --repo "$GH_REPO" --name-only 2>/dev/null | tr '\n' ',' | sed 's/,$//')
-  PR_BODY=$(gh pr view "$NUM" --repo "$GH_REPO" --json body --jq '.body' 2>/dev/null || echo "")
   CLOSES_ISSUE=$(echo "$PR_BODY" | grep -oE '[Cc]loses?\s+#[0-9]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
   # MERGE_AFTER: PR number that must be merged before this one (for Alembic chain safety).
   # Set automatically if the PR body contains "Merges after #NNN" or "Depends on PR #NNN".
@@ -1197,8 +1198,12 @@ git -C "$REPO" status
 
 1. Check whether the work is already merged:
    ```bash
-   gh pr list --state merged --json number,title --jq '.[].number' | \
-     xargs -I{} gh pr diff {} --name-only 2>/dev/null | grep <filename>
+   # MCP: list_pull_requests(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+   #       state="merged") → for each result, extract .number into MERGED_NUMS
+   # Then for each merged PR number, check if its diff contains the dirty file:
+   for num in $MERGED_NUMS; do
+     gh pr diff "$num" --repo "$GH_REPO" --name-only 2>/dev/null | grep <filename>
+   done
    ```
 2. **If already merged** → stale copies. Discard:
    ```bash
@@ -1212,7 +1217,9 @@ git -C "$REPO" status
    git -C "$REPO" add -A
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
-   gh pr create --base dev --head fix/<description> ...
+   # MCP: create_pull_request(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
+   #       title="feat: <description> (rescued from main repo dirty state)",
+   #       base="dev", head="fix/<description>", body="Rescued dirty-state work.")
    ```
 
 ---

--- a/scripts/gen_prompts/templates/pipeline-howto.md.j2
+++ b/scripts/gen_prompts/templates/pipeline-howto.md.j2
@@ -146,7 +146,7 @@ Lets you answer: *"Which specific agent opened this PR / merged this PR?"*
 git log --all --grep="AgentCeption-Batch: eng-20260301T053412Z-a7f2"
 
 # Find the PR opened by a specific agent session:
-gh pr list --repo {{ gh_repo }} --state all --search "eng-20260301T053412Z-a7f2"
+search_pull_requests(q="eng-20260301T053412Z-a7f2 repo:{{ gh_repo }}", state="all")
 
 # Find which batch a commit came from:
 git show <sha> | grep "AgentCeption-"
@@ -160,8 +160,8 @@ git show <sha> | grep "AgentCeption-"
 
 ```bash
 # What's open?
-gh issue list --state open --label "batch-NN" --repo {{ gh_repo }}
-gh pr list --base dev --state open --repo {{ gh_repo }}
+list_issues(label="batch-NN", state="open")   # GitHub MCP
+list_pull_requests(state="open", base="dev")  # GitHub MCP
 
 # What's in flight?
 git worktree list
@@ -174,7 +174,8 @@ git worktree list
 git worktree add -b feat/issue-{N} ~/.agentception/worktrees/{{ repo_name }}/issue-{N} origin/dev
 
 # For each PR to review (checkout the PR's branch):
-BRANCH=$(gh pr view {N} --json headRefName --jq '.headRefName')
+# Call pull_request_read(pullNumber=N) and read the headRefName field
+BRANCH=<headRefName from pull_request_read result>
 git worktree add ~/.agentception/worktrees/{{ repo_name }}/pr-{N} origin/$BRANCH
 ```
 
@@ -220,10 +221,10 @@ Use this when you want the pipeline to run end-to-end without manual interventio
 ```
 You are the CTO. Read <repo-root>/.agentception/roles/cto.md.
 
-Survey the pipeline state with gh issue list and gh pr list.
+Survey the pipeline state using MCP: list_issues(state="open") and list_pull_requests(state="open").
 Dispatch the Engineering Coordinator and QA Coordinator simultaneously using the Task tool.
 Each coordinator launches leaf agents pointing at the canonical prompts — not inline instructions.
-Continue until gh issue list --state open returns 0 results and gh pr list --state open returns 0 results.
+Continue until list_issues(state="open") returns 0 results and list_pull_requests(state="open") returns 0 results.
 GH_REPO={{ gh_repo }}
 Repo: <repo-root>
 ```
@@ -315,10 +316,10 @@ That is the complete prompt. The canonical file has everything else.
 
 ```bash
 # Check open PRs
-gh pr list --base dev --state open --repo {{ gh_repo }}
+list_pull_requests(state="open", base="dev")  # GitHub MCP
 
 # Check open issues remaining in a batch
-gh issue list --label "batch-07" --state open --repo {{ gh_repo }}
+list_issues(label="batch-07", state="open")   # GitHub MCP
 
 # Check worktrees in flight
 git worktree list
@@ -330,7 +331,7 @@ git worktree list
 
 If an agent crashes mid-task:
 
-1. Check if its PR was opened: `gh pr list --state open --repo {{ gh_repo }}`
+1. Check if its PR was opened: `list_pull_requests(state="open")`  *(GitHub MCP)*
 2. Check if its worktree still exists: `git worktree list`
 3. If worktree exists + no PR: re-launch the leaf agent with the same prompt
 4. If worktree missing + PR open: create a review worktree and assign a reviewer

--- a/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
@@ -49,16 +49,14 @@ N=$(grep "^PR_NUMBER=" .agent-task | cut -d= -f2)
 GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
 GH_REPO=${GH_REPO:-{{ gh_repo }}}
 WTNAME=$(basename "$(pwd)")
-# Live lookup — ALL_ISSUE_LABELS is not written to reviewer .agent-task files
-IS_AC=$(gh pr view "$N" --repo "$GH_REPO" --json labels \
-  --jq '[.labels[].name] | join(",")' 2>/dev/null | grep -c "{{ active_label_prefix }}" || true)
-if [ "$IS_AC" -gt 0 ]; then
-  {{ active_mypy }} 2>&1 | tail -5
-else
-  REPO=$(git worktree list | head -1 | awk '{print $1}')
-  cd "$REPO" && docker compose exec agentception sh -c \
-    "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
-fi
+# Determine if this PR is an AgentCeption PR:
+# Call pull_request_read(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", pullNumber=N)
+# If any label name contains "{{ active_label_prefix }}", run:
+#   {{ active_mypy }} 2>&1 | tail -5
+# Otherwise (generic PR — no "{{ active_label_prefix }}" labels), run:
+REPO=$(git worktree list | head -1 | awk '{print $1}')
+cd "$REPO" && docker compose exec agentception sh -c \
+  "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
 ```
 Your job is to ensure the PR does not *introduce* new errors. But if you touch a file with pre-existing errors, you own them.
 


### PR DESCRIPTION
## Summary
- Replace 46 `gh issue`/`gh pr` shell calls across 6 pipeline templates and the pr-reviewer role with their MCP equivalents (`list_issues`, `issue_read`, `issue_write`, `list_pull_requests`, `pull_request_read`, `create_pull_request`, `search_pull_requests`, `github_add_label`, `github_remove_label`)
- Update `agent-command-policy.md` to clearly state MCP-first policy: demote `gh` read commands to "prefer MCP" annotations, rewrite Safe Writes so `gh pr checkout` is the only concrete `gh` command remaining
- Legitimate `gh` keeps unchanged: `gh pr diff`, `gh label create/edit/list`, `gh auth status`, `gh run *`, `gh release *`, `gh pr checkout`
- All 9 generated `.agentception/` files regenerated from updated templates

## Test plan
- [x] Mypy clean — 0 errors in 164 source files
- [x] 52 tests passing, 0 failures, 0 warnings