### PR TITLE
feat(mcp): add 8 query tools for agent state inspection (PR 4)

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -15,7 +15,7 @@ import re as _re
 from pathlib import Path
 from typing import TypedDict
 
-from sqlalchemy import select, text
+from sqlalchemy import func, select, text
 
 from agentception.db.engine import get_session
 from agentception.db.models import (
@@ -2447,3 +2447,151 @@ async def get_terminal_runs_with_worktrees() -> list[TerminalRunRow]:
             "⚠️  get_terminal_runs_with_worktrees DB query failed (non-fatal): %s", exc
         )
         return []
+
+
+# ---------------------------------------------------------------------------
+# MCP query tool helpers — lightweight reads used by query_tools.py
+# ---------------------------------------------------------------------------
+
+
+class RunSummaryRow(TypedDict):
+    """Lightweight run summary for MCP query tools.
+
+    Intentionally omits transcript messages (use get_agent_run_detail when
+    the full message history is needed).
+    """
+
+    run_id: str
+    status: str
+    role: str
+    issue_number: int | None
+    pr_number: int | None
+    branch: str | None
+    worktree_path: str | None
+    batch_id: str | None
+    tier: str | None
+    org_domain: str | None
+    parent_run_id: str | None
+    spawned_at: str
+    last_activity_at: str | None
+    completed_at: str | None
+
+
+def _run_to_summary(row: ACAgentRun) -> RunSummaryRow:
+    """Convert an ACAgentRun ORM row to a RunSummaryRow."""
+    return RunSummaryRow(
+        run_id=row.id,
+        status=row.status,
+        role=row.role,
+        issue_number=row.issue_number,
+        pr_number=row.pr_number,
+        branch=row.branch,
+        worktree_path=row.worktree_path,
+        batch_id=row.batch_id,
+        tier=row.tier,
+        org_domain=row.org_domain,
+        parent_run_id=row.parent_run_id,
+        spawned_at=row.spawned_at.isoformat(),
+        last_activity_at=(row.last_activity_at.isoformat() if row.last_activity_at else None),
+        completed_at=(row.completed_at.isoformat() if row.completed_at else None),
+    )
+
+
+async def get_run_by_id(run_id: str) -> RunSummaryRow | None:
+    """Return lightweight run metadata for a single run.
+
+    Agents call this on startup to determine their current state and decide
+    whether to resume, block, or complete.  Returns ``None`` if the run does
+    not exist or on DB error.
+    """
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun).where(ACAgentRun.id == run_id)
+            )
+            row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return _run_to_summary(row)
+    except Exception as exc:
+        logger.warning("⚠️  get_run_by_id DB query failed (non-fatal): %s", exc)
+        return None
+
+
+async def get_children_by_parent_id(parent_run_id: str) -> list[RunSummaryRow]:
+    """Return all runs spawned by *parent_run_id*, ordered by spawn time.
+
+    Used by ``query_children`` MCP tool.  Returns ``[]`` on DB error.
+    """
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun)
+                .where(ACAgentRun.parent_run_id == parent_run_id)
+                .order_by(ACAgentRun.spawned_at.asc())
+            )
+            rows = result.scalars().all()
+        return [_run_to_summary(r) for r in rows]
+    except Exception as exc:
+        logger.warning("⚠️  get_children_by_parent_id DB query failed (non-fatal): %s", exc)
+        return []
+
+
+class StatusCountRow(TypedDict):
+    """Status → count pair for aggregate queries."""
+
+    status: str
+    count: int
+
+
+async def get_active_runs() -> list[RunSummaryRow]:
+    """Return all runs currently in a live or blocked state.
+
+    Live statuses: ``pending_launch``, ``implementing``, ``reviewing``,
+    ``blocked``.  Used by ``query_active_runs`` MCP tool.
+
+    Returns ``[]`` on DB error.
+    """
+    active_statuses = ["pending_launch", "implementing", "reviewing", "blocked"]
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun)
+                .where(ACAgentRun.status.in_(active_statuses))
+                .order_by(ACAgentRun.spawned_at.desc())
+            )
+            rows = result.scalars().all()
+        return [_run_to_summary(r) for r in rows]
+    except Exception as exc:
+        logger.warning("⚠️  get_active_runs DB query failed (non-fatal): %s", exc)
+        return []
+
+
+async def get_run_status_counts() -> list[StatusCountRow]:
+    """Return total run count per status across all time.
+
+    Used by ``query_dispatcher_state`` and ``query_system_health``.
+    Returns ``[]`` on DB error.
+    """
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun.status, func.count().label("cnt"))
+                .group_by(ACAgentRun.status)
+                .order_by(ACAgentRun.status)
+            )
+            rows = result.all()
+        return [StatusCountRow(status=str(row.status), count=int(row.cnt)) for row in rows]
+    except Exception as exc:
+        logger.warning("⚠️  get_run_status_counts DB query failed (non-fatal): %s", exc)
+        return []
+
+
+async def check_db_reachable() -> bool:
+    """Return True if the DB responds to a trivial query, False otherwise."""
+    try:
+        async with get_session() as session:
+            await session.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        return False

