### PR TITLE
fix: enforce worktree isolation — agents can no longer pollute main repo

### DIFF
--- a/.agentception/parallel-issue-to-pr.md
+++ b/.agentception/parallel-issue-to-pr.md
@@ -741,6 +741,12 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   # (Run targeted tests for the module you're about to modify)
 
   # ── STEP 3.2 — CREATE BRANCH ──────────────────────────────────────────────
+  # ⚠️  WORKTREE ISOLATION RULE: docker compose commands require running from
+  # $REPO (the main repo), but git branch/checkout/commit/push operations MUST
+  # run from $WORKTREE. After every `cd "$REPO"` for Docker, the very next
+  # command touching git MUST be preceded by `cd "$WORKTREE"`. Failure to do
+  # this is what causes feature branches to appear checked out in the main repo.
+  cd "$WORKTREE"
   git checkout -b feat/<short-description>
 
   # ── STEP 3.3 — IMPLEMENT ──────────────────────────────────────────────────
@@ -759,6 +765,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
 
   # ── STEP 3.4 — MYPY (scoped to your codebase only) ────────────────────────
   cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
+  cd "$WORKTREE"  # return to worktree — all subsequent git operations must run here
 
   ⚠️  MYPY RULES — fix correctly, never work around:
     - No cast() at call sites — fix the callee's return type.
@@ -1371,6 +1378,8 @@ git -C "$REPO" status
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
    # MCP: create_pull_request(owner="cgcardona", repo="agentception", title="...", body="...", head="fix/<description>", base="dev")
+   # ⚠️  Return main repo to dev after the rescue so the pipeline stays clean:
+   git -C "$REPO" checkout dev
    ```
 
 ### 5 — Hand off to PR review

--- a/.agentception/parallel-pr-review.md
+++ b/.agentception/parallel-pr-review.md
@@ -792,15 +792,18 @@ STEP 5 — REVIEW:
 
   3. Add/fix tests if weak or missing
 
-  ── STEP 5.A — BASELINE HEALTH SNAPSHOT (run BEFORE checking out the PR branch) ──
+  ── STEP 5.A — BASELINE HEALTH SNAPSHOT (run BEFORE touching any PR code) ──
   Record the pre-existing state of dev so you know what errors are yours vs. already broken.
   This is your contract with the next agent — never skip it.
 
-  # Checkout dev tip first, run full mypy + targeted tests, record results.
-  git stash  # if you already have the PR branch checked out
-  git checkout dev
-  echo "=== PRE-EXISTING MYPY BASELINE (dev before PR) ==="
+  # ⚠️  WORKTREE ISOLATION: do NOT run `git checkout dev` here.
+  # `dev` is already checked out in the main repo; checking it out in a worktree
+  # always fails with "fatal: 'dev' is already checked out at '<main-repo>'".
+  # Instead, run mypy directly against the worktree filesystem — the Docker mount
+  # exposes it at /worktrees/$WTNAME regardless of which branch is checked out.
+  echo "=== PRE-EXISTING MYPY BASELINE (origin/dev state via Docker mount) ==="
   cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -10
+  cd "$WORKTREE"  # return to worktree — all subsequent git operations must run here
   # Note: any error shown here is pre-existing on dev — you own fixing it if it
   # is in a file this PR touches. Errors in untouched files → note in report, do not block merge.
 
@@ -808,8 +811,9 @@ STEP 5 — REVIEW:
   # (Run targeted tests relevant to the PR's module — same files you'll test after merge)
   # Any failure here is pre-existing. Fix it before grading this PR.
 
-  # Then check out the PR branch for review:
-  git checkout "$PR_BRANCH" 2>/dev/null || git fetch origin && git checkout "$PR_BRANCH"
+  # Check out the PR branch for review (stay inside the worktree):
+  git fetch origin "$PR_BRANCH"
+  git checkout "$PR_BRANCH" 2>/dev/null || git checkout -b "$PR_BRANCH" --track "origin/$PR_BRANCH"
 
   ── STEP 5.B — MIGRATION CHAIN VALIDATION (skip if no migration files) ──────────
   # If the PR adds Alembic migration files, validate the revision chain before grading.
@@ -1144,16 +1148,20 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   #    This is the step that prevents "relation does not exist" DB errors when the
   #    coordinator tries to apply migrations before fetching.
   #
-  #    ⚠️  COMMIT GUARD — the main repo may have uncommitted files (e.g. from a
-  #    previous agent run that wrote directly to the main worktree, or from generate.py
-  #    updating role files). An uncommitted working tree aborts git merge. Commit
-  #    whatever is there so the merge can proceed cleanly.
-  git -C "$REPO" add -A
-  git -C "$REPO" diff --cached --quiet || git -C "$REPO" commit -m "chore: save main repo state before post-merge dev sync
-
-AgentCeption-Session: ${AGENT_SESSION:-unset}"
+  #    ⚠️  ISOLATION ASSERTION — the main repo must be clean before any merge.
+  #    If it is not, a prior agent violated worktree isolation by writing files
+  #    directly to the main repo. Do NOT commit those files — that would silently
+  #    land agent artifacts on dev. Instead, abort and surface the violation.
+  DIRTY=$(git -C "$REPO" status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "❌ ISOLATION VIOLATION: main repo has uncommitted changes — aborting merge."
+    echo "$DIRTY"
+    echo "Identify which agent wrote to the main repo and fix the root cause."
+    echo "Do NOT commit these files. Restore with: git -C \"\$REPO\" restore --staged . && git -C \"\$REPO\" restore ."
+    exit 1
+  fi
   git -C "$REPO" fetch origin
-  git -C "$REPO" merge origin/dev
+  git -C "$REPO" merge --ff-only origin/dev
 
 STEP 7 — REGRESSION FEEDBACK LOOP (only if merge succeeded — skip if D/F grade):
   After a successful merge, run targeted tests against dev to detect regressions
@@ -1161,12 +1169,15 @@ STEP 7 — REGRESSION FEEDBACK LOOP (only if merge succeeded — skip if D/F gra
   and re-enter the pipeline — no human triage required.
 
   # Pull the latest dev (contains the just-merged PR).
-  # ⚠️  COMMIT GUARD: same as step 6.9 — guard against uncommitted main-repo state.
-  git -C "$REPO" add -A
-  git -C "$REPO" diff --cached --quiet || git -C "$REPO" commit -m "chore: save main repo state before regression-feedback dev sync
-
-AgentCeption-Session: ${AGENT_SESSION:-unset}"
-  git -C "$REPO" fetch origin && git -C "$REPO" merge origin/dev
+  # ⚠️  ISOLATION ASSERTION: same as step 6.9 — main repo must be clean.
+  DIRTY=$(git -C "$REPO" status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "❌ ISOLATION VIOLATION: main repo has uncommitted changes — aborting regression sync."
+    echo "$DIRTY"
+    echo "Do NOT commit these files. Restore with: git -C \"\$REPO\" restore --staged . && git -C \"\$REPO\" restore ."
+    exit 1
+  fi
+  git -C "$REPO" fetch origin && git -C "$REPO" merge --ff-only origin/dev
 
   # Run TARGETED tests only — never the full suite.
   # Derive test files from what this PR actually changed:
@@ -1321,7 +1332,11 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     if [ -n "$NEXT_ISSUE" ]; then
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/issue-$NEXT_ISSUE"
-      git -C "$REPO" worktree add -b "feat/issue-$NEXT_ISSUE" "$NEXT_WORKTREE" origin/dev
+      # Use --detach + SHA instead of -b to avoid registering a local branch on the
+      # main repo. The leaf agent creates the feat/issue-N branch from inside its
+      # own worktree via `git checkout -b feat/issue-$NEXT_ISSUE` at STEP 3.2.
+      NEXT_DEV_SHA=$(git -C "$REPO" rev-parse origin/dev)
+      git -C "$REPO" worktree add --detach "$NEXT_WORKTREE" "$NEXT_DEV_SHA"
       # Add label only after worktree is confirmed created — prevents permanent lock on creation failure
       # MCP: github_claim_issue(issue_number=$NEXT_ISSUE)
 
@@ -1622,6 +1637,8 @@ git -C "$REPO" status
    # MCP: create_pull_request(owner="cgcardona", repo="agentception",
    #       title="feat: <description> (rescued from main repo dirty state)",
    #       base="dev", head="fix/<description>", body="Rescued dirty-state work.")
+   # ⚠️  Return main repo to dev after the rescue so the pipeline stays clean:
+   git -C "$REPO" checkout dev
    ```
 
 ---

