### PR TITLE
fix: replace all K=V grep reads in prompt templates with tomllib

### DIFF
--- a/.agentception/parallel-bugs-to-issues.md
+++ b/.agentception/parallel-bugs-to-issues.md
@@ -444,14 +444,15 @@ PARALLEL AGENT COORDINATION — BUGS TO ISSUES
 STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
 
-  Parse these TOML v2 fields:
-    task.workflow           — must be "bugs-to-issues"
-    repo.gh_repo            — GitHub repo slug (cgcardona/agentception)
-    target.phase_label      — the phase label to apply to every issue
-    target.labels_to_apply  — list of ALL labels for every issue
-    target.phase_depends_on_issues — upstream issue numbers (already resolved to #N)
-    target.file_ownership   — files this phase owns (awareness, not action)
-    spawn.sub_agents        — if true, follow sub-coordinator path
+  Parse these fields from the header (KEY=value lines):
+    WORKFLOW                — must be "bugs-to-issues"
+    BATCH_NUM               — your phase number
+    GH_REPO                 — GitHub repo slug (cgcardona/agentception)
+    PHASE_LABEL             — the phase label to apply to every issue
+    LABELS_TO_APPLY         — comma-separated list of ALL labels for every issue
+    PHASE_DEPENDS_ON_ISSUES — upstream issue numbers (already resolved to #N)
+    FILE_OWNERSHIP          — files this phase owns (awareness, not action)
+    SPAWN_SUB_AGENTS        — if true, follow sub-coordinator path
 
 STEP 0.5 — LOAD YOUR ROLE:
   ROLE=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['role'])")

--- a/.agentception/parallel-conductor.md
+++ b/.agentception/parallel-conductor.md
@@ -151,7 +151,7 @@ Red = never, ask the user instead.
 STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
 
-  Parse all TOML v2 fields:
+  Parse all KEY=value fields:
     GH_REPO                → GitHub repo slug (always cgcardona/agentception)
     PHASE_FILTER           → restrict to one phase, or empty for all
     MAX_ISSUES_PER_DISPATCH → cap on parallel ISSUE_TO_PR agents (safety valve)

--- a/.agentception/parallel-issue-to-pr.md
+++ b/.agentception/parallel-issue-to-pr.md
@@ -486,7 +486,7 @@ Red = never, ask the user instead.
 STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
 
-  Parse all TOML v2 fields from the task file:
+  Parse all KEY=value fields from the header:
     GH_REPO          → GitHub repo slug (export immediately)
     ISSUE_NUMBER     → your issue number (substitute for <N> throughout)
     ISSUE_TITLE      → issue title

--- a/.agentception/parallel-pr-review.md
+++ b/.agentception/parallel-pr-review.md
@@ -385,7 +385,7 @@ Red = never, ask the user instead.
 STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
 
-  Parse all TOML v2 fields from the task file:
+  Parse all KEY=value fields from the header:
     GH_REPO          → GitHub repo slug (export immediately)
     PR_NUMBER        → your PR number (substitute for <N> throughout)
     PR_TITLE         → PR title

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -968,7 +968,7 @@ Red = never, ask the user instead.
 STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
 
-  Parse all TOML v2 fields from the task file:
+  Parse all KEY=value fields from the header:
     GH_REPO          → GitHub repo slug (export immediately)
     ISSUE_NUMBER     → your issue number (substitute for <N> throughout)
     ISSUE_TITLE      → issue title
@@ -2493,7 +2493,7 @@ Red = never, ask the user instead.
 STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
 
-  Parse all TOML v2 fields from the task file:
+  Parse all KEY=value fields from the header:
     GH_REPO          → GitHub repo slug (export immediately)
     PR_NUMBER        → your PR number (substitute for <N> throughout)
     PR_TITLE         → PR title
@@ -4424,7 +4424,7 @@ Red = never, ask the user instead.
 STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
 
-  Parse all TOML v2 fields from the task file:
+  Parse all KEY=value fields from the header:
     GH_REPO          → GitHub repo slug (export immediately)
     PR_NUMBER        → your PR number (substitute for <N> throughout)
     PR_TITLE         → PR title
@@ -6275,7 +6275,7 @@ Red = never, ask the user instead.
 STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
 
-  Parse all TOML v2 fields from the task file:
+  Parse all KEY=value fields from the header:
     GH_REPO          → GitHub repo slug (export immediately)
     ISSUE_NUMBER     → your issue number (substitute for <N> throughout)
     ISSUE_TITLE      → issue title

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -709,7 +709,7 @@ Red = never, ask the user instead.
 STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
 
-  Parse all TOML v2 fields from the task file:
+  Parse all KEY=value fields from the header:
     GH_REPO          → GitHub repo slug (export immediately)
     ISSUE_NUMBER     → your issue number (substitute for <N> throughout)
     ISSUE_TITLE      → issue title
@@ -2234,7 +2234,7 @@ Red = never, ask the user instead.
 STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
 
-  Parse all TOML v2 fields from the task file:
+  Parse all KEY=value fields from the header:
     GH_REPO          → GitHub repo slug (export immediately)
     PR_NUMBER        → your PR number (substitute for <N> throughout)
     PR_TITLE         → PR title

--- a/.agentception/roles/qa-coordinator.md
+++ b/.agentception/roles/qa-coordinator.md
@@ -565,7 +565,7 @@ Red = never, ask the user instead.
 STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
 
-  Parse all TOML v2 fields from the task file:
+  Parse all KEY=value fields from the header:
     GH_REPO          → GitHub repo slug (export immediately)
     PR_NUMBER        → your PR number (substitute for <N> throughout)
     PR_TITLE         → PR title
@@ -2416,7 +2416,7 @@ Red = never, ask the user instead.
 STEP 0 — READ YOUR TASK FILE:
   cat .agent-task
 
-  Parse all TOML v2 fields from the task file:
+  Parse all KEY=value fields from the header:
     GH_REPO          → GitHub repo slug (export immediately)
     ISSUE_NUMBER     → your issue number (substitute for <N> throughout)
     ISSUE_TITLE      → issue title

--- a/scripts/gen_prompts/templates/parallel-bugs-to-issues.md.j2
+++ b/scripts/gen_prompts/templates/parallel-bugs-to-issues.md.j2
@@ -420,7 +420,7 @@ Task(worktree="~/.agentception/worktrees/agentception/bugs-phase-2", prompt=KICK
 
 ```bash
 REPO=$(git worktree list | head -1 | awk '{print $1}')
-export GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
+export GH_REPO=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['repo']['gh_repo'])")
 export GH_REPO=${GH_REPO:-{{ gh_repo }}}
 ```
 
@@ -455,17 +455,17 @@ STEP 0 — READ YOUR TASK FILE:
     SPAWN_SUB_AGENTS        — if true, follow sub-coordinator path
 
 STEP 0.5 — LOAD YOUR ROLE:
-  ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
+  ROLE=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['role'])")
   REPO=$(git worktree list | head -1 | awk '{print $1}')
   ROLE_FILE="$REPO/.agentception/roles/${ROLE}.md"
   [ -f "$ROLE_FILE" ] && cat "$ROLE_FILE" && echo "✅ Operating as: $ROLE"
 
   Export for all subsequent commands:
-    export GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
-    PHASE_LABEL=$(grep "^PHASE_LABEL=" .agent-task | cut -d= -f2)
-    LABELS_TO_APPLY=$(grep "^LABELS_TO_APPLY=" .agent-task | cut -d= -f2)
-    PHASE_DEPENDS_ON_ISSUES=$(grep "^PHASE_DEPENDS_ON_ISSUES=" .agent-task | cut -d= -f2)
-    ATTEMPT_N=$(grep "^ATTEMPT_N=" .agent-task | cut -d= -f2)
+    export GH_REPO=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['repo']['gh_repo'])")
+    PHASE_LABEL=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('target',{}).get('phase_label',''))")
+    LABELS_TO_APPLY=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(d.get('target',{}).get('labels_to_apply',[])))")
+    PHASE_DEPENDS_ON_ISSUES=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(str(x) for x in d.get('target',{}).get('phase_depends_on_issues',[])))")
+    ATTEMPT_N=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['task']['attempt_n'])")
 
   ⚠️  ANTI-LOOP GUARD: if ATTEMPT_N > 2 → STOP immediately. Report exact failure.
 

