### PR TITLE
feat: enforce cognitive arch confirmation response at every agent tier

### DIFF
--- a/.agentception/parallel-issue-to-pr.md
+++ b/.agentception/parallel-issue-to-pr.md
@@ -554,6 +554,24 @@ STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   # The cognitive architecture, role file, and .agent-task together form
   # your full operating context. Honor all three.
 
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
+
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only
   WTNAME=$(basename "$(pwd)")

--- a/.agentception/parallel-pr-review.md
+++ b/.agentception/parallel-pr-review.md
@@ -459,7 +459,7 @@ STEP 0 — READ YOUR TASK FILE:
   ⚠️  If HAS_MIGRATION=true → you MUST run STEP 5.B (Alembic chain validation)
       before grading. A broken migration chain is an automatic C → mandatory fix.
 
-STEP 0.5 — LOAD YOUR ROLE:
+STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
   echo "✅ Operating as role: $ROLE"
   # Your role definition is embedded at the bottom of this prompt under
@@ -467,6 +467,49 @@ STEP 0.5 — LOAD YOUR ROLE:
   # is metadata only; do NOT read it from disk.
   # Find the ### pr-reviewer section and let its decision hierarchy, quality bar,
   # and failure modes govern all your choices from this point forward.
+
+  # Load cognitive architecture — assembles figure persona + all skill domain fragments
+  # Format: "figure:skill1:skill2" (new multi-skill format, colon-separated)
+  COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+  if [ -n "$COGNITIVE_ARCH" ]; then
+    echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
+    echo ""
+    # resolve_arch.py assembles the full context block:
+    # figures (comma-separated before first ':') + skill domains (colon-separated after).
+    # Use --mode reviewer to load review_checklist fragments instead of implementer fragments.
+    REPO=$(git worktree list | head -1 | awk '{print $1}')
+    RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+    if [ -f "$RESOLVE_ARCH" ]; then
+      ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode reviewer 2>/dev/null)
+      if [ -n "$ARCH_CONTEXT" ]; then
+        echo "$ARCH_CONTEXT"
+      fi
+    else
+      echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+    fi
+    echo ""
+    echo "Let these govern your review approach."
+  else
+    echo "⚠️  No COGNITIVE_ARCH set — using default reviewer approach."
+  fi
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -42,6 +42,42 @@ spawns the next agent for the next unclaimed item before it exits. No batch
 boundaries. No wasted time waiting for the slowest agent before the next one
 starts. The pool stays at 4 concurrent workers continuously until the queue drains.
 
