### PR TITLE
chore: gate CI on main only; local verification replaces CI on dev PRs

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -54,18 +54,24 @@ Only fall back to `gh` CLI when the MCP server does not cover the required opera
 1. `git status` — must be clean before branching.
 2. `git checkout -b fix/<description>` or `feat/<description>` — branch first, always.
 3. Do the work, commit on the branch.
-4. **Open a PR** against `dev` via `create_pull_request` MCP tool (never push directly to `dev`).
-5. **Wait for CI to pass.** After opening the PR, poll `gh run list --branch <branch> --limit 1` or the GitHub Actions API until all checks are green. **Never call `merge_pull_request` before CI completes.** If CI fails, fix the failure on the same branch and push again — do not merge a failing PR.
-6. **Merge the PR** via `merge_pull_request` MCP tool (squash). Never leave a PR open.
-6. **Delete the remote branch** — pass `deleteBranch: true` to `merge_pull_request`, or run `git push origin --delete <branch>`.
-7. **Delete the local branch** — `git checkout dev && git branch -D <branch>`.
-8. **Pull dev** — `git pull origin dev`.
-9. **Verify clean** — `git status` must show `nothing to commit, working tree clean`.
+4. **Verify locally before opening the PR** — in this exact order:
+   - `docker compose exec agentception mypy agentception/ tests/` → must be zero errors
+   - `docker compose exec agentception python3 tools/typing_audit.py --dirs agentception/ tests/ --max-any 0` → must pass
+   - `docker compose exec agentception pytest tests/ -v` → must be all green
+   - `docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py --check` → must show no drift (run `generate.py` without `--check` first if you edited templates)
+   - `npm run build` if any `.js` or `.scss` files changed
+   CI does **not** run on feature → dev PRs. Local verification is the gate.
+5. **Open a PR** against `dev` via `create_pull_request` MCP tool (never push directly to `dev`).
+6. **Merge the PR immediately** via `merge_pull_request` MCP tool (squash). Do not wait for CI — it does not run on dev PRs. Never leave a PR open.
+7. **Delete the remote branch** — pass `deleteBranch: true` to `merge_pull_request`, or run `git push origin --delete <branch>`.
+8. **Delete the local branch** — `git checkout dev && git branch -D <branch>`.
+9. **Pull dev** — `git pull origin dev`.
+10. **Verify clean** — `git status` must show `nothing to commit, working tree clean`.
 
 - **Before starting any work:** run `git status`. If `dev` is not clean, stop. Either restore the dirty files (`git restore .`) or commit them on a branch first. Never carry dirty state from `dev` into a feature branch.
 - **After any file-generating command** (e.g. `generate.py`, `npm run build`, code generators): immediately run `git status`. Stage and commit every modified file — do not switch branches while files are dirty.
 - **`generate.py` rule:** run it only after you are already on a feature branch, never on `dev`. All generated outputs are part of the same commit as their source template changes.
-- **`.agentception/*.md` are derived artifacts — never edit them directly.** They are overwritten on every `generate.py` run. Any direct edit will be silently reverted the next time the generator runs, and will fail the `generated-files` CI check. The only correct workflow: edit the `.j2` template in `scripts/gen_prompts/templates/`, then run `docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py`, then commit both the template and the regenerated output together.
+- **`.agentception/*.md` are derived artifacts — never edit them directly.** They are overwritten on every `generate.py` run. Any direct edit will be silently reverted the next time the generator runs. The only correct workflow: edit the `.j2` template in `scripts/gen_prompts/templates/`, then run `docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py`, then commit both the template and the regenerated output together. Run `generate.py --check` before opening a PR to confirm there is no drift.
 
 The enforcement protocol:
 1. `git status` → must show `nothing to commit, working tree clean` before any `git checkout`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,15 @@
 # CI workflow for cgcardona/agentception
