### PR TITLE
fix: skip markdown section headers in body excerpt so cards show prose

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -1429,21 +1429,46 @@ def _compute_locked(
     return any(dep not in complete_phases for dep in deps)
 
 
-_MD_STRIP_RE = _re.compile(r"[#*`_\[\]!>|~]+|```[^`]*```|\n+")
+_MD_STRIP_RE = _re.compile(r"[*`_\[\]!>|~]+|```[^`]*```")
+_MD_SPACES_RE = _re.compile(r" +")
 
 
 def _body_excerpt(body: str | None, max_chars: int = 120) -> str:
-    """Return a plain-text excerpt from a Markdown issue body.
+    """Return a plain-text excerpt from the first prose paragraph of an issue body.
 
-    Strips common markdown syntax characters and collapses whitespace so the
-    result reads as a short prose snippet suitable for a Kanban card subtitle.
+    Skips markdown section headers (lines beginning with ``#``) and leading
+    blank lines so the card subtitle shows actual description text rather than
+    repeating the section label (e.g. "Context", "Objective").  Stops at the
+    first blank line after content begins, giving one clean prose paragraph.
+
+    Remaining inline markdown (bold, code, etc.) is stripped by ``_MD_STRIP_RE``.
     """
     if not isinstance(body, str) or not body:
         return ""
-    text: str = str(_MD_STRIP_RE.sub(" ", body)).strip()
+
+    # Collect lines from the first prose paragraph, skipping header lines.
+    content_lines: list[str] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            # A new header after content has started ends the first paragraph.
+            if content_lines:
+                break
+            continue
+        if not stripped:
+            # Blank line ends the first paragraph once content has started;
+            # blank lines before any content are ignored.
+            if content_lines:
+                break
+            continue
+        content_lines.append(stripped)
+
+    if not content_lines:
+        return ""
+
+    text = _MD_SPACES_RE.sub(" ", _MD_STRIP_RE.sub(" ", " ".join(content_lines))).strip()
     if len(text) <= max_chars:
         return text
-    # Break at the last word boundary within the limit.
     truncated = text[:max_chars]
     cut = truncated.rfind(" ")
     return (truncated[:cut] if cut > 0 else truncated) + "…"

--- a/agentception/tests/test_build_board_partial.py
+++ b/agentception/tests/test_build_board_partial.py
@@ -651,3 +651,50 @@ async def test_get_issues_grouped_by_phase_filters_closed_deps() -> None:
     assert issue_10["depends_on"] == [], (
         "Closed dep #11 must not appear in depends_on — it is resolved"
     )
+
+
+# ---------------------------------------------------------------------------
+# _body_excerpt: section headers must be skipped so cards show prose, not labels
+# ---------------------------------------------------------------------------
+
+
+def test_body_excerpt_skips_leading_section_header() -> None:
+    """Cards must show prose text, not the markdown section label.
+
+    Regression: bodies structured as '## Context\\nActual text' were excerpted
+    as 'Context Actual text' because the regex stripped '#' chars but kept the
+    header word. The fix skips any leading header lines so the first prose
+    paragraph leads.
+    """
+    from agentception.db.queries import _body_excerpt
+
+    body = "## Context\nEven after the field is propagated the architecture may not be woven in.\n\n## Objective\nFix it."
+    result = _body_excerpt(body)
+    assert not result.startswith("Context"), f"Header word leaked into excerpt: {result!r}"
+    assert "Even after" in result
+
+
+def test_body_excerpt_stops_at_first_paragraph() -> None:
+    """Only the first prose paragraph is excerpted, not subsequent sections."""
+    from agentception.db.queries import _body_excerpt
+
+    body = "## Context\nFirst paragraph text.\n\n## Objective\nSecond section should not appear."
+    result = _body_excerpt(body)
+    assert "Second section" not in result
+
+
+def test_body_excerpt_no_headers_returns_first_paragraph() -> None:
+    """Bodies without section headers return the first paragraph verbatim."""
+    from agentception.db.queries import _body_excerpt
+
+    body = "Plain description here.\n\nSecond paragraph ignored."
+    result = _body_excerpt(body)
+    assert result == "Plain description here."
+
+
+def test_body_excerpt_all_headers_returns_empty() -> None:
+    """A body consisting only of headers returns an empty string."""
+    from agentception.db.queries import _body_excerpt
+
+    body = "## Context\n## Objective\n## Notes"
+    assert _body_excerpt(body) == ""


### PR DESCRIPTION
## Summary

Kanban cards were showing `Context Even after the field is...` instead of just `Even after the field is...`.

Root cause: `_body_excerpt` stripped `#` characters from the raw body but kept the header word, so `## Context\nActual text` became `Context Actual text`.

Fix: split body into lines before excerpting — skip any line that starts with `#`, stop at the first blank line after content begins. Result is the first prose paragraph, with no section label prefix.

## Changes

- `queries.py`: `_body_excerpt` rewritten to skip header lines; `_MD_STRIP_RE` simplified (no longer needs to strip `#` since headers are now dropped at the line level)
- `test_build_board_partial.py`: 4 regression tests covering header-skip, first-paragraph stop, no-header passthrough, all-headers → empty

## Test plan
- [x] mypy clean
- [x] 23/23 tests pass