--- a/agentception/mcp/query_tools.py
+++ b/agentception/mcp/query_tools.py
@@ -16,8 +16,20 @@ Rules
 """
 
 import logging
+from pathlib import Path
 
-from agentception.db.queries import get_pending_launches
+from agentception.db.queries import (
+    check_db_reachable,
+    get_active_runs,
+    get_agent_events_tail,
+    get_agent_run_teardown,
+    get_children_by_parent_id,
+    get_latest_active_batch_id,
+    get_pending_launches,
+    get_run_by_id,
+    get_run_status_counts,
+    get_run_tree_by_batch_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,14 +53,10 @@ async def query_pending_runs() -> dict[str, object]:
     """
     logger.warning("🔍 query_pending_runs: querying DB for pending launches")
     launches = await get_pending_launches()
-    logger.warning(
-        "🔍 query_pending_runs: got %d row(s) from DB",
-        len(launches),
-    )
+    logger.warning("🔍 query_pending_runs: got %d row(s) from DB", len(launches))
     for i, launch in enumerate(launches):
         logger.warning(
-            "🔍   [%d] run_id=%r role=%r status=pending_launch "
-            "host_worktree_path=%r branch=%r",
+            "🔍   [%d] run_id=%r role=%r host_worktree_path=%r branch=%r",
             i,
             launch.get("run_id"),
             launch.get("role"),
@@ -56,3 +64,176 @@ async def query_pending_runs() -> dict[str, object]:
             launch.get("branch"),
         )
     return {"pending": launches, "count": len(launches)}