--- a/scripts/gen_prompts/templates/parallel-conductor.md.j2
+++ b/scripts/gen_prompts/templates/parallel-conductor.md.j2
@@ -159,10 +159,10 @@ STEP 0 — READ YOUR TASK FILE:
     ATTEMPT_N              → how many times conductor has run without progress
 
   Export:
-    export GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
+    export GH_REPO=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['repo']['gh_repo'])")
     export GH_REPO=${GH_REPO:-{{ gh_repo }}}
-    PHASE_FILTER=$(grep "^PHASE_FILTER=" .agent-task | cut -d= -f2)
-    ATTEMPT_N=$(grep "^ATTEMPT_N=" .agent-task | cut -d= -f2)
+    PHASE_FILTER=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('task',{}).get('phase_filter',''))")
+    ATTEMPT_N=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['task']['attempt_n'])")
 
   ⚠️  ANTI-LOOP GUARD: if ATTEMPT_N > 3 → STOP.
     This conductor has run 4+ times without advancing the pipeline.
@@ -360,7 +360,7 @@ STEP 5 — DISPATCH COORDINATORS:
     echo "  MCP: list_issues(owner='{{ gh_repo.split('/')[0] }}', repo='{{ gh_repo.split('/')[1] }}', labels=[<active_phase>], state='open')"
     echo "Match these issue numbers to confirm the set before creating worktrees."
     echo ""
