### PR TITLE
fix: filter closed deps from board dep chips — closed dep is not a blocker

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -1485,6 +1485,10 @@ async def get_issues_grouped_by_phase(
             )
             rows = result.scalars().all()
 
+        # Build a state map so dep chips are only shown for open dependencies.
+        # Closed deps are no longer blockers — they should not appear on cards.
+        issue_state_map: dict[int, str] = {r.github_number: r.state for r in rows}
+
         groups: dict[str, list[PhasedIssueRow]] = {}
         for row in rows:
             issue_labels: list[str] = json.loads(row.labels_json or "[]")
@@ -1503,7 +1507,13 @@ async def get_issues_grouped_by_phase(
             if phase_key is None:
                 continue
 
-            issue_deps: list[int] = json.loads(row.depends_on_json or "[]")
+            all_deps: list[int] = json.loads(row.depends_on_json or "[]")
+            # Only surface deps that are still open — a closed dep is resolved
+            # and should not dim the card or confuse agents about eligibility.
+            open_deps: list[int] = [
+                dep for dep in all_deps
+                if issue_state_map.get(dep, "open") != "closed"
+            ]
             groups.setdefault(phase_key, []).append(
                 PhasedIssueRow(
                     number=row.github_number,
@@ -1512,7 +1522,7 @@ async def get_issues_grouped_by_phase(
                     state=row.state,
                     url=f"https://github.com/{repo}/issues/{row.github_number}",
                     labels=issue_labels,
-                    depends_on=issue_deps,
+                    depends_on=open_deps,
                 )
             )
 

--- a/agentception/tests/test_build_board_partial.py
+++ b/agentception/tests/test_build_board_partial.py
@@ -588,3 +588,66 @@ async def test_build_report_done_skips_teardown_without_run_id() -> None:
 
     assert result == {"ok": True, "event": "done"}
     mock_create_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression: closed deps must not appear as blockers on board cards
+#
+# Issue #175 depends on #176. #176 is closed. The board was still showing
+# "⊘ blocked by #176" because get_issues_grouped_by_phase used the raw
+# depends_on_json without filtering out closed issues.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_issues_grouped_by_phase_filters_closed_deps() -> None:
+    """depends_on chips must only list deps that are still open.
+
+    Regression: issue A depends on B. B closes. A's card must clear the
+    blocked-by chip — closed deps are resolved and must not dim the card.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+    import json
+
+    from agentception.db.models import ACIssue
+    from agentception.db.queries import get_issues_grouped_by_phase
+
+    initiative = "test-init"
+    phase = f"{initiative}/0-work"
+
+    def _make_row(number: int, state: str, depends_on: list[int]) -> MagicMock:
+        row = MagicMock(spec=ACIssue)
+        row.github_number = number
+        row.title = f"Issue {number}"
+        row.state = state
+        row.labels_json = json.dumps([initiative, phase])
+        row.phase_label = None
+        row.depends_on_json = json.dumps(depends_on)
+        row.body = None
+        return row
+
+    # #10 depends on #11; #11 is closed.
+    rows = [_make_row(10, "open", [11]), _make_row(11, "closed", [])]
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = rows
+
+    with (
+        patch("agentception.db.queries.get_session") as mock_session,
+        patch(
+            "agentception.db.queries.get_initiative_phase_meta",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_cm)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_cm.execute = AsyncMock(return_value=mock_result)
+        mock_session.return_value = mock_cm
+
+        groups = await get_issues_grouped_by_phase("owner/repo", initiative=initiative)
+
+    issue_10 = next(i for g in groups for i in g["issues"] if i["number"] == 10)
+    assert issue_10["depends_on"] == [], (
+        "Closed dep #11 must not appear in depends_on — it is resolved"
+    )


### PR DESCRIPTION
## Summary

- Issue #175 showed `⊘ blocked by #176` even though #176 is closed/done.
- Root cause: `get_issues_grouped_by_phase` emitted raw `depends_on_json` without filtering out closed issues.
- Fix: build an `issue_state_map` from the already-fetched rows (no extra DB query) and filter `depends_on` to only open issue numbers.

## Changes

- `queries.py`: one-line dict comprehension builds `issue_state_map`; `depends_on` filtered to open deps only
- `test_build_board_partial.py`: regression test — issue with a closed dep must have empty `depends_on`

## Test plan
- [x] mypy — 0 errors
- [x] 19/19 tests pass (1 new regression test)