### PR TITLE
fix: make ticket-blocked stamping reliable end-to-end

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -56,6 +56,19 @@ def _hash(*parts: str) -> str:
     return hashlib.sha256("".join(parts).encode()).hexdigest()
 
 
+def _parse_blocked_by(body: str) -> list[int]:
+    """Extract blocker issue numbers from a '**Blocked by:** #N, #M' line in an issue body.
+
+    Called during every upsert so depends_on_json is populated even when
+    persist_issue_depends_on loses the race with the DB row not yet existing.
+    Only parses the first matching line; returns [] if no match.
+    """
+    m = re.search(r"\*\*Blocked by:\*\*\s*((?:#\d+(?:,\s*)?)+)", body)
+    if not m:
+        return []
+    return [int(n) for n in re.findall(r"#(\d+)", m.group(1))]
+
+
 # ---------------------------------------------------------------------------
 # Public entry point — called by poller.tick()
 # ---------------------------------------------------------------------------
@@ -170,16 +183,20 @@ async def _upsert_issues(
         )
         existing = result.scalar_one_or_none()
 
+        body_str = str(raw.get("body", ""))
         if existing is None:
             session.add(
                 ACIssue(
                     github_number=num,
                     repo=repo,
                     title=title,
-                    body=str(raw.get("body", "")) or None,
+                    body=body_str or None,
                     state=state_str,
                     phase_label=active_label,
                     labels_json=labels_json,
+                    # Parse "Blocked by" on first insert so depends_on_json is
+                    # populated even when persist_issue_depends_on loses the race.
+                    depends_on_json=json.dumps(_parse_blocked_by(body_str)),
                     content_hash=content_hash,
                     closed_at=closed_at,
                     first_seen_at=now,
@@ -189,6 +206,7 @@ async def _upsert_issues(
         elif existing.content_hash != content_hash or existing.state != state_str:
             # Update when content changed OR state transitioned (open → closed).
             existing.title = title
+            existing.body = body_str or None
             existing.state = state_str
             existing.phase_label = active_label
             existing.labels_json = labels_json
@@ -199,6 +217,14 @@ async def _upsert_issues(
                 existing.closed_at = closed_at
             elif state_str == "closed" and existing.closed_at is None:
                 existing.closed_at = now
+
+        # Backfill depends_on_json from the issue body for rows where
+        # persist_issue_depends_on lost the race (row did not exist yet).
+        # Safe to run unconditionally: only writes when the field is still empty.
+        if existing is not None and existing.depends_on_json == "[]":
+            parsed = _parse_blocked_by(body_str)
+            if parsed:
+                existing.depends_on_json = json.dumps(parsed)
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -2099,6 +2099,48 @@ async def get_ticket_blocked_open_issues(repo: str) -> list[TicketBlockedRow]:
         return []
 
 
+async def get_issues_missing_ticket_blocked(repo: str) -> list[TicketBlockedRow]:
+    """Return open issues that have deps recorded but are missing the ``ticket-blocked`` label.
+
+    Used by the poller's ``_stamp_missing_ticket_blocked`` to re-apply the label
+    when the initial stamp in ``file_issues`` failed silently (e.g. a transient
+    GitHub API error caught by the old shared try/except).  Only issues whose
+    ``depends_on_json`` is non-empty are considered — the body-based backfill in
+    ``_upsert_issues`` ensures this field is populated on the first poller tick
+    after issue creation.
+
+    Falls back to ``[]`` on DB error.
+    """
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACIssue).where(
+                    ACIssue.repo == repo,
+                    ACIssue.state == "open",
+                )
+            )
+            rows = result.scalars().all()
+
+        out: list[TicketBlockedRow] = []
+        for row in rows:
+            dep_numbers: list[int] = json.loads(row.depends_on_json or "[]")
+            if not dep_numbers:
+                continue
+            labels: list[str] = json.loads(row.labels_json or "[]")
+            if "ticket-blocked" in labels:
+                continue
+            out.append(
+                TicketBlockedRow(
+                    github_number=row.github_number,
+                    dep_numbers=dep_numbers,
+                )
+            )
+        return out
+    except Exception as exc:
+        logger.warning("❌ get_issues_missing_ticket_blocked failed: %s", exc)
+        return []
+
+
 async def get_closed_issue_numbers(repo: str) -> set[int]:
     """Return the set of GitHub issue numbers that are closed in the DB.
 

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -616,6 +616,47 @@ async def _auto_unblock_ticket_deps(repo: str) -> None:
         logger.warning("⚠️  _auto_unblock_ticket_deps: failed: %s", exc)
 
 
+async def _stamp_missing_ticket_blocked(repo: str) -> None:
+    """Re-apply ``ticket-blocked`` to issues whose deps are recorded but the label is absent.
+
+    This is the server-side safety net for a silent failure mode in
+    ``file_issues``: if ``add_label_to_issue`` threw a ``RuntimeError`` that was
+    caught by the (now-fixed) shared try/except, the body was edited but the
+    label was never applied.  On the next poller tick this function detects the
+    gap — ``depends_on_json`` non-empty but ``ticket-blocked`` missing — and
+    re-stamps the label provided at least one dep is still open.
+
+    Called on every tick immediately before ``_auto_unblock_ticket_deps`` so the
+    unblock pass always operates on a correct label set.
+    """
+    from agentception.db.queries import get_closed_issue_numbers, get_issues_missing_ticket_blocked
+    from agentception.readers.github import add_label_to_issue
+
+    try:
+        candidates = await get_issues_missing_ticket_blocked(repo)
+        if not candidates:
+            return
+        closed = await get_closed_issue_numbers(repo)
+        for row in candidates:
+            if all(dep in closed for dep in row["dep_numbers"]):
+                continue  # All deps already closed — no need to block
+            try:
+                await add_label_to_issue(row["github_number"], "ticket-blocked")
+                logger.info(
+                    "✅ _stamp_missing_ticket_blocked: re-stamped ticket-blocked on #%d (deps: %s)",
+                    row["github_number"],
+                    row["dep_numbers"],
+                )
+            except Exception as exc:
+                logger.warning(
+                    "⚠️  _stamp_missing_ticket_blocked: could not stamp #%d: %s",
+                    row["github_number"],
+                    exc,
+                )
+    except Exception as exc:
+        logger.warning("⚠️  _stamp_missing_ticket_blocked: failed: %s", exc)
+
+
 async def tick() -> PipelineState:
     """Execute a single polling cycle: collect → merge → detect → persist → enrich → broadcast.
 
@@ -672,6 +713,10 @@ async def tick() -> PipelineState:
         await reseed_missing_initiative_phases(settings.gh_repo)
         # Auto-unblock next-phase issues whenever a phase gate closes.
         await _auto_advance_phases(settings.gh_repo)
+        # Re-stamp ticket-blocked on issues whose label was lost (e.g. silent
+        # API failure during file_issues).  Must run before _auto_unblock so
+        # the unblock pass always sees a correct label set.
+        await _stamp_missing_ticket_blocked(settings.gh_repo)
         # Auto-remove ticket-blocked label when all ticket-level deps have closed.
         await _auto_unblock_ticket_deps(settings.gh_repo)
     except Exception as exc:

--- a/agentception/readers/issue_creator.py
+++ b/agentception/readers/issue_creator.py
@@ -386,23 +386,34 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
             )
             try:
                 await _gh_edit_body(repo, our_number, original_body.rstrip() + blocked_line)
-                # Stamp ticket-blocked so coordinators can filter this issue
-                # out until all its deps are closed.  The poller removes this
-                # label automatically once every dependency is in a closed state.
+            except RuntimeError as exc:
+                logger.warning("⚠️ Could not edit body of #%d for depends_on: %s", our_number, exc)
+                continue
+
+            # Stamp ticket-blocked so coordinators can filter this issue out
+            # until all its deps are closed.  Separated from the body edit so a
+            # label-API failure never silently leaves an issue unblocked: the
+            # poller's _stamp_missing_ticket_blocked will re-apply it next tick.
+            try:
                 await add_label_to_issue(our_number, "ticket-blocked")
+            except RuntimeError as exc:
+                logger.error(
+                    "❌ #%d body edited but ticket-blocked stamp failed — poller will re-stamp: %s",
+                    our_number,
+                    exc,
+                )
+            else:
                 logger.info(
                     "✅ #%d blocked_by %s — ticket-blocked label added",
                     our_number,
                     [f"#{n}" for n in blocker_numbers],
                 )
-                yield BlockedEvent(
-                    t="blocked",
-                    number=our_number,
-                    blocked_by=blocker_numbers,
-                )
-            except RuntimeError as exc:
-                # Non-fatal — log and continue.
-                logger.warning("⚠️ Could not edit #%d for depends_on: %s", our_number, exc)
+
+            yield BlockedEvent(
+                t="blocked",
+                number=our_number,
+                blocked_by=blocker_numbers,
+            )
 
     # Persist ticket-level deps to DB so the Build board can display them.
     await persist_issue_depends_on(repo, issue_deps)

--- a/agentception/tests/test_agentception_poller.py
+++ b/agentception/tests/test_agentception_poller.py
@@ -845,3 +845,96 @@ async def test_auto_unblock_ticket_deps_skips_when_no_candidates() -> None:
 
     closed_mock.assert_not_awaited()
     remove_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _stamp_missing_ticket_blocked — regression for silent label-stamp failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_stamp_missing_ticket_blocked_restamps_when_dep_open() -> None:
+    """ticket-blocked is applied when depends_on_json has an open dep but label is absent.
+
+    Regression: issue_creator used a shared try/except that silently swallowed
+    add_label_to_issue failures, leaving issues dispatchable despite open blockers.
+    """
+    from agentception.poller import _stamp_missing_ticket_blocked
+
+    candidates = [{"github_number": 177, "dep_numbers": [175]}]
+    closed: set[int] = set()  # 175 still open
+    add_mock = AsyncMock()
+
+    with (
+        patch(
+            "agentception.db.queries.get_issues_missing_ticket_blocked",
+            new=AsyncMock(return_value=candidates),
+        ),
+        patch(
+            "agentception.db.queries.get_closed_issue_numbers",
+            new=AsyncMock(return_value=closed),
+        ),
+        patch(
+            "agentception.readers.github.add_label_to_issue",
+            add_mock,
+        ),
+    ):
+        await _stamp_missing_ticket_blocked("cgcardona/agentception")
+
+    add_mock.assert_awaited_once_with(177, "ticket-blocked")
+
+
+@pytest.mark.anyio
+async def test_stamp_missing_ticket_blocked_skips_when_all_deps_closed() -> None:
+    """No label is added when every dep is already closed (issue is about to be unblocked)."""
+    from agentception.poller import _stamp_missing_ticket_blocked
+
+    candidates = [{"github_number": 177, "dep_numbers": [175]}]
+    closed = {175}  # dep already closed
+    add_mock = AsyncMock()
+
+    with (
+        patch(
+            "agentception.db.queries.get_issues_missing_ticket_blocked",
+            new=AsyncMock(return_value=candidates),
+        ),
+        patch(
+            "agentception.db.queries.get_closed_issue_numbers",
+            new=AsyncMock(return_value=closed),
+        ),
+        patch(
+            "agentception.readers.github.add_label_to_issue",
+            add_mock,
+        ),
+    ):
+        await _stamp_missing_ticket_blocked("cgcardona/agentception")
+
+    add_mock.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_stamp_missing_ticket_blocked_skips_when_no_candidates() -> None:
+    """No GitHub calls when every issue already has ticket-blocked or has no deps."""
+    from agentception.poller import _stamp_missing_ticket_blocked
+
+    add_mock = AsyncMock()
+    closed_mock = AsyncMock(return_value=set())
+
+    with (
+        patch(
+            "agentception.db.queries.get_issues_missing_ticket_blocked",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "agentception.db.queries.get_closed_issue_numbers",
+            closed_mock,
+        ),
+        patch(
+            "agentception.readers.github.add_label_to_issue",
+            add_mock,
+        ),
+    ):
+        await _stamp_missing_ticket_blocked("cgcardona/agentception")
+
+    closed_mock.assert_not_awaited()
+    add_mock.assert_not_awaited()

--- a/agentception/tests/test_issue_creator.py
+++ b/agentception/tests/test_issue_creator.py
@@ -258,6 +258,43 @@ async def test_file_issues_edits_body_for_depends_on() -> None:
 
 
 @pytest.mark.anyio
+async def test_file_issues_still_yields_blocked_event_when_label_stamp_fails() -> None:
+    """BlockedEvent is still emitted even when add_label_to_issue raises.
+
+    Regression: the old shared try/except swallowed both the label failure and
+    the BlockedEvent.  After the fix, body edit and label stamp are independent:
+    a label failure only loses the label (poller re-stamps it), not the event.
+    """
+    spec = _make_spec(with_depends_on=True)
+
+    create_count = 0
+
+    def fake_proc(*args: str, **_kwargs: object) -> MagicMock:
+        nonlocal create_count
+        cmd = list(args)
+        if "create" in cmd:
+            create_count += 1
+            return _mock_proc(stdout=_issue_url(500 + create_count))
+        return _mock_proc()
+
+    with (
+        patch("agentception.readers.issue_creator.ensure_label_exists", new_callable=AsyncMock),
+        patch(
+            "agentception.readers.issue_creator.add_label_to_issue",
+            side_effect=RuntimeError("label API down"),
+        ),
+        patch("asyncio.create_subprocess_exec", side_effect=fake_proc),
+    ):
+        events = await _collect(file_issues(spec))
+
+    # BlockedEvent must still be yielded even though label stamp failed.
+    blocked_events = [e for e in events if e["t"] == "blocked"]
+    assert len(blocked_events) == 1, (
+        "BlockedEvent must be emitted regardless of label-stamp failure"
+    )
+
+
+@pytest.mark.anyio
 async def test_file_issues_no_edit_when_no_depends_on() -> None:
     """No gh issue edit is called when no issue has depends_on."""
     spec = _make_spec(with_depends_on=False)

--- a/agentception/tests/test_persist_auto_close.py
+++ b/agentception/tests/test_persist_auto_close.py
@@ -271,3 +271,32 @@ async def test_auto_close_updates_content_hash_to_prevent_reopen() -> None:
         "content_hash must be recomputed with state='closed' "
         "so the next open-issue upsert doesn't flip the issue back to open"
     )
