### PR TITLE
fix(teardown): wire worktree cleanup into MCP build_report_done

### DIFF
--- a/agentception/mcp/build_tools.py
+++ b/agentception/mcp/build_tools.py
@@ -12,11 +12,13 @@ All four functions are async — they write to ``ac_agent_events`` via the
 persist layer and return a lightweight ack dict.
 """
 
+import asyncio
 import logging
 
 from agentception.db.persist import persist_agent_event
 from agentception.db.queries import get_pending_launches
 from agentception.services.spawn_child import ScopeType, SpawnChildError, Tier, spawn_child
+from agentception.services.teardown import teardown_agent_worktree
 
 logger = logging.getLogger(__name__)
 
@@ -248,13 +250,20 @@ async def build_report_done(
     summary: str = "",
     agent_run_id: str | None = None,
 ) -> dict[str, object]:
-    """Record that the agent has finished work and opened a pull request.
+    """Record that the agent has finished work and tear down its worktree.
+
+    Persists the ``done`` event (linking the PR and updating workflow state),
+    then fires ``teardown_agent_worktree`` as a non-blocking background task
+    so the agent receives an immediate ack while cleanup runs asynchronously.
+
+    Teardown removes the git worktree, prunes refs, deletes the remote branch,
+    and deletes the local branch — leaving the main repo clean automatically.
 
     Args:
         issue_number: GitHub issue number the agent worked on.
         pr_url: Full URL of the opened pull request.
         summary: Optional one-sentence description of what was done.
-        agent_run_id: Optional worktree id.
+        agent_run_id: Run ID used to look up the worktree path and branch.
 
     Returns:
         ``{"ok": True, "event": "done"}``
@@ -266,6 +275,17 @@ async def build_report_done(
         agent_run_id=agent_run_id,
     )
     logger.info(
-        "✅ build_report_done: issue=%d pr_url=%r", issue_number, pr_url
+        "✅ build_report_done: issue=%d pr_url=%r run_id=%r", issue_number, pr_url, agent_run_id
     )
+    if agent_run_id:
+        asyncio.create_task(
+            teardown_agent_worktree(agent_run_id),
+            name=f"teardown-{agent_run_id}",
+        )
+        logger.info("🧹 build_report_done: teardown queued for run_id=%r", agent_run_id)
+    else:
+        logger.warning(
+            "⚠️  build_report_done: no agent_run_id — worktree not cleaned up for issue=%d",
+            issue_number,
+        )
     return {"ok": True, "event": "done"}

--- a/agentception/routes/api/runs.py
+++ b/agentception/routes/api/runs.py
@@ -22,7 +22,6 @@ See ``docs/agent-tree-protocol.md`` for the full tier spec.
 import asyncio
 import datetime
 import logging
-from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Response
 from pydantic import BaseModel
@@ -30,7 +29,6 @@ from sqlalchemy import func, select
 
 from typing import Literal
 
-from agentception.config import settings
 from agentception.db.engine import get_session
 from agentception.db.models import ACAgentMessage, ACAgentRun
 from agentception.db.persist import acknowledge_agent_run, persist_agent_event
@@ -40,6 +38,7 @@ from agentception.services.spawn_child import (
     Tier,
     spawn_child,
 )
+from agentception.services.teardown import teardown_agent_worktree
 
 logger = logging.getLogger(__name__)
 
@@ -249,72 +248,12 @@ async def report_decision(run_id: str, req: DecisionReport) -> dict[str, object]
 
 
 async def _teardown_agent_worktree(run_id: str) -> None:
-    """Remove the worktree and delete the remote branch for a completed agent run.
+    """Delegate to the shared teardown service.
 
-    Called non-blocking from ``report_done`` — errors are logged but never
-    propagated so a cleanup failure cannot break the agent's done response.
+    Thin wrapper kept so the ``asyncio.create_task`` call below doesn't change.
+    All logic lives in ``agentception.services.teardown``.
     """
