### PR TITLE
feat(mcp): add build_block_run, build_resume_run, build_cancel_run, build_stop_run

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -27,8 +27,12 @@ import logging
 
 from agentception.db.persist import (
     acknowledge_agent_run,
+    block_agent_run,
+    cancel_agent_run,
     complete_agent_run,
     persist_agent_event,
+    resume_agent_run,
+    stop_agent_run,
 )
 from agentception.db.queries import get_pending_launches
 from agentception.services.spawn_child import ScopeType, SpawnChildError, Tier, spawn_child
@@ -258,3 +262,117 @@ async def build_teardown_worktree(agent_run_id: str) -> dict[str, object]:
     )
     logger.info("🧹 build_teardown_worktree: teardown queued for run_id=%r", agent_run_id)
     return {"ok": True, "run_id": agent_run_id, "teardown": "queued"}
+
+
+async def build_block_run(run_id: str) -> dict[str, object]:
+    """Transition an ``implementing`` run to ``blocked``.
+
+    Call when the agent cannot proceed without external input (a human decision,
+    a dependency resolving, or a required resource becoming available).  The run
+    stays in ``blocked`` until ``build_resume_run`` is called.
+
+    Only valid from ``implementing`` state.
+
+    Args:
+        run_id: The run ID to block.
+
+    Returns:
+        ``{"ok": True, "run_id": run_id, "status": "blocked"}`` on success,
+        ``{"ok": False, "reason": "..."}`` if not in implementing state.
+    """
+    ok = await block_agent_run(run_id)
+    if not ok:
+        logger.warning("⚠️ build_block_run: %r not in implementing state", run_id)
+        return {
+            "ok": False,
+            "reason": f"Run {run_id!r} not found or not in implementing state",
+        }
+    logger.info("✅ build_block_run: %r → blocked", run_id)
+    return {"ok": True, "run_id": run_id, "status": "blocked"}
+
+
+async def build_resume_run(run_id: str, agent_run_id: str) -> dict[str, object]:
+    """Transition a ``blocked`` or ``stopped`` run back to ``implementing``.
+
+    Idempotent: if the run is already ``implementing`` and ``agent_run_id``
+    matches the run id, the call succeeds without a state change (restart-safe
+    — an agent can call this on startup without worrying about duplicate workers).
+
+    Valid from ``blocked`` or ``stopped`` states only.
+
+    Args:
+        run_id: The run ID to resume.
+        agent_run_id: The caller's own run ID (used for idempotency check).
+
+    Returns:
+        ``{"ok": True, "run_id": run_id, "status": "implementing"}`` on success,
+        ``{"ok": False, "reason": "..."}`` if not in a resumable state.
+    """
+    ok = await resume_agent_run(run_id, agent_run_id)
+    if not ok:
+        logger.warning(
+            "⚠️ build_resume_run: %r not in resumable state (or agent_run_id mismatch)", run_id
+        )
+        return {
+            "ok": False,
+            "reason": (
+                f"Run {run_id!r} not found, not in a resumable state (blocked/stopped), "
+                "or agent_run_id does not match"
+            ),
+        }
+    logger.info("✅ build_resume_run: %r → implementing", run_id)
+    return {"ok": True, "run_id": run_id, "status": "implementing"}
+
+
+async def build_cancel_run(run_id: str) -> dict[str, object]:
+    """Transition any active run to ``cancelled``.
+
+    ``cancelled`` is a terminal state — the run cannot be resumed.  Use
+    ``build_stop_run`` if you want to pause and later resume.
+
+    Valid from any non-terminal state (pending_launch, implementing, blocked,
+    reviewing).
+
+    Args:
+        run_id: The run ID to cancel.
+
+    Returns:
+        ``{"ok": True, "run_id": run_id, "status": "cancelled"}`` on success,
+        ``{"ok": False, "reason": "..."}`` if already terminal.
+    """
+    ok = await cancel_agent_run(run_id)
+    if not ok:
+        logger.warning("⚠️ build_cancel_run: %r not found or already terminal", run_id)
+        return {
+            "ok": False,
+            "reason": f"Run {run_id!r} not found or already in a terminal state",
+        }
+    logger.info("✅ build_cancel_run: %r → cancelled", run_id)
+    return {"ok": True, "run_id": run_id, "status": "cancelled"}
+
+
+async def build_stop_run(run_id: str) -> dict[str, object]:
+    """Transition any active run to ``stopped``.
+
+    Unlike ``build_cancel_run``, a stopped run can be resumed via
+    ``build_resume_run``.  Use this when you want to pause a run for inspection
+    without permanently closing it.
+
+    Valid from any non-terminal state.
+
+    Args:
+        run_id: The run ID to stop.
+
+    Returns:
+        ``{"ok": True, "run_id": run_id, "status": "stopped"}`` on success,
+        ``{"ok": False, "reason": "..."}`` if already terminal.
+    """
+    ok = await stop_agent_run(run_id)
+    if not ok:
+        logger.warning("⚠️ build_stop_run: %r not found or already terminal", run_id)
+        return {
+            "ok": False,
+            "reason": f"Run {run_id!r} not found or already in a terminal state",
+        }
+    logger.info("✅ build_stop_run: %r → stopped", run_id)
+    return {"ok": True, "run_id": run_id, "status": "stopped"}

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -27,9 +27,13 @@ import logging
 from typing import cast
 
 from agentception.mcp.build_commands import (
+    build_block_run,
+    build_cancel_run,
     build_claim_run,
     build_complete_run,
+    build_resume_run,
     build_spawn_child_run,
+    build_stop_run,
     build_teardown_worktree,
 )
 from agentception.mcp.log_tools import (
@@ -519,6 +523,76 @@ TOOLS: list[ACToolDef] = [
             "additionalProperties": False,
         },
     ),