-    echo "Coordinator constraint: MAX_ISSUES_PER_DISPATCH=$(grep "^MAX_ISSUES_PER_DISPATCH=" .agent-task | cut -d= -f2)"
+    echo "Coordinator constraint: MAX_ISSUES_PER_DISPATCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('task',{}).get('max_issues_per_dispatch','4'))")"
     echo "If more issues exist than the limit, prioritize by batch label (lowest batch-NN first)."
     # LAUNCH: use the Task tool to spawn the coordinator agent.
     # The coordinator reads PARALLEL_ISSUE_TO_PR.md and follows its coordinator role.
@@ -375,7 +375,7 @@ STEP 5 — DISPATCH COORDINATORS:
     echo "Target PRs:"
     for i in "${READY_PRS[@]}"; do echo "  #${i%%|*}: ${i##*|}"; done
     echo ""
-    echo "Coordinator constraint: MAX_PRS_PER_DISPATCH=$(grep "^MAX_PRS_PER_DISPATCH=" .agent-task | cut -d= -f2)"
+    echo "Coordinator constraint: MAX_PRS_PER_DISPATCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('task',{}).get('max_prs_per_dispatch','4'))")"
     echo "If more PRs exist than the limit, prioritize by batch label (lowest batch-NN first)."
     # LAUNCH: use the Task tool to spawn the coordinator agent.
     # The coordinator reads PARALLEL_PR_REVIEW.md and follows its coordinator role.

--- a/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
+++ b/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
@@ -348,11 +348,11 @@ STEP 0 — READ YOUR TASK FILE:
                        from sub-task sections in this file, then self-destruct)
 
   Export for all subsequent commands:
-    export GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
+    export GH_REPO=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['repo']['gh_repo'])")
     export GH_REPO=${GH_REPO:-{{ gh_repo }}}
-    N=$(grep "^ISSUE_NUMBER=" .agent-task | cut -d= -f2)
-    ATTEMPT_N=$(grep "^ATTEMPT_N=" .agent-task | cut -d= -f2)
-    BATCH_ID=$(grep "^BATCH_ID=" .agent-task | cut -d= -f2)
+    N=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['target']['issue_number'])")
+    ATTEMPT_N=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['task']['attempt_n'])")
+    BATCH_ID=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['pipeline']['batch_id'])")
 
   Generate your unique agent session ID (identifies THIS specific agent run):
     AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
@@ -372,7 +372,7 @@ STEP 0 — READ YOUR TASK FILE:
     unrelated work. When in doubt: commit, then fix forward.
 
 STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