+
+
+# ---------------------------------------------------------------------------
+# _parse_blocked_by — regression for depends_on_json backfill from body
+# ---------------------------------------------------------------------------
+
+
+def test_parse_blocked_by_single_dep() -> None:
+    """Extracts a single blocker number from a '**Blocked by:** #N' line."""
+    body = "Some description.\n\n---\n**Blocked by:** #175"
+    assert _persist._parse_blocked_by(body) == [175]
+
+
+def test_parse_blocked_by_multiple_deps() -> None:
+    """Extracts multiple blocker numbers separated by commas."""
+    body = "Description.\n\n---\n**Blocked by:** #175, #176"
+    assert _persist._parse_blocked_by(body) == [175, 176]
+
+
+def test_parse_blocked_by_no_match_returns_empty() -> None:
+    """Returns [] when the body has no 'Blocked by' line."""
+    assert _persist._parse_blocked_by("Just a plain description.") == []
+    assert _persist._parse_blocked_by("") == []
+
+
+def test_parse_blocked_by_does_not_match_partial() -> None:
+    """Does not false-positive on partial matches like 'blocked by' (lowercase)."""
+    body = "This is blocked by someone but not in the right format."
+    assert _persist._parse_blocked_by(body) == []


### PR DESCRIPTION
## Summary