+    ACToolDef(
+        name="build_block_run",
+        description=(
+            "Transition an implementing run to blocked. "
+            "Call when the agent cannot proceed without external input. "
+            "The run stays blocked until build_resume_run is called. "
+            "Only valid from implementing state."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "The run ID to block."},
+            },
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="build_resume_run",
+        description=(
+            "Transition a blocked or stopped run back to implementing. "
+            "Idempotent: if the run is already implementing and agent_run_id matches, "
+            "returns ok=true without state change (restart-safe). "
+            "Valid from blocked or stopped states only."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "The run ID to resume."},
+                "agent_run_id": {
+                    "type": "string",
+                    "description": "The caller's own run ID (used for idempotency check).",
+                },
+            },
+            "required": ["run_id", "agent_run_id"],
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="build_cancel_run",
+        description=(
+            "Transition any active run to cancelled (terminal — cannot resume). "
+            "Use build_stop_run if you want to pause and later resume. "
+            "Valid from any non-terminal state."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "The run ID to cancel."},
+            },
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="build_stop_run",
+        description=(
+            "Transition any active run to stopped (resumable via build_resume_run). "
+            "Use this to pause a run for inspection without permanently closing it. "
+            "Valid from any non-terminal state."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "The run ID to stop."},
+            },
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    ),
     # ── Log tools — append-only telemetry, no state change ───────────────────
     ACToolDef(
         name="log_run_step",
@@ -732,6 +806,10 @@ def call_tool(name: str, arguments: dict[str, object]) -> ACToolResult:
         "build_spawn_child_run",
         "build_complete_run",
         "build_teardown_worktree",
+        "build_block_run",
+        "build_resume_run",
+        "build_cancel_run",
+        "build_stop_run",
         # Log tools
         "log_run_step",
         "log_run_blocker",
@@ -914,6 +992,64 @@ async def call_tool_async(
                 isError=True,
             )
         result = await build_teardown_worktree(run_id_arg2)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
+        )
+
+    if name == "build_block_run":
+        run_id_arg3 = arguments.get("run_id")
+        if not isinstance(run_id_arg3, str) or not run_id_arg3:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"build_block_run requires a non-empty run_id"}')],
+                isError=True,
+            )
+        result = await build_block_run(run_id_arg3)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
+        )
+
+    if name == "build_resume_run":
+        run_id_arg4 = arguments.get("run_id")
+        agent_run_id_arg = arguments.get("agent_run_id")
+        if (
+            not isinstance(run_id_arg4, str)
+            or not run_id_arg4
+            or not isinstance(agent_run_id_arg, str)
+            or not agent_run_id_arg
+        ):
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"build_resume_run requires run_id and agent_run_id (non-empty strings)"}')],
+                isError=True,
+            )
+        result = await build_resume_run(run_id_arg4, agent_run_id_arg)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
+        )
+
+    if name == "build_cancel_run":
+        run_id_arg5 = arguments.get("run_id")
+        if not isinstance(run_id_arg5, str) or not run_id_arg5:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"build_cancel_run requires a non-empty run_id"}')],
+                isError=True,
+            )
+        result = await build_cancel_run(run_id_arg5)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
+        )
+
+    if name == "build_stop_run":
+        run_id_arg6 = arguments.get("run_id")
+        if not isinstance(run_id_arg6, str) or not run_id_arg6:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"build_stop_run requires a non-empty run_id"}')],
+                isError=True,
+            )
+        result = await build_stop_run(run_id_arg6)
         return ACToolResult(
             content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
             isError=not bool(result.get("ok", False)),

--- a/agentception/tests/test_mcp_build_commands_pr3.py
+++ b/agentception/tests/test_mcp_build_commands_pr3.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+"""Integration + regression tests for PR 3 new build commands.
+
+Tests:
+- build_block_run:   implementing → blocked
+- build_resume_run:  blocked/stopped → implementing; idempotent restart
+- build_cancel_run:  any active → cancelled; rejects terminal
+- build_stop_run:    any active → stopped; rejects terminal
+
+All tests go through the MCP layer (call_tool_async) to verify end-to-end
+dispatch in addition to the unit tests in test_persist_pending_launch_guard.py.
+
+Regression tests named per spec:
+- test_build_resume_run_idempotent_same_agent_run_id
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentception.mcp.server import call_tool_async
+
+
+# ---------------------------------------------------------------------------
+# build_block_run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_block_run_success_via_mcp() -> None:
+    """build_block_run MCP tool returns ok=true when state transition succeeds."""
+    with patch(
+        "agentception.mcp.build_commands.block_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        result = await call_tool_async("build_block_run", {"run_id": "issue-42"})
+
+    assert result["isError"] is False
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is True
+    assert payload["run_id"] == "issue-42"
+    assert payload["status"] == "blocked"
+
+
+@pytest.mark.anyio
+async def test_build_block_run_rejects_wrong_state() -> None:
+    """build_block_run returns isError=True when run is not in implementing state."""
+    with patch(
+        "agentception.mcp.build_commands.block_agent_run",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        result = await call_tool_async("build_block_run", {"run_id": "issue-42"})
+
+    assert result["isError"] is True
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is False
+    assert "reason" in payload
+
+
+@pytest.mark.anyio
+async def test_build_block_run_missing_run_id_returns_error() -> None:
+    """build_block_run returns isError=True when run_id is missing."""
+    result = await call_tool_async("build_block_run", {})
+    assert result["isError"] is True
+
+
+def test_build_block_run_in_tools_list() -> None:
+    """build_block_run is present in the TOOLS registry."""
+    from agentception.mcp.server import TOOLS
+    names = [t["name"] for t in TOOLS]
+    assert "build_block_run" in names
+
+
+# ---------------------------------------------------------------------------
+# build_resume_run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_resume_run_success_via_mcp() -> None:
+    """build_resume_run MCP tool returns ok=true when state transition succeeds."""
+    with patch(
+        "agentception.mcp.build_commands.resume_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        result = await call_tool_async(
+            "build_resume_run",
+            {"run_id": "issue-42", "agent_run_id": "issue-42"},
+        )
+
+    assert result["isError"] is False
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is True
+    assert payload["run_id"] == "issue-42"
+    assert payload["status"] == "implementing"
+
+
+@pytest.mark.anyio
+async def test_build_resume_run_idempotent_same_agent_run_id() -> None:
+    """Regression: build_resume_run with same agent_run_id while already implementing returns ok.
+
+    This is the restart-safe behaviour — an agent that crashes and restarts
+    calls build_resume_run on startup. If the run is already implementing with
+    the same run ID, the call must succeed so the agent can continue work.
+    """
+    with patch(
+        "agentception.mcp.build_commands.resume_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        result = await call_tool_async(
+            "build_resume_run",
+            {"run_id": "issue-42", "agent_run_id": "issue-42"},
+        )
+
+    assert result["isError"] is False
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is True
+
+
+@pytest.mark.anyio
+async def test_build_resume_run_rejects_non_resumable_state() -> None:
+    """build_resume_run returns isError=True when run is not resumable."""
+    with patch(
+        "agentception.mcp.build_commands.resume_agent_run",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        result = await call_tool_async(
+            "build_resume_run",
+            {"run_id": "issue-42", "agent_run_id": "issue-42"},
+        )
+
+    assert result["isError"] is True
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is False
+    assert "reason" in payload
+
+
+@pytest.mark.anyio
+async def test_build_resume_run_missing_args_returns_error() -> None:
+    """build_resume_run returns isError=True when required args are missing."""
+    result = await call_tool_async("build_resume_run", {"run_id": "issue-42"})
+    assert result["isError"] is True
+
+    result2 = await call_tool_async("build_resume_run", {})
+    assert result2["isError"] is True
+
+
+def test_build_resume_run_in_tools_list() -> None:
+    """build_resume_run is present in the TOOLS registry."""
+    from agentception.mcp.server import TOOLS
+    names = [t["name"] for t in TOOLS]
+    assert "build_resume_run" in names
+
+
+# ---------------------------------------------------------------------------
+# build_cancel_run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_cancel_run_success_via_mcp() -> None:
+    """build_cancel_run MCP tool returns ok=true when transition succeeds."""
+    with patch(
+        "agentception.mcp.build_commands.cancel_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        result = await call_tool_async("build_cancel_run", {"run_id": "issue-42"})
+
+    assert result["isError"] is False
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is True
+    assert payload["status"] == "cancelled"
+
+
+@pytest.mark.anyio
+async def test_build_cancel_run_rejects_terminal_state() -> None:
+    """build_cancel_run returns isError=True when run is already terminal."""
+    with patch(
+        "agentception.mcp.build_commands.cancel_agent_run",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        result = await call_tool_async("build_cancel_run", {"run_id": "issue-42"})
+
+    assert result["isError"] is True
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is False
+
+
+@pytest.mark.anyio
+async def test_build_cancel_run_missing_run_id_returns_error() -> None:
+    """build_cancel_run returns isError=True when run_id is missing."""
+    result = await call_tool_async("build_cancel_run", {})
+    assert result["isError"] is True
+
+
+def test_build_cancel_run_in_tools_list() -> None:
+    """build_cancel_run is present in the TOOLS registry."""
+    from agentception.mcp.server import TOOLS
+    names = [t["name"] for t in TOOLS]
+    assert "build_cancel_run" in names
+
+
+# ---------------------------------------------------------------------------
+# build_stop_run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_stop_run_success_via_mcp() -> None:
+    """build_stop_run MCP tool returns ok=true when transition succeeds."""
+    with patch(
+        "agentception.mcp.build_commands.stop_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        result = await call_tool_async("build_stop_run", {"run_id": "issue-42"})
+
+    assert result["isError"] is False
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is True
+    assert payload["status"] == "stopped"
+
+
+@pytest.mark.anyio
+async def test_build_stop_run_rejects_terminal_state() -> None:
+    """build_stop_run returns isError=True when run is already terminal."""
+    with patch(
+        "agentception.mcp.build_commands.stop_agent_run",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        result = await call_tool_async("build_stop_run", {"run_id": "issue-42"})
+
+    assert result["isError"] is True
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is False
+
+
+@pytest.mark.anyio
+async def test_build_stop_run_missing_run_id_returns_error() -> None:
+    """build_stop_run returns isError=True when run_id is missing."""
+    result = await call_tool_async("build_stop_run", {})
+    assert result["isError"] is True
+
+
+def test_build_stop_run_in_tools_list() -> None:
+    """build_stop_run is present in the TOOLS registry."""
+    from agentception.mcp.server import TOOLS
+    names = [t["name"] for t in TOOLS]
+    assert "build_stop_run" in names
+
+
+# ---------------------------------------------------------------------------
+# Integration: claim → block → resume flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_claim_block_resume_flow() -> None:
+    """Integration: claim → block → resume transitions succeed in sequence."""
+    with patch(
+        "agentception.mcp.build_commands.acknowledge_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        claim_result = await call_tool_async("build_claim_run", {"run_id": "issue-99"})
+
+    assert json.loads(claim_result["content"][0]["text"])["ok"] is True
+
+    with patch(
+        "agentception.mcp.build_commands.block_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        block_result = await call_tool_async("build_block_run", {"run_id": "issue-99"})
+
+    assert json.loads(block_result["content"][0]["text"])["status"] == "blocked"
+
+    with patch(
+        "agentception.mcp.build_commands.resume_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        resume_result = await call_tool_async(
+            "build_resume_run",
+            {"run_id": "issue-99", "agent_run_id": "issue-99"},
+        )
+
+    assert json.loads(resume_result["content"][0]["text"])["status"] == "implementing"
+
+
+@pytest.mark.anyio
+async def test_claim_stop_resume_flow() -> None:
+    """Integration: claim → stop → resume transitions succeed in sequence."""
+    with patch(
+        "agentception.mcp.build_commands.acknowledge_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        await call_tool_async("build_claim_run", {"run_id": "issue-100"})
+
+    with patch(
+        "agentception.mcp.build_commands.stop_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        stop_result = await call_tool_async("build_stop_run", {"run_id": "issue-100"})
+
+    assert json.loads(stop_result["content"][0]["text"])["status"] == "stopped"
+
+    with patch(
+        "agentception.mcp.build_commands.resume_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        resume_result = await call_tool_async(
+            "build_resume_run",
+            {"run_id": "issue-100", "agent_run_id": "issue-100"},
+        )
+
+    assert json.loads(resume_result["content"][0]["text"])["status"] == "implementing"


### PR DESCRIPTION
## Summary

- `build_block_run`: transitions `implementing` → `blocked`
- `build_resume_run`: transitions `blocked`/`stopped` → `implementing`; idempotent with same `agent_run_id` for crash-safe restarts
- `build_cancel_run`: transitions any active run → `cancelled` (terminal)
- `build_stop_run`: transitions any active run → `stopped` (resumable)

All transitions validated server-side by the persist layer (PR 1). Clean break — no deprecated aliases.

## Test plan

- [x] mypy clean
- [x] 966 tests passing (0 failures)
- [x] 19 new tests: success, rejection, missing args, TOOLS registry, end-to-end claim→block→resume and claim→stop→resume integration flows
- [x] Regression: `test_build_resume_run_idempotent_same_agent_run_id` — crash-safe restart behavior
