### PR TITLE
feat(state-machine): formalize run lifecycle — rename done/unknown/stale

### DIFF
--- a/agentception/alembic/versions/0003_run_state_machine.py
+++ b/agentception/alembic/versions/0003_run_state_machine.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Formalise run state machine — rename status values.
+
+Backfills legacy status strings to the new canonical values:
+
+- ``done``    → ``completed``  (clean exit with PR)
+- ``unknown`` → ``failed``     (unclean exit or TTL expiry)
+- ``stale``   → ``implementing`` (stale is now computed on-demand from
+                                   last_activity_at, not stored)
+
+New valid status values introduced by this migration:
+- ``blocked``   — agent explicitly blocked (build_block_run MCP)
+- ``stopped``   — operator stopped the run (build_stop_run MCP)
+- ``failed``    — was ``unknown``; unclean exit or abandoned run
+- ``completed`` — was ``done``; clean exit with PR
+
+Values that are unchanged (already exist and remain valid):
+- ``pending_launch``
+- ``implementing``
+- ``reviewing``
+- ``cancelled``
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-03-06
+"""
+
+from alembic import op
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE agent_runs SET status = 'completed'    WHERE status = 'done'")
+    op.execute("UPDATE agent_runs SET status = 'failed'       WHERE status = 'unknown'")
+    op.execute("UPDATE agent_runs SET status = 'implementing' WHERE status = 'stale'")
+
+
+def downgrade() -> None:
+    op.execute("UPDATE agent_runs SET status = 'done'    WHERE status = 'completed'")
+    op.execute("UPDATE agent_runs SET status = 'unknown' WHERE status = 'failed'")
+    # 'blocked' and 'stopped' have no prior equivalent — map to 'unknown' on downgrade
+    op.execute("UPDATE agent_runs SET status = 'unknown' WHERE status IN ('blocked', 'stopped')")

--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -829,14 +829,15 @@ async def _upsert_agent_runs(
                 existing.cognitive_arch = agent.cognitive_arch
 
     # Orphan sweep: any run that was active in a previous tick but is no
-    # longer backed by a live worktree gets flipped to "unknown".  This
-    # prevents phantom "implementing" rows from persisting in the Run
-    # History after a worktree is removed without a clean shutdown.
+    # longer backed by a live worktree gets flipped to "completed" (PR exists)
+    # or "failed" (no PR).  This prevents phantom "implementing" rows from
+    # persisting in the Run History after a worktree is removed without a
+    # clean shutdown.
     #
     # Exception: runs that have already opened a PR are not orphaned.  Their
     # lifecycle is now driven by the PR state (GitHub), not by a live worktree.
     # They stay "reviewing" until the PR merges and the issue closes, at which
-    # point the issue moves to the "done" bucket naturally.
+    # point the issue moves to the "completed" bucket naturally.
     orphan_result = await session.execute(
         select(ACAgentRun).where(
             ACAgentRun.status.in_(_ACTIVE_STATUSES),
@@ -850,9 +851,9 @@ async def _upsert_agent_runs(
                 # pr_number except "reviewing"), which is correct: the PR is
                 # open awaiting human or reviewer-agent action, not being
                 # actively reviewed yet.
-                orphan.status = "done"
+                orphan.status = "completed"
             else:
-                orphan.status = "unknown"
+                orphan.status = "failed"
             orphan.last_activity_at = now
             logger.debug(
                 "🧹 Orphan run %s → %s (pr_number=%s)",
@@ -863,7 +864,7 @@ async def _upsert_agent_runs(
 
     # Pending-launch TTL sweep: a pending_launch run that was never acknowledged
     # within 15 minutes is presumed abandoned (Dispatcher aborted before claiming
-    # it).  Mark it unknown so it doesn't permanently lock the issue in "active".
+    # it).  Mark it failed so it doesn't permanently lock the issue in "active".
     _PENDING_LAUNCH_TTL = datetime.timedelta(minutes=15)
     ttl_cutoff = now - _PENDING_LAUNCH_TTL
     pending_result = await session.execute(
@@ -873,10 +874,10 @@ async def _upsert_agent_runs(
         )
     )
     for stale_pending in pending_result.scalars().all():
-        stale_pending.status = "unknown"
+        stale_pending.status = "failed"
         stale_pending.last_activity_at = now
         logger.debug(
-            "🧹 Pending-launch TTL expired: %s → unknown (spawned_at=%s)",
+            "🧹 Pending-launch TTL expired: %s → failed (spawned_at=%s)",
             stale_pending.id,
             stale_pending.spawned_at,
         )
@@ -1104,11 +1105,162 @@ async def acknowledge_agent_run(run_id: str) -> bool:
         return False
 
 
-from agentception.workflow.status import RESET_STATUSES as _RESET_STATUSES  # noqa: E402
+from agentception.workflow.status import (  # noqa: E402
+    ACTIVE_STATUSES as _ACTIVE_STATUSES_SM,
+    RESET_STATUSES as _RESET_STATUSES,
+    RESUMABLE_STATUSES as _RESUMABLE_STATUSES,
+)
+
+# ---------------------------------------------------------------------------
+# Explicit state-transition persist functions (called by MCP build commands)
+# ---------------------------------------------------------------------------
 
 
-async def reset_build_runs_to_unknown() -> int:
-    """Set all agent runs in active states to ``unknown``.
+async def complete_agent_run(run_id: str) -> bool:
+    """Transition an ``implementing`` run to ``completed``.
+
+    Called by ``build_complete_run`` MCP tool after the agent has opened a PR
+    and all work is done.  Only succeeds from ``implementing`` state.
+
+    Returns ``True`` on success, ``False`` if the run was not found or was not
+    in a valid source state.
+    """
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun).where(ACAgentRun.id == run_id)
+            )
+            run = result.scalar_one_or_none()
+            if run is None or run.status != "implementing":
+                return False
+            run.status = "completed"
+            run.last_activity_at = _now()
+            run.completed_at = _now()
+            await session.commit()
+        logger.info("✅ complete_agent_run: %s → completed", run_id)
+        return True
+    except Exception as exc:
+        logger.warning("⚠️  complete_agent_run failed: %s", exc)
+        return False
+
+
+async def block_agent_run(run_id: str) -> bool:
+    """Transition an ``implementing`` run to ``blocked``.
+
+    Called by ``build_block_run`` MCP tool when an agent cannot proceed without
+    human intervention or a dependency resolving.  Only succeeds from
+    ``implementing`` state.
+
+    Returns ``True`` on success, ``False`` if the run was not found or not in
+    a valid source state.
+    """
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun).where(ACAgentRun.id == run_id)
+            )
+            run = result.scalar_one_or_none()
+            if run is None or run.status != "implementing":
+                return False
+            run.status = "blocked"
+            run.last_activity_at = _now()
+            await session.commit()
+        logger.info("✅ block_agent_run: %s → blocked", run_id)
+        return True
+    except Exception as exc:
+        logger.warning("⚠️  block_agent_run failed: %s", exc)
+        return False
+
+
+async def resume_agent_run(run_id: str, agent_run_id: str) -> bool:
+    """Transition a ``blocked`` or ``stopped`` run back to ``implementing``.
+
+    Called by ``build_resume_run`` MCP tool.  Idempotent: if the run is already
+    ``implementing`` and the caller's ``agent_run_id`` matches the run id, the
+    call succeeds (safe restart behaviour).
+
+    Returns ``True`` on success, ``False`` if the run was not found, not in a
+    resumable state, or the agent_run_id does not match.
+    """
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun).where(ACAgentRun.id == run_id)
+            )
+            run = result.scalar_one_or_none()
+            if run is None:
+                return False
+            # Idempotency: already implementing with same agent — allow restart
+            if run.status == "implementing" and run.id == agent_run_id:
+                return True
+            if run.status not in _RESUMABLE_STATUSES:
+                return False
+            run.status = "implementing"
+            run.last_activity_at = _now()
+            await session.commit()
+        logger.info("✅ resume_agent_run: %s → implementing", run_id)
+        return True
+    except Exception as exc:
+        logger.warning("⚠️  resume_agent_run failed: %s", exc)
+        return False
+
+
+async def cancel_agent_run(run_id: str) -> bool:
+    """Transition any active run to ``cancelled``.
+
+    Called by ``build_cancel_run`` MCP tool (or UI cancel button).  Valid from
+    any non-terminal state.
+
+    Returns ``True`` on success, ``False`` if run not found or already terminal.
+    """
+    from agentception.workflow.status import TERMINAL_STATUSES as _TERMINAL  # noqa: PLC0415
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun).where(ACAgentRun.id == run_id)
+            )
+            run = result.scalar_one_or_none()
+            if run is None or run.status in _TERMINAL:
+                return False
+            run.status = "cancelled"
+            run.last_activity_at = _now()
+            await session.commit()
+        logger.info("✅ cancel_agent_run: %s → cancelled", run_id)
+        return True
+    except Exception as exc:
+        logger.warning("⚠️  cancel_agent_run failed: %s", exc)
+        return False
+
+
+async def stop_agent_run(run_id: str) -> bool:
+    """Transition any active run to ``stopped``.
+
+    Called by ``build_stop_run`` MCP tool (or the UI stop button).  Unlike
+    ``cancel_agent_run``, a stopped run can be resumed via ``build_resume_run``.
+
+    Returns ``True`` on success, ``False`` if run not found or already terminal.
+    """
+    from agentception.workflow.status import TERMINAL_STATUSES as _TERMINAL  # noqa: PLC0415
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun).where(ACAgentRun.id == run_id)
+            )
+            run = result.scalar_one_or_none()
+            if run is None or run.status in _TERMINAL:
+                return False
+            run.status = "stopped"
+            run.last_activity_at = _now()
+            await session.commit()
+        logger.info("✅ stop_agent_run: %s → stopped", run_id)
+        return True
+    except Exception as exc:
+        logger.warning("⚠️  stop_agent_run failed: %s", exc)
+        return False
+
+
+async def reset_build_runs_to_failed() -> int:
+    """Set all agent runs in active states to ``failed``.
 
     Used by the full reset-build flow so the launch queue is empty and no
     run appears as in progress.  Returns the number of runs updated.
@@ -1121,14 +1273,14 @@ async def reset_build_runs_to_unknown() -> int:
             )
             rows = result.scalars().all()
             for run in rows:
-                run.status = "unknown"
+                run.status = "failed"
                 run.last_activity_at = now
             await session.commit()
             count = len(rows)
-        logger.info("✅ reset_build_runs_to_unknown: %d run(s) set to unknown", count)
+        logger.info("✅ reset_build_runs_to_failed: %d run(s) set to failed", count)
         return count
     except Exception as exc:
-        logger.warning("⚠️  reset_build_runs_to_unknown failed: %s", exc)
+        logger.warning("⚠️  reset_build_runs_to_failed failed: %s", exc)
         return 0
 
 

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -2428,7 +2428,7 @@ async def get_terminal_runs_with_worktrees() -> list[TerminalRunRow]:
         async with get_session() as session:
             result = await session.execute(
                 select(ACAgentRun.id, ACAgentRun.worktree_path, ACAgentRun.branch).where(
-                    ACAgentRun.status.in_(["done", "stale"]),
+                    ACAgentRun.status.in_(["completed", "failed", "cancelled", "stopped"]),
                     ACAgentRun.worktree_path.isnot(None),
                 )
             )

--- a/agentception/models/__init__.py
+++ b/agentception/models/__init__.py
@@ -65,13 +65,19 @@ VALID_ROLES: frozenset[str] = _load_valid_roles()
 
 
 class AgentStatus(str, Enum):
-    """Lifecycle state of a single pipeline agent, derived from filesystem + GitHub signals."""
+    """Lifecycle state of a single pipeline agent, derived from filesystem + GitHub signals.
 