-    teardown = await get_agent_run_teardown(run_id)
-    if teardown is None:
-        logger.warning("⚠️  _teardown_agent_worktree: no DB row for run_id=%r", run_id)
-        return
-
-    repo_dir = str(settings.repo_dir)
-    worktree_path = teardown["worktree_path"]
-    branch = teardown["branch"]
-
-    if worktree_path and Path(worktree_path).exists():
-        rm_proc = await asyncio.create_subprocess_exec(
-            "git", "-C", repo_dir, "worktree", "remove", "--force", worktree_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await rm_proc.communicate()
-        if rm_proc.returncode == 0:
-            logger.info("✅ _teardown: removed worktree %s", worktree_path)
-        else:
-            logger.warning("⚠️  _teardown: worktree remove failed: %s", stderr.decode().strip())
-
-    prune_proc = await asyncio.create_subprocess_exec(
-        "git", "-C", repo_dir, "worktree", "prune",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    await prune_proc.communicate()
-
-    if branch:
-        push_proc = await asyncio.create_subprocess_exec(
-            "git", "-C", repo_dir, "push", "origin", "--delete", branch,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, push_stderr = await push_proc.communicate()
-        if push_proc.returncode == 0:
-            logger.info("✅ _teardown: deleted remote branch %r", branch)
-        else:
-            logger.info(
-                "ℹ️  _teardown: remote branch %r not deleted (may already be gone): %s",
-                branch,
-                push_stderr.decode().strip(),
-            )
-
-        # Delete the local branch so it does not accumulate in the main repo.
-        # git worktree remove unlinks the worktree but leaves the local branch
-        # reference in .git/refs/heads/ — this cleans it up.
-        branch_proc = await asyncio.create_subprocess_exec(
-            "git", "-C", repo_dir, "branch", "-D", branch,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, branch_stderr = await branch_proc.communicate()
-        if branch_proc.returncode == 0:
-            logger.info("✅ _teardown: deleted local branch %r", branch)
-        else:
-            logger.info(
-                "ℹ️  _teardown: local branch %r not deleted (may already be gone): %s",
-                branch,
-                branch_stderr.decode().strip(),
-            )
+    await teardown_agent_worktree(run_id)
 
 
 @router.post("/{run_id}/done")

--- a/agentception/services/teardown.py
+++ b/agentception/services/teardown.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+"""Agent worktree teardown service.
+
+Called from two places:
+- ``agentception/routes/api/runs.py`` — HTTP ``POST /api/runs/{run_id}/done``
+- ``agentception/mcp/build_tools.py`` — MCP ``build_report_done``
+
+Keeping teardown here prevents the MCP layer from importing the routes layer
+(a layering violation) and keeps the git operations in one place.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+
+from agentception.config import settings
+from agentception.db.queries import get_agent_run_teardown
+
+logger = logging.getLogger(__name__)
+
+
+async def teardown_agent_worktree(run_id: str) -> None:
+    """Remove the worktree, prune refs, and delete the branch for a finished agent.
+
+    Safe to call from any context — all errors are logged and swallowed so a
+    cleanup failure never breaks the caller.  Idempotent: if the worktree or
+    branch is already gone, each step logs an info message and continues.
+
+    Steps:
+    1. ``git worktree remove --force <worktree_path>``
+    2. ``git worktree prune``
+    3. ``git push origin --delete <branch>`` (remote branch)
+    4. ``git branch -D <branch>`` (local branch ref in the main repo)
+    """
+    teardown = await get_agent_run_teardown(run_id)
+    if teardown is None:
+        logger.warning("⚠️  teardown_agent_worktree: no DB row for run_id=%r", run_id)
+        return
+
+    repo_dir = str(settings.repo_dir)
+    worktree_path = teardown["worktree_path"]
+    branch = teardown["branch"]
+
+    if worktree_path and Path(worktree_path).exists():
+        rm_proc = await asyncio.create_subprocess_exec(
+            "git", "-C", repo_dir, "worktree", "remove", "--force", worktree_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await rm_proc.communicate()
+        if rm_proc.returncode == 0:
+            logger.info("✅ teardown[%s]: removed worktree %s", run_id, worktree_path)
+        else:
+            logger.warning(
+                "⚠️  teardown[%s]: worktree remove failed: %s",
+                run_id,
+                stderr.decode().strip(),
+            )
+
+    prune_proc = await asyncio.create_subprocess_exec(
+        "git", "-C", repo_dir, "worktree", "prune",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await prune_proc.communicate()
+
+    if branch:
+        push_proc = await asyncio.create_subprocess_exec(
+            "git", "-C", repo_dir, "push", "origin", "--delete", branch,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, push_stderr = await push_proc.communicate()
+        if push_proc.returncode == 0:
+            logger.info("✅ teardown[%s]: deleted remote branch %r", run_id, branch)
+        else:
+            logger.info(
+                "ℹ️  teardown[%s]: remote branch %r already gone or not pushed: %s",
+                run_id,
+                branch,
+                push_stderr.decode().strip(),
+            )
+
+        branch_proc = await asyncio.create_subprocess_exec(
+            "git", "-C", repo_dir, "branch", "-D", branch,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, branch_stderr = await branch_proc.communicate()
+        if branch_proc.returncode == 0:
+            logger.info("✅ teardown[%s]: deleted local branch %r", run_id, branch)
+        else:
+            logger.info(
+                "ℹ️  teardown[%s]: local branch %r already gone: %s",
+                run_id,
+                branch,
+                branch_stderr.decode().strip(),
+            )
+
+    logger.info("✅ teardown[%s]: complete", run_id)

--- a/agentception/tests/test_build_board_partial.py
+++ b/agentception/tests/test_build_board_partial.py
@@ -531,3 +531,60 @@ async def test_persist_agent_event_non_done_does_not_call_recompute() -> None:
         )
 
     mock_recompute.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Regression: build_report_done triggers worktree teardown automatically
+#
+# Before this fix, agents that called the MCP build_report_done tool had their
+# worktrees and branches left behind permanently — cleanup only happened if the
+# orphan sweep caught them or an operator clicked "Kill". After the fix,
+# build_report_done fires teardown_agent_worktree as a background task when
+# agent_run_id is provided.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_report_done_triggers_teardown_when_run_id_given() -> None:
+    """build_report_done queues teardown_agent_worktree when agent_run_id is set."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from agentception.mcp.build_tools import build_report_done
+
+    mock_task = MagicMock()
+    with (
+        patch("agentception.mcp.build_tools.persist_agent_event", new_callable=AsyncMock),
+        patch("agentception.mcp.build_tools.teardown_agent_worktree", new_callable=AsyncMock) as mock_teardown,
+        patch("agentception.mcp.build_tools.asyncio.create_task", return_value=mock_task) as mock_create_task,
+    ):
+        result = await build_report_done(
+            issue_number=42,
+            pr_url="https://github.com/cgcardona/agentception/pull/99",
+            agent_run_id="issue-42-abc123",
+        )
+
+    assert result == {"ok": True, "event": "done"}
+    mock_create_task.assert_called_once()
+    task_coro = mock_create_task.call_args.args[0]
+    assert mock_create_task.call_args.kwargs.get("name") == "teardown-issue-42-abc123"
+    task_coro.close()  # avoid ResourceWarning for unawaited coroutine
+
+
+@pytest.mark.anyio
+async def test_build_report_done_skips_teardown_without_run_id() -> None:
+    """build_report_done does not crash and skips teardown when agent_run_id is absent."""
+    from unittest.mock import AsyncMock, patch
+
+    from agentception.mcp.build_tools import build_report_done
+
+    with (
+        patch("agentception.mcp.build_tools.persist_agent_event", new_callable=AsyncMock),
+        patch("agentception.mcp.build_tools.asyncio.create_task") as mock_create_task,
+    ):
+        result = await build_report_done(
+            issue_number=42,
+            pr_url="https://github.com/cgcardona/agentception/pull/99",
+        )
+
+    assert result == {"ok": True, "event": "done"}
+    mock_create_task.assert_not_called()


### PR DESCRIPTION
## Summary

**Root cause of stale worktrees:** Agents call the MCP `build_report_done` tool when they finish, but that tool only persisted the event to the DB — it never triggered any git cleanup. The HTTP `POST /api/runs/{id}/done` endpoint *does* trigger cleanup, but agents are briefed to use the MCP tool. Result: every completed agent left its worktree directory and branch behind permanently, accumulating indefinitely.

**Fix:**
- Extract `_teardown_agent_worktree` from `routes/api/runs.py` into `services/teardown.py` as `teardown_agent_worktree` so both callers share one implementation
- Wire `teardown_agent_worktree` into `build_report_done` as a non-blocking `asyncio.create_task` — agents get an immediate ack, cleanup runs in the background
- `runs.py` `_teardown_agent_worktree` becomes a one-line delegate to the service (no duplicate logic)
- Log a `⚠️` warning when `agent_run_id` is missing so any remaining gap is visible in logs

**Teardown sequence (unchanged behaviour, now triggered from MCP):**
1. `git worktree remove --force <path>`
2. `git worktree prune`
3. `git push origin --delete <branch>` (remote)
4. `git branch -D <branch>` (local)

## Test plan
- [x] `test_build_report_done_triggers_teardown_when_run_id_given` — regression test confirming teardown is queued
- [x] `test_build_report_done_skips_teardown_without_run_id` — no crash when run_id absent
- [x] 905/905 tests pass
- [x] `mypy` strict: zero errors