### PR TITLE
feat: inject cognitive architecture into system prompt for sub-coordinators and leaf agents (#175)

### DIFF
--- a/.agentception/parallel-bugs-to-issues.md
+++ b/.agentception/parallel-bugs-to-issues.md
@@ -454,11 +454,52 @@ STEP 0 — READ YOUR TASK FILE:
     FILE_OWNERSHIP          — files this phase owns (awareness, not action)
     SPAWN_SUB_AGENTS        — if true, follow sub-coordinator path
 
-STEP 0.5 — LOAD YOUR ROLE:
+STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   ROLE=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['role'])")
   REPO=$(git worktree list | head -1 | awk '{print $1}')
   ROLE_FILE="$REPO/.agentception/roles/${ROLE}.md"
   [ -f "$ROLE_FILE" ] && cat "$ROLE_FILE" && echo "✅ Operating as: $ROLE"
+
+  # Load cognitive architecture — assembles figure persona + all skill domain fragments
+  # Format: "figure:skill1:skill2" (colon-separated)
+  COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent'].get('cognitive_arch',''))")
+  if [ -n "$COGNITIVE_ARCH" ]; then
+    echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
+    echo ""
+    # resolve_arch.py assembles the full context block from the COGNITIVE_ARCH string.
+    # Output is ready-to-read Markdown — no manual YAML parsing needed.
+    RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+    if [ -f "$RESOLVE_ARCH" ]; then
+      ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode implementer 2>/dev/null)
+      if [ -n "$ARCH_CONTEXT" ]; then
+        echo "$ARCH_CONTEXT"
+      fi
+    else
+      echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+    fi
+    echo ""
+    echo "Let these govern your approach to this task."
+  else
+    echo "⚠️  No COGNITIVE_ARCH set — using default coordinator approach."
+  fi
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
 
   Export for all subsequent commands:
     export GH_REPO=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['repo']['gh_repo'])")

--- a/.agentception/parallel-conductor.md
+++ b/.agentception/parallel-conductor.md
@@ -148,7 +148,7 @@ Read .agentception/agent-command-policy.md before issuing any shell commands.
 Green-tier commands run without confirmation. Yellow = check scope first.
 Red = never, ask the user instead.
 
-STEP 0 — READ YOUR TASK FILE:
+STEP 0 — READ YOUR TASK FILE AND COGNITIVE ARCHITECTURE:
   cat .agent-task
 
   Parse all KEY=value fields:
@@ -163,6 +163,42 @@ STEP 0 — READ YOUR TASK FILE:
     export GH_REPO=${GH_REPO:-cgcardona/agentception}
     PHASE_FILTER=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('task',{}).get('phase_filter',''))")
     ATTEMPT_N=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['task']['attempt_n'])")
+    REPO=$(git worktree list | head -1 | awk '{print $1}')
+
+  # Load cognitive architecture — assembles figure persona + all skill domain fragments
+  # Format: "figure:skill1:skill2" (colon-separated)
+  COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent'].get('cognitive_arch',''))")
+  if [ -n "$COGNITIVE_ARCH" ]; then
+    echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
+    echo ""
+    RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+    if [ -f "$RESOLVE_ARCH" ]; then
+      ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode implementer 2>/dev/null)
+      if [ -n "$ARCH_CONTEXT" ]; then
+        echo "$ARCH_CONTEXT"
+      fi
+    else
+      echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+    fi
+    echo ""
+    echo "Let these govern your approach to this task."
+  else
+    echo "⚠️  No COGNITIVE_ARCH set — using default coordinator approach."
+  fi
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE STEP 1:
+  Send the following as your **first text response** to the user:
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** conductor
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
 
   ⚠️  ANTI-LOOP GUARD: if ATTEMPT_N > 3 → STOP.
     This conductor has run 4+ times without advancing the pipeline.