-  ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
+  ROLE=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['role'])")
   echo "✅ Operating as role: $ROLE"
   # Your role definition is embedded at the bottom of this prompt under
   # ## Embedded Role Definitions — no file read needed. ROLE_FILE in .agent-task
@@ -381,7 +381,7 @@ STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
 
   # Load cognitive architecture — assembles figure persona + all skill domain fragments
   # Format: "figure:skill1:skill2" (new multi-skill format, colon-separated)
-  COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+  COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['cognitive_arch'])")
   if [ -n "$COGNITIVE_ARCH" ]; then
     echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
     echo ""
@@ -513,7 +513,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   # before implementing — your code may import from them at runtime.
   #
   # ⚠️  DEPENDS_ON is a comma-separated list (e.g. "614,615"). Iterate each number separately.
-  DEPENDS_ON_RAW=$(grep "^DEPENDS_ON=" .agent-task | cut -d= -f2)
+  DEPENDS_ON_RAW=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(str(x) for x in d.get('target',{}).get('depends_on',[])))")
   if [ -n "$DEPENDS_ON_RAW" ] && [ "$DEPENDS_ON_RAW" != "none" ]; then
     echo "ℹ️  DEPENDS_ON: $DEPENDS_ON_RAW"
     echo "   Checking whether dependencies are already on dev..."
@@ -563,7 +563,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
   echo "=== PRE-EXISTING TEST BASELINE (targeted files) ==="
   # Run targeted tests BEFORE branching to capture baseline failures.
   # Any test that fails before your change is pre-existing — you own fixing it.
-  FILE_OWNERSHIP=$(grep "^FILE_OWNERSHIP=" .agent-task | cut -d= -f2)
+  FILE_OWNERSHIP=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(d.get('target',{}).get('file_ownership',[])))")
   # (Run targeted tests for the module you're about to modify)
 
   # ── STEP 3.2 — CREATE BRANCH ──────────────────────────────────────────────

--- a/scripts/gen_prompts/templates/parallel-pr-review.md.j2
+++ b/scripts/gen_prompts/templates/parallel-pr-review.md.j2
@@ -281,24 +281,24 @@ STEP 0 — READ YOUR TASK FILE:
                        for types/tests/docs and emit a composite grade)
 
   Export for all subsequent commands:
-    export GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
+    export GH_REPO=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['repo']['gh_repo'])")
     export GH_REPO=${GH_REPO:-{{ gh_repo }}}
-    N=$(grep "^PR_NUMBER=" .agent-task | cut -d= -f2)
-    BRANCH=$(grep "^PR_BRANCH=" .agent-task | cut -d= -f2)
-    MERGE_AFTER=$(grep "^MERGE_AFTER=" .agent-task | cut -d= -f2)
-    HAS_MIGRATION=$(grep "^HAS_MIGRATION=" .agent-task | cut -d= -f2)
-    ATTEMPT_N=$(grep "^ATTEMPT_N=" .agent-task | cut -d= -f2)
-    BATCH_ID=$(grep "^BATCH_ID=" .agent-task | cut -d= -f2)
+    N=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['target']['pr_number'])")
+    BRANCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['target']['pr_branch'])")
+    MERGE_AFTER=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('target',{}).get('merge_after','none'))")
+    HAS_MIGRATION=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(str(d.get('target',{}).get('has_migration',False)).lower())")
+    ATTEMPT_N=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['task']['attempt_n'])")
+    BATCH_ID=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['pipeline']['batch_id'])")
 
   Generate your unique reviewer session ID (identifies THIS specific reviewer run):
     AGENT_SESSION="qa-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
-    COGNITIVE_ARCH=$(grep "^COGNITIVE_ARCH=" .agent-task | cut -d= -f2)
-    WAVE=$(grep "^WAVE=" .agent-task | cut -d= -f2)
+    COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['cognitive_arch'])")
+    WAVE=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('pipeline',{}).get('wave',''))")
     echo "🤖 Reviewer session: $AGENT_SESSION  Batch: ${BATCH_ID:-unset}  Arch: ${COGNITIVE_ARCH:-unset}"
 
   Post an identity comment on the PR immediately so the audit trail is visible from the start:
     REPO=$(git worktree list | head -1 | awk '{print $1}')
