### PR TITLE
fix: wire build_report_done directly into workflow state, drop all fallbacks

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -1291,6 +1291,67 @@ def _pr_number_from_url(pr_url: str) -> int | None:
         return None
 
 
+async def persist_pr_link_and_recompute(
+    pr_number: int,
+    issue_number: int,
+    gh_repo: str,
+) -> None:
+    """Write an explicit PR↔Issue link and immediately recompute workflow state.
+
+    Called from ``persist_agent_event`` when an agent reports ``build_report_done``
+    with a ``pr_url``.  The agent knows exactly which PR belongs to which issue —
+    no regex, no inference, no poller cycle needed.
+
+    Writes a confidence-100 ``ACPRIssueLink`` row, then runs
+    ``_recompute_workflow_state`` so the board card moves on the next board
+    refresh (every 5 s) rather than waiting for the next poller tick.
+    """
+    now = _now()
+    try:
+        async with get_session() as session:
+            existing = (
+                await session.execute(
+                    select(ACPRIssueLink).where(
+                        ACPRIssueLink.repo == gh_repo,
+                        ACPRIssueLink.pr_number == pr_number,
+                        ACPRIssueLink.issue_number == issue_number,
+                        ACPRIssueLink.link_method == "explicit",
+                    )
+                )
+            ).scalar_one_or_none()
+            if existing is None:
+                session.add(
+                    ACPRIssueLink(
+                        repo=gh_repo,
+                        pr_number=pr_number,
+                        issue_number=issue_number,
+                        link_method="explicit",
+                        confidence=100,
+                        evidence_json=json.dumps({"source": "build_report_done"}),
+                        first_seen_at=now,
+                        last_seen_at=now,
+                    )
+                )
+            else:
+                existing.last_seen_at = now
+            await session.commit()
+    except Exception as exc:
+        logger.warning("⚠️  persist_pr_link_and_recompute (link upsert) failed: %s", exc)
+        return
+
+    try:
+        async with get_session() as session:
+            await _recompute_workflow_state(session, gh_repo)
+            await session.commit()
+        logger.info(
+            "✅ persist_pr_link_and_recompute: pr=%d → issue=%d, workflow recomputed",
+            pr_number,
+            issue_number,
+        )
+    except Exception as exc:
+        logger.warning("⚠️  persist_pr_link_and_recompute (recompute) failed: %s", exc)
+
+
 async def persist_agent_event(
     issue_number: int,
     event_type: str,
@@ -1299,14 +1360,13 @@ async def persist_agent_event(
 ) -> None:
     """Write one structured agent event row to ``agent_events``.
 
-    Called by the ``build_report_*`` HTTP endpoints when a running agent
-    signals a lifecycle change.  The optional ``agent_run_id`` is included
-    if the caller can resolve it; otherwise only ``issue_number`` is set.
-
     When ``event_type == "done"`` and ``payload`` contains ``pr_url``, the
-    corresponding run (by ``agent_run_id`` or latest run for ``issue_number``)
-    is updated with ``pr_number`` so the Kanban shows the issue in PR Open.
+    PR number is parsed from the URL and ``persist_pr_link_and_recompute`` is
+    called immediately so the board card moves without waiting for the poller.
+    If a matching ``ACAgentRun`` exists it is also updated with ``pr_number``.
     """
+    from agentception.config import settings
+
     try:
         async with get_session() as session:
             session.add(
@@ -1322,33 +1382,38 @@ async def persist_agent_event(
                 pr_url = payload.get("pr_url")
                 pr_num = _pr_number_from_url(str(pr_url)) if pr_url else None
                 if pr_num is not None:
+                    # Update ACAgentRun.pr_number when a run exists for this issue.
                     run_id = agent_run_id
+                    run_row: ACAgentRun | None = None
                     if run_id:
-                        run_result = await session.execute(
-                            select(ACAgentRun).where(ACAgentRun.id == run_id)
-                        )
-                        run_row = run_result.scalar_one_or_none()
-                    else:
-                        run_row = None
+                        run_row = (
+                            await session.execute(
+                                select(ACAgentRun).where(ACAgentRun.id == run_id)
+                            )
+                        ).scalar_one_or_none()
                     if run_row is None and issue_number:
-                        run_result = await session.execute(
-                            select(ACAgentRun)
-                            .where(ACAgentRun.issue_number == issue_number)
-                            .order_by(ACAgentRun.spawned_at.desc())
-                            .limit(1)
-                        )
-                        run_row = run_result.scalar_one_or_none()
+                        run_row = (
+                            await session.execute(
+                                select(ACAgentRun)
+                                .where(ACAgentRun.issue_number == issue_number)
+                                .order_by(ACAgentRun.spawned_at.desc())
+                                .limit(1)
+                            )
+                        ).scalar_one_or_none()
                     if run_row is not None:
                         run_row.pr_number = pr_num
                         run_row.last_activity_at = _now()
-                        logger.info(
-                            "✅ persist_agent_event: run %s pr_number=%d (from done)",
-                            run_row.id,
-                            pr_num,
-                        )
             await session.commit()
     except Exception as exc:
         logger.warning("⚠️  persist_agent_event failed (non-fatal): %s", exc)
+
+    # Immediately wire the explicit PR↔Issue link and recompute workflow state.
+    # This is the authoritative path — no regex or poller cycle needed.
+    if event_type == "done":
+        pr_url = payload.get("pr_url")
+        pr_num = _pr_number_from_url(str(pr_url)) if pr_url else None
+        if pr_num is not None and issue_number:
+            await persist_pr_link_and_recompute(pr_num, issue_number, settings.gh_repo)
 
 
 async def persist_agent_messages_async(

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -436,7 +436,7 @@ _STALE_THRESHOLD_SECONDS: int = int(STALE_THRESHOLD.total_seconds())
 
 #: Branch naming convention for engineer feature branches.
 #: Group 1 captures the issue number so we can link the PR back to its issue.
-_FEAT_ISSUE_BRANCH_RE: _re.Pattern[str] = _re.compile(r"^feat/issue-(\d+)-")
+_AC_ISSUE_BRANCH_RE: _re.Pattern[str] = _re.compile(r"^ac/issue-(\d+)")
 
 
 class _RunStepData(TypedDict):
@@ -1738,9 +1738,9 @@ async def get_open_prs_by_issue(
                         pr_number=row.github_number,
                         head_ref=row.head_ref,
                     )
-            # Signal 2: branch naming convention feat/issue-{N}-*.
+            # Signal 2: branch naming convention ac/issue-{N}.
             if row.head_ref:
-                m = _FEAT_ISSUE_BRANCH_RE.match(row.head_ref)
+                m = _AC_ISSUE_BRANCH_RE.match(row.head_ref)
                 if m:
                     issue_num = int(m.group(1))
                     if issue_num in issue_set and issue_num not in out:

--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -34,17 +34,14 @@ from agentception.config import settings
 from agentception.db.engine import get_session
 from agentception.db.models import ACAgentRun
 from agentception.db.queries import (
-    OpenPRForIssueRow,
     PhaseGroupRow,
     RunForIssueRow,
     RunTreeNodeRow,
-    WorkflowStateRow,
     get_agent_events_tail,
     get_agent_thoughts_tail,
     get_initiatives,
     get_issues_grouped_by_phase,
     get_latest_active_batch_id,
-    get_open_prs_by_issue,
     get_run_tree_by_batch_id,
     get_runs_for_issue_numbers,
     get_workflow_states_by_issue,
@@ -85,39 +82,6 @@ class EnrichedPhaseGroupRow(TypedDict):
     depends_on: list[str]
 
 
-def _compute_swim_lane(
-    issue_state: str,
-    run: RunForIssueRow | None,
-    open_pr: OpenPRForIssueRow | None,
-) -> str:
-    """Compute the deterministic swim lane for a board issue card.
-
-    This is the single canonical definition of swim lane assignment.
-    There must be no other place in the codebase that decides which lane
-    a card belongs in — Jinja2 templates, JS, and API responses all read
-    the ``swim_lane`` field produced here.
-
-    Priority (highest wins):
-    1. DONE      — ``ac_issues.state == 'closed'``  (GitHub is the source of truth)
-    2. REVIEWING — open PR in ``ac_pull_requests`` AND active reviewer agent run
-    3. PR_OPEN   — open PR in ``ac_pull_requests``  (authoritative; not ac_agent_runs.pr_number)
-    4. ACTIVE    — active agent run with no open PR yet
-    5. TODO      — none of the above
-    """
-    if issue_state == "closed":
-        return "done"
-    if open_pr is not None:
-        if run is not None and run["agent_status"] == "reviewing":
-            return "reviewing"
-        return "pr_open"
-    if run is not None and run["agent_status"] in (
-        "implementing",
-        "pending_launch",
-        "stale",
-        "reviewing",
-    ):
-        return "active"
-    return "todo"
 
 logger = logging.getLogger(__name__)
 
@@ -149,21 +113,19 @@ async def _build_enriched_groups(
     """Fetch and enrich all phase groups for *initiative*.
 
     Returns ``(enriched_groups, total_issue_count, open_issue_count)``.
-    Centralises the DB fan-out so both the full page and the HTMX partial
-    share a single implementation.
 
-    Reads swim lanes from the canonical ``ac_issue_workflow_state`` table.
-    Falls back to ad-hoc ``_compute_swim_lane()`` for issues that haven't
-    been computed yet (graceful dual-run during migration).
+    Swim lanes and PR numbers come exclusively from ``ac_issue_workflow_state``
+    — the canonical persisted state written by the workflow state machine on
+    every poller tick and immediately on ``build_report_done``.  There is no
+    fallback; if a row is absent the issue is ``todo``.
     """
     groups = await get_issues_grouped_by_phase(repo, initiative=initiative)
     all_issue_numbers = [i["number"] for g in groups for i in g["issues"]]
     open_issue_count = sum(
         1 for g in groups for i in g["issues"] if i["state"] != "closed"
     )
-    runs, open_prs, workflow_states = await asyncio.gather(
+    runs, workflow_states = await asyncio.gather(
         get_runs_for_issue_numbers(all_issue_numbers),
-        get_open_prs_by_issue(all_issue_numbers, repo),
         get_workflow_states_by_issue(all_issue_numbers, repo),
     )
     enriched: list[EnrichedPhaseGroupRow] = [
@@ -179,16 +141,15 @@ async def _build_enriched_groups(
                     labels=i["labels"],
                     depends_on=i["depends_on"],
                     run=runs.get(i["number"]),
-                    swim_lane=_resolve_swim_lane(
-                        i["number"],
-                        i["state"],
-                        runs.get(i["number"]),
-                        open_prs.get(i["number"]),
-                        workflow_states.get(i["number"]),
+                    swim_lane=(
+                        workflow_states[i["number"]]["lane"]
+                        if i["number"] in workflow_states
+                        else "todo"
                     ),
-                    pr_number=_resolve_pr_number(
-                        runs.get(i["number"]),
-                        workflow_states.get(i["number"]),
+                    pr_number=(
+                        workflow_states[i["number"]].get("pr_number")
+                        if i["number"] in workflow_states
+                        else None
                     ),
                 )
                 for i in g["issues"]
@@ -200,39 +161,6 @@ async def _build_enriched_groups(
         for g in groups
     ]
     return enriched, len(all_issue_numbers), open_issue_count
-
-
-def _resolve_swim_lane(
-    issue_number: int,
-    issue_state: str,
-    run: RunForIssueRow | None,
-    open_pr: OpenPRForIssueRow | None,
-    workflow_state: WorkflowStateRow | None,
-) -> str:
-    """Return the canonical swim lane, preferring the persisted workflow state.
-
-    During dual-run / migration, falls back to ``_compute_swim_lane()``
-    for issues without a persisted state row yet.
-    """
-    if workflow_state is not None:
-        return workflow_state["lane"]
-    return _compute_swim_lane(issue_state, run, open_pr)
-
-
-def _resolve_pr_number(
-    run: RunForIssueRow | None,
-    workflow_state: WorkflowStateRow | None,
-) -> int | None:
-    """Return the best PR number for an issue.
-
-    Prefers the canonical workflow state (linker-derived), falls back to
-    the agent run's ``pr_number`` for issues without a persisted state.
-    """
-    if workflow_state is not None and workflow_state.get("pr_number"):
-        return workflow_state["pr_number"]
-    if run is not None and run.get("pr_number"):
-        return run["pr_number"]
-    return None
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/services/spawn_child.py
+++ b/agentception/services/spawn_child.py
@@ -170,10 +170,10 @@ def _make_run_id(scope_type: ScopeType, scope_value: str) -> str:
 def _make_branch(scope_type: ScopeType, scope_value: str) -> str:
     hex4 = uuid.uuid4().hex[:4]
     if scope_type == "label":
-        return f"agent/{_slug(scope_value)}-{hex4}"
+        return f"ac/coord-{_slug(scope_value)}-{hex4}"
     if scope_type == "issue":
-        return f"feat/issue-{scope_value}-{hex4}"
-    return f"review/pr-{scope_value}-{hex4}"
+        return f"ac/issue-{scope_value}"
+    return f"ac/review-{scope_value}-{hex4}"
 
 
 def _make_batch_id(scope_type: ScopeType, scope_value: str) -> str:

--- a/agentception/tests/test_advance_phase_endpoint.py
+++ b/agentception/tests/test_advance_phase_endpoint.py
@@ -213,10 +213,6 @@ def test_build_board_renders_advance_button_when_prev_complete_and_locked(
             new=AsyncMock(return_value={}),
         ),
         patch(
-            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
-            new=AsyncMock(return_value={}),
-        ),
-        patch(
             "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
             new=AsyncMock(return_value={}),
         ),
@@ -242,10 +238,6 @@ def test_build_board_no_advance_button_when_not_locked(client: TestClient) -> No
         ),
         patch(
             "agentception.routes.ui.build_ui.get_runs_for_issue_numbers",
-            new=AsyncMock(return_value={}),
-        ),
-        patch(
-            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
             new=AsyncMock(return_value={}),
         ),
         patch(
@@ -277,10 +269,6 @@ def test_build_board_no_advance_button_when_prev_not_complete(
             new=AsyncMock(return_value={}),
         ),
         patch(
-            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
-            new=AsyncMock(return_value={}),
-        ),
-        patch(
             "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
             new=AsyncMock(return_value={}),
         ),
@@ -308,10 +296,6 @@ def test_build_board_no_advance_button_single_phase(
         ),
         patch(
             "agentception.routes.ui.build_ui.get_runs_for_issue_numbers",
-            new=AsyncMock(return_value={}),
-        ),
-        patch(
-            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
             new=AsyncMock(return_value={}),
         ),
         patch(

--- a/agentception/tests/test_agentception_spawn_child.py
+++ b/agentception/tests/test_agentception_spawn_child.py
@@ -70,17 +70,17 @@ def test_make_run_id_pr_prefix() -> None:
 
 def test_make_branch_label() -> None:
     branch = _make_branch("label", "ac-workflow")
-    assert branch.startswith("agent/ac-workflow-")
+    assert branch.startswith("ac/coord-ac-workflow-")
 
 
 def test_make_branch_issue() -> None:
     branch = _make_branch("issue", "42")
-    assert branch.startswith("feat/issue-42-")
+    assert branch == "ac/issue-42"
 
 
 def test_make_branch_pr() -> None:
     branch = _make_branch("pr", "112")
-    assert branch.startswith("review/pr-112-")
+    assert branch.startswith("ac/review-112-")
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/tests/test_build_board_partial.py
+++ b/agentception/tests/test_build_board_partial.py
@@ -31,7 +31,6 @@ from agentception.db.queries import (
     _compute_agent_status,
     _get_step_data_for_runs,
     get_runs_for_issue_numbers,
-    OpenPRForIssueRow,
 )
 
 
@@ -188,9 +187,9 @@ def test_build_board_partial_shows_status_badge(client: TestClient) -> None:
             return_value={82: _mock_run_dict()},
         ),
         patch(
-            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
+            "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
             new_callable=AsyncMock,
-            return_value={},
+            return_value={82: {"lane": "active", "pr_number": None}},
         ),
     ):
         resp = client.get("/ship/phase-1/board")
@@ -216,9 +215,9 @@ def test_build_board_partial_shows_current_step(client: TestClient) -> None:
             },
         ),
         patch(
-            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
+            "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
             new_callable=AsyncMock,
-            return_value={},
+            return_value={82: {"lane": "active", "pr_number": None}},
         ),
     ):
         resp = client.get("/ship/phase-1/board")
@@ -244,7 +243,7 @@ def test_build_board_partial_no_run_renders_without_error(
             return_value={},
         ),
         patch(
-            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
+            "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
             new_callable=AsyncMock,
             return_value={},
         ),
@@ -298,9 +297,9 @@ def test_build_board_partial_complete_phase_hides_launch_button(
             return_value={},
         ),
         patch(
-            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
+            "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
             new_callable=AsyncMock,
-            return_value={},
+            return_value={10: {"lane": "done", "pr_number": None}},
         ),
     ):
         resp = client.get("/ship/my-initiative/board")
@@ -345,9 +344,9 @@ def test_build_board_partial_complete_phase_cards_not_clickable(
             return_value={},
         ),
         patch(
-            "agentception.routes.ui.build_ui.get_open_prs_by_issue",
+            "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
             new_callable=AsyncMock,
-            return_value={},
+            return_value={11: {"lane": "done", "pr_number": None}},
         ),
     ):
         resp = client.get("/ship/my-initiative/board")
@@ -482,171 +481,53 @@ async def test_get_issues_grouped_by_phase_phase_key_initiative_prefix() -> None
 
 
 # ---------------------------------------------------------------------------
-# State machine unit tests — _compute_swim_lane
+# Regression: build_report_done wires the PR→issue link immediately
 #
-# These tests encode the formal state machine invariants.  Every transition
-# trigger must have at least one test; any code change that breaks an
-# invariant will break a test here, making regressions visible immediately.
-#
-# Invariants:
-# I1. closed issue → 'done'  (no exceptions)
-# I2. open PR in ac_pull_requests → swim_lane in ('pr_open', 'reviewing', 'done')
-# I3. no worktree AND no open PR → swim_lane in ('todo', 'done')
-# I4. active run with no open PR → 'active'
-# I5. active run with open PR → 'pr_open'  (PR signal wins)
-# I6. active reviewer run + open PR → 'reviewing'
+# When an agent calls build_report_done(issue_number=N, pr_url=".../pull/M"),
+# persist_pr_link_and_recompute must be called with the correct pr_number and
+# issue_number so the board card moves to pr_open on the next refresh —
+# without waiting for the poller.
 # ---------------------------------------------------------------------------
 
 
-from agentception.db.queries import RunForIssueRow
-from agentception.routes.ui.build_ui import _compute_swim_lane
+@pytest.mark.anyio
+async def test_persist_agent_event_done_calls_link_and_recompute() -> None:
+    """build_report_done triggers persist_pr_link_and_recompute with correct args."""
+    from unittest.mock import AsyncMock, patch
+
+    from agentception.db.persist import persist_agent_event
+
+    with patch(
+        "agentception.db.persist.persist_pr_link_and_recompute",
+        new_callable=AsyncMock,
+    ) as mock_recompute:
+        await persist_agent_event(
+            issue_number=161,
+            event_type="done",
+            payload={"pr_url": "https://github.com/cgcardona/agentception/pull/169"},
+        )
+
+    mock_recompute.assert_awaited_once()
+    call_args = mock_recompute.call_args
+    assert call_args.args[0] == 169   # pr_number
+    assert call_args.args[1] == 161   # issue_number
 
 
-def _run(agent_status: str, pr_number: int | None = None) -> RunForIssueRow:
-    """Build a minimal RunForIssueRow for state machine tests."""
-    return RunForIssueRow(
-        id="run-test",
-        role="python-developer",
-        cognitive_arch=None,
-        status=agent_status,
-        agent_status=agent_status,
-        pr_number=pr_number,
-        branch="feat/issue-99-test",
-        spawned_at="2026-03-06T12:00:00+00:00",
-        last_activity_at=None,
-        current_step=None,
-        steps_completed=0,
-        tier="engineer",
-        org_domain="engineering",
-        batch_id="issue-99-batch",
-    )
+@pytest.mark.anyio
+async def test_persist_agent_event_non_done_does_not_call_recompute() -> None:
+    """step_start and blocker events must not trigger persist_pr_link_and_recompute."""
+    from unittest.mock import AsyncMock, patch
 
+    from agentception.db.persist import persist_agent_event
 
-def _open_pr(pr_number: int = 200) -> OpenPRForIssueRow:
-    return OpenPRForIssueRow(pr_number=pr_number, head_ref="feat/issue-99-test")
+    with patch(
+        "agentception.db.persist.persist_pr_link_and_recompute",
+        new_callable=AsyncMock,
+    ) as mock_recompute:
+        await persist_agent_event(
+            issue_number=161,
+            event_type="step_start",
+            payload={"step": "Reading codebase"},
+        )
 
-
-# ── Invariant I1: closed issue always → done ─────────────────────────────────
-
-
-def test_swim_lane_closed_issue_no_run() -> None:
-    """I1: closed issue with no run → done."""
-    assert _compute_swim_lane("closed", None, None) == "done"
-
-
-def test_swim_lane_closed_issue_with_active_run() -> None:
-    """I1: closed issue even with an active run → done (state wins over run)."""
-    assert _compute_swim_lane("closed", _run("implementing"), None) == "done"
-
-
-def test_swim_lane_closed_issue_with_open_pr() -> None:
-    """I1: closed issue even with an open PR → done (issue close wins over PR)."""
-    assert _compute_swim_lane("closed", None, _open_pr()) == "done"
-
-
-def test_swim_lane_closed_issue_with_run_and_open_pr() -> None:
-    """I1: closed issue with both active run and open PR → done."""
-    assert _compute_swim_lane("closed", _run("reviewing"), _open_pr()) == "done"
-
-
-# ── Invariant I2: open PR → pr_open or reviewing or done ─────────────────────
-
-
-def test_swim_lane_open_pr_no_run() -> None:
-    """I2: open PR + no run → pr_open."""
-    assert _compute_swim_lane("open", None, _open_pr()) == "pr_open"
-
-
-def test_swim_lane_open_pr_with_implementing_run() -> None:
-    """I2: open PR + implementing run → pr_open (PR signal takes precedence)."""
-    assert _compute_swim_lane("open", _run("implementing"), _open_pr()) == "pr_open"
-
-
-def test_swim_lane_open_pr_with_stale_run() -> None:
-    """I2: open PR + stale run → pr_open (PR signal takes precedence)."""
-    assert _compute_swim_lane("open", _run("stale"), _open_pr()) == "pr_open"
-
-
-def test_swim_lane_open_pr_with_done_run() -> None:
-    """I2: open PR + done run → pr_open (PR open means issue is not closed)."""
-    assert _compute_swim_lane("open", _run("done"), _open_pr()) == "pr_open"
-
-
-def test_swim_lane_open_pr_with_reviewing_run() -> None:
-    """I2+I6: open PR + reviewing run → reviewing."""
-    assert _compute_swim_lane("open", _run("reviewing"), _open_pr()) == "reviewing"
-
-
-# ── Invariant I3: no worktree AND no PR → todo or done ───────────────────────
-
-
-def test_swim_lane_no_run_no_pr() -> None:
-    """I3: no run and no PR → todo."""
-    assert _compute_swim_lane("open", None, None) == "todo"
-
-
-def test_swim_lane_unknown_run_no_pr() -> None:
-    """I3: unknown-status run (treated as no effective run) + no PR → todo."""
-    assert _compute_swim_lane("open", _run("unknown"), None) == "todo"
-
-
-def test_swim_lane_done_run_no_pr() -> None:
-    """I3: done run with no PR → todo (orphan sweep set unknown; issue not closed)."""
-    assert _compute_swim_lane("open", _run("done"), None) == "todo"
-
-
-# ── Invariant I4: active run + no PR → active ────────────────────────────────
-
-
-def test_swim_lane_implementing_no_pr() -> None:
-    """I4: implementing run + no PR → active."""
-    assert _compute_swim_lane("open", _run("implementing"), None) == "active"
-
-
-def test_swim_lane_pending_launch_no_pr() -> None:
-    """I4: pending_launch run + no PR → active."""
-    assert _compute_swim_lane("open", _run("pending_launch"), None) == "active"
-
-
-def test_swim_lane_stale_no_pr() -> None:
-    """I4: stale run (active but frozen) + no PR → active."""
-    assert _compute_swim_lane("open", _run("stale"), None) == "active"
-
-
-def test_swim_lane_reviewing_no_pr() -> None:
-    """I4: reviewing run but no open PR in ac_pull_requests → active (degraded)."""
-    assert _compute_swim_lane("open", _run("reviewing"), None) == "active"
-
-
-# ── Invariant I5: active run + open PR → pr_open (PR signal wins) ────────────
-
-
-def test_swim_lane_implementing_with_open_pr() -> None:
-    """I5: agent still implementing but PR already open → pr_open."""
-    assert _compute_swim_lane("open", _run("implementing"), _open_pr()) == "pr_open"
-
-
-# ── Invariant I6: reviewer run + open PR → reviewing ─────────────────────────
-
-
-def test_swim_lane_reviewing_with_open_pr() -> None:
-    """I6: reviewer agent active + PR open → reviewing."""
-    assert _compute_swim_lane("open", _run("reviewing"), _open_pr()) == "reviewing"
-
-
-# ── Priority ordering: closed > pr > active > todo ───────────────────────────
-
-
-def test_swim_lane_priority_closed_beats_pr() -> None:
-    """Closed issue beats open PR — issue closure is final."""
-    assert _compute_swim_lane("closed", _run("reviewing"), _open_pr()) == "done"
-
-
-def test_swim_lane_priority_pr_beats_active_run() -> None:
-    """Open PR beats active run — PR is the more advanced state."""
-    assert _compute_swim_lane("open", _run("implementing"), _open_pr()) == "pr_open"
-
-
-def test_swim_lane_priority_active_beats_todo() -> None:
-    """Active run beats todo — agent is working even without a PR."""
-    assert _compute_swim_lane("open", _run("implementing"), None) == "active"
+    mock_recompute.assert_not_awaited()

--- a/agentception/tests/test_workflow_state_machine.py
+++ b/agentception/tests/test_workflow_state_machine.py
@@ -8,7 +8,7 @@ state machine specification.  They must pass before any merge.
 Coverage:
 
 1. Open PR with ``Closes #17`` and non-standard branch → lane ``pr_open``
-2. Open PR with no body but branch ``feat/issue-17-x`` → lane ``pr_open``
+2. Open PR with no body but branch ``ac/issue-17`` → lane ``pr_open``
 3. Run has ``pr_number=42`` but PR not yet in DB → warning + deterministic behaviour
 4. PR targets ``main`` not ``dev`` → lane ``pr_open`` + warning ``wrong_base``
 5. PR merges → lane ``done`` (with stabilisation even if issue still open)
@@ -105,7 +105,7 @@ def _best_pr(
     pr_number: int = 42,
     pr_state: str = "open",
     pr_base: str | None = "dev",
-    pr_head_ref: str | None = "feat/issue-17-fix",
+    pr_head_ref: str | None = "ac/issue-17",
     link_method: str = "body_closes",
     confidence: int = 95,
 ) -> BestPR:
@@ -122,7 +122,7 @@ def _best_pr(
 def _pr_row(
     number: int = 42,
     title: str = "Fix the thing",
-    head_ref: str | None = "feat/issue-17-fix",
+    head_ref: str | None = "ac/issue-17",
     base_ref: str | None = "dev",
     body: str = "",
     labels: list[str] | None = None,
@@ -159,7 +159,7 @@ class TestLaneComputation:
         assert result["lane"] == LANE_PR_OPEN
 
     def test_open_pr_with_branch_regex_is_pr_open(self) -> None:
-        """Acceptance criterion 2: no body but feat/issue-17-x branch."""
+        """Acceptance criterion 2: no body but ac/issue-17 branch."""
         result = compute_workflow_state(
             _issue(),
             _run(),
@@ -323,20 +323,20 @@ class TestLinkDiscovery:
         assert nums == {17, 18, 19}
 
     def test_branch_regex(self) -> None:
-        pr = _pr_row(head_ref="feat/issue-17-fix-buttons")
+        """ac/issue-{N} branch convention is detected as branch_regex at confidence 90."""
+        pr = _pr_row(head_ref="ac/issue-17")
         links = discover_links_for_pr(pr, _REPO)
         branch_links = [l for l in links if l["link_method"] == "branch_regex"]
         assert len(branch_links) == 1
         assert branch_links[0]["issue_number"] == 17
         assert branch_links[0]["confidence"] == 90
 
-    def test_explicit_label(self) -> None:
-        pr = _pr_row(labels=["agent:issue-17"])
+    def test_old_feat_branch_not_matched(self) -> None:
+        """Legacy feat/issue-{N}-slug branches are no longer matched."""
+        pr = _pr_row(head_ref="feat/issue-17-fix-buttons")
         links = discover_links_for_pr(pr, _REPO)
-        explicit_links = [l for l in links if l["link_method"] == "explicit"]
-        assert len(explicit_links) == 1
-        assert explicit_links[0]["issue_number"] == 17
-        assert explicit_links[0]["confidence"] == 100
+        branch_links = [l for l in links if l["link_method"] == "branch_regex"]
+        assert branch_links == []
 
     def test_run_pr_number(self) -> None:
         pr = _pr_row(number=42)
@@ -347,24 +347,16 @@ class TestLinkDiscovery:
         assert run_links[0]["issue_number"] == 17
         assert run_links[0]["confidence"] == 85
 
-    def test_title_mention(self) -> None:
-        pr = _pr_row(title="Fix #17 button rendering", head_ref="random/no-issue-ref")
-        links = discover_links_for_pr(pr, _REPO)
-        title_links = [l for l in links if l["link_method"] == "title_mention"]
-        assert len(title_links) == 1
-        assert title_links[0]["issue_number"] == 17
-        assert title_links[0]["confidence"] == 60
-
     def test_no_signals_empty(self) -> None:
         pr = _pr_row(head_ref="main", body="No references here")
         links = discover_links_for_pr(pr, _REPO)
         assert links == []
 
     def test_sorted_by_confidence_desc(self) -> None:
+        """Results from multiple signals are sorted highest confidence first."""
         pr = _pr_row(
-            head_ref="feat/issue-17-fix",
+            head_ref="ac/issue-17",
             body="Closes #17",
-            labels=["agent:issue-17"],
         )
         links = discover_links_for_pr(pr, _REPO)
         confidences = [l["confidence"] for l in links]
@@ -380,8 +372,8 @@ class TestBestPRSelection:
             CandidateLink(repo=_REPO, pr_number=2, issue_number=17, link_method="body_closes", confidence=95, evidence_json="{}"),
         ]
         pr_info = {
-            1: PRInfo(number=1, state="merged", base_ref="dev", head_ref="feat/issue-17-a"),
-            2: PRInfo(number=2, state="open", base_ref="dev", head_ref="feat/issue-17-b"),
+            1: PRInfo(number=1, state="merged", base_ref="dev", head_ref="ac/issue-17"),
+            2: PRInfo(number=2, state="open", base_ref="dev", head_ref="ac/issue-17-b"),
         }
         best = best_pr_for_issue(17, links, pr_info)
         assert best is not None
@@ -562,10 +554,10 @@ class TestEndToEndLaneDerivation:
         assert result["lane"] == LANE_PR_OPEN
 
     def test_branch_convention_drives_pr_open(self) -> None:
-        """Acceptance criterion 2: feat/issue-17-x → pr_open."""
-        pr = _pr_row(number=42, head_ref="feat/issue-17-some-slug", body="")
+        """Acceptance criterion 2: ac/issue-17 branch → pr_open."""
+        pr = _pr_row(number=42, head_ref="ac/issue-17", body="")
         links = discover_links_for_pr(pr, _REPO)
-        pr_info = {42: PRInfo(number=42, state="open", base_ref="dev", head_ref="feat/issue-17-some-slug")}
+        pr_info = {42: PRInfo(number=42, state="open", base_ref="dev", head_ref="ac/issue-17")}
         best = best_pr_for_issue(17, links, pr_info)
         result = compute_workflow_state(_issue(number=17), _run(), best)
         assert result["lane"] == LANE_PR_OPEN
@@ -582,9 +574,9 @@ class TestEndToEndLaneDerivation:
 
     def test_wrong_base_still_pr_open(self) -> None:
         """Acceptance criterion 4: PR against main → pr_open + warning."""
-        pr = _pr_row(number=42, head_ref="feat/issue-17-fix", body="Closes #17", base_ref="main")
+        pr = _pr_row(number=42, head_ref="ac/issue-17", body="Closes #17", base_ref="main")
         links = discover_links_for_pr(pr, _REPO)
-        pr_info = {42: PRInfo(number=42, state="open", base_ref="main", head_ref="feat/issue-17-fix")}
+        pr_info = {42: PRInfo(number=42, state="open", base_ref="main", head_ref="ac/issue-17")}
         best = best_pr_for_issue(17, links, pr_info)
         result = compute_workflow_state(_issue(number=17), _run(), best)
         assert result["lane"] == LANE_PR_OPEN

--- a/agentception/workflow/linking.py
+++ b/agentception/workflow/linking.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 """Multi-signal PR↔Issue linker with auditable provenance.
 
-Discovers candidate links between pull requests and issues using five
+Discovers candidate links between pull requests and issues using four
 signals (in decreasing confidence order):
 
-1. **Explicit metadata** — PR labels like ``agent:issue-123`` (confidence 100).
+1. **Explicit DB link** — written directly by ``persist_pr_link_and_recompute``
+   when an agent calls ``build_report_done`` (confidence 100). This is the
+   authoritative path — the agent tells us exactly which PR closes which issue.
 2. **Body closes references** — ``Closes/Fixes/Resolves #N`` (confidence 95).
-3. **Branch regex** — ``feat/issue-{N}-*`` (confidence 90).
+3. **Branch regex** — ``ac/issue-{N}`` (confidence 90).
 4. **Run pr_number** — an agent run claims this PR (confidence 85).
-5. **Title mention** — ``#123`` or ``issue 123`` in PR title (confidence 60).
 
 Each candidate is persisted as a row in ``ac_pr_issue_links`` with method,
 confidence, and evidence.  The ``best_pr_for_issue`` function chooses the
@@ -32,16 +33,8 @@ _CLOSES_RE = re.compile(
 )
 """Matches ``Closes #17``, ``fixes owner/repo#123``, ``Resolves #42``."""
 
-_FEAT_ISSUE_BRANCH_RE = re.compile(r"feat/issue-(\d+)")
-"""Matches ``feat/issue-17-some-slug`` and extracts the issue number."""
-
-_AGENT_ISSUE_LABEL_RE = re.compile(r"agent:issue-(\d+)")
-"""Matches ``agent:issue-123`` label on PRs (explicit metadata signal)."""
-
-_TITLE_ISSUE_RE = re.compile(
-    r"(?:^|\W)#(\d+)(?:\W|$)|\bissue[\s-]?(\d+)\b", re.IGNORECASE
-)
-"""Loose match for ``#123`` or ``issue 123`` / ``issue-123`` in PR title."""
+_AC_ISSUE_BRANCH_RE = re.compile(r"ac/issue-(\d+)")
+"""Matches ``ac/issue-17`` branches created by spawn_child for engineer scope."""
 
 
 # ---------------------------------------------------------------------------
@@ -113,18 +106,10 @@ def discover_links_for_pr(
     candidates: list[CandidateLink] = []
     pr_num = pr["number"]
 
-    # Signal 1: explicit metadata labels (agent:issue-123)
-    for label in pr["labels"]:
-        m = _AGENT_ISSUE_LABEL_RE.match(label)
-        if m:
-            candidates.append(CandidateLink(
-                repo=repo,
-                pr_number=pr_num,
-                issue_number=int(m.group(1)),
-                link_method="explicit",
-                confidence=100,
-                evidence_json=json.dumps({"label": label}),
-            ))
+    # Signal 1 (confidence 100) — explicit links are written directly to
+    # ``ac_pr_issue_links`` by ``persist_pr_link_and_recompute`` when an agent
+    # calls ``build_report_done``.  They are not discovered here; they are
+    # already in the DB before this function runs.
 
     # Signal 2: body closes references
     body = pr["body"] or ""
@@ -139,9 +124,10 @@ def discover_links_for_pr(
             evidence_json=json.dumps({"matched_text": m.group(0).strip()}),
         ))
 
-    # Signal 3: branch regex
+    # Signal 3: branch regex — matches ``ac/issue-{N}`` branches created by
+    # spawn_child for engineer-scope runs.
     head_ref = pr["head_ref"] or ""
-    branch_match = _FEAT_ISSUE_BRANCH_RE.match(head_ref)
+    branch_match = _AC_ISSUE_BRANCH_RE.match(head_ref)
     if branch_match:
         issue_num = int(branch_match.group(1))
         candidates.append(CandidateLink(
@@ -165,21 +151,6 @@ def discover_links_for_pr(
                     confidence=85,
                     evidence_json=json.dumps({"run_id": run["id"]}),
                 ))
-
-    # Signal 5: title mention
-    title = pr["title"] or ""
-    for m in _TITLE_ISSUE_RE.finditer(title):
-        issue_num = int(m.group(1) or m.group(2))
-        already_found = any(c["issue_number"] == issue_num for c in candidates)
-        if not already_found:
-            candidates.append(CandidateLink(
-                repo=repo,
-                pr_number=pr_num,
-                issue_number=issue_num,
-                link_method="title_mention",
-                confidence=60,
-                evidence_json=json.dumps({"matched_text": m.group(0).strip()}),
-            ))
 
     candidates.sort(key=lambda c: c["confidence"], reverse=True)
     return candidates


### PR DESCRIPTION
## Summary

- `build_report_done` now writes a confidence-100 `ACPRIssueLink` and immediately recomputes workflow state — the board card moves on the next 5 s refresh, no poller cycle required
- Removed dead Signal 1 (`agent:issue-N` label — never applied by Python) and Signal 5 (title mention, confidence 60) from the linker
- Branch naming standardised to `ac/issue-{N}` across `spawn_child.py`, `linking.py`, and `queries.py`; old `feat/issue-N-*` patterns dropped entirely
- `_compute_swim_lane` fallback and `get_open_prs_by_issue` removed from `build_ui.py` — the board reads exclusively from `ac_issue_workflow_state`

## Root cause

The agent already tells us the PR number via `build_report_done`, but the system only tried to set `ACAgentRun.pr_number`, which silently failed when no `ACAgentRun` existed for the issue (common with sub-Task engineers). The three signals the linker relied on were all broken simultaneously.

## Test plan

- [x] `mypy agentception/ tests/` — strict, 0 errors
- [x] 906 tests pass
- [x] Regression tests added: `test_persist_agent_event_done_calls_link_and_recompute`, `test_persist_agent_event_non_done_does_not_call_recompute`
- [x] Branch convention tests updated to assert `ac/issue-{N}` format
- [x] `test_old_feat_branch_not_matched` asserts legacy branches are no longer matched