--- a/agentception/services/prompt_assembly.py
+++ b/agentception/services/prompt_assembly.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+"""System prompt assembly for all agent types.
+
+Provides :func:`build_system_prompt` — the single entry-point for assembling
+an agent's system prompt from a ``cognitive_arch`` string plus role-specific
+instructions.
+
+Required ordering
+-----------------
+Every system prompt assembled by this module follows this contract:
+
+1. **Cognitive architecture persona block (always first).**
+   Establishes who the agent *is* before it reads its role.  The persona
+   block contains the figure's display name and mental-model description
+   loaded from the cognitive_archetypes YAML files.
+
+2. **Role-specific instructions.**
+   What the agent is asked to do in this execution context — coordinator
+   survey, leaf implementation, PR review, etc.
+
+3. **Tool/capability declarations.**
+   Any trailing capability or tool-usage context appended by the caller.
+
+This ordering must be preserved.  Swapping (1) and (2) causes the agent to
+anchor on role identity before persona, which weakens the cognitive
+architecture's influence on reasoning style.
+"""
+
+import logging
+from pathlib import Path
+
+import yaml
+
+from agentception.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_system_prompt(
+    cognitive_arch: str | None,
+    role_instructions: str,
+    *,
+    agent_type: str = "leaf",
+) -> str:
+    """Assemble the full system prompt for any agent type.
+
+    Enforces the required ordering:
+
+    1. Cognitive architecture persona block (always first).
+    2. Role-specific instructions.
+    3. Tool/capability declarations (appended by the caller after this call).
+
+    Args:
+        cognitive_arch: The cognitive architecture string from the agent's
+            ``.agent-task`` file (``[agent].cognitive_arch`` field), e.g.
+            ``"guido_van_rossum:postgresql:python"``.  Pass ``None`` when the
+            field is absent — a warning will be logged.
+        role_instructions: Role-specific instructions text (coordinator survey
+            steps, leaf implementation steps, PR review criteria, etc.).
+        agent_type: Descriptive tag used in log messages; ``"coordinator"``
+            or ``"leaf"``.  Does not affect the assembled content.
+
+    Returns:
+        The assembled system prompt string, ready to be passed as the
+        ``system_prompt`` argument to an LLM call.
+    """
+    persona_block = _build_persona_block(cognitive_arch, agent_type)
+    parts: list[str] = []
+    if persona_block:
+        parts.append(persona_block)
+    parts.append(role_instructions)
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_persona_block(cognitive_arch: str | None, agent_type: str) -> str:
+    """Build the cognitive architecture persona block for the top of a system prompt.
+
+    Loads the figure YAML from ``scripts/gen_prompts/cognitive_archetypes/figures/``
+    and returns a block of the form::
+
+        You are {display_name}. Your cognitive architecture: {description}
+
+    Returns an empty string — **never raises** — when the arch string is absent,
+    malformed, or the figure YAML cannot be found.  All failure paths emit a
+    warning so injection failures are visible in logs.
+
+    Args:
+        cognitive_arch: Raw ``cognitive_arch`` field value, e.g.
+            ``"guido_van_rossum:postgresql:python"``.
+        agent_type: Used only in log messages.
+
+    Returns:
+        Persona block string, or ``""`` when the arch is missing/invalid.
+    """
+    if not cognitive_arch:
+        logger.warning(
+            "⚠️ build_system_prompt: cognitive_arch is absent for %s agent — "
+            "persona block will be omitted from system prompt.",
+            agent_type,
+        )
+        return ""
+
+    parts = [p.strip() for p in cognitive_arch.split(":") if p.strip()]
+    if not parts:
+        logger.warning(
+            "⚠️ build_system_prompt: cognitive_arch %r is malformed for %s agent — "
+            "persona block will be omitted.",
+            cognitive_arch,
+            agent_type,
+        )
+        return ""
+
+    figure_id = parts[0]
+    display_name, description = _load_figure_identity(figure_id)
+    return _format_persona(display_name, description)
+
+
+def _load_figure_identity(figure_id: str) -> tuple[str, str]:
+    """Load display name and description from a figure YAML file.
+
+    Returns:
+        ``(display_name, description)`` — both strings, non-empty only when the
+        YAML exists and contains the respective fields.  Falls back to
+        ``(figure_id, "")`` on any error.
+    """
+    figures_dir: Path = (
+        settings.repo_dir
+        / "scripts"
+        / "gen_prompts"
+        / "cognitive_archetypes"
+        / "figures"
+    )
+    figure_path = figures_dir / f"{figure_id}.yaml"
+
+    if not figure_path.exists():
+        logger.warning(
+            "⚠️ build_system_prompt: figure YAML not found for %r at %s — "
+            "using bare figure_id as persona name.",
+            figure_id,
+            figure_path,
+        )
+        return figure_id, ""
+
+    try:
+        raw: object = yaml.safe_load(figure_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "⚠️ build_system_prompt: failed to parse figure YAML for %r: %s",
+            figure_id,
+            exc,
+        )
+        return figure_id, ""
+
+    if not isinstance(raw, dict):
+        logger.warning(
+            "⚠️ build_system_prompt: figure YAML for %r is not a mapping.",
+            figure_id,
+        )
+        return figure_id, ""
+
+    display_name = str(raw.get("display_name", figure_id))
+    description = str(raw.get("description", "")).strip()
+    return display_name, description
+
+
+def _format_persona(display_name: str, description: str) -> str:
+    """Format the persona line from display name and description.
+
+    Returns a single-sentence block ``"You are {name}. Your cognitive
+    architecture: {description}"`` when a description is available, or
+    ``"You are {name}."`` otherwise.
+    """
+    if description:
+        return f"You are {display_name}. Your cognitive architecture: {description}"
+    return f"You are {display_name}."

