### PR TITLE
fix: push branch after conflict resolution in STEP 3 so CI can run

### DIFF
--- a/.agentception/parallel-pr-review.md
+++ b/.agentception/parallel-pr-review.md
@@ -718,6 +718,13 @@ STEP 3 — CHECKOUT & SYNC (only if STEP 2 shows the PR is open and unreviewed):
         git checkout -- <file>   ← discard checkout-introduced changes, then retry merge
     - Then retry: git merge origin/dev
 
+  # 5. Push the branch now — before grading — so CI can run on a clean tip.
+  #    If the PR had merge conflicts, GitHub blocked CI entirely until the
+  #    conflict is resolved. Pushing here (after the conflict playbook above)
+  #    gives GitHub a conflict-free commit to run checks against.
+  #    If there were no conflicts, git push is a fast-forward no-op.
+  git push origin "$BRANCH"
+
 STEP 4 — TARGETED TEST SCOPING (before review):
   Identify which test files to run based on what this PR changes.
   NEVER run the full suite — that is CI's job, not an agent's job.

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -2826,6 +2826,13 @@ STEP 3 — CHECKOUT & SYNC (only if STEP 2 shows the PR is open and unreviewed):
         git checkout -- <file>   ← discard checkout-introduced changes, then retry merge
     - Then retry: git merge origin/dev
 
+  # 5. Push the branch now — before grading — so CI can run on a clean tip.
+  #    If the PR had merge conflicts, GitHub blocked CI entirely until the
+  #    conflict is resolved. Pushing here (after the conflict playbook above)
+  #    gives GitHub a conflict-free commit to run checks against.
+  #    If there were no conflicts, git push is a fast-forward no-op.
+  git push origin "$BRANCH"
+
 STEP 4 — TARGETED TEST SCOPING (before review):
   Identify which test files to run based on what this PR changes.
   NEVER run the full suite — that is CI's job, not an agent's job.
@@ -4756,6 +4763,13 @@ STEP 3 — CHECKOUT & SYNC (only if STEP 2 shows the PR is open and unreviewed):
     - If they came from the branch checkout (left dirty files), run:
         git checkout -- <file>   ← discard checkout-introduced changes, then retry merge
     - Then retry: git merge origin/dev
+
+  # 5. Push the branch now — before grading — so CI can run on a clean tip.
+  #    If the PR had merge conflicts, GitHub blocked CI entirely until the
+  #    conflict is resolved. Pushing here (after the conflict playbook above)
+  #    gives GitHub a conflict-free commit to run checks against.
+  #    If there were no conflicts, git push is a fast-forward no-op.
+  git push origin "$BRANCH"
 
 STEP 4 — TARGETED TEST SCOPING (before review):
   Identify which test files to run based on what this PR changes.

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -2567,6 +2567,13 @@ STEP 3 — CHECKOUT & SYNC (only if STEP 2 shows the PR is open and unreviewed):
         git checkout -- <file>   ← discard checkout-introduced changes, then retry merge
     - Then retry: git merge origin/dev
 
+  # 5. Push the branch now — before grading — so CI can run on a clean tip.
+  #    If the PR had merge conflicts, GitHub blocked CI entirely until the
+  #    conflict is resolved. Pushing here (after the conflict playbook above)
+  #    gives GitHub a conflict-free commit to run checks against.
+  #    If there were no conflicts, git push is a fast-forward no-op.
+  git push origin "$BRANCH"
+
 STEP 4 — TARGETED TEST SCOPING (before review):
   Identify which test files to run based on what this PR changes.
   NEVER run the full suite — that is CI's job, not an agent's job.

--- a/.agentception/roles/qa-coordinator.md
+++ b/.agentception/roles/qa-coordinator.md
@@ -898,6 +898,13 @@ STEP 3 — CHECKOUT & SYNC (only if STEP 2 shows the PR is open and unreviewed):
         git checkout -- <file>   ← discard checkout-introduced changes, then retry merge
     - Then retry: git merge origin/dev
 
+  # 5. Push the branch now — before grading — so CI can run on a clean tip.
+  #    If the PR had merge conflicts, GitHub blocked CI entirely until the
+  #    conflict is resolved. Pushing here (after the conflict playbook above)
+  #    gives GitHub a conflict-free commit to run checks against.
+  #    If there were no conflicts, git push is a fast-forward no-op.
+  git push origin "$BRANCH"
+
 STEP 4 — TARGETED TEST SCOPING (before review):
   Identify which test files to run based on what this PR changes.
   NEVER run the full suite — that is CI's job, not an agent's job.

--- a/scripts/gen_prompts/templates/parallel-pr-review.md.j2
+++ b/scripts/gen_prompts/templates/parallel-pr-review.md.j2
@@ -465,6 +465,13 @@ STEP 3 — CHECKOUT & SYNC (only if STEP 2 shows the PR is open and unreviewed):
         git checkout -- <file>   ← discard checkout-introduced changes, then retry merge
     - Then retry: git merge origin/dev
 
+  # 5. Push the branch now — before grading — so CI can run on a clean tip.
+  #    If the PR had merge conflicts, GitHub blocked CI entirely until the
+  #    conflict is resolved. Pushing here (after the conflict playbook above)
+  #    gives GitHub a conflict-free commit to run checks against.
+  #    If there were no conflicts, git push is a fast-forward no-op.
+  git push origin "$BRANCH"
+
 STEP 4 — TARGETED TEST SCOPING (before review):
   Identify which test files to run based on what this PR changes.
   NEVER run the full suite — that is CI's job, not an agent's job.


### PR DESCRIPTION
## Summary

- Adds `git push origin "$BRANCH"` in STEP 3 of the reviewer prompt, immediately after conflict resolution and before grading begins.
- The same push is already present in STEP 6 (pre-merge sync), so this is an early push only — no behaviour change for conflict-free PRs.
- Regenerated `.agentception/parallel-pr-review.md`, `roles/cto.md`, `roles/engineering-coordinator.md`, `roles/qa-coordinator.md` from the updated template.

## Root cause

When a PR has a merge conflict GitHub does not trigger CI. The reviewer agent already resolves conflicts via `git merge origin/dev` + the conflict playbook in STEP 3, but the resolved branch was not pushed until STEP 6. With no CI run present, any agent following the "wait for CI" rule would poll indefinitely (or give up) and refuse to merge.

## Fix

Push immediately after conflict resolution in STEP 3. This gives GitHub a clean, conflict-free commit to run checks against before grading begins. If there were no conflicts the push is a fast-forward no-op.

## Test plan

- [ ] mypy strict — 0 errors ✅
- [ ] `generate.py` produced 4 updated files ✅
- [ ] Reviewer agents now push the conflict-resolved branch in STEP 3 so CI triggers before grading