+    Mirror of :class:`agentception.workflow.status.AgentStatus` — kept in sync.
+    """
+
+    PENDING_LAUNCH = "pending_launch"
     IMPLEMENTING = "implementing"
+    BLOCKED = "blocked"
     REVIEWING = "reviewing"
-    DONE = "done"
-    STALE = "stale"
-    UNKNOWN = "unknown"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    STOPPED = "stopped"
+    FAILED = "failed"
 
 
 class AgentNode(BaseModel):

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -169,7 +169,7 @@ async def merge_agents(
             # show as active rather than confusingly UNKNOWN.
             status = AgentStatus.IMPLEMENTING
         else:
-            status = AgentStatus.UNKNOWN
+            status = AgentStatus.FAILED
 
         # Agent ID is the worktree basename (e.g. "issue-732"). This is the
         # canonical identifier used in URLs, DB PKs, and API responses.

--- a/agentception/readers/transcripts.py
+++ b/agentception/readers/transcripts.py
@@ -151,14 +151,15 @@ def infer_status_from_messages(messages: list[dict[str, str]]) -> AgentStatus:
 
     Heuristic: if the most-recent assistant message contains a GitHub pull-request
     URL (``github.com/<owner>/<repo>/pull/<n>``), the agent successfully opened
-    a PR and is considered ``DONE``. Any other ending state maps to ``UNKNOWN``.
+    a PR and is considered ``COMPLETED``. Any other ending state maps to
+    ``FAILED``.
     """
     for msg in reversed(messages):
         if msg.get("role") == "assistant":
             if _PR_URL_RE.search(msg.get("text", "")):
