### PR TITLE
fix(ci): install pyyaml for generated-files drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install Jinja2
-        run: pip install jinja2
+      - name: Install generate.py dependencies
+        run: pip install jinja2 pyyaml
 
       - name: Check .agentception/ outputs match .j2 templates
         # generate.py --check exits 1 if any output would change.


### PR DESCRIPTION
## Summary

The `generated-files` CI job introduced in #185 was only installing `jinja2`, but `generate.py` also imports `yaml` (PyYAML) at the top level. The script crashed with `ModuleNotFoundError: No module named 'yaml'` before it could check anything, causing a false-failure exit code 1.

## Fix

Add `pyyaml` to the `pip install` step. These are the only two third-party packages `generate.py` uses (`jinja2` and `pyyaml`).

## Test plan

- [x] CI `generated-files` job will now be able to import both packages and run the actual drift check