-# Runs on every PR targeting dev or main, and on pushes to main.
-# Jobs run in dependency order: generated-files → typecheck → (typing-ceiling + test) → smoke
+# Runs ONLY on PRs targeting main and on direct pushes to main.
+# Feature-branch → dev PRs are verified locally (mypy + tests + generate.py --check)
+# before the PR is opened. CI is the final gate before production, not a feedback
+# loop on every feature branch.
 name: CI
 
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [dev, main]
+    branches: [main]
 
 env:
   # Docker Compose reads DB_PASSWORD from the environment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,13 +67,20 @@ Every task follows this complete lifecycle — no step is optional:
 2. **Branch first.** `git checkout -b fix/<description>` or `git checkout -b feat/<description>` is the **first** command of every task, not an afterthought.
 3. **Stage everything before switching.** After any file-generating command (`generate.py`, `npm run build`, code generators, etc.), run `git status` and stage every modified file. Never switch branches while files are dirty — unstaged changes follow you and end up on the wrong branch.
 4. **Include all generated outputs in the same commit.** Template source changes and their regenerated outputs (`generate.py` → `.agentception/*.md`) belong in one commit on the feature branch. Never split them across branches.
-5. **`.agentception/*.md` are derived artifacts — never edit them directly.** Editing an output file instead of its `.j2` template source will be silently overwritten on the next `generate.py` run, and will fail the `generated-files` CI job that now runs on every PR to `dev` and `main`. The only correct workflow: edit the `.j2` template in `scripts/gen_prompts/templates/`, then run `docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py`, then commit template + regenerated output together in one commit.
-5. **Open a pull request.** Always create a PR against `dev` — never push directly. Use the `create_pull_request` MCP tool (preferred) or `gh pr create`. Every change, no matter how small, goes through a PR.
-6. **Wait for CI to pass.** After opening the PR, poll the GitHub Actions run until every check is green. Use `gh run list --branch <branch> --limit 1` to get the run ID, then `gh run watch <run_id>` or poll `gh run view <run_id> --json conclusion` until `conclusion` is `"success"`. **Never call `merge_pull_request` before CI is green.** If CI fails, fix the problem on the same branch (push a new commit) and wait for CI again. Merging a failing PR is not allowed under any circumstances.
-7. **Merge the PR.** Use `merge_pull_request` MCP tool (squash merge). Do not leave PRs open at the end of a session.
-7. **Delete the remote branch.** After merging, delete the remote tracking branch. The `merge_pull_request` MCP tool does this automatically with `deleteBranch: true`; if using `gh`, run `git push origin --delete <branch>`.
-8. **Delete the local branch.** `git checkout dev && git branch -D <branch>`.
-9. **Pull dev.** `git pull origin dev` — confirm `git status` shows `nothing to commit, working tree clean` before starting the next task.
+5. **`.agentception/*.md` are derived artifacts — never edit them directly.** The only correct workflow: edit the `.j2` template in `scripts/gen_prompts/templates/`, run `docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py`, then commit template + regenerated output together in one commit.
+6. **Verify locally before opening the PR.** CI does not run on feature → dev PRs — local verification is the gate. Run in this exact order:
+   ```bash
+   docker compose exec agentception mypy agentception/ tests/                              # zero errors
+   docker compose exec agentception python3 tools/typing_audit.py --dirs agentception/ tests/ --max-any 0  # passes
+   docker compose exec agentception pytest tests/ -v                                       # all green
+   docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py --check  # no drift
+   npm run build   # only if .js or .scss files changed
+   ```
+7. **Open a pull request.** Always create a PR against `dev` — never push directly. Use the `create_pull_request` MCP tool (preferred) or `gh pr create`. Every change, no matter how small, goes through a PR.
+8. **Merge the PR immediately.** Use `merge_pull_request` MCP tool (squash merge). Do not wait for CI — it does not run on feature → dev PRs. Do not leave PRs open.
+9. **Delete the remote branch.** The `merge_pull_request` MCP tool does this automatically with `deleteBranch: true`; if using `gh`, run `git push origin --delete <branch>`.
+10. **Delete the local branch.** `git checkout dev && git branch -D <branch>`.
+11. **Pull dev.** `git pull origin dev` — confirm `git status` shows `nothing to commit, working tree clean` before starting the next task.
 
 ### Complete task teardown sequence
 