+## STEP 0 — LOAD COGNITIVE ARCHITECTURE (do this before the loop)
+
+Your cognitive architecture is `von_neumann` — systematic, architectural, throughput-obsessed.
+Load the full context block now:
+
+```bash
+REPO=$(git rev-parse --show-toplevel 2>/dev/null || echo "<repo-root>")
+COGNITIVE_ARCH="von_neumann"
+ROLE="cto"
+RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+if [ -f "$RESOLVE_ARCH" ]; then
+  ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode implementer 2>/dev/null)
+  echo "$ARCH_CONTEXT"
+else
+  echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+fi
+```
+
+⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ENTERING THE LOOP:
+Immediately send the following as your **first text response** to the user
+(not a shell command, not a tool call, not chain-of-thought — actual visible
+output text in your reply message):
+
+---
+🧠 **Cognitive architecture correctly injected.**
+
+**My name is:** [extract the figure display name from the first
+  "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+**My role:** CTO / Pipeline Orchestrator
+**My cognitive architecture string:** von_neumann
+
+[Paste the full content of $ARCH_CONTEXT here verbatim]
+---
+
+Do not enter the loop until this response has been sent.
+
 ## Your autonomous loop
 
 ```
@@ -231,8 +267,41 @@ You are **autonomous and self-looping** — you run until no open issues remain.
 You never write a single line of feature code. You route work and report to your parent node.
 
 Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
-Run `python scripts/gen_prompts/resolve_arch.py "$COGNITIVE_ARCH"` to load your
-persona and skill context before acting.
+Load it as the very first thing you do — see STEP 0 below.
+
+## STEP 0 — LOAD COGNITIVE ARCHITECTURE (do this before anything else)
+
+```bash
+REPO=$(git rev-parse --show-toplevel 2>/dev/null || git worktree list | head -1 | awk '{print $1}')
+COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
+RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+if [ -n "$COGNITIVE_ARCH" ] && [ -f "$RESOLVE_ARCH" ]; then
+  ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode implementer 2>/dev/null)
+  echo "$ARCH_CONTEXT"
+else
+  echo "⚠️  COGNITIVE_ARCH not set or resolve_arch.py missing — proceeding with default hamming persona."
+  COGNITIVE_ARCH="${COGNITIVE_ARCH:-hamming}"
+fi
+```
+
+⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE SEEDING ANY AGENTS:
+Immediately send the following as your **first text response** to the user
+(not a shell command, not a tool call, not chain-of-thought — actual visible
+output text in your reply message):
+
+---
+🧠 **Cognitive architecture correctly injected.**
+
+**My name is:** [extract the figure display name from the first
+  "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+**My role:** Engineering Coordinator ([value of $ROLE])
+**My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+[Paste the full content of $ARCH_CONTEXT here verbatim]
+---
+
+Do not proceed to the SEED block until this response has been sent.
 
 ## Your job: seed the pool once, then wait
 
@@ -966,6 +1035,24 @@ STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   fi
   # The cognitive architecture, role file, and .agent-task together form
   # your full operating context. Honor all three.
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only
@@ -2468,7 +2555,7 @@ STEP 0 — READ YOUR TASK FILE:
   ⚠️  If HAS_MIGRATION=true → you MUST run STEP 5.B (Alembic chain validation)
       before grading. A broken migration chain is an automatic C → mandatory fix.
 
-STEP 0.5 — LOAD YOUR ROLE:
+STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
   echo "✅ Operating as role: $ROLE"
   # Your role definition is embedded at the bottom of this prompt under
@@ -2476,6 +2563,49 @@ STEP 0.5 — LOAD YOUR ROLE:
   # is metadata only; do NOT read it from disk.
   # Find the ### pr-reviewer section and let its decision hierarchy, quality bar,
   # and failure modes govern all your choices from this point forward.
+
+  # Load cognitive architecture — assembles figure persona + all skill domain fragments
+  # Format: "figure:skill1:skill2" (new multi-skill format, colon-separated)
+  COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+  if [ -n "$COGNITIVE_ARCH" ]; then
+    echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
+    echo ""
+    # resolve_arch.py assembles the full context block:
+    # figures (comma-separated before first ':') + skill domains (colon-separated after).
+    # Use --mode reviewer to load review_checklist fragments instead of implementer fragments.
+    REPO=$(git worktree list | head -1 | awk '{print $1}')
+    RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+    if [ -f "$RESOLVE_ARCH" ]; then
+      ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode reviewer 2>/dev/null)
+      if [ -n "$ARCH_CONTEXT" ]; then
+        echo "$ARCH_CONTEXT"
+      fi
+    else
+      echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+    fi
+    echo ""
+    echo "Let these govern your review approach."
+  else
+    echo "⚠️  No COGNITIVE_ARCH set — using default reviewer approach."
+  fi
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only
@@ -3699,8 +3829,43 @@ You are **autonomous and self-looping** — you run until no open PRs remain.
 You never review code yourself. You route work and report to your parent node.
 
 Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
-Run `python scripts/gen_prompts/resolve_arch.py "$COGNITIVE_ARCH"` to load your
-persona and skill context before acting. The quality bar below is non-negotiable
+Load it as the very first thing you do — see STEP 0 below.
+
+## STEP 0 — LOAD COGNITIVE ARCHITECTURE (do this before anything else)
+
+```bash
+REPO=$(git rev-parse --show-toplevel 2>/dev/null || git worktree list | head -1 | awk '{print $1}')
+COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
+RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+if [ -n "$COGNITIVE_ARCH" ] && [ -f "$RESOLVE_ARCH" ]; then
+  ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode reviewer 2>/dev/null)
+  echo "$ARCH_CONTEXT"
+else
+  echo "⚠️  COGNITIVE_ARCH not set or resolve_arch.py missing — proceeding with default dijkstra persona."
+  COGNITIVE_ARCH="${COGNITIVE_ARCH:-dijkstra}"
+fi
+```
+
+⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE SEEDING ANY REVIEWERS:
+Immediately send the following as your **first text response** to the user
+(not a shell command, not a tool call, not chain-of-thought — actual visible
+output text in your reply message):
+
+---
+🧠 **Cognitive architecture correctly injected.**
+
+**My name is:** [extract the figure display name from the first
+  "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+**My role:** QA Coordinator ([value of $ROLE])
+**My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+[Paste the full content of $ARCH_CONTEXT here verbatim]
+---
+
+Do not proceed to the SEED block until this response has been sent.
+
+The quality bar below is non-negotiable
 regardless of persona — it is a property of the pipeline, not of any individual agent.
 
 You enforce the pipeline quality bar without compromise: **warnings are failures**,
@@ -4295,7 +4460,7 @@ STEP 0 — READ YOUR TASK FILE:
   ⚠️  If HAS_MIGRATION=true → you MUST run STEP 5.B (Alembic chain validation)
       before grading. A broken migration chain is an automatic C → mandatory fix.
 
-STEP 0.5 — LOAD YOUR ROLE:
+STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
   echo "✅ Operating as role: $ROLE"
   # Your role definition is embedded at the bottom of this prompt under
@@ -4303,6 +4468,49 @@ STEP 0.5 — LOAD YOUR ROLE:
   # is metadata only; do NOT read it from disk.
   # Find the ### pr-reviewer section and let its decision hierarchy, quality bar,
   # and failure modes govern all your choices from this point forward.
+
+  # Load cognitive architecture — assembles figure persona + all skill domain fragments
+  # Format: "figure:skill1:skill2" (new multi-skill format, colon-separated)
+  COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+  if [ -n "$COGNITIVE_ARCH" ]; then
+    echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
+    echo ""
+    # resolve_arch.py assembles the full context block:
+    # figures (comma-separated before first ':') + skill domains (colon-separated after).
+    # Use --mode reviewer to load review_checklist fragments instead of implementer fragments.
+    REPO=$(git worktree list | head -1 | awk '{print $1}')
+    RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+    if [ -f "$RESOLVE_ARCH" ]; then
+      ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode reviewer 2>/dev/null)
+      if [ -n "$ARCH_CONTEXT" ]; then
+        echo "$ARCH_CONTEXT"
+      fi
+    else
+      echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+    fi
+    echo ""
+    echo "Let these govern your review approach."
+  else
+    echo "⚠️  No COGNITIVE_ARCH set — using default reviewer approach."
+  fi
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only
@@ -6070,6 +6278,24 @@ STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   fi
   # The cognitive architecture, role file, and .agent-task together form
   # your full operating context. Honor all three.
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -8,8 +8,41 @@ You are **autonomous and self-looping** — you run until no open issues remain.
 You never write a single line of feature code. You route work and report to your parent node.
 
 Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
-Run `python scripts/gen_prompts/resolve_arch.py "$COGNITIVE_ARCH"` to load your
-persona and skill context before acting.
+Load it as the very first thing you do — see STEP 0 below.
+
+## STEP 0 — LOAD COGNITIVE ARCHITECTURE (do this before anything else)
+
+```bash
+REPO=$(git rev-parse --show-toplevel 2>/dev/null || git worktree list | head -1 | awk '{print $1}')
+COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
+RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+if [ -n "$COGNITIVE_ARCH" ] && [ -f "$RESOLVE_ARCH" ]; then
+  ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode implementer 2>/dev/null)
+  echo "$ARCH_CONTEXT"
+else
+  echo "⚠️  COGNITIVE_ARCH not set or resolve_arch.py missing — proceeding with default hamming persona."
+  COGNITIVE_ARCH="${COGNITIVE_ARCH:-hamming}"
+fi
+```
+
+⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE SEEDING ANY AGENTS:
+Immediately send the following as your **first text response** to the user
+(not a shell command, not a tool call, not chain-of-thought — actual visible
+output text in your reply message):
+
+---
+🧠 **Cognitive architecture correctly injected.**
+
+**My name is:** [extract the figure display name from the first
+  "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+**My role:** Engineering Coordinator ([value of $ROLE])
+**My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+[Paste the full content of $ARCH_CONTEXT here verbatim]
+---
+
+Do not proceed to the SEED block until this response has been sent.
 
 ## Your job: seed the pool once, then wait
 
@@ -743,6 +776,24 @@ STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   fi
   # The cognitive architecture, role file, and .agent-task together form
   # your full operating context. Honor all three.
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only
@@ -2245,7 +2296,7 @@ STEP 0 — READ YOUR TASK FILE:
   ⚠️  If HAS_MIGRATION=true → you MUST run STEP 5.B (Alembic chain validation)
       before grading. A broken migration chain is an automatic C → mandatory fix.
 
-STEP 0.5 — LOAD YOUR ROLE:
+STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
   echo "✅ Operating as role: $ROLE"
   # Your role definition is embedded at the bottom of this prompt under
@@ -2253,6 +2304,49 @@ STEP 0.5 — LOAD YOUR ROLE:
   # is metadata only; do NOT read it from disk.
   # Find the ### pr-reviewer section and let its decision hierarchy, quality bar,
   # and failure modes govern all your choices from this point forward.
+
+  # Load cognitive architecture — assembles figure persona + all skill domain fragments
+  # Format: "figure:skill1:skill2" (new multi-skill format, colon-separated)
+  COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+  if [ -n "$COGNITIVE_ARCH" ]; then
+    echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
+    echo ""
+    # resolve_arch.py assembles the full context block:
+    # figures (comma-separated before first ':') + skill domains (colon-separated after).
+    # Use --mode reviewer to load review_checklist fragments instead of implementer fragments.
+    REPO=$(git worktree list | head -1 | awk '{print $1}')
+    RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+    if [ -f "$RESOLVE_ARCH" ]; then
+      ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode reviewer 2>/dev/null)
+      if [ -n "$ARCH_CONTEXT" ]; then
+        echo "$ARCH_CONTEXT"
+      fi
+    else
+      echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+    fi
+    echo ""
+    echo "Let these govern your review approach."
+  else
+    echo "⚠️  No COGNITIVE_ARCH set — using default reviewer approach."
+  fi
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only

--- a/.agentception/roles/qa-coordinator.md
+++ b/.agentception/roles/qa-coordinator.md
@@ -8,8 +8,43 @@ You are **autonomous and self-looping** — you run until no open PRs remain.
 You never review code yourself. You route work and report to your parent node.
 
 Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
-Run `python scripts/gen_prompts/resolve_arch.py "$COGNITIVE_ARCH"` to load your
-persona and skill context before acting. The quality bar below is non-negotiable
+Load it as the very first thing you do — see STEP 0 below.
+
+## STEP 0 — LOAD COGNITIVE ARCHITECTURE (do this before anything else)
+
+```bash
+REPO=$(git rev-parse --show-toplevel 2>/dev/null || git worktree list | head -1 | awk '{print $1}')
+COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
+RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+if [ -n "$COGNITIVE_ARCH" ] && [ -f "$RESOLVE_ARCH" ]; then
+  ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode reviewer 2>/dev/null)
+  echo "$ARCH_CONTEXT"
+else
+  echo "⚠️  COGNITIVE_ARCH not set or resolve_arch.py missing — proceeding with default dijkstra persona."
+  COGNITIVE_ARCH="${COGNITIVE_ARCH:-dijkstra}"
+fi
+```
+
+⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE SEEDING ANY REVIEWERS:
+Immediately send the following as your **first text response** to the user
+(not a shell command, not a tool call, not chain-of-thought — actual visible
+output text in your reply message):
+
+---
+🧠 **Cognitive architecture correctly injected.**
+
+**My name is:** [extract the figure display name from the first
+  "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+**My role:** QA Coordinator ([value of $ROLE])
+**My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+[Paste the full content of $ARCH_CONTEXT here verbatim]
+---
+
+Do not proceed to the SEED block until this response has been sent.
+
+The quality bar below is non-negotiable
 regardless of persona — it is a property of the pipeline, not of any individual agent.
 
 You enforce the pipeline quality bar without compromise: **warnings are failures**,
@@ -604,7 +639,7 @@ STEP 0 — READ YOUR TASK FILE:
   ⚠️  If HAS_MIGRATION=true → you MUST run STEP 5.B (Alembic chain validation)
       before grading. A broken migration chain is an automatic C → mandatory fix.
 
-STEP 0.5 — LOAD YOUR ROLE:
+STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
   echo "✅ Operating as role: $ROLE"
   # Your role definition is embedded at the bottom of this prompt under
@@ -612,6 +647,49 @@ STEP 0.5 — LOAD YOUR ROLE:
   # is metadata only; do NOT read it from disk.
   # Find the ### pr-reviewer section and let its decision hierarchy, quality bar,
   # and failure modes govern all your choices from this point forward.
+
+  # Load cognitive architecture — assembles figure persona + all skill domain fragments
+  # Format: "figure:skill1:skill2" (new multi-skill format, colon-separated)
+  COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+  if [ -n "$COGNITIVE_ARCH" ]; then
+    echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
+    echo ""
+    # resolve_arch.py assembles the full context block:
+    # figures (comma-separated before first ':') + skill domains (colon-separated after).
+    # Use --mode reviewer to load review_checklist fragments instead of implementer fragments.
+    REPO=$(git worktree list | head -1 | awk '{print $1}')
+    RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+    if [ -f "$RESOLVE_ARCH" ]; then
+      ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode reviewer 2>/dev/null)
+      if [ -n "$ARCH_CONTEXT" ]; then
+        echo "$ARCH_CONTEXT"
+      fi
+    else
+      echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+    fi
+    echo ""
+    echo "Let these govern your review approach."
+  else
+    echo "⚠️  No COGNITIVE_ARCH set — using default reviewer approach."
+  fi
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only
@@ -2379,6 +2457,24 @@ STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   fi
   # The cognitive architecture, role file, and .agent-task together form
   # your full operating context. Honor all three.
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only

--- a/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
+++ b/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
@@ -405,6 +405,24 @@ STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   # The cognitive architecture, role file, and .agent-task together form
   # your full operating context. Honor all three.
 
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
+
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only
   WTNAME=$(basename "$(pwd)")

--- a/scripts/gen_prompts/templates/parallel-pr-review.md.j2
+++ b/scripts/gen_prompts/templates/parallel-pr-review.md.j2
@@ -316,7 +316,7 @@ STEP 0 — READ YOUR TASK FILE:
   ⚠️  If HAS_MIGRATION=true → you MUST run STEP 5.B (Alembic chain validation)
       before grading. A broken migration chain is an automatic C → mandatory fix.
 
-STEP 0.5 — LOAD YOUR ROLE:
+STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
   echo "✅ Operating as role: $ROLE"
   # Your role definition is embedded at the bottom of this prompt under
@@ -324,6 +324,49 @@ STEP 0.5 — LOAD YOUR ROLE:
   # is metadata only; do NOT read it from disk.
   # Find the ### pr-reviewer section and let its decision hierarchy, quality bar,
   # and failure modes govern all your choices from this point forward.
+
+  # Load cognitive architecture — assembles figure persona + all skill domain fragments
+  # Format: "figure:skill1:skill2" (new multi-skill format, colon-separated)
+  COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+  if [ -n "$COGNITIVE_ARCH" ]; then
+    echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
+    echo ""
+    # resolve_arch.py assembles the full context block:
+    # figures (comma-separated before first ':') + skill domains (colon-separated after).
+    # Use --mode reviewer to load review_checklist fragments instead of implementer fragments.
+    REPO=$(git worktree list | head -1 | awk '{print $1}')
+    RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+    if [ -f "$RESOLVE_ARCH" ]; then
+      ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode reviewer 2>/dev/null)
+      if [ -n "$ARCH_CONTEXT" ]; then
+        echo "$ARCH_CONTEXT"
+      fi
+    else
+      echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+    fi
+    echo ""
+    echo "Let these govern your review approach."
+  else
+    echo "⚠️  No COGNITIVE_ARCH set — using default reviewer approach."
+  fi
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
 
 STEP 1 — DERIVE PATHS:
   REPO=$(git worktree list | head -1 | awk '{print $1}')   # local filesystem path only

--- a/scripts/gen_prompts/templates/roles/cto.md.j2
+++ b/scripts/gen_prompts/templates/roles/cto.md.j2
@@ -41,6 +41,42 @@ spawns the next agent for the next unclaimed item before it exits. No batch
 boundaries. No wasted time waiting for the slowest agent before the next one
 starts. The pool stays at 4 concurrent workers continuously until the queue drains.
 
+## STEP 0 — LOAD COGNITIVE ARCHITECTURE (do this before the loop)
+
+Your cognitive architecture is `von_neumann` — systematic, architectural, throughput-obsessed.
+Load the full context block now:
+
+```bash
+REPO=$(git rev-parse --show-toplevel 2>/dev/null || echo "<repo-root>")
+COGNITIVE_ARCH="von_neumann"
+ROLE="cto"
+RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+if [ -f "$RESOLVE_ARCH" ]; then
+  ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode implementer 2>/dev/null)
+  echo "$ARCH_CONTEXT"
+else
+  echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+fi
+```
+
+⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ENTERING THE LOOP:
+Immediately send the following as your **first text response** to the user
+(not a shell command, not a tool call, not chain-of-thought — actual visible
+output text in your reply message):
+
+---
+🧠 **Cognitive architecture correctly injected.**
+
+**My name is:** [extract the figure display name from the first
+  "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+**My role:** CTO / Pipeline Orchestrator
+**My cognitive architecture string:** von_neumann
+
+[Paste the full content of $ARCH_CONTEXT here verbatim]
+---
+
+Do not enter the loop until this response has been sent.
+
 ## Your autonomous loop
 
 ```