--- a/agentception/tests/test_prompt_assembly.py
+++ b/agentception/tests/test_prompt_assembly.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+"""Unit tests for agentception.services.prompt_assembly.
+
+Covers:
+- build_system_prompt returns persona block before role instructions (coordinator)
+- build_system_prompt returns persona block before role instructions (leaf)
+- build_system_prompt logs a warning when cognitive_arch is None
+- build_system_prompt logs a warning when cognitive_arch is an empty string
+- _build_persona_block returns the display name for a known figure
+- _build_persona_block returns non-empty string for valid arch with known figure
+- _build_persona_block returns bare figure_id when YAML is missing
+- _format_persona produces the correct single-line block with and without description
+"""
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentception.services.prompt_assembly import (
+    _build_persona_block,
+    _format_persona,
+    build_system_prompt,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_figure_yaml(tmp_path: Path, figure_id: str, display_name: str, description: str) -> Path:
+    """Write a minimal figure YAML file and return its parent directory (figures_dir)."""
+    figures_dir = tmp_path / "figures"
+    figures_dir.mkdir(parents=True)
+    yaml_content = (
+        f"id: {figure_id}\n"
+        f'display_name: "{display_name}"\n'
+        f"description: |\n"
+        + "".join(f"  {line}\n" for line in description.splitlines())
+    )
+    (figures_dir / f"{figure_id}.yaml").write_text(yaml_content, encoding="utf-8")
+    return figures_dir
+
+
+def _patch_figures_dir(monkeypatch: pytest.MonkeyPatch, figures_dir: Path) -> None:
+    """Patch settings.repo_dir so _load_figure_identity resolves to tmp figures."""
+    repo_root = figures_dir.parent.parent.parent  # figures_dir = <repo>/scripts/gen_prompts/cognitive_archetypes/figures
+    fake_settings = MagicMock()
+    fake_settings.repo_dir = figures_dir.parent.parent.parent
+    monkeypatch.setattr(
+        "agentception.services.prompt_assembly.settings",
+        fake_settings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _format_persona
+# ---------------------------------------------------------------------------
+
+
+def test_format_persona_with_description() -> None:
+    """_format_persona includes name and description when description is non-empty."""
+    result = _format_persona("Guido van Rossum", "Creator of Python.")
+    assert result == "You are Guido van Rossum. Your cognitive architecture: Creator of Python."
+
+
+def test_format_persona_without_description() -> None:
+    """_format_persona returns 'You are {name}.' when description is empty."""
+    result = _format_persona("Guido van Rossum", "")
+    assert result == "You are Guido van Rossum."
+
+
+# ---------------------------------------------------------------------------
+# _build_persona_block — None / empty cognitive_arch
+# ---------------------------------------------------------------------------
+
+
+def test_build_persona_block_none_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """_build_persona_block returns '' and logs a warning when cognitive_arch is None."""
+    with caplog.at_level(logging.WARNING, logger="agentception.services.prompt_assembly"):
+        result = _build_persona_block(None, "leaf")
+    assert result == ""
+    assert any("cognitive_arch is absent" in r.message for r in caplog.records)
+
+
+def test_build_persona_block_empty_str_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """_build_persona_block returns '' and logs a warning when cognitive_arch is ''."""
+    with caplog.at_level(logging.WARNING, logger="agentception.services.prompt_assembly"):
+        result = _build_persona_block("", "coordinator")
+    assert result == ""
+    assert any("cognitive_arch is absent" in r.message for r in caplog.records)
+
+
+def test_build_persona_block_missing_yaml_logs_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """_build_persona_block logs a warning when figure YAML does not exist."""
+    fake_settings = MagicMock()
+    fake_settings.repo_dir = tmp_path
+    with (
+        patch("agentception.services.prompt_assembly.settings", fake_settings),
+        caplog.at_level(logging.WARNING, logger="agentception.services.prompt_assembly"),
+    ):
+        result = _build_persona_block("nonexistent_figure:python", "leaf")
+    # Falls back to bare figure_id without raising
+    assert "nonexistent_figure" in result
+    assert any("figure YAML not found" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _build_persona_block — valid figure
+# ---------------------------------------------------------------------------
+
+
+def test_build_persona_block_known_figure(tmp_path: Path) -> None:
+    """_build_persona_block returns a persona block containing display_name."""
+    figures_dir = _make_figure_yaml(
+        tmp_path,
+        figure_id="test_figure",
+        display_name="Test Figure",
+        description="A test figure for unit testing.",
+    )
+    # Restructure tmp_path so settings.repo_dir resolves correctly:
+    # settings.repo_dir / scripts / gen_prompts / cognitive_archetypes / figures / test_figure.yaml
+    scripts_dir = tmp_path / "scripts" / "gen_prompts" / "cognitive_archetypes" / "figures"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / "test_figure.yaml").write_text(
+        'id: test_figure\ndisplay_name: "Test Figure"\ndescription: "A test figure for unit testing."\n',
+        encoding="utf-8",
+    )
+    fake_settings = MagicMock()
+    fake_settings.repo_dir = tmp_path
+
+    with patch("agentception.services.prompt_assembly.settings", fake_settings):
+        result = _build_persona_block("test_figure:python", "leaf")
+
+    assert "Test Figure" in result
+    assert result.startswith("You are Test Figure.")
+
+
+# ---------------------------------------------------------------------------
+# build_system_prompt — coordinator
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_prompt_includes_arch_block(tmp_path: Path) -> None:
+    """build_system_prompt for a coordinator contains the persona block before role instructions."""
+    scripts_dir = tmp_path / "scripts" / "gen_prompts" / "cognitive_archetypes" / "figures"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / "von_neumann.yaml").write_text(
+        'id: von_neumann\ndisplay_name: "John von Neumann"\ndescription: "Mathematician and architect of the stored-program computer."\n',
+        encoding="utf-8",
+    )
+    fake_settings = MagicMock()
+    fake_settings.repo_dir = tmp_path
+
+    role_instructions = "Survey the label scope. Spawn child agents for each unclaimed issue."
+
+    with patch("agentception.services.prompt_assembly.settings", fake_settings):
+        prompt = build_system_prompt(
+            "von_neumann:python",
+            role_instructions,
+            agent_type="coordinator",
+        )
+
+    # Persona block must appear before role instructions
+    persona_pos = prompt.index("John von Neumann")
+    role_pos = prompt.index("Survey the label scope")
+    assert persona_pos < role_pos, "Persona block must appear before role instructions"
+
+    # Persona block contains name and mental-model description
+    assert "You are John von Neumann." in prompt
+    assert "Mathematician" in prompt
+
+
+# ---------------------------------------------------------------------------
+# build_system_prompt — leaf
+# ---------------------------------------------------------------------------
+
+
+def test_leaf_prompt_includes_arch_block(tmp_path: Path) -> None:
+    """build_system_prompt for a leaf agent contains the persona block before role instructions."""
+    scripts_dir = tmp_path / "scripts" / "gen_prompts" / "cognitive_archetypes" / "figures"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / "guido_van_rossum.yaml").write_text(
+        'id: guido_van_rossum\ndisplay_name: "Guido van Rossum"\ndescription: "Creator of Python."\n',
+        encoding="utf-8",
+    )
+    fake_settings = MagicMock()
+    fake_settings.repo_dir = tmp_path
+
+    role_instructions = "Implement the GitHub issue. Create a PR. Run tests."
+
+    with patch("agentception.services.prompt_assembly.settings", fake_settings):
+        prompt = build_system_prompt(
+            "guido_van_rossum:python",
+            role_instructions,
+            agent_type="leaf",
+        )
+
+    # Persona block must appear before role instructions
+    persona_pos = prompt.index("Guido van Rossum")
+    role_pos = prompt.index("Implement the GitHub issue")
+    assert persona_pos < role_pos, "Persona block must appear before role instructions"
+
+    # Persona block contains name and mental-model description
+    assert "You are Guido van Rossum." in prompt
+    assert "Creator of Python" in prompt
+
+
+# ---------------------------------------------------------------------------
+# build_system_prompt — missing arch logs warning
+# ---------------------------------------------------------------------------
+
+
+def test_missing_arch_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """build_system_prompt emits a WARNING when cognitive_arch is None."""
+    with caplog.at_level(logging.WARNING, logger="agentception.services.prompt_assembly"):
+        prompt = build_system_prompt(
+            None,
+            "Do the work.",
+            agent_type="leaf",
+        )
+    # Warning must be logged
+    assert any("cognitive_arch is absent" in r.message for r in caplog.records)
+    # Prompt still contains role instructions even without persona block
+    assert "Do the work." in prompt
+
+
+def test_missing_arch_empty_string_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """build_system_prompt emits a WARNING when cognitive_arch is an empty string."""
+    with caplog.at_level(logging.WARNING, logger="agentception.services.prompt_assembly"):
+        prompt = build_system_prompt(
+            "",
+            "Coordinate the wave.",
+            agent_type="coordinator",
+        )
+    assert any("cognitive_arch is absent" in r.message for r in caplog.records)
+    assert "Coordinate the wave." in prompt
+
+
+# ---------------------------------------------------------------------------
+# build_system_prompt — ordering invariant
+# ---------------------------------------------------------------------------
+
+
+def test_persona_block_always_first(tmp_path: Path) -> None:
+    """build_system_prompt always places persona block at position 0 in the output."""
+    scripts_dir = tmp_path / "scripts" / "gen_prompts" / "cognitive_archetypes" / "figures"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / "turing.yaml").write_text(
+        'id: turing\ndisplay_name: "Alan Turing"\ndescription: "Pioneer of theoretical computer science."\n',
+        encoding="utf-8",
+    )
+    fake_settings = MagicMock()
+    fake_settings.repo_dir = tmp_path
+
+    with patch("agentception.services.prompt_assembly.settings", fake_settings):
+        prompt = build_system_prompt("turing:python", "Role instructions here.", agent_type="leaf")
+
+    assert prompt.startswith("You are Alan Turing.")
+
+
+# ---------------------------------------------------------------------------
+# build_system_prompt — role instructions always present
+# ---------------------------------------------------------------------------
+
+
+def test_role_instructions_always_present_even_without_arch() -> None:
+    """build_system_prompt always includes role_instructions even without arch."""
+    prompt = build_system_prompt(None, "Always include this.", agent_type="leaf")
+    assert "Always include this." in prompt

