### PR TITLE
docs: enforce no-work-on-dev rule in cursorrules and AGENTS.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -43,6 +43,21 @@ The `user-github` MCP server (officially maintained by GitHub) is available in e
 
 Only fall back to `gh` CLI when the MCP server does not cover the required operation (e.g. `gh worktree`, `gh auth`).
 
+## Branch discipline — absolute rule
+
+**Never do any work directly on `dev` or `main`.** This applies to every agent and to Cursor sessions.
+
+- **AgentCeption pipeline:** all agent work happens inside a git worktree. The worktree is created from `origin/dev` at dispatch time. The PR is created from the worktree branch. `dev` is never touched.
+- **Cursor / interactive sessions:** create a feature branch before touching any file. `git checkout -b fix/<description>` or `git checkout -b feat/<description>` is the first command, not an afterthought.
+- **Before starting any work:** run `git status`. If `dev` is not clean, stop. Either restore the dirty files (`git restore .`) or commit them on a branch first. Never carry dirty state from `dev` into a feature branch.
+- **After any file-generating command** (e.g. `generate.py`, `npm run build`, code generators): immediately run `git status`. Stage and commit every modified file — do not switch branches while files are dirty.
+- **`generate.py` rule:** run it only after you are already on a feature branch, never on `dev`. All generated outputs are part of the same commit as their source template changes.
+
+The enforcement protocol:
+1. `git status` → must show `nothing to commit, working tree clean` before any `git checkout`.
+2. If it shows modified files → commit them on the current branch or restore them. Never ignore them.
+3. After merging a PR → `git checkout dev && git pull origin dev && git status` must be clean before starting the next task.
+
 ## Execution
 
 - **Docker-first:** Never run Python on the host. `docker compose exec agentception <cmd>`.
@@ -120,6 +135,8 @@ The browser loads **compiled bundles**, not source files directly:
 
 ## Anti-patterns (never do these)
 
+- **Never work directly on `dev` or `main`.** Every change — one line or a thousand — goes on a feature branch (Cursor sessions) or a worktree (AgentCeption pipeline). No exceptions. See Branch discipline above.
+- **Never run file-modifying commands on `dev` without a clean checkout.** Running `generate.py`, `npm run build`, or any generator on `dev` dirties the branch. Always be on a feature branch first.
 - **No legacy, no deprecated, no backwards compatibility.** Remove dead code, dead fields, dead endpoints on sight. Never add fallback paths for old API shapes.
 - Business logic in route handlers. Global mutable state outside designated stores.
 - Hardcoded model IDs, secrets, or URLs outside config.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ You do NOT:
 - Redesign architecture unless explicitly requested.
 - Introduce new dependencies without justification and user approval.
 - Make changes that break the API contract (SSE events, tool schemas, endpoint signatures) without a handoff.
+- **Work directly on `dev` or `main`. Ever.** See Branch Discipline below.
 
 ---
 
@@ -47,6 +48,35 @@ When facing ambiguity:
 3. **Choose correct over simple** — when they diverge, choose correct.
 4. **Document assumptions** — if you assumed something, say it.
 5. **Ask** — when in doubt, ask the user rather than guessing.
+
+---
+
+## Branch Discipline — Absolute Rule
+
+**`dev` and `main` are read-only for all agents and all Cursor sessions. Every piece of work — one line or a thousand — happens on a branch or in a worktree.**
+
+### AgentCeption pipeline (worktree)
+
+All agent work runs inside a git worktree created from `origin/dev` at dispatch time. The PR is opened from the worktree branch. The main repo's `dev` branch is never modified by an agent. When the agent finishes, it removes its own worktree.
+
+### Cursor / interactive sessions (feature branch)
+
+1. **Start clean.** Before touching any file, run `git status`. If `dev` is not clean, stop — restore or commit the dirty files before doing anything else.
+2. **Branch first.** `git checkout -b fix/<description>` or `git checkout -b feat/<description>` is the **first** command of every task, not an afterthought.
+3. **Stage everything before switching.** After any file-generating command (`generate.py`, `npm run build`, code generators, etc.), run `git status` and stage every modified file. Never switch branches while files are dirty — unstaged changes follow you and end up on the wrong branch.
+4. **Include all generated outputs in the same commit.** Template source changes and their regenerated outputs (`generate.py` → `.agentception/*.md`) belong in one commit on the feature branch. Never split them across branches.
+5. **Verify clean after merge.** After merging a PR and returning to `dev`: `git checkout dev && git pull origin dev && git status` must show `nothing to commit, working tree clean` before starting the next task.
+
+### Enforcement protocol
+
+| Checkpoint | Command | Expected result |
+|-----------|---------|-----------------|
+| Before creating a branch | `git status` | `nothing to commit, working tree clean` |
+| After any file-modifying command | `git status` | Stage or restore every modified file immediately |
+| After switching to a branch | `git status` | Only files you intentionally changed are modified |
+| After merging and returning to dev | `git status` | `nothing to commit, working tree clean` |
+
+Carrying dirty state from `dev` into a feature branch, then committing only some of the dirty files, is the root cause of every "uncommitted changes on dev" incident. The protocol above prevents it.
 
 ---
 
@@ -227,6 +257,7 @@ Before considering work complete, run in this order (mypy first so type fixes do
 
 > **Dev bind mounts are active.** Your host file edits are instantly visible inside the container — do NOT rebuild for code changes. Only rebuild when `requirements.txt`, `Dockerfile`, or `entrypoint.sh` change.
 
+0. [ ] Confirm you are on a feature branch or inside a worktree — **never on `dev` or `main`**
 1. [ ] `docker compose exec agentception mypy agentception/ tests/` — clean, zero errors
 2. [ ] `python tools/typing_audit.py --dirs agentception/ tests/ --max-any 0` — passes
 3. [ ] Unit tests pass: `docker compose exec agentception pytest tests/unit/ -v`


### PR DESCRIPTION
## Summary

- Add **Branch Discipline** section to `AGENTS.md` covering both the AgentCeption worktree workflow and Cursor interactive sessions. Includes a four-step protocol, an enforcement checkpoint table, and explanation of the root cause of every "uncommitted changes on dev" incident.
- Mirror the rule in `.cursorrules` as a prominent **Branch discipline** section (pre-Execution) and two new **Anti-patterns** bullets.
- Add item 0 to the Verification Checklist: confirm you are on a feature branch or worktree before considering work complete.

## Root Cause

Every incident of dirty `dev` state has the same pattern: a file-generating command runs on `dev`, only some of the modified files get staged, the rest stay dirty. This PR codifies the protocol that prevents it: branch first, stage everything, verify clean at each checkpoint.

## Verification

- [ ] `git status` clean on dev after merge