-    COORD_FINGERPRINT=$(grep "^COORD_FINGERPRINT=" .agent-task | cut -d= -f2)
+    COORD_FINGERPRINT=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('pipeline',{}).get('coord_fingerprint',''))")
     REVIEW_START=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 {{ fingerprint_block("REVIEW_FINGERPRINT", "pr-reviewer", "$REVIEW_START") }}
     # MCP: add_issue_comment(owner="cgcardona", repo="agentception", issue_number=N,
@@ -317,7 +317,7 @@ STEP 0 — READ YOUR TASK FILE:
       before grading. A broken migration chain is an automatic C → mandatory fix.
 
 STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
-  ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
+  ROLE=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['role'])")
   echo "✅ Operating as role: $ROLE"
   # Your role definition is embedded at the bottom of this prompt under
   # ## Embedded Role Definitions — no file read needed. ROLE_FILE in .agent-task
@@ -327,7 +327,7 @@ STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
 
   # Load cognitive architecture — assembles figure persona + all skill domain fragments
   # Format: "figure:skill1:skill2" (new multi-skill format, colon-separated)
-  COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
+  COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['cognitive_arch'])")
   if [ -n "$COGNITIVE_ARCH" ]; then
     echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
     echo ""
@@ -690,7 +690,7 @@ STEP 5 — REVIEW:
 
 STEP 5.5 — MERGE ORDER GATE (sequential chain safety):
   Read the MERGE_AFTER field from .agent-task:
-    MERGE_AFTER=$(grep "^MERGE_AFTER=" .agent-task | cut -d= -f2)
+    MERGE_AFTER=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('target',{}).get('merge_after','none'))")
 
   If MERGE_AFTER is empty or "none" → skip this step, go directly to STEP 6.
 
@@ -824,7 +824,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
 {{ fingerprint_block("CLOSE_FINGERPRINT", "pr-reviewer", "$MERGED_AT") }}
        CLOSE_COMMENT="✅ Closed by PR #$N (merged).\n\n$CLOSE_FINGERPRINT"
 
-       CLOSES_ISSUES=$(grep "^CLOSES_ISSUES=" .agent-task | cut -d= -f2)
+       CLOSES_ISSUES=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(str(x) for x in d.get('target',{}).get('closes',[])))")
        if [ -n "$CLOSES_ISSUES" ]; then
          # For each issue number in CLOSES_ISSUES (comma-separated):
          # MCP: issue_write(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
@@ -841,7 +841,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
        fi
 
   # 10. Mark linked issues as merged (conductor reads this as "done").
-  CLOSES_ISSUES_FOR_LABEL=$(grep "^CLOSES_ISSUES=" .agent-task | cut -d= -f2)
+  CLOSES_ISSUES_FOR_LABEL=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(str(x) for x in d.get('target',{}).get('closes',[])))")
   if [ -n "$CLOSES_ISSUES_FOR_LABEL" ]; then
     # For each issue in CLOSES_ISSUES_FOR_LABEL:
     # MCP: github_remove_label(issue_number=<N>, label="status/pr-open")
@@ -964,7 +964,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
   # SPAWN_MODE=chain  → spawned by an engineer; spawn the next ENGINEER for the next issue
   # SPAWN_MODE=pool   → spawned by a QA Coordinator; spawn the next REVIEWER for the next PR (legacy pool behavior)
   # (absent/empty)    → default to pool behavior
-  SPAWN_MODE=$(grep "^SPAWN_MODE=" .agent-task 2>/dev/null | cut -d= -f2)
+  SPAWN_MODE=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('spawn',{}).get('mode','single'))" 2>/dev/null)
 
   if [ "$SPAWN_MODE" = "chain" ]; then
     # ── CHAIN MODE: merge happened → spawn next engineer for next unclaimed issue ──
@@ -986,7 +986,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
     # Fallback: if no agentception/* label has open issues, try the batch label from the task file.
     # This supports non-agentception chain workflows (e.g. batch-01, batch-02).
     if [ -z "$ACTIVE_LABEL" ]; then