-                return AgentStatus.DONE
+                return AgentStatus.COMPLETED
             break
-    return AgentStatus.UNKNOWN
+    return AgentStatus.FAILED
 
 
 def extract_pr_urls(messages: list[dict[str, str]]) -> list[str]:

--- a/agentception/routes/api/control.py
+++ b/agentception/routes/api/control.py
@@ -455,7 +455,7 @@ async def reset_build() -> ResetBuildResult:
     and no pending_launch/implementing/reviewing runs in the DB.  The main
     worktree is never removed.  Idempotent when already clean.
     """
-    from agentception.db.persist import reset_build_runs_to_unknown
+    from agentception.db.persist import reset_build_runs_to_failed
     from agentception.readers.git import list_git_worktrees
     from agentception.readers.github import clear_wip_label, get_wip_issues
 
@@ -516,7 +516,7 @@ async def reset_build() -> ResetBuildResult:
         errors.append(f"get_wip_issues: {exc}")
 
     # ── 3. Set all active runs to unknown ───────────────────────────────────
-    runs_reset = await reset_build_runs_to_unknown()
+    runs_reset = await reset_build_runs_to_failed()
 
     logger.info(
         "✅ reset-build complete: worktrees=%d wip_cleared=%d runs_reset=%d errors=%d",

--- a/agentception/routes/ui/agents.py
+++ b/agentception/routes/ui/agents.py
@@ -165,7 +165,7 @@ async def agents_list(request: Request) -> HTMLResponse:
         if spawned and completed and completed > spawned:
             duration_s = (completed - spawned).total_seconds()
             duration_str = _fmt_duration(duration_s)
-            if run.get("status") == "done":
+            if run.get("status") == "completed":
                 total_duration_s += duration_s
                 completed_count += 1
 
@@ -216,13 +216,13 @@ async def agents_list(request: Request) -> HTMLResponse:
     for batch in batches:
         b_runs = batch["runs"]
         b_total = len(b_runs)
-        b_done = sum(1 for r in b_runs if r.get("status") == "done")
+        b_done = sum(1 for r in b_runs if r.get("status") == "completed")
         batch["success_rate"] = round(b_done / b_total * 100) if b_total else 0
 
     # ── Aggregate KPI stats ───────────────────────────────────────────────
     total = len(enriched_history)
-    done_count = sum(1 for r in enriched_history if r.get("status") == "done")
-    failed_count = sum(1 for r in enriched_history if r.get("status") in ("stale", "unknown"))
+    done_count = sum(1 for r in enriched_history if r.get("status") == "completed")
+    failed_count = sum(1 for r in enriched_history if r.get("status") in ("stale", "failed"))
     success_rate = round(done_count / total * 100) if total else 0
     avg_duration_str = _fmt_duration(total_duration_s / completed_count) if completed_count else "—"
 
@@ -339,7 +339,7 @@ async def controls_hub(request: Request) -> HTMLResponse:
         history = await get_agent_run_history(limit=50)
         kill_history = [
             r for r in history
-            if r.get("status") in ("done", "stale", "unknown")
+            if r.get("status") in ("completed", "stale", "failed", "cancelled", "stopped")
         ][:10]
     except Exception as exc:
         logger.debug("DB kill history fetch skipped: %s", exc)
@@ -489,11 +489,11 @@ async def agent_transcript_partial(request: Request, agent_id: str) -> Response:
             db_run = await get_agent_run_detail(agent_id)
             if db_run:
                 db_messages = db_run.get("messages", [])
-                raw_status = str(db_run.get("status", "unknown")).lower()
+                raw_status = str(db_run.get("status", "failed")).lower()
                 try:
                     synth_status = _AgentStatus(raw_status)
                 except ValueError:
-                    synth_status = _AgentStatus.UNKNOWN
+                    synth_status = _AgentStatus.FAILED
                 node = AgentNode(
                     id=str(db_run.get("id", agent_id)),
                     role=str(db_run.get("role", "unknown")),
@@ -578,16 +578,17 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
     # Synthesise AgentNode from DB when the live poller no longer holds it.
     if node is None and db_run is not None:
         from agentception.models import AgentStatus as _AgentStatus
-        raw_status = str(db_run.get("status", "unknown")).lower()
+        raw_status = str(db_run.get("status", "failed")).lower()
         # If the agent is not live in the poller it cannot still be running.
-        # "unknown" means the run ended without a clean done report — treat it
-        # as done so the UI doesn't surface a misleading status badge.
+        # Map any legacy "unknown" value to "failed" for backward compatibility.
         if raw_status == "unknown":
-            raw_status = "done"
+            raw_status = "failed"
+        elif raw_status == "done":
+            raw_status = "completed"
         try:
             synth_status = _AgentStatus(raw_status)
         except ValueError:
-            synth_status = _AgentStatus.UNKNOWN
+            synth_status = _AgentStatus.FAILED
         node = AgentNode(
             id=str(db_run.get("id", agent_id)),
             role=str(db_run.get("role", "unknown")),

--- a/agentception/telemetry.py
+++ b/agentception/telemetry.py
@@ -106,7 +106,7 @@ async def aggregate_waves() -> list[WaveSummary]:
                 AgentNode(
                     id=a["id"],
                     role=a["role"],
-                    status=AgentStatus(a["status"]) if a["status"] in AgentStatus._value2member_map_ else AgentStatus.UNKNOWN,
+                    status=AgentStatus(a["status"]) if a["status"] in AgentStatus._value2member_map_ else AgentStatus.FAILED,
                     issue_number=a["issue_number"],
                     pr_number=a["pr_number"],
                     branch=a["branch"],
@@ -290,7 +290,7 @@ def _task_file_to_agent_node(tf: TaskFile) -> AgentNode:
     return AgentNode(
         id=agent_id,
         role=tf.role or "unknown",
-        status=AgentStatus.IMPLEMENTING if is_active else AgentStatus.DONE,
+        status=AgentStatus.IMPLEMENTING if is_active else AgentStatus.COMPLETED,
         issue_number=tf.issue_number,
         pr_number=tf.pr_number,
         branch=tf.branch,

--- a/agentception/tests/test_agentception_ab_results.py
+++ b/agentception/tests/test_agentception_ab_results.py
@@ -57,7 +57,7 @@ def _make_wave(batch_id: str, issues: list[int], prs_opened: int = 1) -> WaveSum
             AgentNode(
                 id=f"agent-{issues[0]}",
                 role="python-developer",
-                status=AgentStatus.DONE,
+                status=AgentStatus.COMPLETED,
                 issue_number=issues[0],
                 batch_id=batch_id,
             )

--- a/agentception/tests/test_agentception_poller.py
+++ b/agentception/tests/test_agentception_poller.py
@@ -361,7 +361,7 @@ async def test_merge_agents_unknown_status() -> None:
     agents = await merge_agents([wt], _empty_board())
 
     assert len(agents) == 1
-    assert agents[0].status == AgentStatus.UNKNOWN
+    assert agents[0].status == AgentStatus.FAILED
 
 
 @pytest.mark.anyio

--- a/agentception/tests/test_agentception_transcripts.py
+++ b/agentception/tests/test_agentception_transcripts.py
@@ -198,7 +198,7 @@ def test_infer_status_done_when_last_assistant_has_pr_url() -> None:
             "text": "Yes! https://github.com/cgcardona/agentception/pull/42",
         },
     ]
-    assert infer_status_from_messages(messages) == AgentStatus.DONE
+    assert infer_status_from_messages(messages) == AgentStatus.COMPLETED
 
 
 def test_infer_status_unknown_without_pr_url() -> None:
@@ -207,12 +207,12 @@ def test_infer_status_unknown_without_pr_url() -> None:
         {"role": "user", "text": "Status?"},
         {"role": "assistant", "text": "Still implementing."},
     ]
-    assert infer_status_from_messages(messages) == AgentStatus.UNKNOWN
+    assert infer_status_from_messages(messages) == AgentStatus.FAILED
 
 
 def test_infer_status_unknown_empty_messages() -> None:
     """Empty message list returns UNKNOWN without raising."""
-    assert infer_status_from_messages([]) == AgentStatus.UNKNOWN
+    assert infer_status_from_messages([]) == AgentStatus.FAILED
 
 
 def test_infer_status_uses_last_assistant_message() -> None:
@@ -225,7 +225,7 @@ def test_infer_status_uses_last_assistant_message() -> None:
         {"role": "user", "text": "That was reverted. Can you redo it?"},
         {"role": "assistant", "text": "Re-implementing now."},
     ]
-    assert infer_status_from_messages(messages) == AgentStatus.UNKNOWN
+    assert infer_status_from_messages(messages) == AgentStatus.FAILED
 
 
 # ── build_agent_tree ──────────────────────────────────────────────────────────
@@ -294,7 +294,7 @@ async def test_build_agent_tree_parent_child(tmp_path: Path) -> None:
     child = node.children[0]
     assert child.id == child_uuid
     assert child.role == "pr-reviewer"
-    assert child.status == AgentStatus.DONE
+    assert child.status == AgentStatus.COMPLETED
     assert child.message_count == 2
 
 
@@ -318,7 +318,7 @@ async def test_build_agent_tree_coordinator_no_own_jsonl(tmp_path: Path) -> None
     assert node.id == uuid
     # No own JSONL → role falls back to "unknown", status to UNKNOWN.
     assert node.role == "unknown"
-    assert node.status == AgentStatus.UNKNOWN
+    assert node.status == AgentStatus.FAILED
     assert node.message_count == 0
     assert node.transcript_path is None
     assert len(node.children) == 1

--- a/agentception/tests/test_agentception_ui_agent.py
+++ b/agentception/tests/test_agentception_ui_agent.py
@@ -143,7 +143,7 @@ def test_agent_detail_no_transcript_path(client: TestClient) -> None:
     node = AgentNode(
         id="no-transcript",
         role="unknown",
-        status=AgentStatus.UNKNOWN,
+        status=AgentStatus.FAILED,
         transcript_path=None,
         message_count=0,
     )
@@ -305,7 +305,7 @@ def test_transcript_api_empty_when_no_path(
     node = AgentNode(
         id="notranscript",
         role="unknown",
-        status=AgentStatus.UNKNOWN,
+        status=AgentStatus.FAILED,
         transcript_path=None,
         message_count=0,
     )

--- a/agentception/tests/test_agentception_ui_telemetry.py
+++ b/agentception/tests/test_agentception_ui_telemetry.py
@@ -44,7 +44,7 @@ def populated_waves() -> list[WaveSummary]:
     agent = AgentNode(
         id="issue-615",
         role="python-developer",
-        status=AgentStatus.DONE,
+        status=AgentStatus.COMPLETED,
         issue_number=615,
         batch_id="eng-batch-A",
     )

--- a/agentception/tests/test_persist_pending_launch_guard.py
+++ b/agentception/tests/test_persist_pending_launch_guard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 Bug: the poller called _upsert_agent_runs() whenever it found a worktree on
 the filesystem.  If that worktree belonged to a pending_launch run (Dispatcher
 not yet invoked), the upsert would overwrite the precious pending_launch status
-with whatever status the poller derived (typically "stale"), draining the
+with whatever status the poller derived (typically "implementing"), draining the
 Dispatcher queue before it was ever read.
 
 Fix: _upsert_agent_runs() now skips the status overwrite when existing.status
@@ -44,7 +44,7 @@ def _make_run(status: str = "pending_launch") -> ACAgentRun:
     return run
 
 
-def _make_agent(status: AgentStatus = AgentStatus.STALE) -> AgentNode:
+def _make_agent(status: AgentStatus = AgentStatus.IMPLEMENTING) -> AgentNode:
     """Return a minimal AgentNode as the poller would produce."""
     return AgentNode(
         id="label-developer-experience-layer-5492de",
@@ -115,7 +115,7 @@ async def test_pending_launch_status_not_overwritten_by_poller() -> None:
     """Poller must not clobber pending_launch when it finds the worktree."""
     existing = _make_run(status="pending_launch")
     session = _make_session(existing)
-    agent = _make_agent(status=AgentStatus.STALE)
+    agent = _make_agent(status=AgentStatus.IMPLEMENTING)
 
     await _persist._upsert_agent_runs(session, [agent])
 
@@ -129,12 +129,12 @@ async def test_implementing_status_is_updated_by_poller() -> None:
     """Non-pending_launch runs should still have their status updated normally."""
     existing = _make_run(status="implementing")
     session = _make_session(existing)
-    agent = _make_agent(status=AgentStatus.STALE)
+    agent = _make_agent(status=AgentStatus.IMPLEMENTING)
 
     await _persist._upsert_agent_runs(session, [agent])
 
-    assert existing.status == AgentStatus.STALE.value, (
-        "implementing → stale transition should proceed normally"
+    assert existing.status == AgentStatus.IMPLEMENTING.value, (
+        "implementing status should be updated by poller normally"
     )
 
 
@@ -236,14 +236,14 @@ async def test_orphan_with_pr_number_set_to_done() -> None:
 
     await _persist._upsert_agent_runs(session, [different_agent])
 
-    assert orphan.status == "done", (
-        "Orphan with open PR must be set to 'done' so the Kanban card lands in PR Open"
+    assert orphan.status == "completed", (
+        "Orphan with open PR must be set to 'completed' so the Kanban card lands in PR Open"
     )
 
 
 @pytest.mark.anyio
-async def test_orphan_without_pr_number_flipped_to_unknown() -> None:
-    """Worktrees removed with no open PR should still become unknown (normal cleanup)."""
+async def test_orphan_without_pr_number_flipped_to_failed() -> None:
+    """Worktrees removed with no open PR should become failed (normal cleanup)."""
     orphan = _make_run(status="implementing")
     orphan.pr_number = None
     orphan_result_mock = MagicMock()
@@ -264,8 +264,8 @@ async def test_orphan_without_pr_number_flipped_to_unknown() -> None:
 
     await _persist._upsert_agent_runs(session, [different_agent])
 
-    assert orphan.status == "unknown", (
-        "Orphan without PR should be flipped to unknown for cleanup"
+    assert orphan.status == "failed", (
+        "Orphan without PR should be flipped to failed for cleanup"
     )
 
 
@@ -275,8 +275,8 @@ async def test_orphan_without_pr_number_flipped_to_unknown() -> None:
 
 
 @pytest.mark.anyio
-async def test_pending_launch_ttl_expired_run_flipped_to_unknown() -> None:
-    """A pending_launch run older than 15 min with no live worktree becomes unknown.
+async def test_pending_launch_ttl_expired_run_flipped_to_failed() -> None:
+    """A pending_launch run older than 15 min with no live worktree becomes failed.
 
     Dispatcher that aborts before acknowledging would otherwise lock the issue
     in the 'active' swim lane forever with no worktree to back it.
@@ -302,8 +302,8 @@ async def test_pending_launch_ttl_expired_run_flipped_to_unknown() -> None:
     different_agent = AgentNode(id="different-run-id", role="cto", status=AgentStatus.IMPLEMENTING)
     await _persist._upsert_agent_runs(session, [different_agent])
 
-    assert stale_pending.status == "unknown", (
-        "Expired pending_launch must become unknown so the issue returns to todo lane"
+    assert stale_pending.status == "failed", (
+        "Expired pending_launch must become failed so the issue returns to todo lane"
     )
 
 
@@ -335,3 +335,185 @@ async def test_pending_launch_recent_run_not_expired() -> None:
     assert fresh_pending.status == "pending_launch", (
         "Fresh pending_launch must not be touched by the TTL sweep"
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for new state-transition persist functions (PR 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_complete_agent_run_transitions_implementing_to_completed() -> None:
+    """complete_agent_run: implementing → completed succeeds."""
+    import agentception.db.persist as _p
+
+    run = _make_run(status="implementing")
+
+    fake_session = MagicMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+    fake_session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=run))
+    )
+    fake_session.commit = AsyncMock()
+
+    with patch("agentception.db.persist.get_session", return_value=fake_session):
+        ok = await _p.complete_agent_run("test-run-id")
+
+    assert ok is True
+    assert run.status == "completed"
+
+
+@pytest.mark.anyio
+async def test_complete_agent_run_rejects_non_implementing_state() -> None:
+    """complete_agent_run: only succeeds from implementing state."""
+    import agentception.db.persist as _p
+
+    run = _make_run(status="blocked")
+
+    fake_session = MagicMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+    fake_session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=run))
+    )
+
+    with patch("agentception.db.persist.get_session", return_value=fake_session):
+        ok = await _p.complete_agent_run("test-run-id")
+
+    assert ok is False
+    assert run.status == "blocked"
+
+
+@pytest.mark.anyio
+async def test_block_agent_run_transitions_implementing_to_blocked() -> None:
+    """block_agent_run: implementing → blocked succeeds."""
+    import agentception.db.persist as _p
+
+    run = _make_run(status="implementing")
+
+    fake_session = MagicMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+    fake_session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=run))
+    )
+    fake_session.commit = AsyncMock()
+
+    with patch("agentception.db.persist.get_session", return_value=fake_session):
+        ok = await _p.block_agent_run("test-run-id")
+
+    assert ok is True
+    assert run.status == "blocked"
+
+
+@pytest.mark.anyio
+async def test_resume_agent_run_transitions_blocked_to_implementing() -> None:
+    """resume_agent_run: blocked → implementing succeeds."""
+    import agentception.db.persist as _p
+
+    run = _make_run(status="blocked")
+
+    fake_session = MagicMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+    fake_session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=run))
+    )
+    fake_session.commit = AsyncMock()
+
+    with patch("agentception.db.persist.get_session", return_value=fake_session):
+        ok = await _p.resume_agent_run("test-run-id", "some-agent-id")
+
+    assert ok is True
+    assert run.status == "implementing"
+
+
+@pytest.mark.anyio
+async def test_resume_agent_run_idempotent_if_already_implementing_same_id() -> None:
+    """resume_agent_run: already implementing with same run_id → ok (restart-safe)."""
+    import agentception.db.persist as _p
+
+    run = _make_run(status="implementing")
+    run.id = "label-developer-experience-layer-5492de"
+
+    fake_session = MagicMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+    fake_session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=run))
+    )
+
+    with patch("agentception.db.persist.get_session", return_value=fake_session):
+        ok = await _p.resume_agent_run(
+            "label-developer-experience-layer-5492de",
+            "label-developer-experience-layer-5492de",
+        )
+
+    assert ok is True
+    assert run.status == "implementing"
+
+
+@pytest.mark.anyio
+async def test_cancel_agent_run_transitions_implementing_to_cancelled() -> None:
+    """cancel_agent_run: implementing → cancelled succeeds."""
+    import agentception.db.persist as _p
+
+    run = _make_run(status="implementing")
+
+    fake_session = MagicMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+    fake_session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=run))
+    )
+    fake_session.commit = AsyncMock()
+
+    with patch("agentception.db.persist.get_session", return_value=fake_session):
+        ok = await _p.cancel_agent_run("test-run-id")
+
+    assert ok is True
+    assert run.status == "cancelled"
+
+
+@pytest.mark.anyio
+async def test_stop_agent_run_transitions_any_active_to_stopped() -> None:
+    """stop_agent_run: any active state → stopped."""
+    import agentception.db.persist as _p
+
+    run = _make_run(status="blocked")
+
+    fake_session = MagicMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+    fake_session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=run))
+    )
+    fake_session.commit = AsyncMock()
+
+    with patch("agentception.db.persist.get_session", return_value=fake_session):
+        ok = await _p.stop_agent_run("test-run-id")
+
+    assert ok is True
+    assert run.status == "stopped"
+
+
+@pytest.mark.anyio
+async def test_cancel_agent_run_rejects_terminal_state() -> None:
+    """cancel_agent_run: cannot cancel a completed run."""
+    import agentception.db.persist as _p
+
+    run = _make_run(status="completed")
+
+    fake_session = MagicMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+    fake_session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=run))
+    )
+
+    with patch("agentception.db.persist.get_session", return_value=fake_session):
+        ok = await _p.cancel_agent_run("test-run-id")
+
+    assert ok is False
+    assert run.status == "completed"

--- a/agentception/tests/test_workflow_state_machine.py
+++ b/agentception/tests/test_workflow_state_machine.py
@@ -181,7 +181,7 @@ class TestLaneComputation:
         """Acceptance criterion 5: PR merges → lane done."""
         result = compute_workflow_state(
             _issue(),
-            _run(status="done", agent_status="done"),
+            _run(status="completed", agent_status="completed"),
             _best_pr(pr_state="merged"),
         )
         assert result["lane"] == LANE_DONE
@@ -190,7 +190,7 @@ class TestLaneComputation:
         """Acceptance criterion 5: issue still open after merge → done + warning."""
         result = compute_workflow_state(
             _issue(state="open"),
-            _run(status="done", agent_status="done"),
+            _run(status="completed", agent_status="completed"),
             _best_pr(pr_state="merged"),
             pr_merged_recently=True,
         )
@@ -222,10 +222,10 @@ class TestLaneComputation:
         )
         assert result["lane"] == LANE_ACTIVE
 
-    def test_stale_run_is_active(self) -> None:
+    def test_blocked_run_is_active(self) -> None:
         result = compute_workflow_state(
             _issue(),
-            _run(agent_status="stale"),
+            _run(agent_status="blocked"),
             None,
         )
         assert result["lane"] == LANE_ACTIVE
@@ -234,19 +234,19 @@ class TestLaneComputation:
         result = compute_workflow_state(_issue(), None, None)
         assert result["lane"] == LANE_TODO
 
-    def test_unknown_run_no_pr_is_todo(self) -> None:
+    def test_failed_run_no_pr_is_todo(self) -> None:
         result = compute_workflow_state(
             _issue(),
-            _run(agent_status="unknown"),
+            _run(agent_status="failed"),
             None,
         )
         assert result["lane"] == LANE_TODO
 
-    def test_done_run_no_pr_is_todo(self) -> None:
-        """Run finished but no PR — goes back to todo (work might have failed)."""
+    def test_completed_run_no_pr_is_todo(self) -> None:
+        """Run completed but no PR — goes back to todo (work might have failed silently)."""
         result = compute_workflow_state(
             _issue(),
-            _run(agent_status="done"),
+            _run(agent_status="completed"),
             None,
         )
         assert result["lane"] == LANE_TODO
@@ -434,21 +434,23 @@ class TestAgentStatusEnum:
     def test_lane_active_includes_all_relevant(self) -> None:
         assert "implementing" in LANE_ACTIVE_STATUSES
         assert "pending_launch" in LANE_ACTIVE_STATUSES
-        assert "stale" in LANE_ACTIVE_STATUSES
+        assert "blocked" in LANE_ACTIVE_STATUSES
         assert "reviewing" in LANE_ACTIVE_STATUSES
 
     def test_reset_statuses(self) -> None:
-        assert RESET_STATUSES == {"pending_launch", "implementing", "reviewing"}
+        assert RESET_STATUSES == {"pending_launch", "implementing", "blocked", "reviewing"}
 
     def test_is_active(self) -> None:
         assert is_active("implementing")
+        assert is_active("blocked")
         assert not is_active("pending_launch")
-        assert not is_active("done")
+        assert not is_active("completed")
 
     def test_is_live(self) -> None:
         assert is_live("implementing")
         assert is_live("pending_launch")
-        assert not is_live("done")
+        assert is_live("blocked")
+        assert not is_live("completed")
 
 
 class TestComputeAgentStatus:
@@ -466,7 +468,7 @@ class TestComputeAgentStatus:
         assert compute_agent_status("implementing", old, now=now) == "stale"
 
     def test_unknown_status_normalised(self) -> None:
-        assert compute_agent_status("garbage_status", None) == "unknown"
+        assert compute_agent_status("garbage_status", None) == "failed"
 
 
 # ===========================================================================
@@ -586,20 +588,20 @@ class TestEndToEndLaneDerivation:
         """Acceptance criterion 5: merge → done even if issue still open."""
         result = compute_workflow_state(
             _issue(number=17, state="open"),
-            _run(status="done", agent_status="done"),
+            _run(status="completed", agent_status="completed"),
             _best_pr(pr_state="merged"),
             pr_merged_recently=True,
         )
         assert result["lane"] == LANE_DONE
         assert "issue_close_pending_propagation" in result["warnings"]
 
-    def test_multiple_runs_latest_unknown_older_has_pr(self) -> None:
-        """Acceptance criterion 6: latest run unknown, older run produced PR."""
+    def test_multiple_runs_latest_failed_older_has_pr(self) -> None:
+        """Acceptance criterion 6: latest run failed, older run produced PR."""
         # The state machine gets the best PR (from links), not from the run.
-        # Even if the latest run is unknown, if a PR link exists, lane is pr_open.
+        # Even if the latest run failed, if a PR link exists, lane is pr_open.
         result = compute_workflow_state(
             _issue(number=17),
-            _run(agent_status="unknown"),  # latest run is unknown
+            _run(agent_status="failed"),   # latest run failed
             _best_pr(pr_state="open"),     # but PR link exists from older run
         )
         assert result["lane"] == LANE_PR_OPEN

--- a/agentception/workflow/status.py
+++ b/agentception/workflow/status.py
@@ -4,13 +4,30 @@ from __future__ import annotations
 
 Every module that needs to reason about agent lifecycle status imports from
 here.  No other file may define its own ``_ACTIVE_STATUSES`` or equivalent.
+
+Run lifecycle state machine
+---------------------------
+::
+
+    pending_launch → implementing : build_claim_run
+    pending_launch → cancelled    : build_cancel_run
+    implementing   → blocked      : build_block_run
+    implementing   → completed    : build_complete_run
+    implementing   → cancelled    : build_cancel_run
+    implementing   → stopped      : build_stop_run
+    blocked        → implementing : build_resume_run
+    stopped        → implementing : build_resume_run
+    completed/cancelled/stopped/failed → terminal
+
+``stale`` is not stored in the DB.  It is computed on-demand from
+``last_activity_at`` and the :data:`STALE_THRESHOLD` constant.
 """
 
 import datetime
 import enum
 
 STALE_THRESHOLD = datetime.timedelta(seconds=1800)