--- a/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
@@ -7,8 +7,41 @@ You are **autonomous and self-looping** — you run until no open issues remain.
 You never write a single line of feature code. You route work and report to your parent node.
 
 Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
-Run `python scripts/gen_prompts/resolve_arch.py "$COGNITIVE_ARCH"` to load your
-persona and skill context before acting.
+Load it as the very first thing you do — see STEP 0 below.
+
+## STEP 0 — LOAD COGNITIVE ARCHITECTURE (do this before anything else)
+
+```bash
+REPO=$(git rev-parse --show-toplevel 2>/dev/null || git worktree list | head -1 | awk '{print $1}')
+COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
+RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+if [ -n "$COGNITIVE_ARCH" ] && [ -f "$RESOLVE_ARCH" ]; then
+  ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode implementer 2>/dev/null)
+  echo "$ARCH_CONTEXT"
+else
+  echo "⚠️  COGNITIVE_ARCH not set or resolve_arch.py missing — proceeding with default hamming persona."
+  COGNITIVE_ARCH="${COGNITIVE_ARCH:-hamming}"
+fi
+```
+
+⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE SEEDING ANY AGENTS:
+Immediately send the following as your **first text response** to the user
+(not a shell command, not a tool call, not chain-of-thought — actual visible
+output text in your reply message):
+
+---
+🧠 **Cognitive architecture correctly injected.**
+
+**My name is:** [extract the figure display name from the first
+  "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+**My role:** Engineering Coordinator ([value of $ROLE])
+**My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+[Paste the full content of $ARCH_CONTEXT here verbatim]
+---
+
+Do not proceed to the SEED block until this response has been sent.
 
 ## Your job: seed the pool once, then wait
 

--- a/scripts/gen_prompts/templates/roles/qa-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/qa-coordinator.md.j2
@@ -7,8 +7,43 @@ You are **autonomous and self-looping** — you run until no open PRs remain.
 You never review code yourself. You route work and report to your parent node.
 
 Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
-Run `python scripts/gen_prompts/resolve_arch.py "$COGNITIVE_ARCH"` to load your
-persona and skill context before acting. The quality bar below is non-negotiable
+Load it as the very first thing you do — see STEP 0 below.
+
+## STEP 0 — LOAD COGNITIVE ARCHITECTURE (do this before anything else)
+
+```bash
+REPO=$(git rev-parse --show-toplevel 2>/dev/null || git worktree list | head -1 | awk '{print $1}')
+COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
+RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+if [ -n "$COGNITIVE_ARCH" ] && [ -f "$RESOLVE_ARCH" ]; then
+  ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode reviewer 2>/dev/null)
+  echo "$ARCH_CONTEXT"
+else
+  echo "⚠️  COGNITIVE_ARCH not set or resolve_arch.py missing — proceeding with default dijkstra persona."
+  COGNITIVE_ARCH="${COGNITIVE_ARCH:-dijkstra}"
+fi
+```
+
+⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE SEEDING ANY REVIEWERS:
+Immediately send the following as your **first text response** to the user
+(not a shell command, not a tool call, not chain-of-thought — actual visible
+output text in your reply message):
+
+---
+🧠 **Cognitive architecture correctly injected.**
+
+**My name is:** [extract the figure display name from the first
+  "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+**My role:** QA Coordinator ([value of $ROLE])
+**My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+[Paste the full content of $ARCH_CONTEXT here verbatim]
+---
+
+Do not proceed to the SEED block until this response has been sent.
+
+The quality bar below is non-negotiable
 regardless of persona — it is a property of the pipeline, not of any individual agent.
 
 You enforce the pipeline quality bar without compromise: **warnings are failures**,


### PR DESCRIPTION
## Summary

- Every agent tier (CTO, Engineering Coordinator, QA Coordinator, leaf engineer, PR reviewer) now has a mandatory first-response requirement: before taking any other action it must output a visible `🧠 Cognitive architecture correctly injected.` message with its figure name, role, architecture string, and the full assembled context block.
- **Biggest regression fixed:** the PR Reviewer's Step 0.5 previously loaded the role only and completely skipped cognitive architecture — it now calls `resolve_arch.py --mode reviewer` and emits the confirmation.
- The CTO had no cognitive arch loading at all; a new STEP 0 was added that hardcodes `von_neumann` (matching `team.yaml`) and runs `resolve_arch.py` before entering the autonomous loop.
- The Engineering and QA Coordinator templates replaced vague `"run resolve_arch.py"` prose with formal bash STEP 0 blocks.
- All five `.j2` source templates regenerated into `.agentception/` (5 generated files updated).

## Test plan

- [ ] Launch a CTO agent and confirm its first response contains the `🧠 Cognitive architecture correctly injected.` header with `von_neumann` details
- [ ] Launch an Engineering Coordinator and confirm the same for `hamming`
- [ ] Launch a QA Coordinator and confirm the same for `dijkstra`
- [ ] Launch a leaf engineer agent and confirm the confirmation fires before Step 1
- [ ] Launch a PR reviewer agent and confirm cognitive arch loads (it was missing entirely before this PR)