--- a/.agentception/role-versions.json
+++ b/.agentception/role-versions.json
@@ -1,7 +1,7 @@
 {
   "versions": {
     "cto": {
-      "current": "v90",
+      "current": "v100",
       "history": [
         {
           "sha": "abcdef1234567890abcdef1234567890abcdef12",
@@ -452,6 +452,56 @@
           "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
           "label": "v90",
           "timestamp": 1772830751
+        },
+        {
+          "sha": "abcdef1234567890abcdef1234567890abcdef12",
+          "label": "v91",
+          "timestamp": 1772837059
+        },
+        {
+          "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "label": "v92",
+          "timestamp": 1772837059
+        },
+        {
+          "sha": "abcdef1234567890abcdef1234567890abcdef12",
+          "label": "v93",
+          "timestamp": 1772837088
+        },
+        {
+          "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "label": "v94",
+          "timestamp": 1772837088
+        },
+        {
+          "sha": "abcdef1234567890abcdef1234567890abcdef12",
+          "label": "v95",
+          "timestamp": 1772837106
+        },
+        {
+          "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "label": "v96",
+          "timestamp": 1772837106
+        },
+        {
+          "sha": "abcdef1234567890abcdef1234567890abcdef12",
+          "label": "v97",
+          "timestamp": 1772837154
+        },
+        {
+          "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "label": "v98",
+          "timestamp": 1772837154
+        },
+        {
+          "sha": "abcdef1234567890abcdef1234567890abcdef12",
+          "label": "v99",
+          "timestamp": 1772837286
+        },
+        {
+          "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "label": "v100",
+          "timestamp": 1772837286
         }
       ]
     }

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -1223,6 +1223,12 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   # (Run targeted tests for the module you're about to modify)
 
   # ── STEP 3.2 — CREATE BRANCH ──────────────────────────────────────────────
+  # ⚠️  WORKTREE ISOLATION RULE: docker compose commands require running from
+  # $REPO (the main repo), but git branch/checkout/commit/push operations MUST
+  # run from $WORKTREE. After every `cd "$REPO"` for Docker, the very next
+  # command touching git MUST be preceded by `cd "$WORKTREE"`. Failure to do
+  # this is what causes feature branches to appear checked out in the main repo.
+  cd "$WORKTREE"
   git checkout -b feat/<short-description>
 
   # ── STEP 3.3 — IMPLEMENT ──────────────────────────────────────────────────
@@ -1241,6 +1247,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
 
   # ── STEP 3.4 — MYPY (scoped to your codebase only) ────────────────────────
   cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
+  cd "$WORKTREE"  # return to worktree — all subsequent git operations must run here
 
   ⚠️  MYPY RULES — fix correctly, never work around:
     - No cast() at call sites — fix the callee's return type.
@@ -1853,6 +1860,8 @@ git -C "$REPO" status
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
    # MCP: create_pull_request(owner="cgcardona", repo="agentception", title="...", body="...", head="fix/<description>", base="dev")
+   # ⚠️  Return main repo to dev after the rescue so the pipeline stays clean:
+   git -C "$REPO" checkout dev
    ```
 
 ### 5 — Hand off to PR review
@@ -2888,15 +2897,18 @@ STEP 5 — REVIEW:
 
   3. Add/fix tests if weak or missing
 
-  ── STEP 5.A — BASELINE HEALTH SNAPSHOT (run BEFORE checking out the PR branch) ──
+  ── STEP 5.A — BASELINE HEALTH SNAPSHOT (run BEFORE touching any PR code) ──
   Record the pre-existing state of dev so you know what errors are yours vs. already broken.
   This is your contract with the next agent — never skip it.
 
-  # Checkout dev tip first, run full mypy + targeted tests, record results.
-  git stash  # if you already have the PR branch checked out
-  git checkout dev
-  echo "=== PRE-EXISTING MYPY BASELINE (dev before PR) ==="
+  # ⚠️  WORKTREE ISOLATION: do NOT run `git checkout dev` here.
+  # `dev` is already checked out in the main repo; checking it out in a worktree
+  # always fails with "fatal: 'dev' is already checked out at '<main-repo>'".
+  # Instead, run mypy directly against the worktree filesystem — the Docker mount
+  # exposes it at /worktrees/$WTNAME regardless of which branch is checked out.
+  echo "=== PRE-EXISTING MYPY BASELINE (origin/dev state via Docker mount) ==="
   cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -10
+  cd "$WORKTREE"  # return to worktree — all subsequent git operations must run here
   # Note: any error shown here is pre-existing on dev — you own fixing it if it
   # is in a file this PR touches. Errors in untouched files → note in report, do not block merge.
 
@@ -2904,8 +2916,9 @@ STEP 5 — REVIEW:
   # (Run targeted tests relevant to the PR's module — same files you'll test after merge)
   # Any failure here is pre-existing. Fix it before grading this PR.
 
-  # Then check out the PR branch for review:
-  git checkout "$PR_BRANCH" 2>/dev/null || git fetch origin && git checkout "$PR_BRANCH"
+  # Check out the PR branch for review (stay inside the worktree):
+  git fetch origin "$PR_BRANCH"
+  git checkout "$PR_BRANCH" 2>/dev/null || git checkout -b "$PR_BRANCH" --track "origin/$PR_BRANCH"
 
   ── STEP 5.B — MIGRATION CHAIN VALIDATION (skip if no migration files) ──────────
   # If the PR adds Alembic migration files, validate the revision chain before grading.
@@ -3240,16 +3253,20 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   #    This is the step that prevents "relation does not exist" DB errors when the
   #    coordinator tries to apply migrations before fetching.
   #
-  #    ⚠️  COMMIT GUARD — the main repo may have uncommitted files (e.g. from a
-  #    previous agent run that wrote directly to the main worktree, or from generate.py
-  #    updating role files). An uncommitted working tree aborts git merge. Commit
-  #    whatever is there so the merge can proceed cleanly.
-  git -C "$REPO" add -A
-  git -C "$REPO" diff --cached --quiet || git -C "$REPO" commit -m "chore: save main repo state before post-merge dev sync
-
-AgentCeption-Session: ${AGENT_SESSION:-unset}"
+  #    ⚠️  ISOLATION ASSERTION — the main repo must be clean before any merge.
+  #    If it is not, a prior agent violated worktree isolation by writing files
+  #    directly to the main repo. Do NOT commit those files — that would silently
+  #    land agent artifacts on dev. Instead, abort and surface the violation.
+  DIRTY=$(git -C "$REPO" status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "❌ ISOLATION VIOLATION: main repo has uncommitted changes — aborting merge."
+    echo "$DIRTY"
+    echo "Identify which agent wrote to the main repo and fix the root cause."
+    echo "Do NOT commit these files. Restore with: git -C \"\$REPO\" restore --staged . && git -C \"\$REPO\" restore ."
+    exit 1
+  fi
   git -C "$REPO" fetch origin
-  git -C "$REPO" merge origin/dev
+  git -C "$REPO" merge --ff-only origin/dev
 
 STEP 7 — REGRESSION FEEDBACK LOOP (only if merge succeeded — skip if D/F grade):
   After a successful merge, run targeted tests against dev to detect regressions
@@ -3257,12 +3274,15 @@ STEP 7 — REGRESSION FEEDBACK LOOP (only if merge succeeded — skip if D/F gra
   and re-enter the pipeline — no human triage required.
 
   # Pull the latest dev (contains the just-merged PR).
-  # ⚠️  COMMIT GUARD: same as step 6.9 — guard against uncommitted main-repo state.
-  git -C "$REPO" add -A
-  git -C "$REPO" diff --cached --quiet || git -C "$REPO" commit -m "chore: save main repo state before regression-feedback dev sync
-
-AgentCeption-Session: ${AGENT_SESSION:-unset}"
-  git -C "$REPO" fetch origin && git -C "$REPO" merge origin/dev
+  # ⚠️  ISOLATION ASSERTION: same as step 6.9 — main repo must be clean.
+  DIRTY=$(git -C "$REPO" status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "❌ ISOLATION VIOLATION: main repo has uncommitted changes — aborting regression sync."
+    echo "$DIRTY"
+    echo "Do NOT commit these files. Restore with: git -C \"\$REPO\" restore --staged . && git -C \"\$REPO\" restore ."
+    exit 1
+  fi
+  git -C "$REPO" fetch origin && git -C "$REPO" merge --ff-only origin/dev
 
   # Run TARGETED tests only — never the full suite.
   # Derive test files from what this PR actually changed:
@@ -3417,7 +3437,11 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     if [ -n "$NEXT_ISSUE" ]; then
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/issue-$NEXT_ISSUE"
-      git -C "$REPO" worktree add -b "feat/issue-$NEXT_ISSUE" "$NEXT_WORKTREE" origin/dev
+      # Use --detach + SHA instead of -b to avoid registering a local branch on the
+      # main repo. The leaf agent creates the feat/issue-N branch from inside its
+      # own worktree via `git checkout -b feat/issue-$NEXT_ISSUE` at STEP 3.2.
+      NEXT_DEV_SHA=$(git -C "$REPO" rev-parse origin/dev)
+      git -C "$REPO" worktree add --detach "$NEXT_WORKTREE" "$NEXT_DEV_SHA"
       # Add label only after worktree is confirmed created — prevents permanent lock on creation failure
       # MCP: github_claim_issue(issue_number=$NEXT_ISSUE)
 
@@ -3718,6 +3742,8 @@ git -C "$REPO" status
    # MCP: create_pull_request(owner="cgcardona", repo="agentception",
    #       title="feat: <description> (rescued from main repo dirty state)",
    #       base="dev", head="fix/<description>", body="Rescued dirty-state work.")
+   # ⚠️  Return main repo to dev after the rescue so the pipeline stays clean:
+   git -C "$REPO" checkout dev
    ```
 
 ---
@@ -4793,15 +4819,18 @@ STEP 5 — REVIEW:
 
   3. Add/fix tests if weak or missing
 
-  ── STEP 5.A — BASELINE HEALTH SNAPSHOT (run BEFORE checking out the PR branch) ──
+  ── STEP 5.A — BASELINE HEALTH SNAPSHOT (run BEFORE touching any PR code) ──
   Record the pre-existing state of dev so you know what errors are yours vs. already broken.
   This is your contract with the next agent — never skip it.
 
-  # Checkout dev tip first, run full mypy + targeted tests, record results.
-  git stash  # if you already have the PR branch checked out
-  git checkout dev
-  echo "=== PRE-EXISTING MYPY BASELINE (dev before PR) ==="
+  # ⚠️  WORKTREE ISOLATION: do NOT run `git checkout dev` here.
+  # `dev` is already checked out in the main repo; checking it out in a worktree
+  # always fails with "fatal: 'dev' is already checked out at '<main-repo>'".
+  # Instead, run mypy directly against the worktree filesystem — the Docker mount
+  # exposes it at /worktrees/$WTNAME regardless of which branch is checked out.
+  echo "=== PRE-EXISTING MYPY BASELINE (origin/dev state via Docker mount) ==="
   cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -10
+  cd "$WORKTREE"  # return to worktree — all subsequent git operations must run here
   # Note: any error shown here is pre-existing on dev — you own fixing it if it
   # is in a file this PR touches. Errors in untouched files → note in report, do not block merge.
 
@@ -4809,8 +4838,9 @@ STEP 5 — REVIEW:
   # (Run targeted tests relevant to the PR's module — same files you'll test after merge)
   # Any failure here is pre-existing. Fix it before grading this PR.
 
-  # Then check out the PR branch for review:
-  git checkout "$PR_BRANCH" 2>/dev/null || git fetch origin && git checkout "$PR_BRANCH"
+  # Check out the PR branch for review (stay inside the worktree):
+  git fetch origin "$PR_BRANCH"
+  git checkout "$PR_BRANCH" 2>/dev/null || git checkout -b "$PR_BRANCH" --track "origin/$PR_BRANCH"
 
   ── STEP 5.B — MIGRATION CHAIN VALIDATION (skip if no migration files) ──────────
   # If the PR adds Alembic migration files, validate the revision chain before grading.
@@ -5145,16 +5175,20 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   #    This is the step that prevents "relation does not exist" DB errors when the
   #    coordinator tries to apply migrations before fetching.
   #
-  #    ⚠️  COMMIT GUARD — the main repo may have uncommitted files (e.g. from a
-  #    previous agent run that wrote directly to the main worktree, or from generate.py
-  #    updating role files). An uncommitted working tree aborts git merge. Commit
-  #    whatever is there so the merge can proceed cleanly.
-  git -C "$REPO" add -A
-  git -C "$REPO" diff --cached --quiet || git -C "$REPO" commit -m "chore: save main repo state before post-merge dev sync
-
-AgentCeption-Session: ${AGENT_SESSION:-unset}"
+  #    ⚠️  ISOLATION ASSERTION — the main repo must be clean before any merge.
+  #    If it is not, a prior agent violated worktree isolation by writing files
+  #    directly to the main repo. Do NOT commit those files — that would silently
+  #    land agent artifacts on dev. Instead, abort and surface the violation.
+  DIRTY=$(git -C "$REPO" status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "❌ ISOLATION VIOLATION: main repo has uncommitted changes — aborting merge."
+    echo "$DIRTY"
+    echo "Identify which agent wrote to the main repo and fix the root cause."
+    echo "Do NOT commit these files. Restore with: git -C \"\$REPO\" restore --staged . && git -C \"\$REPO\" restore ."
+    exit 1
+  fi
   git -C "$REPO" fetch origin
-  git -C "$REPO" merge origin/dev
+  git -C "$REPO" merge --ff-only origin/dev
 
 STEP 7 — REGRESSION FEEDBACK LOOP (only if merge succeeded — skip if D/F grade):
   After a successful merge, run targeted tests against dev to detect regressions
@@ -5162,12 +5196,15 @@ STEP 7 — REGRESSION FEEDBACK LOOP (only if merge succeeded — skip if D/F gra
   and re-enter the pipeline — no human triage required.
 
   # Pull the latest dev (contains the just-merged PR).
-  # ⚠️  COMMIT GUARD: same as step 6.9 — guard against uncommitted main-repo state.
-  git -C "$REPO" add -A
-  git -C "$REPO" diff --cached --quiet || git -C "$REPO" commit -m "chore: save main repo state before regression-feedback dev sync
-
-AgentCeption-Session: ${AGENT_SESSION:-unset}"
-  git -C "$REPO" fetch origin && git -C "$REPO" merge origin/dev
+  # ⚠️  ISOLATION ASSERTION: same as step 6.9 — main repo must be clean.
+  DIRTY=$(git -C "$REPO" status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "❌ ISOLATION VIOLATION: main repo has uncommitted changes — aborting regression sync."
+    echo "$DIRTY"
+    echo "Do NOT commit these files. Restore with: git -C \"\$REPO\" restore --staged . && git -C \"\$REPO\" restore ."
+    exit 1
+  fi
+  git -C "$REPO" fetch origin && git -C "$REPO" merge --ff-only origin/dev
 
   # Run TARGETED tests only — never the full suite.
   # Derive test files from what this PR actually changed:
@@ -5322,7 +5359,11 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     if [ -n "$NEXT_ISSUE" ]; then
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/issue-$NEXT_ISSUE"
-      git -C "$REPO" worktree add -b "feat/issue-$NEXT_ISSUE" "$NEXT_WORKTREE" origin/dev
+      # Use --detach + SHA instead of -b to avoid registering a local branch on the
+      # main repo. The leaf agent creates the feat/issue-N branch from inside its
+      # own worktree via `git checkout -b feat/issue-$NEXT_ISSUE` at STEP 3.2.
+      NEXT_DEV_SHA=$(git -C "$REPO" rev-parse origin/dev)
+      git -C "$REPO" worktree add --detach "$NEXT_WORKTREE" "$NEXT_DEV_SHA"
       # Add label only after worktree is confirmed created — prevents permanent lock on creation failure
       # MCP: github_claim_issue(issue_number=$NEXT_ISSUE)
 
@@ -5623,6 +5664,8 @@ git -C "$REPO" status
    # MCP: create_pull_request(owner="cgcardona", repo="agentception",
    #       title="feat: <description> (rescued from main repo dirty state)",
    #       base="dev", head="fix/<description>", body="Rescued dirty-state work.")
+   # ⚠️  Return main repo to dev after the rescue so the pipeline stays clean:
+   git -C "$REPO" checkout dev
    ```
 
 ---
@@ -6466,6 +6509,12 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   # (Run targeted tests for the module you're about to modify)
 
   # ── STEP 3.2 — CREATE BRANCH ──────────────────────────────────────────────
+  # ⚠️  WORKTREE ISOLATION RULE: docker compose commands require running from
+  # $REPO (the main repo), but git branch/checkout/commit/push operations MUST
+  # run from $WORKTREE. After every `cd "$REPO"` for Docker, the very next
+  # command touching git MUST be preceded by `cd "$WORKTREE"`. Failure to do
+  # this is what causes feature branches to appear checked out in the main repo.
+  cd "$WORKTREE"
   git checkout -b feat/<short-description>
 
   # ── STEP 3.3 — IMPLEMENT ──────────────────────────────────────────────────
@@ -6484,6 +6533,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
 
   # ── STEP 3.4 — MYPY (scoped to your codebase only) ────────────────────────
   cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
+  cd "$WORKTREE"  # return to worktree — all subsequent git operations must run here
 
   ⚠️  MYPY RULES — fix correctly, never work around:
     - No cast() at call sites — fix the callee's return type.
@@ -7096,6 +7146,8 @@ git -C "$REPO" status
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
    # MCP: create_pull_request(owner="cgcardona", repo="agentception", title="...", body="...", head="fix/<description>", base="dev")
+   # ⚠️  Return main repo to dev after the rescue so the pipeline stays clean:
+   git -C "$REPO" checkout dev
    ```
 
 ### 5 — Hand off to PR review

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -964,6 +964,12 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   # (Run targeted tests for the module you're about to modify)
 
   # ── STEP 3.2 — CREATE BRANCH ──────────────────────────────────────────────
+  # ⚠️  WORKTREE ISOLATION RULE: docker compose commands require running from
+  # $REPO (the main repo), but git branch/checkout/commit/push operations MUST
+  # run from $WORKTREE. After every `cd "$REPO"` for Docker, the very next
+  # command touching git MUST be preceded by `cd "$WORKTREE"`. Failure to do
+  # this is what causes feature branches to appear checked out in the main repo.
+  cd "$WORKTREE"
   git checkout -b feat/<short-description>
 
   # ── STEP 3.3 — IMPLEMENT ──────────────────────────────────────────────────
@@ -982,6 +988,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
 
   # ── STEP 3.4 — MYPY (scoped to your codebase only) ────────────────────────
   cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
+  cd "$WORKTREE"  # return to worktree — all subsequent git operations must run here
 
   ⚠️  MYPY RULES — fix correctly, never work around:
     - No cast() at call sites — fix the callee's return type.
@@ -1594,6 +1601,8 @@ git -C "$REPO" status
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
    # MCP: create_pull_request(owner="cgcardona", repo="agentception", title="...", body="...", head="fix/<description>", base="dev")
+   # ⚠️  Return main repo to dev after the rescue so the pipeline stays clean:
+   git -C "$REPO" checkout dev
    ```
 
 ### 5 — Hand off to PR review
@@ -2629,15 +2638,18 @@ STEP 5 — REVIEW:
 
   3. Add/fix tests if weak or missing
 
-  ── STEP 5.A — BASELINE HEALTH SNAPSHOT (run BEFORE checking out the PR branch) ──
+  ── STEP 5.A — BASELINE HEALTH SNAPSHOT (run BEFORE touching any PR code) ──
   Record the pre-existing state of dev so you know what errors are yours vs. already broken.
   This is your contract with the next agent — never skip it.
 
-  # Checkout dev tip first, run full mypy + targeted tests, record results.
-  git stash  # if you already have the PR branch checked out
-  git checkout dev
-  echo "=== PRE-EXISTING MYPY BASELINE (dev before PR) ==="
+  # ⚠️  WORKTREE ISOLATION: do NOT run `git checkout dev` here.
+  # `dev` is already checked out in the main repo; checking it out in a worktree
+  # always fails with "fatal: 'dev' is already checked out at '<main-repo>'".
+  # Instead, run mypy directly against the worktree filesystem — the Docker mount
+  # exposes it at /worktrees/$WTNAME regardless of which branch is checked out.
+  echo "=== PRE-EXISTING MYPY BASELINE (origin/dev state via Docker mount) ==="
   cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -10
+  cd "$WORKTREE"  # return to worktree — all subsequent git operations must run here
   # Note: any error shown here is pre-existing on dev — you own fixing it if it
   # is in a file this PR touches. Errors in untouched files → note in report, do not block merge.
 
@@ -2645,8 +2657,9 @@ STEP 5 — REVIEW:
   # (Run targeted tests relevant to the PR's module — same files you'll test after merge)
   # Any failure here is pre-existing. Fix it before grading this PR.
 
-  # Then check out the PR branch for review:
-  git checkout "$PR_BRANCH" 2>/dev/null || git fetch origin && git checkout "$PR_BRANCH"
+  # Check out the PR branch for review (stay inside the worktree):
+  git fetch origin "$PR_BRANCH"
+  git checkout "$PR_BRANCH" 2>/dev/null || git checkout -b "$PR_BRANCH" --track "origin/$PR_BRANCH"
 
   ── STEP 5.B — MIGRATION CHAIN VALIDATION (skip if no migration files) ──────────
   # If the PR adds Alembic migration files, validate the revision chain before grading.
@@ -2981,16 +2994,20 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   #    This is the step that prevents "relation does not exist" DB errors when the
   #    coordinator tries to apply migrations before fetching.
   #
-  #    ⚠️  COMMIT GUARD — the main repo may have uncommitted files (e.g. from a
-  #    previous agent run that wrote directly to the main worktree, or from generate.py
-  #    updating role files). An uncommitted working tree aborts git merge. Commit
-  #    whatever is there so the merge can proceed cleanly.
-  git -C "$REPO" add -A
-  git -C "$REPO" diff --cached --quiet || git -C "$REPO" commit -m "chore: save main repo state before post-merge dev sync
-
-AgentCeption-Session: ${AGENT_SESSION:-unset}"
+  #    ⚠️  ISOLATION ASSERTION — the main repo must be clean before any merge.
+  #    If it is not, a prior agent violated worktree isolation by writing files
+  #    directly to the main repo. Do NOT commit those files — that would silently
+  #    land agent artifacts on dev. Instead, abort and surface the violation.
+  DIRTY=$(git -C "$REPO" status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "❌ ISOLATION VIOLATION: main repo has uncommitted changes — aborting merge."
+    echo "$DIRTY"
+    echo "Identify which agent wrote to the main repo and fix the root cause."
+    echo "Do NOT commit these files. Restore with: git -C \"\$REPO\" restore --staged . && git -C \"\$REPO\" restore ."
+    exit 1
+  fi
   git -C "$REPO" fetch origin
-  git -C "$REPO" merge origin/dev
+  git -C "$REPO" merge --ff-only origin/dev
 
 STEP 7 — REGRESSION FEEDBACK LOOP (only if merge succeeded — skip if D/F grade):
   After a successful merge, run targeted tests against dev to detect regressions
@@ -2998,12 +3015,15 @@ STEP 7 — REGRESSION FEEDBACK LOOP (only if merge succeeded — skip if D/F gra
   and re-enter the pipeline — no human triage required.
 
   # Pull the latest dev (contains the just-merged PR).
-  # ⚠️  COMMIT GUARD: same as step 6.9 — guard against uncommitted main-repo state.
-  git -C "$REPO" add -A
-  git -C "$REPO" diff --cached --quiet || git -C "$REPO" commit -m "chore: save main repo state before regression-feedback dev sync
-
-AgentCeption-Session: ${AGENT_SESSION:-unset}"
-  git -C "$REPO" fetch origin && git -C "$REPO" merge origin/dev
+  # ⚠️  ISOLATION ASSERTION: same as step 6.9 — main repo must be clean.
+  DIRTY=$(git -C "$REPO" status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "❌ ISOLATION VIOLATION: main repo has uncommitted changes — aborting regression sync."
+    echo "$DIRTY"
+    echo "Do NOT commit these files. Restore with: git -C \"\$REPO\" restore --staged . && git -C \"\$REPO\" restore ."
+    exit 1
+  fi
+  git -C "$REPO" fetch origin && git -C "$REPO" merge --ff-only origin/dev
 
   # Run TARGETED tests only — never the full suite.
   # Derive test files from what this PR actually changed:
@@ -3158,7 +3178,11 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     if [ -n "$NEXT_ISSUE" ]; then
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/issue-$NEXT_ISSUE"
-      git -C "$REPO" worktree add -b "feat/issue-$NEXT_ISSUE" "$NEXT_WORKTREE" origin/dev
+      # Use --detach + SHA instead of -b to avoid registering a local branch on the
+      # main repo. The leaf agent creates the feat/issue-N branch from inside its
+      # own worktree via `git checkout -b feat/issue-$NEXT_ISSUE` at STEP 3.2.
+      NEXT_DEV_SHA=$(git -C "$REPO" rev-parse origin/dev)
+      git -C "$REPO" worktree add --detach "$NEXT_WORKTREE" "$NEXT_DEV_SHA"
       # Add label only after worktree is confirmed created — prevents permanent lock on creation failure
       # MCP: github_claim_issue(issue_number=$NEXT_ISSUE)
 
@@ -3459,6 +3483,8 @@ git -C "$REPO" status
    # MCP: create_pull_request(owner="cgcardona", repo="agentception",
    #       title="feat: <description> (rescued from main repo dirty state)",
    #       base="dev", head="fix/<description>", body="Rescued dirty-state work.")
+   # ⚠️  Return main repo to dev after the rescue so the pipeline stays clean:
+   git -C "$REPO" checkout dev
    ```
 
 ---

--- a/.agentception/roles/qa-coordinator.md
+++ b/.agentception/roles/qa-coordinator.md
@@ -972,15 +972,18 @@ STEP 5 — REVIEW:
 
   3. Add/fix tests if weak or missing
 
-  ── STEP 5.A — BASELINE HEALTH SNAPSHOT (run BEFORE checking out the PR branch) ──
+  ── STEP 5.A — BASELINE HEALTH SNAPSHOT (run BEFORE touching any PR code) ──
   Record the pre-existing state of dev so you know what errors are yours vs. already broken.
   This is your contract with the next agent — never skip it.
 
-  # Checkout dev tip first, run full mypy + targeted tests, record results.
-  git stash  # if you already have the PR branch checked out
-  git checkout dev
-  echo "=== PRE-EXISTING MYPY BASELINE (dev before PR) ==="
+  # ⚠️  WORKTREE ISOLATION: do NOT run `git checkout dev` here.
+  # `dev` is already checked out in the main repo; checking it out in a worktree
+  # always fails with "fatal: 'dev' is already checked out at '<main-repo>'".
+  # Instead, run mypy directly against the worktree filesystem — the Docker mount
+  # exposes it at /worktrees/$WTNAME regardless of which branch is checked out.
+  echo "=== PRE-EXISTING MYPY BASELINE (origin/dev state via Docker mount) ==="
   cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -10
+  cd "$WORKTREE"  # return to worktree — all subsequent git operations must run here
   # Note: any error shown here is pre-existing on dev — you own fixing it if it
   # is in a file this PR touches. Errors in untouched files → note in report, do not block merge.
 
@@ -988,8 +991,9 @@ STEP 5 — REVIEW:
   # (Run targeted tests relevant to the PR's module — same files you'll test after merge)
   # Any failure here is pre-existing. Fix it before grading this PR.
 
-  # Then check out the PR branch for review:
-  git checkout "$PR_BRANCH" 2>/dev/null || git fetch origin && git checkout "$PR_BRANCH"
+  # Check out the PR branch for review (stay inside the worktree):
+  git fetch origin "$PR_BRANCH"
+  git checkout "$PR_BRANCH" 2>/dev/null || git checkout -b "$PR_BRANCH" --track "origin/$PR_BRANCH"
 
   ── STEP 5.B — MIGRATION CHAIN VALIDATION (skip if no migration files) ──────────
   # If the PR adds Alembic migration files, validate the revision chain before grading.
@@ -1324,16 +1328,20 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   #    This is the step that prevents "relation does not exist" DB errors when the
   #    coordinator tries to apply migrations before fetching.
   #
-  #    ⚠️  COMMIT GUARD — the main repo may have uncommitted files (e.g. from a
-  #    previous agent run that wrote directly to the main worktree, or from generate.py
-  #    updating role files). An uncommitted working tree aborts git merge. Commit
-  #    whatever is there so the merge can proceed cleanly.
-  git -C "$REPO" add -A
-  git -C "$REPO" diff --cached --quiet || git -C "$REPO" commit -m "chore: save main repo state before post-merge dev sync
-
-AgentCeption-Session: ${AGENT_SESSION:-unset}"
+  #    ⚠️  ISOLATION ASSERTION — the main repo must be clean before any merge.
+  #    If it is not, a prior agent violated worktree isolation by writing files
+  #    directly to the main repo. Do NOT commit those files — that would silently
+  #    land agent artifacts on dev. Instead, abort and surface the violation.
+  DIRTY=$(git -C "$REPO" status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "❌ ISOLATION VIOLATION: main repo has uncommitted changes — aborting merge."
+    echo "$DIRTY"
+    echo "Identify which agent wrote to the main repo and fix the root cause."
+    echo "Do NOT commit these files. Restore with: git -C \"\$REPO\" restore --staged . && git -C \"\$REPO\" restore ."
+    exit 1
+  fi
   git -C "$REPO" fetch origin
-  git -C "$REPO" merge origin/dev
+  git -C "$REPO" merge --ff-only origin/dev
 
 STEP 7 — REGRESSION FEEDBACK LOOP (only if merge succeeded — skip if D/F grade):
   After a successful merge, run targeted tests against dev to detect regressions
@@ -1341,12 +1349,15 @@ STEP 7 — REGRESSION FEEDBACK LOOP (only if merge succeeded — skip if D/F gra
   and re-enter the pipeline — no human triage required.
 
   # Pull the latest dev (contains the just-merged PR).
-  # ⚠️  COMMIT GUARD: same as step 6.9 — guard against uncommitted main-repo state.
-  git -C "$REPO" add -A
-  git -C "$REPO" diff --cached --quiet || git -C "$REPO" commit -m "chore: save main repo state before regression-feedback dev sync
-
-AgentCeption-Session: ${AGENT_SESSION:-unset}"
-  git -C "$REPO" fetch origin && git -C "$REPO" merge origin/dev
+  # ⚠️  ISOLATION ASSERTION: same as step 6.9 — main repo must be clean.
+  DIRTY=$(git -C "$REPO" status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "❌ ISOLATION VIOLATION: main repo has uncommitted changes — aborting regression sync."
+    echo "$DIRTY"
+    echo "Do NOT commit these files. Restore with: git -C \"\$REPO\" restore --staged . && git -C \"\$REPO\" restore ."
+    exit 1
+  fi
+  git -C "$REPO" fetch origin && git -C "$REPO" merge --ff-only origin/dev
 
   # Run TARGETED tests only — never the full suite.
   # Derive test files from what this PR actually changed:
@@ -1501,7 +1512,11 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     if [ -n "$NEXT_ISSUE" ]; then
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/issue-$NEXT_ISSUE"
-      git -C "$REPO" worktree add -b "feat/issue-$NEXT_ISSUE" "$NEXT_WORKTREE" origin/dev
+      # Use --detach + SHA instead of -b to avoid registering a local branch on the
+      # main repo. The leaf agent creates the feat/issue-N branch from inside its
+      # own worktree via `git checkout -b feat/issue-$NEXT_ISSUE` at STEP 3.2.
+      NEXT_DEV_SHA=$(git -C "$REPO" rev-parse origin/dev)
+      git -C "$REPO" worktree add --detach "$NEXT_WORKTREE" "$NEXT_DEV_SHA"
       # Add label only after worktree is confirmed created — prevents permanent lock on creation failure
       # MCP: github_claim_issue(issue_number=$NEXT_ISSUE)
 
@@ -1802,6 +1817,8 @@ git -C "$REPO" status
    # MCP: create_pull_request(owner="cgcardona", repo="agentception",
    #       title="feat: <description> (rescued from main repo dirty state)",
    #       base="dev", head="fix/<description>", body="Rescued dirty-state work.")
+   # ⚠️  Return main repo to dev after the rescue so the pipeline stays clean:
+   git -C "$REPO" checkout dev
    ```
 
 ---
@@ -2645,6 +2662,12 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   # (Run targeted tests for the module you're about to modify)
 
   # ── STEP 3.2 — CREATE BRANCH ──────────────────────────────────────────────
+  # ⚠️  WORKTREE ISOLATION RULE: docker compose commands require running from
+  # $REPO (the main repo), but git branch/checkout/commit/push operations MUST
+  # run from $WORKTREE. After every `cd "$REPO"` for Docker, the very next
+  # command touching git MUST be preceded by `cd "$WORKTREE"`. Failure to do
+  # this is what causes feature branches to appear checked out in the main repo.
+  cd "$WORKTREE"
   git checkout -b feat/<short-description>
 
   # ── STEP 3.3 — IMPLEMENT ──────────────────────────────────────────────────
@@ -2663,6 +2686,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
 
   # ── STEP 3.4 — MYPY (scoped to your codebase only) ────────────────────────
   cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
+  cd "$WORKTREE"  # return to worktree — all subsequent git operations must run here
 
   ⚠️  MYPY RULES — fix correctly, never work around:
     - No cast() at call sites — fix the callee's return type.
@@ -3275,6 +3299,8 @@ git -C "$REPO" status
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
    # MCP: create_pull_request(owner="cgcardona", repo="agentception", title="...", body="...", head="fix/<description>", base="dev")
+   # ⚠️  Return main repo to dev after the rescue so the pipeline stays clean:
+   git -C "$REPO" checkout dev
    ```
 
 ### 5 — Hand off to PR review

--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -44,6 +44,29 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/dispatch", tags=["dispatch"])
 
+
+async def _resolve_dev_sha() -> str:
+    """Return the current SHA of origin/dev.
+
+    Pinning the worktree start point to a concrete SHA rather than the
+    symbolic HEAD of the main repo prevents agents from inheriting local
+    commits that are not yet on origin/dev and keeps each worktree
+    reproducibly anchored to the same commit regardless of the main
+    repo's checked-out branch.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "git", "rev-parse", "origin/dev",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(settings.repo_dir),
+    )
+    stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git rev-parse origin/dev failed: {stderr.decode().strip()}"
+        )
+    return stdout.decode().strip()
+
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 # ---------------------------------------------------------------------------
@@ -163,8 +186,13 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
             detail=f"Worktree already exists at {worktree_path}. Remove it before re-dispatching.",
         )
 
+    try:
+        dev_sha = await _resolve_dev_sha()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
     proc = await asyncio.create_subprocess_exec(
-        "git", "worktree", "add", worktree_path, "-b", branch,
+        "git", "worktree", "add", worktree_path, "-b", branch, dev_sha,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         cwd=str(settings.repo_dir),
@@ -455,8 +483,13 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
             detail=f"Worktree already exists at {worktree_path}.",
         )
 
+    try:
+        dev_sha = await _resolve_dev_sha()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
     proc = await asyncio.create_subprocess_exec(
-        "git", "worktree", "add", worktree_path, "-b", branch,
+        "git", "worktree", "add", worktree_path, "-b", branch, dev_sha,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         cwd=str(settings.repo_dir),

--- a/agentception/routes/api/runs.py
+++ b/agentception/routes/api/runs.py
@@ -298,6 +298,24 @@ async def _teardown_agent_worktree(run_id: str) -> None:
                 push_stderr.decode().strip(),
             )
 
+        # Delete the local branch so it does not accumulate in the main repo.
+        # git worktree remove unlinks the worktree but leaves the local branch
+        # reference in .git/refs/heads/ — this cleans it up.
+        branch_proc = await asyncio.create_subprocess_exec(
+            "git", "-C", repo_dir, "branch", "-D", branch,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, branch_stderr = await branch_proc.communicate()
+        if branch_proc.returncode == 0:
+            logger.info("✅ _teardown: deleted local branch %r", branch)
+        else:
+            logger.info(
+                "ℹ️  _teardown: local branch %r not deleted (may already be gone): %s",
+                branch,
+                branch_stderr.decode().strip(),
+            )
+
 
 @router.post("/{run_id}/done")
 async def report_done(run_id: str, req: DoneReport) -> dict[str, object]:

--- a/agentception/services/spawn_child.py
+++ b/agentception/services/spawn_child.py
@@ -433,9 +433,26 @@ async def spawn_child(
         role, tier, org_domain, scope_type, scope_value, cognitive_arch,
     )
 
-    # Create git worktree
+    # Resolve origin/dev SHA to pin the worktree start point.
+    # Using a concrete SHA instead of the main repo's HEAD prevents agents
+    # from inheriting local commits not yet on origin/dev and decouples the
+    # worktree from whatever branch the main repo currently has checked out.
+    sha_proc = await asyncio.create_subprocess_exec(
+        "git", "rev-parse", "origin/dev",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(settings.repo_dir),
+    )
+    sha_out, sha_err = await sha_proc.communicate()
+    if sha_proc.returncode != 0:
+        err = sha_err.decode().strip()
+        logger.error("❌ spawn_child: git rev-parse origin/dev failed — %s", err)
+        raise SpawnChildError(f"git rev-parse origin/dev failed: {err}")
+    dev_sha = sha_out.decode().strip()
+
+    # Create git worktree anchored to the resolved SHA
     proc = await asyncio.create_subprocess_exec(
-        "git", "worktree", "add", worktree_path, "-b", branch,
+        "git", "worktree", "add", worktree_path, "-b", branch, dev_sha,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         cwd=str(settings.repo_dir),

--- a/agentception/tests/test_agentception_spawn_child.py
+++ b/agentception/tests/test_agentception_spawn_child.py
@@ -431,14 +431,23 @@ async def test_spawn_child_skills_hint_overrides_body_extraction() -> None:
 
 @pytest.mark.anyio
 async def test_spawn_child_worktree_failure_raises_spawn_child_error() -> None:
-    mock_proc = MagicMock()
-    mock_proc.returncode = 1
-    mock_proc.communicate = AsyncMock(return_value=(b"", b"fatal: branch already exists"))
+    # spawn_child now calls create_subprocess_exec twice:
+    #   1. git rev-parse origin/dev  → succeeds (returns a SHA)
+    #   2. git worktree add ...      → fails (the case under test)
+    sha_proc = MagicMock()
+    sha_proc.returncode = 0
+    sha_proc.communicate = AsyncMock(
+        return_value=(b"abc1234abc1234abc1234abc1234abc1234abc1234\n", b"")
+    )
+
+    fail_proc = MagicMock()
+    fail_proc.returncode = 1
+    fail_proc.communicate = AsyncMock(return_value=(b"", b"fatal: branch already exists"))
 
     with (
         patch(
             "agentception.services.spawn_child.asyncio.create_subprocess_exec",
-            return_value=mock_proc,
+            side_effect=[sha_proc, fail_proc],
         ),
         pytest.raises(SpawnChildError, match="git worktree add failed"),
     ):
@@ -482,9 +491,9 @@ async def test_spawn_child_file_write_failure_cleans_up_worktree() -> None:
             gh_repo="owner/repo",
         )
 
-    # Second subprocess call should be the cleanup worktree remove
-    assert len(cleanup_calls) == 2
-    assert "remove" in cleanup_calls[1]
+    # Subprocess calls are now: git rev-parse, git worktree add, git worktree remove
+    assert len(cleanup_calls) == 3
+    assert "remove" in cleanup_calls[2]
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/tests/test_agentception_ui_plan.py
+++ b/agentception/tests/test_agentception_ui_plan.py
@@ -176,18 +176,21 @@ def test_plan_run_text_not_found(client: TestClient, tmp_path: Path) -> None:
 
 
 def test_plan_page_done_state_has_batch_pill_and_track_agents(client: TestClient) -> None:
-    """GET /plan must render the batch_id pill and 'Track Agents' / 'View Issues' links in the done state."""
+    """GET /plan must render the batch_id pill and done-state action buttons.
+
+    The done screen was redesigned in PR #162 — CTAs are now 'Build Board'
+    (links to /) and 'View on GitHub' (links to the initiative's GitHub issues
+    page).  The batch pill elements are unchanged.
+    """
     resp = client.get("/plan")
     assert resp.status_code == 200
     # Batch pill elements — present in the done state section.
     assert "plan-done-batch" in resp.text
     assert "plan-done-batch-id" in resp.text
     assert "copyBatchId" in resp.text
-    # Done step CTAs per issue #42: Track Agents → (/controls), View Issues → (GitHub).
-    assert "Track Agents" in resp.text
-    assert "/controls" in resp.text
-    assert "View Issues" in resp.text
-    assert "/issues" in resp.text
+    # Done step CTAs (redesigned in PR #162).
+    assert "Build Board" in resp.text
+    assert "View on GitHub" in resp.text
 
 
 def test_plan_page_wires_step_1a_draft_and_sse(client: TestClient) -> None:

--- a/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
+++ b/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
@@ -567,6 +567,12 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   # (Run targeted tests for the module you're about to modify)
 
   # ── STEP 3.2 — CREATE BRANCH ──────────────────────────────────────────────
+  # ⚠️  WORKTREE ISOLATION RULE: docker compose commands require running from
+  # $REPO (the main repo), but git branch/checkout/commit/push operations MUST
+  # run from $WORKTREE. After every `cd "$REPO"` for Docker, the very next
+  # command touching git MUST be preceded by `cd "$WORKTREE"`. Failure to do
+  # this is what causes feature branches to appear checked out in the main repo.
+  cd "$WORKTREE"
   git checkout -b feat/<short-description>
 
   # ── STEP 3.3 — IMPLEMENT ──────────────────────────────────────────────────
@@ -585,6 +591,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
 
   # ── STEP 3.4 — MYPY (scoped to your codebase only) ────────────────────────
   cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
+  cd "$WORKTREE"  # return to worktree — all subsequent git operations must run here
 
   ⚠️  MYPY RULES — fix correctly, never work around:
     - No cast() at call sites — fix the callee's return type.
@@ -1033,6 +1040,8 @@ git -C "$REPO" status
    git -C "$REPO" commit -m "feat: <description> (rescued from main repo dirty state)"
    git push origin fix/<description>
    # MCP: create_pull_request(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", title="...", body="...", head="fix/<description>", base="dev")
+   # ⚠️  Return main repo to dev after the rescue so the pipeline stays clean:
+   git -C "$REPO" checkout dev
    ```
 
 ### 5 — Hand off to PR review

--- a/scripts/gen_prompts/templates/parallel-pr-review.md.j2
+++ b/scripts/gen_prompts/templates/parallel-pr-review.md.j2
@@ -539,15 +539,18 @@ STEP 5 — REVIEW:
 
   3. Add/fix tests if weak or missing
 
-  ── STEP 5.A — BASELINE HEALTH SNAPSHOT (run BEFORE checking out the PR branch) ──
+  ── STEP 5.A — BASELINE HEALTH SNAPSHOT (run BEFORE touching any PR code) ──
   Record the pre-existing state of dev so you know what errors are yours vs. already broken.
   This is your contract with the next agent — never skip it.
 
-  # Checkout dev tip first, run full mypy + targeted tests, record results.
-  git stash  # if you already have the PR branch checked out
-  git checkout dev
-  echo "=== PRE-EXISTING MYPY BASELINE (dev before PR) ==="
+  # ⚠️  WORKTREE ISOLATION: do NOT run `git checkout dev` here.
+  # `dev` is already checked out in the main repo; checking it out in a worktree
+  # always fails with "fatal: 'dev' is already checked out at '<main-repo>'".
+  # Instead, run mypy directly against the worktree filesystem — the Docker mount
+  # exposes it at /worktrees/$WTNAME regardless of which branch is checked out.
+  echo "=== PRE-EXISTING MYPY BASELINE (origin/dev state via Docker mount) ==="
   cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -10
+  cd "$WORKTREE"  # return to worktree — all subsequent git operations must run here
   # Note: any error shown here is pre-existing on dev — you own fixing it if it
   # is in a file this PR touches. Errors in untouched files → note in report, do not block merge.
 
@@ -555,8 +558,9 @@ STEP 5 — REVIEW:
   # (Run targeted tests relevant to the PR's module — same files you'll test after merge)
   # Any failure here is pre-existing. Fix it before grading this PR.
 
-  # Then check out the PR branch for review:
-  git checkout "$PR_BRANCH" 2>/dev/null || git fetch origin && git checkout "$PR_BRANCH"
+  # Check out the PR branch for review (stay inside the worktree):
+  git fetch origin "$PR_BRANCH"
+  git checkout "$PR_BRANCH" 2>/dev/null || git checkout -b "$PR_BRANCH" --track "origin/$PR_BRANCH"
 
   ── STEP 5.B — MIGRATION CHAIN VALIDATION (skip if no migration files) ──────────
   # If the PR adds Alembic migration files, validate the revision chain before grading.
@@ -841,16 +845,20 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   #    This is the step that prevents "relation does not exist" DB errors when the
   #    coordinator tries to apply migrations before fetching.
   #
-  #    ⚠️  COMMIT GUARD — the main repo may have uncommitted files (e.g. from a
-  #    previous agent run that wrote directly to the main worktree, or from generate.py
-  #    updating role files). An uncommitted working tree aborts git merge. Commit
-  #    whatever is there so the merge can proceed cleanly.
-  git -C "$REPO" add -A
-  git -C "$REPO" diff --cached --quiet || git -C "$REPO" commit -m "chore: save main repo state before post-merge dev sync
-
-AgentCeption-Session: ${AGENT_SESSION:-unset}"
+  #    ⚠️  ISOLATION ASSERTION — the main repo must be clean before any merge.
+  #    If it is not, a prior agent violated worktree isolation by writing files
+  #    directly to the main repo. Do NOT commit those files — that would silently
+  #    land agent artifacts on dev. Instead, abort and surface the violation.
+  DIRTY=$(git -C "$REPO" status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "❌ ISOLATION VIOLATION: main repo has uncommitted changes — aborting merge."
+    echo "$DIRTY"
+    echo "Identify which agent wrote to the main repo and fix the root cause."
+    echo "Do NOT commit these files. Restore with: git -C \"\$REPO\" restore --staged . && git -C \"\$REPO\" restore ."
+    exit 1
+  fi
   git -C "$REPO" fetch origin
-  git -C "$REPO" merge origin/dev
+  git -C "$REPO" merge --ff-only origin/dev
 
 STEP 7 — REGRESSION FEEDBACK LOOP (only if merge succeeded — skip if D/F grade):
   After a successful merge, run targeted tests against dev to detect regressions
@@ -858,12 +866,15 @@ STEP 7 — REGRESSION FEEDBACK LOOP (only if merge succeeded — skip if D/F gra
   and re-enter the pipeline — no human triage required.
 
   # Pull the latest dev (contains the just-merged PR).
-  # ⚠️  COMMIT GUARD: same as step 6.9 — guard against uncommitted main-repo state.
-  git -C "$REPO" add -A
-  git -C "$REPO" diff --cached --quiet || git -C "$REPO" commit -m "chore: save main repo state before regression-feedback dev sync
-
-AgentCeption-Session: ${AGENT_SESSION:-unset}"
-  git -C "$REPO" fetch origin && git -C "$REPO" merge origin/dev
+  # ⚠️  ISOLATION ASSERTION: same as step 6.9 — main repo must be clean.
+  DIRTY=$(git -C "$REPO" status --porcelain)
+  if [ -n "$DIRTY" ]; then
+    echo "❌ ISOLATION VIOLATION: main repo has uncommitted changes — aborting regression sync."
+    echo "$DIRTY"
+    echo "Do NOT commit these files. Restore with: git -C \"\$REPO\" restore --staged . && git -C \"\$REPO\" restore ."
+    exit 1
+  fi
+  git -C "$REPO" fetch origin && git -C "$REPO" merge --ff-only origin/dev
 
   # Run TARGETED tests only — never the full suite.
   # Derive test files from what this PR actually changed:
@@ -1016,7 +1027,11 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     if [ -n "$NEXT_ISSUE" ]; then
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/issue-$NEXT_ISSUE"
-      git -C "$REPO" worktree add -b "feat/issue-$NEXT_ISSUE" "$NEXT_WORKTREE" origin/dev
+      # Use --detach + SHA instead of -b to avoid registering a local branch on the
+      # main repo. The leaf agent creates the feat/issue-N branch from inside its
+      # own worktree via `git checkout -b feat/issue-$NEXT_ISSUE` at STEP 3.2.
+      NEXT_DEV_SHA=$(git -C "$REPO" rev-parse origin/dev)
+      git -C "$REPO" worktree add --detach "$NEXT_WORKTREE" "$NEXT_DEV_SHA"
       # Add label only after worktree is confirmed created — prevents permanent lock on creation failure
       # MCP: github_claim_issue(issue_number=$NEXT_ISSUE)
 
@@ -1313,6 +1328,8 @@ git -C "$REPO" status
    # MCP: create_pull_request(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
    #       title="feat: <description> (rescued from main repo dirty state)",
    #       base="dev", head="fix/<description>", body="Rescued dirty-state work.")
+   # ⚠️  Return main repo to dev after the rescue so the pipeline stays clean:
+   git -C "$REPO" checkout dev
    ```
 
 ---


### PR DESCRIPTION
## Summary

- **Root cause A (template)**: `parallel-issue-to-pr.md.j2` STEP 3.1 left the shell in `$REPO` after running Docker commands; STEP 3.2's `git checkout -b` then ran in the main repo, leaving the main repo checked out on a feature branch. Fixed by inserting `cd "$WORKTREE"` before every git operation that follows a `cd "$REPO"` docker command.
- **Root cause B (template)**: `parallel-pr-review.md.j2` STEP 5.A instructed reviewers to `git checkout dev` inside their worktree — this always fails because dev is already checked out in the main repo. STEP 6.9 and STEP 7 then ran `git -C "$REPO" add -A && git commit`, silently committing any dirty files onto dev. Both fixed: baseline capture uses Docker mount directly, commit guard replaced with a hard dirty-check assertion that aborts instead of committing.
- **Root cause C (teardown)**: `runs.py` removed worktrees and deleted remote branches but never ran `git branch -D`, leaving local branch refs accumulating in the main repo's `.git`. Fixed by adding local branch deletion to `_teardown_agent_worktree`.
- **Root cause D (dispatch/spawn)**: All three `git worktree add` call sites in `dispatch.py` and `spawn_child.py` omitted the starting commit, defaulting to the main repo's current HEAD. Fixed by resolving `origin/dev` to a SHA and passing it explicitly.
- **Additional fixes**: rescue procedures in both templates now return the main repo to `dev` after creating a rescue branch; chain-mode successor worktrees now use `--detach + SHA` instead of `-b` to avoid registering local branches.
- Two pre-existing test failures fixed: spawn_child mocks updated for the new `rev-parse` call; plan page done-screen assertions updated for the PR #162 redesign.

## Test plan

- [ ] Dispatch an issue agent — confirm main repo stays on `dev` with no uncommitted changes throughout
- [ ] Let agent complete — confirm `git branch` shows no leftover feature branch after teardown
- [ ] Dispatch a label/coordinator agent — same check
- [ ] Let a PR reviewer run — confirm STEP 5.A no longer crashes, main repo stays clean through STEP 6.9 and STEP 7
- [ ] Trigger rescue procedure — confirm main repo returns to `dev` after the rescue branch is created