@@ -96,7 +103,8 @@ git status                               # must be clean
 | Before creating a branch | `git status` | `nothing to commit, working tree clean` |
 | After any file-modifying command | `git status` | Stage or restore every modified file immediately |
 | After switching to a branch | `git status` | Only files you intentionally changed are modified |
-| After task complete | PR created, merged, branch deleted locally and remotely | `git status` on `dev` is clean |
+| Before opening PR | `mypy` + `typing_audit` + `pytest` + `generate.py --check` | All pass locally |
+| After task complete | PR created, merged immediately, branch deleted locally and remotely | `git status` on `dev` is clean |
 
 Carrying dirty state from `dev` into a feature branch, then committing only some of the dirty files, is the root cause of every "uncommitted changes on dev" incident. The protocol above prevents it.
 
@@ -275,19 +283,19 @@ There is no third option. A codebase with known broken tests that everyone steps
 
 ## Verification Checklist
 
-Before considering work complete, run in this order (mypy first so type fixes don't force a re-run of tests):
+**Run locally before opening a PR — in this exact order.** CI does not run on feature → dev PRs; this checklist is the gate.
 
 > **Dev bind mounts are active.** Your host file edits are instantly visible inside the container — do NOT rebuild for code changes. Only rebuild when `requirements.txt`, `Dockerfile`, or `entrypoint.sh` change.
 
 0. [ ] Confirm you are on a feature branch or inside a worktree — **never on `dev` or `main`**
 1. [ ] `docker compose exec agentception mypy agentception/ tests/` — clean, zero errors
-2. [ ] `python tools/typing_audit.py --dirs agentception/ tests/ --max-any 0` — passes
-3. [ ] Unit tests pass: `docker compose exec agentception pytest tests/unit/ -v`
-4. [ ] Integration tests pass: `docker compose exec agentception pytest tests/integration/ -v`
-5. [ ] E2E tests pass (if applicable): `docker compose exec agentception pytest tests/e2e/ -v`
-6. [ ] Regression test added if this is a bug fix
-7. [ ] Zero broken tests in the full suite — fix any you find, not just yours
-8. [ ] Affected docs updated
-9. [ ] No secrets, no `print()`, no dead code, no `Any`, no bare collections, no `cast()`, no `# type: ignore`
-10. [ ] JS/CSS bundles rebuilt if static source changed (`npm run build`)
-11. [ ] If API contract changed → handoff prompt produced
+2. [ ] `docker compose exec agentception python3 tools/typing_audit.py --dirs agentception/ tests/ --max-any 0` — passes
+3. [ ] `docker compose exec agentception pytest tests/ -v` — all green (unit + integration + regression)
+4. [ ] Regression test added if this is a bug fix (named `test_<what_broke>_<fixed_behavior>`)
+5. [ ] `docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py --check` — no drift (run without `--check` first if you edited `.j2` templates, then re-run with `--check`)
+6. [ ] Zero broken tests — fix any you find, not just yours
+7. [ ] Affected docs updated in the same commit
+8. [ ] No secrets, no `print()`, no dead code, no `Any`, no bare collections, no `cast()`, no `# type: ignore`
+9. [ ] JS/CSS bundles rebuilt if static source changed (`npm run build`)
+10. [ ] If API contract changed → handoff prompt produced
+11. [ ] **Open PR and merge immediately** — do not wait for CI (it does not run on dev PRs)


### PR DESCRIPTION
## Summary

- CI on every feature → dev PR costs 3+ minutes per merge and does not scale to an agent-wave workflow.
- CI now runs only on `dev → main` PRs and direct pushes to `main` — the final gate before production.
- Local verification (`mypy` + `typing_audit` + `pytest` + `generate.py --check`) is now the required gate before opening a feature → dev PR, documented in both `.cursorrules` and `AGENTS.md`.

## Changes

- `.github/workflows/ci.yml`: changed `pull_request: branches: [dev, main]` to `pull_request: branches: [main]`
- `.cursorrules`: branch lifecycle step 5 ("Wait for CI") replaced with local pre-PR verification checklist; merge is now immediate
- `AGENTS.md`: same update to lifecycle steps 6-8; enforcement table and verification checklist both updated

## Note

This PR itself does not trigger CI because the new `ci.yml` on this branch only fires for `main` PRs.