- **Bug 1 (issue_creator.py):** `_gh_edit_body` and `add_label_to_issue` shared one `try/except RuntimeError` — a transient label-API failure silently swallowed the stamp while the body edit succeeded, leaving the issue with `**Blocked by:** #175` in the body but no `ticket-blocked` label. Split into two independent try blocks.
- **Bug 2 (persist.py):** `_upsert_issues` never populated `depends_on_json` from the issue body, so the race condition in `persist_issue_depends_on` (row not yet in DB at call time) left the column as `"[]"` permanently. Added `_parse_blocked_by()` and wire it into the INSERT and backfill paths.
- **Bug 3 (poller.py / queries.py):** No server-side task existed to re-stamp `ticket-blocked` when the label was missing. Added `_stamp_missing_ticket_blocked()` which runs every tick before `_auto_unblock_ticket_deps`, finds open issues with non-empty `depends_on_json` but missing `ticket-blocked`, and re-applies the label if any dep is still open.

## Test plan
- [ ] `test_file_issues_still_yields_blocked_event_when_label_stamp_fails` — regression for Bug 1
- [ ] `test_stamp_missing_ticket_blocked_restamps_when_dep_open` — regression for Bug 3
- [ ] `test_stamp_missing_ticket_blocked_skips_when_all_deps_closed` — guard: no spurious re-block after dep closes
- [ ] `test_stamp_missing_ticket_blocked_skips_when_no_candidates` — guard: no GH API calls when nothing to fix
- [ ] `test_parse_blocked_by_*` — unit coverage for the body parser (Bug 2)
- [ ] 982 existing tests all green