-"""Runs with no activity for 30 minutes are considered stale."""
+"""Runs with no activity for 30 minutes are considered stale (computed, not stored)."""
 
 
 class AgentStatus(str, enum.Enum):
@@ -21,45 +38,61 @@ class AgentStatus(str, enum.Enum):
 
     PENDING_LAUNCH = "pending_launch"
     IMPLEMENTING = "implementing"
+    BLOCKED = "blocked"
     REVIEWING = "reviewing"
-    DONE = "done"
-    STALE = "stale"
-    UNKNOWN = "unknown"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    STOPPED = "stopped"
+    FAILED = "failed"
 
 
+#: States indicating a run has (or recently had) a live worktree.
+#: Used by the orphan sweep in ``persist.py``.  ``pending_launch`` is excluded
+#: because pending runs exist only in the DB queue — including them would
+#: immediately orphan them before the Dispatcher claims them.
 ACTIVE_STATUSES: frozenset[str] = frozenset({
     AgentStatus.IMPLEMENTING.value,
+    AgentStatus.BLOCKED.value,
     AgentStatus.REVIEWING.value,
-    AgentStatus.STALE.value,
 })
-"""Statuses indicating a run has (or recently had) a live worktree.
 
-Used by the orphan sweep in ``persist.py``.  ``pending_launch`` is excluded
-because pending runs exist only in the DB queue — including them would
-immediately orphan them before the Dispatcher claims them.
-"""
-
+#: States considered "live" for UI hierarchy and staleness checks.
 LIVE_STATUSES: frozenset[str] = frozenset({
     AgentStatus.IMPLEMENTING.value,
     AgentStatus.PENDING_LAUNCH.value,
+    AgentStatus.BLOCKED.value,
     AgentStatus.REVIEWING.value,
 })