-      TASK_BATCH_ID=$(grep "^BATCH_ID=" .agent-task 2>/dev/null | cut -d= -f2 || echo "")
+      TASK_BATCH_ID=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('pipeline',{}).get('batch_id',''))" 2>/dev/null || echo "")
       BATCH_LABEL_PREFIX=$(echo "$TASK_BATCH_ID" | grep -oE 'batch-[0-9]+' | head -1)
       if [ -n "$BATCH_LABEL_PREFIX" ]; then
         # MCP: github_list_issues(label="$BATCH_LABEL_PREFIX", state="open") → .count

--- a/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
@@ -13,8 +13,8 @@ Load it as the very first thing you do — see STEP 0 below.
 
 ```bash
 REPO=$(git rev-parse --show-toplevel 2>/dev/null || git worktree list | head -1 | awk '{print $1}')
-COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
-ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
+COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['cognitive_arch'])")
+ROLE=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['role'])")
 RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
 if [ -n "$COGNITIVE_ARCH" ] && [ -f "$RESOLVE_ARCH" ]; then
   ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode implementer 2>/dev/null)

--- a/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
@@ -8,7 +8,7 @@ You do not negotiate on type safety. You do not ship dirty mypy. You fix C-grade
 
 ```bash
 REPO=$(git worktree list | head -1 | awk '{print $1}')
-COGNITIVE_ARCH=$(grep "^COGNITIVE_ARCH=" .agent-task 2>/dev/null | cut -d= -f2 || echo "knuth:python")
+COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('agent',{}).get('cognitive_arch','knuth:python'))" 2>/dev/null || echo "knuth:python")
 
 # resolve_arch.py assembles the full reviewer context:
 # - Figure persona (HOW you think about code quality)
@@ -45,8 +45,8 @@ Your review checklist above is your minimum bar. Every item in the checklist is 
 
 Before checking out the PR branch, record the pre-existing mypy state on `dev`:
 ```bash
-N=$(grep "^PR_NUMBER=" .agent-task | cut -d= -f2)
-GH_REPO=$(grep "^GH_REPO=" .agent-task | cut -d= -f2)
+N=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['target']['pr_number'])")
+GH_REPO=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['repo']['gh_repo'])")
 GH_REPO=${GH_REPO:-{{ gh_repo }}}
 WTNAME=$(basename "$(pwd)")
 # Determine if this PR is an AgentCeption PR:

--- a/scripts/gen_prompts/templates/roles/qa-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/qa-coordinator.md.j2
@@ -13,8 +13,8 @@ Load it as the very first thing you do — see STEP 0 below.
 
 ```bash
 REPO=$(git rev-parse --show-toplevel 2>/dev/null || git worktree list | head -1 | awk '{print $1}')
-COGNITIVE_ARCH=$(grep '^COGNITIVE_ARCH=' .agent-task | cut -d= -f2)
-ROLE=$(grep '^ROLE=' .agent-task | cut -d= -f2)
+COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['cognitive_arch'])")
+ROLE=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['role'])")
 RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
 if [ -n "$COGNITIVE_ARCH" ] && [ -f "$RESOLVE_ARCH" ]; then
   ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode reviewer 2>/dev/null)


### PR DESCRIPTION
## Summary

- Commit `5f4bb26` fixed 163 grep-based `.agent-task` reads in the `.agentception/` output files but never touched the `.j2` template sources. Every subsequent `generate.py` run would silently overwrite those fixes with the old flat-key `grep | cut` format.
- This PR fixes the root cause: all 44 remaining `grep "^KEY=" .agent-task | cut -d= -f2` patterns in 6 template files are replaced with `python3 -c "import tomllib; ..."` reads against the TOML v2 key hierarchy.
- `generate.py` is re-run to produce outputs consistent with the fixed templates — zero `grep` patterns remain in either templates or outputs.

## Test plan

- [x] `grep -r 'grep.*\.agent-task.*cut -d=' scripts/gen_prompts/templates/` → no output
- [x] `grep -r 'grep.*\.agent-task.*cut -d=' .agentception/` → no output
- [x] `generate.py` produces no diff against the committed outputs (idempotent)