+
+
+async def query_run(run_id: str) -> dict[str, object]:
+    """Return lightweight metadata for a single run.
+
+    Agents call this on startup to determine their current state and decide
+    whether to claim, resume, complete, or block.
+
+    Args:
+        run_id: The run ID to look up.
+
+    Returns:
+        ``{"ok": True, "run": {...}}`` when found, or
+        ``{"ok": False, "error": "not found"}`` when the run does not exist.
+    """
+    row = await get_run_by_id(run_id)
+    if row is None:
+        logger.warning("🔍 query_run: run_id=%r not found", run_id)
+        return {"ok": False, "error": f"Run {run_id!r} not found"}
+    logger.info("✅ query_run: found run_id=%r status=%r", run_id, row["status"])
+    return {"ok": True, "run": dict(row)}
+
+
+async def query_children(run_id: str) -> dict[str, object]:
+    """Return all runs spawned by *run_id*, ordered by spawn time.
+
+    Coordinator and VP-tier agents use this to track the state of the
+    engineers they dispatched.
+
+    Args:
+        run_id: The parent run ID.
+
+    Returns:
+        ``{"ok": True, "children": [...], "count": N}``
+    """
+    children = await get_children_by_parent_id(run_id)
+    logger.info("✅ query_children: run_id=%r → %d child(ren)", run_id, len(children))
+    return {"ok": True, "children": [dict(c) for c in children], "count": len(children)}
+
+
+async def query_run_events(run_id: str, after_id: int = 0) -> dict[str, object]:
+    """Return structured MCP events for *run_id* with ``id > after_id``.
+
+    Agents can use this to reconstruct what happened in a previous session
+    (i.e. after a crash and restart).  Pass ``after_id`` to page through
+    events incrementally.
+
+    Args:
+        run_id: The run to query events for.
+        after_id: Return only events with DB id strictly greater than this.
+
+    Returns:
+        ``{"ok": True, "events": [...], "count": N}``
+    """
+    events = await get_agent_events_tail(run_id, after_id=after_id)
+    logger.info("✅ query_run_events: run_id=%r after_id=%d → %d event(s)", run_id, after_id, len(events))
+    return {"ok": True, "events": [dict(e) for e in events], "count": len(events)}
+
+
+async def query_agent_task(run_id: str) -> dict[str, object]:
+    """Return the parsed contents of the ``.agent-task`` file for *run_id*.
+
+    The file is read from disk at ``{worktree_path}/.agent-task``.  If the
+    worktree does not exist yet (pending launch) or has already been torn
+    down, returns ``{"ok": False, "error": "..."}`` so agents can handle
+    the failure gracefully.
+
+    Args:
+        run_id: The run to read the agent task for.
+
+    Returns:
+        ``{"ok": True, "path": "...", "content": "..."}`` on success, or
+        ``{"ok": False, "error": "..."}`` when the file cannot be read.
+    """
+    teardown = await get_agent_run_teardown(run_id)
+    if teardown is None:
+        return {"ok": False, "error": f"Run {run_id!r} not found"}
+    worktree = teardown.get("worktree_path")
+    if not worktree:
+        return {"ok": False, "error": f"Run {run_id!r} has no worktree_path"}
+    task_path = Path(worktree) / ".agent-task"
+    if not task_path.exists():
+        return {
+            "ok": False,
+            "error": f".agent-task not found at {task_path}",
+        }
+    try:
+        content = task_path.read_text()
+    except OSError as exc:
+        return {"ok": False, "error": f"Could not read .agent-task: {exc}"}
+    logger.info("✅ query_agent_task: run_id=%r read %d bytes", run_id, len(content))
+    return {"ok": True, "path": str(task_path), "content": content}
+
+
+async def query_active_runs() -> dict[str, object]:
+    """Return all runs currently in a live or blocked state.
+
+    Live statuses: ``pending_launch``, ``implementing``, ``reviewing``,
+    ``blocked``.  Supervisory agents and the Dispatcher use this to get
+    a snapshot of system-wide active work.
+
+    Returns:
+        ``{"ok": True, "runs": [...], "count": N}``
+    """
+    runs = await get_active_runs()
+    logger.info("✅ query_active_runs: %d active run(s)", len(runs))
+    return {"ok": True, "runs": [dict(r) for r in runs], "count": len(runs)}
+
+
+async def query_run_tree(batch_id: str) -> dict[str, object]:
+    """Return the full run tree for *batch_id* as a flat list.
+
+    Each node contains ``id``, ``parent_run_id``, ``role``, ``status``,
+    ``tier``, ``org_domain``, ``issue_number``, and ``spawned_at``.
+    Assemble into a tree by following ``parent_run_id`` references.
+
+    Args:
+        batch_id: The batch fingerprint to query.
+
+    Returns:
+        ``{"ok": True, "nodes": [...], "count": N}``
+    """
+    nodes = await get_run_tree_by_batch_id(batch_id)
+    logger.info("✅ query_run_tree: batch_id=%r → %d node(s)", batch_id, len(nodes))
+    return {"ok": True, "nodes": [dict(n) for n in nodes], "count": len(nodes)}
+
+
+async def query_dispatcher_state() -> dict[str, object]:
+    """Return current dispatcher state for supervisory agents.
+
+    Provides:
+      - ``status_counts``  — run count per status across all time
+      - ``active_count``   — total of pending_launch + implementing + reviewing + blocked
+      - ``latest_batch_id``— batch_id of the most recently active wave (or null)
+
+    Returns:
+        ``{"ok": True, "status_counts": [...], "active_count": N, "latest_batch_id": "..." | null}``
+    """
+    counts = await get_run_status_counts()
+    active_statuses = {"pending_launch", "implementing", "reviewing", "blocked"}
+    active_count = sum(r["count"] for r in counts if r["status"] in active_statuses)
+    latest_batch_id = await get_latest_active_batch_id()
+    logger.info(
+        "✅ query_dispatcher_state: active_count=%d latest_batch=%r",
+        active_count, latest_batch_id,
+    )
+    return {
+        "ok": True,
+        "status_counts": [dict(c) for c in counts],
+        "active_count": active_count,
+        "latest_batch_id": latest_batch_id,
+    }
+
+
+async def query_system_health() -> dict[str, object]:
+    """Return a system-health snapshot for supervisory agents.
+
+    Checks DB reachability and returns aggregate run counts per status.
+    Always returns a result — ``db_ok: False`` signals a degraded database
+    without raising an exception.
+
+    Returns:
+        ``{"ok": True, "db_ok": bool, "status_counts": [...], "total_runs": N}``
+    """
+    db_ok = await check_db_reachable()
+    counts: list[dict[str, object]] = []
+    total = 0
+    if db_ok:
+        status_counts = await get_run_status_counts()
+        counts = [dict(c) for c in status_counts]
+        total = sum(c["count"] for c in status_counts)
+    logger.info("✅ query_system_health: db_ok=%r total_runs=%d", db_ok, total)
+    return {"ok": True, "db_ok": db_ok, "status_counts": counts, "total_runs": total}

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -42,7 +42,17 @@ from agentception.mcp.log_tools import (
     log_run_message,
     log_run_step,
 )