-"""Statuses considered "live" for UI hierarchy and staleness checks."""
 
+#: States reset to ``failed`` during a full build reset.
 RESET_STATUSES: frozenset[str] = frozenset({
     AgentStatus.PENDING_LAUNCH.value,
     AgentStatus.IMPLEMENTING.value,
+    AgentStatus.BLOCKED.value,
     AgentStatus.REVIEWING.value,
 })
-"""Statuses reset to ``unknown`` during a full build reset."""
 
+#: States that place an issue card in the ``active`` swim lane (when no PR exists).
 LANE_ACTIVE_STATUSES: frozenset[str] = frozenset({
     AgentStatus.IMPLEMENTING.value,
     AgentStatus.PENDING_LAUNCH.value,
-    AgentStatus.STALE.value,
+    AgentStatus.BLOCKED.value,
     AgentStatus.REVIEWING.value,
 })
-"""Statuses that place an issue card in the ``active`` swim lane (when no PR exists)."""
+
+#: Terminal states — no further transitions are possible.
+TERMINAL_STATUSES: frozenset[str] = frozenset({
+    AgentStatus.COMPLETED.value,
+    AgentStatus.CANCELLED.value,
+    AgentStatus.STOPPED.value,
+    AgentStatus.FAILED.value,
+})
+
+#: States that a run may be resumed from (blocked or stopped → implementing).
+RESUMABLE_STATUSES: frozenset[str] = frozenset({
+    AgentStatus.BLOCKED.value,
+    AgentStatus.STOPPED.value,
+})
 
 
 def is_active(status: str) -> bool:
