### PR TITLE
feat: add build_acknowledge_run MCP tool so Dispatcher never uses curl

### DIFF
--- a/.agentception/dispatcher.md
+++ b/.agentception/dispatcher.md
@@ -73,8 +73,10 @@ For each pending launch (spawn all simultaneously using parallel Task calls):
 
 ### 3a. Claim the run
 
-```bash
-curl -s -X POST http://localhost:10003/api/runs/{run_id}/acknowledge
+Call the MCP tool (server: `agentception`):
+
+```
+build_acknowledge_run(run_id="{run_id}")
 ```
 
 This atomically marks the run as `implementing` so no other Dispatcher can

--- a/agentception/mcp/build_tools.py
+++ b/agentception/mcp/build_tools.py
@@ -15,7 +15,7 @@ persist layer and return a lightweight ack dict.
 import asyncio
 import logging
 
-from agentception.db.persist import persist_agent_event
+from agentception.db.persist import acknowledge_agent_run, persist_agent_event
 from agentception.db.queries import get_pending_launches
 from agentception.services.spawn_child import ScopeType, SpawnChildError, Tier, spawn_child
 from agentception.services.teardown import teardown_agent_worktree
@@ -56,6 +56,33 @@ async def build_get_pending_launches() -> dict[str, object]:
             launch.get("branch"),
         )
     return {"pending": launches, "count": len(launches)}
+
+
+async def build_acknowledge_run(run_id: str) -> dict[str, object]:
+    """Atomically claim a pending run before spawning its Task agent.
+
+    The Dispatcher calls this immediately before spawning a Task so the run
+    cannot be double-claimed if two Dispatchers run concurrently.  Transitions
+    the run from ``pending_launch`` → ``implementing``.
+
+    Args:
+        run_id: The ``run_id`` returned by ``build_get_pending_launches``
+                (e.g. ``"label-cognitive-arch-propagation-7352b9"``).
+
+    Returns:
+        ``{"ok": True, "run_id": run_id}`` on success, or
+        ``{"ok": False, "reason": "..."}`` when the run is not found or was
+        already claimed by another Dispatcher.
+    """
+    ok = await acknowledge_agent_run(run_id)
+    if not ok:
+        logger.warning(
+            "⚠️ build_acknowledge_run: %r not found or already claimed — skipping",
+            run_id,
+        )
+        return {"ok": False, "reason": f"Run {run_id!r} not found or not in pending_launch state"}
+    logger.info("✅ build_acknowledge_run: %r claimed", run_id)
+    return {"ok": True, "run_id": run_id}
 
 
 async def build_report_step(

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -27,6 +27,7 @@ import logging
 from typing import cast
 
 from agentception.mcp.build_tools import (
+    build_acknowledge_run,
     build_get_pending_launches,
     build_report_blocker,
     build_report_decision,
@@ -361,6 +362,28 @@ TOOLS: list[ACToolDef] = [
         },
     ),
     ACToolDef(
+        name="build_acknowledge_run",
+        description=(
+            "Atomically claim a pending run before spawning its Task agent. "
+            "Call this with the run_id from build_get_pending_launches immediately "
+            "before firing the Task so the run cannot be double-claimed by a concurrent "
+            "Dispatcher. Transitions the run from pending_launch to implementing. "
+            "Returns {ok: true, run_id} on success, or {ok: false, reason} if the run "
+            "was already claimed — skip that item and continue with the next."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {
+                    "type": "string",
+                    "description": "run_id returned by build_get_pending_launches",
+                },
+            },
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
         name="build_spawn_child",
         description=(
             "Create a child agent node in the agent tree. "
@@ -653,6 +676,7 @@ def call_tool(name: str, arguments: dict[str, object]) -> ACToolResult:
         "plan_spawn_coordinator",
         "plan_advance_phase",
         "build_get_pending_launches",
+        "build_acknowledge_run",
         "build_spawn_child",
         "build_report_step",
         "build_report_blocker",
@@ -728,6 +752,22 @@ async def call_tool_async(
         return ACToolResult(
             content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
             isError=False,
+        )
+
+    if name == "build_acknowledge_run":
+        run_id_arg = arguments.get("run_id")
+        if not isinstance(run_id_arg, str) or not run_id_arg:
+            return ACToolResult(
+                content=[ACToolContent(
+                    type="text",
+                    text=_tool_result_to_text({"error": "build_acknowledge_run requires a non-empty string run_id"}),
+                )],
+                isError=True,
+            )
+        result = await build_acknowledge_run(run_id_arg)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
         )
 
     if name == "build_spawn_child":

--- a/agentception/tests/test_agentception_mcp_plan.py
+++ b/agentception/tests/test_agentception_mcp_plan.py
@@ -28,7 +28,7 @@ from agentception.mcp.plan_tools import (
     plan_validate_manifest,
     plan_validate_spec,
 )
-from agentception.mcp.server import TOOLS, call_tool, handle_request, list_tools
+from agentception.mcp.server import TOOLS, call_tool, call_tool_async, handle_request, list_tools
 from agentception.mcp.types import (
     ACToolDef,
     ACToolResult,
@@ -838,3 +838,57 @@ async def test_plan_spawn_coordinator_agent_task_write_failure_removes_worktree(
     remove_call = git_calls[1]
     assert "remove" in remove_call, f"Expected 'remove' in cleanup call: {remove_call}"
     assert "--force" in remove_call, f"Expected '--force' in cleanup call: {remove_call}"
+
+
+# ---------------------------------------------------------------------------
+# build_acknowledge_run — MCP tool dispatches to acknowledge_agent_run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_acknowledge_run_success_via_call_tool() -> None:
+    """build_acknowledge_run MCP tool returns ok=true on successful claim.
+
+    Regression: before this tool existed the Dispatcher fell back to curl.
+    """
+    with patch(
+        "agentception.mcp.build_tools.acknowledge_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        result = await call_tool_async("build_acknowledge_run", {"run_id": "test-run-abc123"})
+
+    assert result["isError"] is False
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is True
+    assert payload["run_id"] == "test-run-abc123"
+
+
+@pytest.mark.anyio
+async def test_build_acknowledge_run_already_claimed_via_call_tool() -> None:
+    """build_acknowledge_run returns isError=True when run was already claimed."""
+    with patch(
+        "agentception.mcp.build_tools.acknowledge_agent_run",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        result = await call_tool_async("build_acknowledge_run", {"run_id": "test-run-already"})
+
+    assert result["isError"] is True
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is False
+    assert "reason" in payload
+
+
+@pytest.mark.anyio
+async def test_build_acknowledge_run_missing_run_id_returns_error() -> None:
+    """build_acknowledge_run MCP tool returns isError=True when run_id is absent."""
+    result = await call_tool_async("build_acknowledge_run", {})
+
+    assert result["isError"] is True
+
+
+def test_build_acknowledge_run_in_tools_list() -> None:
+    """build_acknowledge_run is present in the TOOLS registry."""
+    names = [t["name"] for t in TOOLS]
+    assert "build_acknowledge_run" in names

--- a/scripts/gen_prompts/templates/dispatcher.md.j2
+++ b/scripts/gen_prompts/templates/dispatcher.md.j2
@@ -73,8 +73,10 @@ For each pending launch (spawn all simultaneously using parallel Task calls):
 
 ### 3a. Claim the run
 
-```bash
-curl -s -X POST http://localhost:10003/api/runs/{run_id}/acknowledge
+Call the MCP tool (server: `agentception`):
+
+```
+build_acknowledge_run(run_id="{run_id}")
 ```
 
 This atomically marks the run as `implementing` so no other Dispatcher can


### PR DESCRIPTION
## Summary

- The Dispatcher was claiming runs via a raw `curl` POST to `/api/runs/{run_id}/acknowledge` because no MCP tool existed for that operation
- Adds `build_acknowledge_run(run_id)` to `build_tools.py`, registers it in the MCP server (tool definition + `call_tool_async` dispatch), and updates the dispatcher prompt template to call the MCP tool instead of curl
- Adds 4 regression tests: success, already-claimed, missing run_id, and presence in TOOLS registry

## Test plan

- [x] `mypy` clean on all modified files
- [x] `test_build_acknowledge_run_success_via_call_tool` — ok=true path
- [x] `test_build_acknowledge_run_already_claimed_via_call_tool` — isError=True when run already claimed
- [x] `test_build_acknowledge_run_missing_run_id_returns_error` — isError=True on bad input
- [x] `test_build_acknowledge_run_in_tools_list` — tool registered in TOOLS registry