--- a/scripts/gen_prompts/templates/parallel-bugs-to-issues.md.j2
+++ b/scripts/gen_prompts/templates/parallel-bugs-to-issues.md.j2
@@ -454,11 +454,52 @@ STEP 0 — READ YOUR TASK FILE:
     FILE_OWNERSHIP          — files this phase owns (awareness, not action)
     SPAWN_SUB_AGENTS        — if true, follow sub-coordinator path
 
-STEP 0.5 — LOAD YOUR ROLE:
+STEP 0.5 — LOAD YOUR ROLE AND COGNITIVE ARCHITECTURE:
   ROLE=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['role'])")
   REPO=$(git worktree list | head -1 | awk '{print $1}')
   ROLE_FILE="$REPO/.agentception/roles/${ROLE}.md"
   [ -f "$ROLE_FILE" ] && cat "$ROLE_FILE" && echo "✅ Operating as: $ROLE"
+
+  # Load cognitive architecture — assembles figure persona + all skill domain fragments
+  # Format: "figure:skill1:skill2" (colon-separated)
+  COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent'].get('cognitive_arch',''))")
+  if [ -n "$COGNITIVE_ARCH" ]; then
+    echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
+    echo ""
+    # resolve_arch.py assembles the full context block from the COGNITIVE_ARCH string.
+    # Output is ready-to-read Markdown — no manual YAML parsing needed.
+    RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+    if [ -f "$RESOLVE_ARCH" ]; then
+      ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode implementer 2>/dev/null)
+      if [ -n "$ARCH_CONTEXT" ]; then
+        echo "$ARCH_CONTEXT"
+      fi
+    else
+      echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+    fi
+    echo ""
+    echo "Let these govern your approach to this task."
+  else
+    echo "⚠️  No COGNITIVE_ARCH set — using default coordinator approach."
+  fi
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE ANY OTHER ACTION:
+  Immediately send the following as your **first text response** to the user
+  (not a shell command, not a tool call, not chain-of-thought — actual visible
+  output text in your reply message):
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** [value of $ROLE]
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
+
+  Do not proceed to STEP 1 until this response has been sent.
 
   Export for all subsequent commands:
     export GH_REPO=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['repo']['gh_repo'])")