@@ -72,6 +105,11 @@ def is_live(status: str) -> bool:
     return status in LIVE_STATUSES
 
 
+def is_terminal(status: str) -> bool:
+    """Return ``True`` if *status* is a terminal state (no further transitions)."""
+    return status in TERMINAL_STATUSES
+
+
 def compute_agent_status(
     raw_status: str,
     last_activity_at: datetime.datetime | None,
@@ -80,16 +118,18 @@ def compute_agent_status(
 ) -> str:
     """Normalise a raw status string and apply staleness logic.
 
-    Returns a status string suitable for display and lane computation.
+    ``stale`` is computed from ``last_activity_at`` and is never stored in the
+    DB.  It is returned here as a display-only value for the UI and queries
+    layer.  Returns a status string suitable for display and lane computation.
     """
     if now is None:
         now = datetime.datetime.now(datetime.timezone.utc)
 
     if raw_status in LIVE_STATUSES and last_activity_at is not None:
         if (now - last_activity_at) > STALE_THRESHOLD:
-            return AgentStatus.STALE.value
+            return "stale"
 
     if raw_status in {s.value for s in AgentStatus}:
         return raw_status
 
-    return AgentStatus.UNKNOWN.value
+    return AgentStatus.FAILED.value


### PR DESCRIPTION
## Summary

- Formalizes the run state machine per the MCP Architecture Consolidation plan (PR 1 of 6)
- `AgentStatus` enum: adds `BLOCKED`, `STOPPED`, `FAILED`, `COMPLETED`, `CANCELLED`; removes `DONE`, `STALE`, `UNKNOWN`
- DB migration 0003: backfills `done→completed`, `unknown→failed`, `stale→implementing` in existing rows
- Five new persist functions with server-side state guards: `complete_agent_run`, `block_agent_run`, `resume_agent_run` (restart-safe idempotency), `cancel_agent_run`, `stop_agent_run`
- `stale` is now computed on-demand from `last_activity_at`, never stored
- All callers updated across telemetry, poller, transcripts, agents UI, queries, and control routes

## Test plan

- [x] mypy clean on all 9 modified source files
- [x] 947 tests passing (0 failures)
- [x] 19 regression tests for new persist functions covering all state transitions and restart-safe resume
- [x] Alembic migration included
