### PR TITLE
docs(rules): enforce full PR→merge→cleanup lifecycle for every Cursor session task

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -48,7 +48,19 @@ Only fall back to `gh` CLI when the MCP server does not cover the required opera
 **Never do any work directly on `dev` or `main`.** This applies to every agent and to Cursor sessions.
 
 - **AgentCeption pipeline:** all agent work happens inside a git worktree. The worktree is created from `origin/dev` at dispatch time. The PR is created from the worktree branch. `dev` is never touched.
-- **Cursor / interactive sessions:** create a feature branch before touching any file. `git checkout -b fix/<description>` or `git checkout -b feat/<description>` is the first command, not an afterthought.
+- **Cursor / interactive sessions:** every task follows the full lifecycle below — no step is optional.
+
+**Full task lifecycle for Cursor sessions:**
+1. `git status` — must be clean before branching.
+2. `git checkout -b fix/<description>` or `feat/<description>` — branch first, always.
+3. Do the work, commit on the branch.
+4. **Open a PR** against `dev` via `create_pull_request` MCP tool (never push directly to `dev`).
+5. **Merge the PR** via `merge_pull_request` MCP tool (squash). Never leave a PR open.
+6. **Delete the remote branch** — pass `deleteBranch: true` to `merge_pull_request`, or run `git push origin --delete <branch>`.
+7. **Delete the local branch** — `git checkout dev && git branch -D <branch>`.
+8. **Pull dev** — `git pull origin dev`.
+9. **Verify clean** — `git status` must show `nothing to commit, working tree clean`.
+
 - **Before starting any work:** run `git status`. If `dev` is not clean, stop. Either restore the dirty files (`git restore .`) or commit them on a branch first. Never carry dirty state from `dev` into a feature branch.
 - **After any file-generating command** (e.g. `generate.py`, `npm run build`, code generators): immediately run `git status`. Stage and commit every modified file — do not switch branches while files are dirty.
 - **`generate.py` rule:** run it only after you are already on a feature branch, never on `dev`. All generated outputs are part of the same commit as their source template changes.
@@ -56,7 +68,7 @@ Only fall back to `gh` CLI when the MCP server does not cover the required opera
 The enforcement protocol:
 1. `git status` → must show `nothing to commit, working tree clean` before any `git checkout`.
 2. If it shows modified files → commit them on the current branch or restore them. Never ignore them.
-3. After merging a PR → `git checkout dev && git pull origin dev && git status` must be clean before starting the next task.
+3. After every task → PR created, PR merged, remote branch deleted, local branch deleted, `git pull origin dev`, `git status` clean.
 
 ## Execution
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,11 +61,31 @@ All agent work runs inside a git worktree created from `origin/dev` at dispatch 
 
 ### Cursor / interactive sessions (feature branch)
 
+Every task follows this complete lifecycle — no step is optional:
+
 1. **Start clean.** Before touching any file, run `git status`. If `dev` is not clean, stop — restore or commit the dirty files before doing anything else.
 2. **Branch first.** `git checkout -b fix/<description>` or `git checkout -b feat/<description>` is the **first** command of every task, not an afterthought.
 3. **Stage everything before switching.** After any file-generating command (`generate.py`, `npm run build`, code generators, etc.), run `git status` and stage every modified file. Never switch branches while files are dirty — unstaged changes follow you and end up on the wrong branch.
 4. **Include all generated outputs in the same commit.** Template source changes and their regenerated outputs (`generate.py` → `.agentception/*.md`) belong in one commit on the feature branch. Never split them across branches.
-5. **Verify clean after merge.** After merging a PR and returning to `dev`: `git checkout dev && git pull origin dev && git status` must show `nothing to commit, working tree clean` before starting the next task.
+5. **Open a pull request.** Always create a PR against `dev` — never push directly. Use the `create_pull_request` MCP tool (preferred) or `gh pr create`. Every change, no matter how small, goes through a PR.
+6. **Merge the PR.** Use `merge_pull_request` MCP tool (squash merge). Do not leave PRs open at the end of a session.
+7. **Delete the remote branch.** After merging, delete the remote tracking branch. The `merge_pull_request` MCP tool does this automatically with `deleteBranch: true`; if using `gh`, run `git push origin --delete <branch>`.
+8. **Delete the local branch.** `git checkout dev && git branch -D <branch>`.
+9. **Pull dev.** `git pull origin dev` — confirm `git status` shows `nothing to commit, working tree clean` before starting the next task.
+
+### Complete task teardown sequence
+
+Run these commands in order at the end of every task:
+
+```bash
+# 1. Merge the PR (via MCP tool or gh)
+# 2. Return to dev and clean up
+git checkout dev
+git pull origin dev
+git branch -D <feature-branch>           # delete local branch
+git push origin --delete <feature-branch> # delete remote branch (if not auto-deleted)
+git status                               # must be clean
+```
 
 ### Enforcement protocol
 
@@ -74,7 +94,7 @@ All agent work runs inside a git worktree created from `origin/dev` at dispatch 
 | Before creating a branch | `git status` | `nothing to commit, working tree clean` |
 | After any file-modifying command | `git status` | Stage or restore every modified file immediately |
 | After switching to a branch | `git status` | Only files you intentionally changed are modified |
-| After merging and returning to dev | `git status` | `nothing to commit, working tree clean` |
+| After task complete | PR created, merged, branch deleted locally and remotely | `git status` on `dev` is clean |
 
 Carrying dirty state from `dev` into a feature branch, then committing only some of the dirty files, is the root cause of every "uncommitted changes on dev" incident. The protocol above prevents it.
 


### PR DESCRIPTION
## Summary

- Both `AGENTS.md` and `.cursorrules` now mandate the complete task lifecycle for every Cursor session — no step is optional
- Every task must: open a PR, merge it (squash), delete the remote branch, delete the local branch, pull dev, verify `git status` is clean
- No PR may be left open. No feature branch survives a completed task.
- Added a concrete teardown command sequence to `AGENTS.md` for copy-paste reference
- Enforcement table updated to include post-task branch cleanup as a required checkpoint