--- a/scripts/gen_prompts/templates/parallel-conductor.md.j2
+++ b/scripts/gen_prompts/templates/parallel-conductor.md.j2
@@ -148,7 +148,7 @@ Read .agentception/agent-command-policy.md before issuing any shell commands.
 Green-tier commands run without confirmation. Yellow = check scope first.
 Red = never, ask the user instead.
 
-STEP 0 — READ YOUR TASK FILE:
+STEP 0 — READ YOUR TASK FILE AND COGNITIVE ARCHITECTURE:
   cat .agent-task
 
   Parse all KEY=value fields:
@@ -163,6 +163,42 @@ STEP 0 — READ YOUR TASK FILE:
     export GH_REPO=${GH_REPO:-{{ gh_repo }}}
     PHASE_FILTER=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('task',{}).get('phase_filter',''))")
     ATTEMPT_N=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['task']['attempt_n'])")
+    REPO=$(git worktree list | head -1 | awk '{print $1}')
+
+  # Load cognitive architecture — assembles figure persona + all skill domain fragments
+  # Format: "figure:skill1:skill2" (colon-separated)
+  COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent'].get('cognitive_arch',''))")
+  if [ -n "$COGNITIVE_ARCH" ]; then
+    echo "🧠 Cognitive architecture: $COGNITIVE_ARCH"
+    echo ""
+    RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
+    if [ -f "$RESOLVE_ARCH" ]; then
+      ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode implementer 2>/dev/null)
+      if [ -n "$ARCH_CONTEXT" ]; then
+        echo "$ARCH_CONTEXT"
+      fi
+    else
+      echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+    fi
+    echo ""
+    echo "Let these govern your approach to this task."
+  else
+    echo "⚠️  No COGNITIVE_ARCH set — using default coordinator approach."
+  fi
+
+  ⚠️  MANDATORY FIRST RESPONSE — DO THIS NOW, BEFORE STEP 1:
+  Send the following as your **first text response** to the user:
+
+  ---
+  🧠 **Cognitive architecture correctly injected.**
+
+  **My name is:** [extract the figure display name from the first
+    "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
+  **My role:** conductor
+  **My cognitive architecture string:** [value of $COGNITIVE_ARCH]
+
+  [Paste the full content of $ARCH_CONTEXT here verbatim]
+  ---
 
   ⚠️  ANTI-LOOP GUARD: if ATTEMPT_N > 3 → STOP.
     This conductor has run 4+ times without advancing the pipeline.


### PR DESCRIPTION
## Summary

- Add `agentception/services/prompt_assembly.py` with `build_system_prompt()` — the single source of truth for assembling an agent's system prompt with the cognitive architecture persona block prepended before role instructions.
- Update `parallel-bugs-to-issues.md.j2` (coordinator template) and `parallel-conductor.md.j2` (conductor template) to read `COGNITIVE_ARCH` from `.agent-task` and call `resolve_arch.py` in STEP 0.5 — same injection pattern already used by the leaf (`parallel-issue-to-pr.md.j2`) and reviewer templates.
- Add 12 unit tests in `agentception/tests/test_prompt_assembly.py` covering coordinator prompt, leaf prompt, missing arch warning, and ordering invariant.
- Regenerate `.agentception/parallel-bugs-to-issues.md` and `.agentception/parallel-conductor.md` from updated templates (no drift).

## Acceptance criteria satisfied

- [x] The system prompt for a sub-coordinator contains the persona name and mental model description from `cognitive_architecture`.
- [x] The system prompt for a leaf agent contains the persona name and mental model description from `cognitive_architecture`.
- [x] If `cognitive_architecture` is absent or `None`, a warning is logged (not a silent skip).
- [x] The persona block appears before role-specific instructions in the assembled prompt string.
- [x] Existing root-coordinator prompt assembly is not regressed.

## Test plan

- [x] `mypy agentception/ tests/` — zero errors
- [x] `typing_audit.py --max-any 0` — passes
- [x] `pytest agentception/tests/ -v` — 939 passed
- [x] `generate.py --check` — no drift

Closes #175