-from agentception.mcp.query_tools import query_pending_runs
+from agentception.mcp.query_tools import (
+    query_active_runs,
+    query_agent_task,
+    query_children,
+    query_dispatcher_state,
+    query_pending_runs,
+    query_run,
+    query_run_events,
+    query_run_tree,
+    query_system_health,
+)
 from agentception.mcp.github_tools import (
     github_add_label,
     github_claim_issue,
@@ -363,6 +373,130 @@ TOOLS: list[ACToolDef] = [
             "The role tells you what kind of agent to spawn — a leaf worker implements "
             "one issue directly; a coordinator reads its role file and spawns its own "
             "children via the Task tool."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="query_run",
+        description=(
+            "Return lightweight metadata for a single run by run_id. "
+            "Agents call this on startup to determine their current state (status, "
+            "issue_number, parent_run_id, worktree_path, tier, role, batch_id). "
+            "Returns ok=false when the run does not exist."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "The run ID to look up."},
+            },
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="query_children",
+        description=(
+            "Return all runs spawned by a given parent run_id, ordered by spawn time. "
+            "Coordinator and VP-tier agents use this to track the state of engineers they dispatched."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "The parent run ID."},
+            },
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="query_run_events",
+        description=(
+            "Return structured MCP events for a run (log_run_step, log_run_blocker, etc.). "
+            "Agents use this to reconstruct what happened in a previous session after a crash. "
+            "Pass after_id to page through events incrementally."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "The run to query events for."},
+                "after_id": {
+                    "type": "integer",
+                    "description": "Return only events with DB id > this value. Defaults to 0.",
+                    "default": 0,
+                },
+            },
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="query_agent_task",
+        description=(
+            "Return the raw text content of the .agent-task TOML file for a run. "
+            "Agents use this to verify their own configuration on startup or after a restart. "
+            "Returns ok=false if the worktree has been torn down or the file does not exist."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "The run to read the agent task for."},
+            },
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="query_active_runs",
+        description=(
+            "Return all runs currently in a live or blocked state "
+            "(pending_launch, implementing, reviewing, blocked). "
+            "Supervisory agents and the Dispatcher use this for a system-wide snapshot."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="query_run_tree",
+        description=(
+            "Return all runs in a batch as a flat list with parent_run_id references. "
+            "Assemble into a tree by following parent_run_id. "
+            "Used by the Dispatcher and supervisory agents to visualise the run hierarchy."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "batch_id": {"type": "string", "description": "The batch fingerprint to query."},
+            },
+            "required": ["batch_id"],
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="query_dispatcher_state",
+        description=(
+            "Return current dispatcher state: run counts per status, active run total, "
+            "and the latest active batch_id. "
+            "Designed for supervisory agents that need a high-level view of the system."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="query_system_health",
+        description=(
+            "Return a system-health snapshot: DB reachability, total runs per status. "
+            "Always returns a result — db_ok=false signals a degraded database. "
+            "Use for diagnostics and health checks."
         ),
         inputSchema={
             "type": "object",
@@ -801,6 +935,14 @@ def call_tool(name: str, arguments: dict[str, object]) -> ACToolResult:
         "plan_advance_phase",
         # Query tools
         "query_pending_runs",
+        "query_run",
+        "query_children",
+        "query_run_events",
+        "query_agent_task",
+        "query_active_runs",
+        "query_run_tree",
+        "query_dispatcher_state",
+        "query_system_health",
         # Build commands
         "build_claim_run",
         "build_spawn_child_run",
@@ -884,6 +1026,94 @@ async def call_tool_async(
 
     if name == "query_pending_runs":
         result = await query_pending_runs()
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=False,
+        )
+
+    if name == "query_run":
+        qr_run_id = arguments.get("run_id")
+        if not isinstance(qr_run_id, str) or not qr_run_id:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"query_run requires a non-empty run_id"}')],
+                isError=True,
+            )
+        result = await query_run(qr_run_id)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
+        )
+
+    if name == "query_children":
+        qc_run_id = arguments.get("run_id")
+        if not isinstance(qc_run_id, str) or not qc_run_id:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"query_children requires a non-empty run_id"}')],
+                isError=True,
+            )
+        result = await query_children(qc_run_id)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=False,
+        )
+
+    if name == "query_run_events":
+        qre_run_id = arguments.get("run_id")
+        if not isinstance(qre_run_id, str) or not qre_run_id:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"query_run_events requires a non-empty run_id"}')],
+                isError=True,
+            )
+        after_id_raw = arguments.get("after_id", 0)
+        after_id = int(after_id_raw) if isinstance(after_id_raw, int) else 0
+        result = await query_run_events(qre_run_id, after_id)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=False,
+        )
+
+    if name == "query_agent_task":
+        qat_run_id = arguments.get("run_id")
+        if not isinstance(qat_run_id, str) or not qat_run_id:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"query_agent_task requires a non-empty run_id"}')],
+                isError=True,
+            )
+        result = await query_agent_task(qat_run_id)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
+        )
+
+    if name == "query_active_runs":
+        result = await query_active_runs()
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=False,
+        )
+
+    if name == "query_run_tree":
+        qrt_batch_id = arguments.get("batch_id")
+        if not isinstance(qrt_batch_id, str) or not qrt_batch_id:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"query_run_tree requires a non-empty batch_id"}')],
+                isError=True,
+            )
+        result = await query_run_tree(qrt_batch_id)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=False,
+        )
+
+    if name == "query_dispatcher_state":
+        result = await query_dispatcher_state()
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=False,
+        )
+
+    if name == "query_system_health":
+        result = await query_system_health()
         return ACToolResult(
             content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
             isError=False,

--- a/agentception/tests/test_mcp_query_tools_pr4.py
+++ b/agentception/tests/test_mcp_query_tools_pr4.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+"""Tests for PR 4 MCP query tools.
+
+Covers all 8 new tools via the MCP layer (call_tool_async):
+  - query_run
+  - query_children
+  - query_run_events
+  - query_agent_task
+  - query_active_runs
+  - query_run_tree
+  - query_dispatcher_state
+  - query_system_health
+
+Each tool is tested for:
+  - Success path (ok=True, correct payload shape)
+  - Missing/invalid argument handling (isError=True)
+  - TOOLS registry presence
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentception.mcp.server import TOOLS, call_tool_async
+from agentception.mcp.types import ACToolResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _payload(result: ACToolResult) -> dict[str, object]:
+    """Decode the first content item of an ACToolResult as JSON."""
+    raw: str = result["content"][0]["text"]
+    out: dict[str, object] = json.loads(raw)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# query_run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_query_run_returns_run_on_success() -> None:
+    """query_run MCP tool returns ok=True with run metadata when run exists."""
+    mock_row = {
+        "run_id": "issue-42",
+        "status": "implementing",
+        "role": "python-developer",
+        "issue_number": 42,
+        "pr_number": None,
+        "branch": "ac/issue-42",
+        "worktree_path": "/worktrees/issue-42",
+        "batch_id": "batch-abc",
+        "tier": "engineer",
+        "org_domain": "engineering",
+        "parent_run_id": "issue-10",
+        "spawned_at": "2026-03-01T00:00:00+00:00",
+        "last_activity_at": None,
+        "completed_at": None,
+    }
+    with patch("agentception.mcp.query_tools.get_run_by_id", new_callable=AsyncMock, return_value=mock_row):
+        result = await call_tool_async("query_run", {"run_id": "issue-42"})
+
+    assert result["isError"] is False
+    payload = _payload(result)
+    assert payload["ok"] is True
+    run = payload["run"]
+    assert isinstance(run, dict)
+    assert run["run_id"] == "issue-42"
+    assert run["status"] == "implementing"
+
+
+@pytest.mark.anyio
+async def test_query_run_returns_error_when_not_found() -> None:
+    """query_run returns isError=True when the run does not exist."""
+    with patch("agentception.mcp.query_tools.get_run_by_id", new_callable=AsyncMock, return_value=None):
+        result = await call_tool_async("query_run", {"run_id": "issue-999"})
+
+    assert result["isError"] is True
+    assert _payload(result)["ok"] is False
+
+
+@pytest.mark.anyio
+async def test_query_run_missing_run_id_returns_error() -> None:
+    """query_run returns isError=True when run_id argument is absent."""
+    result = await call_tool_async("query_run", {})
+    assert result["isError"] is True
+
+
+def test_query_run_in_tools_list() -> None:
+    names = [t["name"] for t in TOOLS]
+    assert "query_run" in names
+
+
+# ---------------------------------------------------------------------------
+# query_children
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_query_children_returns_list_on_success() -> None:
+    """query_children MCP tool returns ok=True with children list."""
+    mock_children = [
+        {
+            "run_id": "issue-100",
+            "status": "implementing",
+            "role": "python-developer",
+            "issue_number": 100,
+            "pr_number": None,
+            "branch": None,
+            "worktree_path": None,
+            "batch_id": "batch-abc",
+            "tier": "engineer",
+            "org_domain": "engineering",
+            "parent_run_id": "issue-42",
+            "spawned_at": "2026-03-01T01:00:00+00:00",
+            "last_activity_at": None,
+            "completed_at": None,
+        }
+    ]
+    with patch(
+        "agentception.mcp.query_tools.get_children_by_parent_id",
+        new_callable=AsyncMock,
+        return_value=mock_children,
+    ):
+        result = await call_tool_async("query_children", {"run_id": "issue-42"})
+
+    assert result["isError"] is False
+    payload = _payload(result)
+    assert payload["ok"] is True
+    assert payload["count"] == 1
+    children = payload["children"]
+    assert isinstance(children, list)
+    assert children[0]["run_id"] == "issue-100"
+
+
+@pytest.mark.anyio
+async def test_query_children_returns_empty_list_when_none() -> None:
+    """query_children returns ok=True with empty list when no children exist."""
+    with patch(
+        "agentception.mcp.query_tools.get_children_by_parent_id",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        result = await call_tool_async("query_children", {"run_id": "issue-42"})
+
+    assert result["isError"] is False
+    payload = _payload(result)
+    assert payload["count"] == 0
+    assert payload["children"] == []
+
+
+@pytest.mark.anyio
+async def test_query_children_missing_run_id_returns_error() -> None:
+    """query_children returns isError=True when run_id is absent."""
+    result = await call_tool_async("query_children", {})
+    assert result["isError"] is True
+
+
+def test_query_children_in_tools_list() -> None:
+    names = [t["name"] for t in TOOLS]
+    assert "query_children" in names
+
+
+# ---------------------------------------------------------------------------
+# query_run_events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_query_run_events_returns_events() -> None:
+    """query_run_events returns ok=True with events list."""
+    mock_events = [
+        {"id": 1, "event_type": "step_start", "payload": "{}", "recorded_at": "2026-03-01T00:01:00+00:00"},
+        {"id": 2, "event_type": "blocker", "payload": '{"msg":"waiting"}', "recorded_at": "2026-03-01T00:02:00+00:00"},
+    ]
+    with patch(
+        "agentception.mcp.query_tools.get_agent_events_tail",
+        new_callable=AsyncMock,
+        return_value=mock_events,
+    ):
+        result = await call_tool_async("query_run_events", {"run_id": "issue-42", "after_id": 0})
+
+    assert result["isError"] is False
+    payload = _payload(result)
+    assert payload["ok"] is True
+    assert payload["count"] == 2
+
+
+@pytest.mark.anyio
+async def test_query_run_events_passes_after_id() -> None:
+    """query_run_events passes after_id correctly to the DB function."""
+    with patch(
+        "agentception.mcp.query_tools.get_agent_events_tail",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as mock_fn:
+        await call_tool_async("query_run_events", {"run_id": "issue-42", "after_id": 5})
+
+    mock_fn.assert_awaited_once_with("issue-42", after_id=5)
+
+
+@pytest.mark.anyio
+async def test_query_run_events_missing_run_id_returns_error() -> None:
+    """query_run_events returns isError=True when run_id is absent."""
+    result = await call_tool_async("query_run_events", {})
+    assert result["isError"] is True
+
+
+def test_query_run_events_in_tools_list() -> None:
+    names = [t["name"] for t in TOOLS]
+    assert "query_run_events" in names
+
+
+# ---------------------------------------------------------------------------
+# query_agent_task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_query_agent_task_returns_content(tmp_path: Path) -> None:
+    """query_agent_task returns ok=True with file content when .agent-task exists."""
+    task_file = tmp_path / ".agent-task"
+    task_file.write_text("[agent]\nrun_id = 42\n")
+
+    mock_teardown = {"worktree_path": str(tmp_path), "branch": "ac/issue-42"}
+    with patch(
+        "agentception.mcp.query_tools.get_agent_run_teardown",
+        new_callable=AsyncMock,
+        return_value=mock_teardown,
+    ):
+        result = await call_tool_async("query_agent_task", {"run_id": "issue-42"})
+
+    assert result["isError"] is False
+    payload = _payload(result)
+    assert payload["ok"] is True
+    assert "run_id = 42" in str(payload["content"])
+
+
+@pytest.mark.anyio
+async def test_query_agent_task_returns_error_when_run_not_found() -> None:
+    """query_agent_task returns isError=True when run does not exist."""
+    with patch(
+        "agentception.mcp.query_tools.get_agent_run_teardown",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await call_tool_async("query_agent_task", {"run_id": "issue-999"})
+
+    assert result["isError"] is True
+    assert _payload(result)["ok"] is False
+
+
+@pytest.mark.anyio
+async def test_query_agent_task_returns_error_when_file_missing(tmp_path: Path) -> None:
+    """query_agent_task returns isError=True when .agent-task file does not exist."""
+    mock_teardown = {"worktree_path": str(tmp_path), "branch": "ac/issue-42"}
+    with patch(
+        "agentception.mcp.query_tools.get_agent_run_teardown",
+        new_callable=AsyncMock,
+        return_value=mock_teardown,
+    ):
+        result = await call_tool_async("query_agent_task", {"run_id": "issue-42"})
+
+    assert result["isError"] is True
+    assert _payload(result)["ok"] is False
+
+
+@pytest.mark.anyio
+async def test_query_agent_task_missing_run_id_returns_error() -> None:
+    """query_agent_task returns isError=True when run_id is absent."""
+    result = await call_tool_async("query_agent_task", {})
+    assert result["isError"] is True
+
+
+def test_query_agent_task_in_tools_list() -> None:
+    names = [t["name"] for t in TOOLS]
+    assert "query_agent_task" in names
+
+
+# ---------------------------------------------------------------------------
+# query_active_runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_query_active_runs_returns_list() -> None:
+    """query_active_runs MCP tool returns ok=True with active runs."""
+    mock_runs = [
+        {
+            "run_id": "issue-1",
+            "status": "implementing",
+            "role": "python-developer",
+            "issue_number": 1,
+            "pr_number": None,
+            "branch": None,
+            "worktree_path": None,
+            "batch_id": "batch-x",
+            "tier": "engineer",
+            "org_domain": "engineering",
+            "parent_run_id": None,
+            "spawned_at": "2026-03-01T00:00:00+00:00",
+            "last_activity_at": None,
+            "completed_at": None,
+        }
+    ]
+    with patch(
+        "agentception.mcp.query_tools.get_active_runs",
+        new_callable=AsyncMock,
+        return_value=mock_runs,
+    ):
+        result = await call_tool_async("query_active_runs", {})
+
+    assert result["isError"] is False
+    payload = _payload(result)
+    assert payload["ok"] is True
+    assert payload["count"] == 1
+
+
+def test_query_active_runs_in_tools_list() -> None:
+    names = [t["name"] for t in TOOLS]
+    assert "query_active_runs" in names
+
+
+# ---------------------------------------------------------------------------
+# query_run_tree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_query_run_tree_returns_nodes() -> None:
+    """query_run_tree MCP tool returns ok=True with tree nodes."""
+    mock_nodes = [
+        {
+            "id": "issue-1",
+            "role": "cto",
+            "status": "implementing",
+            "agent_status": "implementing",
+            "tier": "executive",
+            "org_domain": "c-suite",
+            "parent_run_id": None,
+            "issue_number": None,
+            "pr_number": None,
+            "batch_id": "batch-x",
+            "spawned_at": "2026-03-01T00:00:00+00:00",
+            "last_activity_at": None,
+            "current_step": None,
+        }
+    ]
+    with patch(
+        "agentception.mcp.query_tools.get_run_tree_by_batch_id",
+        new_callable=AsyncMock,
+        return_value=mock_nodes,
+    ):
+        result = await call_tool_async("query_run_tree", {"batch_id": "batch-x"})
+
+    assert result["isError"] is False
+    payload = _payload(result)
+    assert payload["ok"] is True
+    assert payload["count"] == 1
+    nodes = payload["nodes"]
+    assert isinstance(nodes, list)
+    assert nodes[0]["id"] == "issue-1"
+
+
+@pytest.mark.anyio
+async def test_query_run_tree_missing_batch_id_returns_error() -> None:
+    """query_run_tree returns isError=True when batch_id is absent."""
+    result = await call_tool_async("query_run_tree", {})
+    assert result["isError"] is True
+
+
+def test_query_run_tree_in_tools_list() -> None:
+    names = [t["name"] for t in TOOLS]
+    assert "query_run_tree" in names
+
+
+# ---------------------------------------------------------------------------
+# query_dispatcher_state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_query_dispatcher_state_returns_state() -> None:
+    """query_dispatcher_state MCP tool returns ok=True with status counts."""
+    mock_counts = [
+        {"status": "implementing", "count": 3},
+        {"status": "completed", "count": 10},
+    ]
+    with (
+        patch(
+            "agentception.mcp.query_tools.get_run_status_counts",
+            new_callable=AsyncMock,
+            return_value=mock_counts,
+        ),
+        patch(
+            "agentception.mcp.query_tools.get_latest_active_batch_id",
+            new_callable=AsyncMock,
+            return_value="batch-xyz",
+        ),
+    ):
+        result = await call_tool_async("query_dispatcher_state", {})
+
+    assert result["isError"] is False
+    payload = _payload(result)
+    assert payload["ok"] is True
+    assert payload["active_count"] == 3
+    assert payload["latest_batch_id"] == "batch-xyz"
+    sc = payload["status_counts"]
+    assert isinstance(sc, list)
+    assert len(sc) == 2
+
+
+def test_query_dispatcher_state_in_tools_list() -> None:
+    names = [t["name"] for t in TOOLS]
+    assert "query_dispatcher_state" in names
+
+
+# ---------------------------------------------------------------------------
+# query_system_health
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_query_system_health_db_up() -> None:
+    """query_system_health returns ok=True with db_ok=True when DB is reachable."""
+    mock_counts = [{"status": "implementing", "count": 2}]
+    with (
+        patch(
+            "agentception.mcp.query_tools.check_db_reachable",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.query_tools.get_run_status_counts",
+            new_callable=AsyncMock,
+            return_value=mock_counts,
+        ),
+    ):
+        result = await call_tool_async("query_system_health", {})
+
+    assert result["isError"] is False
+    payload = _payload(result)
+    assert payload["ok"] is True
+    assert payload["db_ok"] is True
+    assert payload["total_runs"] == 2
+
+
+@pytest.mark.anyio
+async def test_query_system_health_db_down() -> None:
+    """Regression: query_system_health returns ok=True but db_ok=False when DB is unreachable.
+
+    The tool must never raise — it degrades gracefully so supervisory agents
+    can detect the outage without crashing.
+    """
+    with patch(
+        "agentception.mcp.query_tools.check_db_reachable",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        result = await call_tool_async("query_system_health", {})
+
+    assert result["isError"] is False
+    payload = _payload(result)
+    assert payload["ok"] is True
+    assert payload["db_ok"] is False
+    assert payload["total_runs"] == 0
+    assert payload["status_counts"] == []
+
+
+def test_query_system_health_in_tools_list() -> None:
+    names = [t["name"] for t in TOOLS]
+    assert "query_system_health" in names


### PR DESCRIPTION
## Summary

- `query_run` — agents call on startup to reconstruct state without relying on prompts
- `query_children` — coordinators track engineers they dispatched
- `query_run_events` — crash-recovery event replay with `after_id` paging
- `query_agent_task` — reads `.agent-task` from disk; returns `ok=false` gracefully if torn down
- `query_active_runs` — system-wide snapshot of all live/blocked runs
- `query_run_tree` — full batch hierarchy as flat list with `parent_run_id` refs
- `query_dispatcher_state` — status counts + `latest_batch_id` for supervisory agents
- `query_system_health` — DB health check; always returns, never raises

Also adds lightweight DB helpers (`get_run_by_id`, `get_children_by_parent_id`, `get_active_runs`, `get_run_status_counts`, `check_db_reachable`) using fully-typed SQLAlchemy expressions.

## Test plan

- [x] mypy clean on all 4 changed files
- [x] 993 tests passing (0 failures)
- [x] 27 new tests covering success, not-found, missing args, graceful degradation, and TOOLS registry presence
- [x] Regression: `test_query_system_health_db_down` — tool returns `ok=True, db_ok=False` (never raises) when DB is unreachable
