### PR TITLE
feat(mcp): remove github read wrappers; route to user-github (PR 5)

### DIFF
--- a/.agentception/dispatcher.md
+++ b/.agentception/dispatcher.md
@@ -57,10 +57,10 @@ to make and which children to spawn:
 
 | TIER | SCOPE_TYPE | What SCOPE_VALUE means | GitHub queries |
 |------|-----------|------------------------|----------------|
-| `executive` | `label` | GitHub label string | `github_list_issues` + `github_list_prs` filtered to the label |
-| `coordinator` | `label` | GitHub label string | `github_list_issues` only (engineering) or `github_list_prs` only (qa) |
-| `engineer` | `issue` | Issue number (string) | `github_get_issue(issue_number=SCOPE_VALUE)` |
-| `reviewer` | `pr` | PR number (string) | `github_get_pr(pr_number=SCOPE_VALUE)` |
+| `executive` | `label` | GitHub label string | `list_issues (user-github)` + `list_pull_requests (user-github)` filtered to the label |
+| `coordinator` | `label` | GitHub label string | `list_issues (user-github)` only (engineering) or `list_pull_requests (user-github)` only (qa) |
+| `engineer` | `issue` | Issue number (string) | `issue_read (user-github)(issue_number=SCOPE_VALUE)` |
+| `reviewer` | `pr` | PR number (string) | `pull_request_read (user-github)(pr_number=SCOPE_VALUE)` |
 
 The `.agent-task` file contains inline comments with the MCP tool calls
 for this tier — pass them verbatim to the spawned agent in the briefing below.
@@ -119,13 +119,13 @@ Step 2: Read your .agent-task file:
 Step 3: Run your tier's GitHub queries via MCP to discover what needs doing.
 
   executive tier — call BOTH MCP tools:
-    github_list_issues(label="{scope_value}", state="open")
-    github_list_prs(state="open")
+    list_issues (user-github)(label="{scope_value}", state="open")
+    list_pull_requests (user-github)(state="open")
   Then: spawn engineering-coordinator if open issues exist,
         spawn qa-coordinator if open PRs exist (cleanup sweep only).
 
   coordinator tier (engineering-coordinator role) — call:
-    github_list_issues(label="{scope_value}", state="open")
+    list_issues (user-github)(label="{scope_value}", state="open")
   Filter out any issues with label "agent:wip" (already claimed),
   "blocked" (phase-gated — prior phase not yet complete), or "ticket-blocked"
   (has unresolved ticket-level dependencies — do not dispatch until all are closed).
@@ -133,7 +133,7 @@ Step 3: Run your tier's GitHub queries via MCP to discover what needs doing.
   Then: spawn one engineer per eligible issue (all in parallel via Task calls).
 
   coordinator tier (qa-coordinator role) — call:
-    github_list_prs(state="open")
+    list_pull_requests (user-github)(state="open")
   Then: spawn one pr-reviewer per open PR (all in parallel via Task calls).
 
 Step 4: For each child you spawn:
@@ -172,8 +172,8 @@ Step 2: Read your .agent-task file:
   {host_worktree_path}/.agent-task
 
 Step 3: Read your assigned {scope_type} via MCP:
-  engineer  → github_get_issue(number={scope_value})
-  reviewer  → github_get_pr(number={scope_value})
+  engineer  → issue_read (user-github)(number={scope_value})
+  reviewer  → pull_request_read (user-github)(number={scope_value})
 
 Step 4: Follow your role instructions exactly.
   engineer  → implement the issue in your worktree, open a PR against dev.

--- a/.agentception/parallel-issue-to-pr.md
+++ b/.agentception/parallel-issue-to-pr.md
@@ -440,10 +440,10 @@ writes — they add caching, structured output, and logging.
 
 | MCP tool | Replaces |
 |----------|---------|
-| `github_list_issues(state, label)` | `gh issue list --label X` |
-| `github_get_issue(issue_number)` | `gh issue view N --json ...` |
-| `github_list_prs(state)` | `gh pr list` |
-| `github_get_pr(pr_number)` | `gh pr view N --json ...` |
+| `list_issues (user-github)(state, label)` | `gh issue list --label X` |
+| `issue_read (user-github)(issue_number)` | `gh issue view N --json ...` |
+| `list_pull_requests (user-github)(state)` | `gh pr list` |
+| `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
 | `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
@@ -468,7 +468,7 @@ and all `git` commands.
 ### Command policy
 
 Consult `.agentception/agent-command-policy.md` for the full tier list. Summary:
-- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `github_get_issue`, `github_list_prs`, `mypy`, `pytest`, `rg`
+- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `issue_read (user-github)`, `list_pull_requests (user-github)`, `mypy`, `pytest`, `rg`
 - **Yellow (review before running):** `docker compose build`, `rm <single file>`, `git rebase`
 - **Red (never):** `rm -rf`, `git push --force`, `git push origin dev`, `docker system prune`
 
@@ -586,7 +586,7 @@ STEP 1 — DERIVE PATHS:
   export GH_REPO=cgcardona/agentception
 
   # ⚠️  VALIDATION — run this immediately to catch slug errors early:
-  # MCP: github_list_issues(state="open") → if it errors, GH_REPO is wrong. Stop and fix.
+  # MCP: list_issues (user-github)(state="open") → if it errors, GH_REPO is wrong. Stop and fix.
 
 STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
@@ -628,8 +628,8 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   #   body="🔖 **Claimed by agent**\n\n$CLAIM_FINGERPRINT")
 
   # 0. Is the issue itself already closed? (fastest exit — check this FIRST)
-  # MCP: github_get_issue(issue_number=N) → .state
-  ISSUE_STATE=<github_get_issue(N).state>
+  # MCP: issue_read (user-github)(issue_number=N) → .state
+  ISSUE_STATE=<issue_read (user-github)(N).state>
   if [ "$ISSUE_STATE" = "CLOSED" ]; then
     echo "⚠️  Issue #<N> is already CLOSED on GitHub. No work needed."
     # MCP: github_remove_label(issue_number=N, label="status/in-progress")
@@ -697,9 +697,9 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
     for DEP in "${DEP_NUMS[@]}"; do
       DEP=$(echo "$DEP" | tr -d '[:space:]')
       [ -z "$DEP" ] && continue
-      # MCP: github_get_issue(issue_number=DEP) → .state and .stateReason
-      DEP_STATE=<github_get_issue(DEP).state>
-      DEP_REASON=<github_get_issue(DEP).stateReason>
+      # MCP: issue_read (user-github)(issue_number=DEP) → .state and .stateReason
+      DEP_STATE=<issue_read (user-github)(DEP).state>
+      DEP_REASON=<issue_read (user-github)(DEP).stateReason>
       if [ "$DEP_STATE" != "CLOSED" ] || [ "$DEP_REASON" != "COMPLETED" ]; then
         echo "⚠️  Dependency #$DEP is $DEP_STATE (reason=$DEP_REASON) — not yet merged to dev. Note in PR body."
         ALL_DEPS_MET=false
@@ -1082,7 +1082,7 @@ STEP 5 — PUSH & CREATE PR:
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"
   # appears verbatim in the PR body. Verify now so you don't leave a ghost issue.
-  # MCP: github_get_pr(pr_number=MY_PR_NUM) → .body
+  # MCP: pull_request_read (user-github)(pr_number=MY_PR_NUM) → .body
   # Check: result.body must contain "Closes #<N>" (case-insensitive)
   # If missing → MCP: update_pull_request(owner=..., repo=..., pullNumber=MY_PR_NUM,
   #                      body=<existing body + "\n\nCloses #<N>">)
@@ -1112,12 +1112,12 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # resolve_arch.py will switch to --mode reviewer to load the checklist instead of
     # the implementer fragments.
     REVIEWER_ARCH="${COGNITIVE_ARCH:-knuth:python}"
-    # MCP: github_get_pr(pr_number=MY_PR) → use .title, .body, .headRefName
-    PR_TITLE_VAL=<github_get_pr(MY_PR).title>
+    # MCP: pull_request_read (user-github)(pr_number=MY_PR) → use .title, .body, .headRefName
+    PR_TITLE_VAL=<pull_request_read (user-github)(MY_PR).title>
     # MCP: pull_request_read(owner="cgcardona", repo="agentception",
     #      method="get_files", pullNumber=MY_PR) → join file paths with commas
     PR_FILES_VAL=<comma-separated file list from MCP pull_request_read get_files>
-    CLOSES_VAL=<parse "Closes #NNN" from github_get_pr(MY_PR).body, join with commas>
+    CLOSES_VAL=<parse "Closes #NNN" from pull_request_read (user-github)(MY_PR).body, join with commas>
     HAS_MIG=$(echo "$PR_FILES_VAL" | grep -c "alembic/versions/" || echo 0)
     [ "$HAS_MIG" -gt 0 ] && HAS_MIG_VAL=true || HAS_MIG_VAL=false
     cat > "$REVIEW_WORKTREE/.agent-task" <<TASK
@@ -1205,7 +1205,7 @@ Run this before touching the Setup script:
 
 ```
 # List every open issue for the current phase — this IS your candidate pool.
-# MCP: github_list_issues(state="open", label="phase-1")
+# MCP: list_issues (user-github)(state="open", label="phase-1")
 # → returns [{number, title, url, labels, ...}] — print each as "#N  title\n  url"
 ```
 
@@ -1222,7 +1222,7 @@ From the label audit output, choose issues that satisfy **both** criteria in
 candidate's body to identify affected files:
 
 ```
-# MCP: github_get_issue(issue_number=N) → .body and .title
+# MCP: issue_read (user-github)(issue_number=N) → .body and .title
 ```
 
 Confirm no two selected issues share a file. Document your selection in the
@@ -1245,8 +1245,8 @@ for num in <result from MCP list_pull_requests>; do
   #      method="get_files", pullNumber=num) → assign file paths to: files
   files=<file list from MCP pull_request_read get_files for PR num>
   if [ -n "$files" ]; then
-    # MCP: github_get_pr(pr_number=num) → .title
-    title=$(github_get_pr result .title)
+    # MCP: pull_request_read (user-github)(pr_number=num) → .title
+    title=$(pull_request_read (user-github) result .title)
     echo ""
     echo "PR #$num — $title:"
     echo "$files" | sed 's/^/  /'

--- a/.agentception/parallel-pr-review.md
+++ b/.agentception/parallel-pr-review.md
@@ -334,10 +334,10 @@ writes — they add caching, structured output, and logging.
 
 | MCP tool | Replaces |
 |----------|---------|
-| `github_list_issues(state, label)` | `gh issue list --label X` |
-| `github_get_issue(issue_number)` | `gh issue view N --json ...` |
-| `github_list_prs(state)` | `gh pr list` |
-| `github_get_pr(pr_number)` | `gh pr view N --json ...` |
+| `list_issues (user-github)(state, label)` | `gh issue list --label X` |
+| `issue_read (user-github)(issue_number)` | `gh issue view N --json ...` |
+| `list_pull_requests (user-github)(state)` | `gh pr list` |
+| `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
 | `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
@@ -362,7 +362,7 @@ and all `git` commands.
 ### Command policy
 
 Consult `.agentception/agent-command-policy.md` for the full tier list. Summary:
-- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `github_get_issue`, `github_list_prs`, `mypy`, `pytest`, `rg`
+- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `issue_read (user-github)`, `list_pull_requests (user-github)`, `mypy`, `pytest`, `rg`
 - **Yellow (review before running):** `docker compose build`, `rm <single file>`, `git rebase`
 - **Red (never):** `rm -rf`, `git push --force`, `git push origin dev`, `docker system prune`
 
@@ -962,8 +962,8 @@ STEP 5.5 — MERGE ORDER GATE (sequential chain safety):
   DO NOT loop indefinitely — escalate and self-destruct instead.
 
     for i in $(seq 1 15); do
-      # MCP: github_get_pr(pr_number=MERGE_AFTER) → .state
-      STATE=<github_get_pr(MERGE_AFTER).state>
+      # MCP: pull_request_read (user-github)(pr_number=MERGE_AFTER) → .state
+      STATE=<pull_request_read (user-github)(MERGE_AFTER).state>
       echo "[$i/15] Gate PR #$MERGE_AFTER state: $STATE"
       if [ "$STATE" = "MERGED" ]; then
         echo "✅ Gate cleared — PR #$MERGE_AFTER is merged. Proceeding to merge."
@@ -1145,7 +1145,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
-         # MCP: github_get_pr(pr_number=N) → .body → parse "Closes #NNN" patterns
+         # MCP: pull_request_read (user-github)(pr_number=N) → .body → parse "Closes #NNN" patterns
          # Then for each parsed issue number, call MCP issue_write to close it.
          echo "Parse PR body for Closes #NNN patterns, then close each via MCP issue_write"
        fi
@@ -1287,7 +1287,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
        for label in ac-ui/0-critical-bugs ac-ui/1-design-tokens \
                         ac-ui/2-data-model ac-ui/3-core-pages \
                         ac-ui/4-controls-intelligence ac-ui/5-polish; do
-      # MCP: github_list_issues(label="$label", state="open") → .count
+      # MCP: list_issues (user-github)(label="$label", state="open") → .count
       COUNT=<count from MCP response>
       if [ "$COUNT" -gt 0 ]; then
         ACTIVE_LABEL="$label"
@@ -1301,7 +1301,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       TASK_BATCH_ID=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('pipeline',{}).get('batch_id',''))" 2>/dev/null || echo "")
       BATCH_LABEL_PREFIX=$(echo "$TASK_BATCH_ID" | grep -oE 'batch-[0-9]+' | head -1)
       if [ -n "$BATCH_LABEL_PREFIX" ]; then
-        # MCP: github_list_issues(label="$BATCH_LABEL_PREFIX", state="open") → .count
+        # MCP: list_issues (user-github)(label="$BATCH_LABEL_PREFIX", state="open") → .count
         BATCH_COUNT=<count from MCP response>
         if [ "$BATCH_COUNT" -gt 0 ]; then
           ACTIVE_LABEL="$BATCH_LABEL_PREFIX"
@@ -1314,7 +1314,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       echo "ℹ️  No open ac-ui/ or batch issues remain — chain complete."
     else
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
-      # MCP: github_list_issues(label="$ACTIVE_LABEL", state="open")
+      # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "agent:wip" (already claimed),
       # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
@@ -1324,14 +1324,14 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     # Dependency gate: only proceed if all "Depends on #NNN" references are CLOSED.
     if [ -n "$NEXT_ISSUE" ]; then
-      # MCP: github_get_issue(number=$NEXT_ISSUE) → .body
+      # MCP: issue_read (user-github)(number=$NEXT_ISSUE) → .body
       # Parse "Depends on #NNN" references from body text.
       # For each dependency:
-      #   MCP: github_get_issue(number=<dep>) → check .state and .state_reason
+      #   MCP: issue_read (user-github)(number=<dep>) → check .state and .state_reason
       #   If state != "closed" or state_reason != "completed" → skip this issue.
       DEPS=<parsed dependency issue numbers>
       for dep in $DEPS; do
-        # MCP: github_get_issue(number=$dep) → .state
+        # MCP: issue_read (user-github)(number=$dep) → .state
         DEP_STATE=<state from MCP>
         if [ "$DEP_STATE" != "closed" ]; then
           echo "ℹ️  Issue #$NEXT_ISSUE blocked by dependency #$dep (state=$DEP_STATE) — chain complete for now."
@@ -1359,7 +1359,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # MCP: github_claim_issue(issue_number=$NEXT_ISSUE)
 
       # Resolve the primary label so the engineer can route mypy/tests correctly.
-      # MCP: github_get_issue(number=$NEXT_ISSUE) → .labels
+      # MCP: issue_read (user-github)(number=$NEXT_ISSUE) → .labels
       # Pick the first label starting with "ac-ui/"
       NEXT_ISSUE_LABEL=<label from MCP response>
 
@@ -1419,12 +1419,12 @@ TASK
   else
     # ── POOL MODE: spawned by QA Coordinator; spawn the next REVIEWER for the next open PR ──
 
-    # MCP: github_list_prs(state="open") → filter out any with label "agent:wip"
+    # MCP: list_pull_requests (user-github)(state="open") → filter out any with label "agent:wip"
     # Take the first unclaimed PR targeting dev.
     NEXT_PR=<first unclaimed PR number from MCP response>
 
     if [ -n "$NEXT_PR" ]; then
-      # MCP: github_get_pr(pr_number=$NEXT_PR) → .headRefName, .title, .body
+      # MCP: pull_request_read (user-github)(pr_number=$NEXT_PR) → .headRefName, .title, .body
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
@@ -1568,7 +1568,7 @@ If two PRs in the batch share a file:
 ### Step 1 — Confirm PRs are open
 
 ```
-# MCP: github_list_prs(state="open")
+# MCP: list_pull_requests (user-github)(state="open")
 ```
 
 ### Step 2 — Confirm `dev` is up to date
@@ -1606,7 +1606,7 @@ docker compose exec agentception ls /worktrees/
 REPO=$(git rev-parse --show-toplevel)
 git -C "$REPO" fetch origin
 git -C "$REPO" merge origin/dev
-# MCP: github_list_prs(state="open")   # any PRs the batch failed to merge?
+# MCP: list_pull_requests (user-github)(state="open")   # any PRs the batch failed to merge?
 ```
 
 ### 2 — Worktree cleanup

--- a/.agentception/roles/coordinator.md
+++ b/.agentception/roles/coordinator.md
@@ -5,9 +5,9 @@ You route work. You do not do work. You never implement features, write migratio
 
 ## Decision Hierarchy
 
-1. **GitHub state is truth.** Never assume readiness without querying. Use MCP tools (`github_list_issues`, `github_list_prs`, `github_get_pr`) — never assume state.
+1. **GitHub state is truth.** Never assume readiness without querying. Use MCP tools (`list_issues (user-github)`, `list_pull_requests (user-github)`, `pull_request_read (user-github)`) — never assume state.
 2. **Dependency order before parallelism.** Check `DEPENDS_ON` before dispatching. Starting before a dependency merges creates conflicts.
-3. **Artifact proof required.** "Done" without a PR URL is not done. Require the URL. Verify with MCP `github_get_pr` or `pull_request_read`.
+3. **Artifact proof required.** "Done" without a PR URL is not done. Require the URL. Verify with MCP `pull_request_read (user-github)` or `pull_request_read`.
 4. **Human gates before migration phases.** Any `phase-1/db-schema` or `security` work requires explicit human sign-off. Stop and ask.
 
 ## What You Dispatch

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -95,12 +95,12 @@ LOOP:
        # worktree + open PR = active claim, not a stale one.
        MAIN_REPO="<repo-root>"
 
-       # MCP: github_list_issues(state="open", label="agent:wip")
+       # MCP: list_issues (user-github)(state="open", label="agent:wip")
        # → returns list of {number, title, labels, ...}; iterate each .number as NUM
-       for NUM in <numbers from github_list_issues result>; do
+       for NUM in <numbers from list_issues (user-github) result>; do
          # Open PR guard — branch name is the canonical link between issue and PR.
-         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
-         OPEN_PR=<pr_number from github_list_prs result, or empty>
+         # MCP: list_pull_requests (user-github)(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
+         OPEN_PR=<pr_number from list_pull_requests (user-github) result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "CTO preflight: keeping agent:wip on #$NUM (open PR #$OPEN_PR — worktree pruning expected)"
            continue
@@ -124,16 +124,16 @@ LOOP:
        # SCOPE_VALUE was loaded from .agent-task in Step 2 of your briefing.
        # Discover phase sub-labels dynamically from open issues — never hardcode.
 
-       # MCP: github_list_issues(state="open", label="$SCOPE_VALUE")
+       # MCP: list_issues (user-github)(state="open", label="$SCOPE_VALUE")
        # → from the result, collect all label names that start with "$SCOPE_VALUE/",
        #   deduplicate, and sort. These are your PHASES.
-       PHASES=<unique sorted sub-labels from github_list_issues result>
+       PHASES=<unique sorted sub-labels from list_issues (user-github) result>
 
        # Find the first phase with open issues (phases sort lexicographically).
        ACTIVE_LABEL=""
        for label in $PHASES; do
-         # MCP: github_list_issues(state="open", label="$label")
-         COUNT=<length of github_list_issues result>
+         # MCP: list_issues (user-github)(state="open", label="$label")
+         COUNT=<length of list_issues (user-github) result>
          if [ "$COUNT" -gt 0 ]; then
            ACTIVE_LABEL="$label"
            ISSUES=$COUNT
@@ -143,14 +143,14 @@ LOOP:
 
        # Fallback: no phase sub-labels found — use SCOPE_VALUE as the single label.
        if [ -z "$ACTIVE_LABEL" ]; then
-         # MCP: github_list_issues(state="open", label="$SCOPE_VALUE")
-         COUNT=<length of github_list_issues result>
+         # MCP: list_issues (user-github)(state="open", label="$SCOPE_VALUE")
+         COUNT=<length of list_issues (user-github) result>
          [ "$COUNT" -gt 0 ] && ACTIVE_LABEL="$SCOPE_VALUE" && ISSUES=$COUNT
        fi
 
        # PRs: all open PRs against dev are always in scope.
-       # MCP: github_list_prs(state="open") → filter where .baseRefName == "dev"
-       PRS=<count from github_list_prs result>
+       # MCP: list_pull_requests (user-github)(state="open") → filter where .baseRefName == "dev"
+       PRS=<count from list_pull_requests (user-github) result>
 
        # If no active label found, all issues are closed — check PRs only.
        [ -z "$ACTIVE_LABEL" ] && ISSUES=0
@@ -338,13 +338,13 @@ SEED:
        # If the worktree exists AND has commits, the claim is ACTIVE — do NOT touch it.
        MAIN_REPO=$(git -C "<repo-root>" rev-parse --show-toplevel 2>/dev/null || echo "<repo-root>")
 
-       # MCP: github_list_issues(state="open", label="agent:wip")
+       # MCP: list_issues (user-github)(state="open", label="agent:wip")
        # → returns list of {number, title, labels, ...}; iterate each .number as NUM
-       for NUM in <numbers from github_list_issues result>; do
+       for NUM in <numbers from list_issues (user-github) result>; do
          # If an open PR already references this issue (via branch name or close keyword),
          # the claim is ACTIVE even if the implementer worktree was pruned. Never clear it.
-         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
-         OPEN_PR=<pr_number from github_list_prs result, or empty>
+         # MCP: list_pull_requests (user-github)(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
+         OPEN_PR=<pr_number from list_pull_requests (user-github) result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "Keeping agent:wip on #$NUM (open PR #$OPEN_PR exists — worktree pruning is expected)"
            continue
@@ -370,7 +370,7 @@ SEED:
        # NEVER query all ac-ui/* labels — you are scoped to exactly one label per coordinator run.
        # This prevents you from accidentally claiming issues from a later phase.
        ACTIVE_LABEL="<from dispatch prompt>"
-       # MCP: github_list_issues(state="open", label="$ACTIVE_LABEL")
+       # MCP: list_issues (user-github)(state="open", label="$ACTIVE_LABEL")
        # → filter result to exclude issues that have any of these labels:
        #     "agent:wip"  (already claimed by another agent)
        #     "blocked"            (phase-gated — prior phase not yet complete)
@@ -384,8 +384,8 @@ SEED:
        # the stale sweep to (incorrectly) clear agent:wip and expose the issue again.
        # Always re-verify before seeding — branch naming is the canonical signal.
        for NUM in <candidate numbers from step 3>; do
-         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
-         OPEN_PR=<pr_number from github_list_prs result, or empty>
+         # MCP: list_pull_requests (user-github)(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
+         OPEN_PR=<pr_number from list_pull_requests (user-github) result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "SKIP #$NUM — open PR #$OPEN_PR already exists for this issue"
            # Remove from candidate list
@@ -400,13 +400,13 @@ SEED:
      Secondary signal (belt-and-suspenders): parse "Blocked by #NNN" from the
      issue body and verify each dep is CLOSED. Skip if any dep is still OPEN.
        for NUM in <candidate numbers>; do
-         # MCP: github_get_issue(number=NUM) → .body
+         # MCP: issue_read (user-github)(number=NUM) → .body
          # Extract "Blocked by #NNN" patterns from .body, iterate each dep number.
-         DEPS=<dep numbers parsed from github_get_issue(NUM).body>
+         DEPS=<dep numbers parsed from issue_read (user-github)(NUM).body>
          ALL_MET=true
          for dep in $DEPS; do
-           # MCP: github_get_issue(number=dep) → .state
-           STATE=<github_get_issue(dep).state>
+           # MCP: issue_read (user-github)(number=dep) → .state
+           STATE=<issue_read (user-github)(dep).state>
            [ "$STATE" != "closed" ] && ALL_MET=false && break
          done
          [ "$ALL_MET" = "true" ] && echo "SEED $NUM" || echo "SKIP $NUM (deps unmet)"
@@ -420,7 +420,7 @@ SEED:
   5. Take the first 4 unclaimed issues. For each:
        a. Claim:  MCP: github_add_label(issue_number=N, label="agent:wip")
        b. Read the issue body:
-            # MCP: github_get_issue(number=N) → use .body and .title
+            # MCP: issue_read (user-github)(number=N) → use .body and .title
        c. Call ``build_spawn_child`` MCP tool to create the engineer node atomically:
           ```
           build_spawn_child(
@@ -930,10 +930,10 @@ writes — they add caching, structured output, and logging.
 
 | MCP tool | Replaces |
 |----------|---------|
-| `github_list_issues(state, label)` | `gh issue list --label X` |
-| `github_get_issue(issue_number)` | `gh issue view N --json ...` |
-| `github_list_prs(state)` | `gh pr list` |
-| `github_get_pr(pr_number)` | `gh pr view N --json ...` |
+| `list_issues (user-github)(state, label)` | `gh issue list --label X` |
+| `issue_read (user-github)(issue_number)` | `gh issue view N --json ...` |
+| `list_pull_requests (user-github)(state)` | `gh pr list` |
+| `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
 | `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
@@ -958,7 +958,7 @@ and all `git` commands.
 ### Command policy
 
 Consult `.agentception/agent-command-policy.md` for the full tier list. Summary:
-- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `github_get_issue`, `github_list_prs`, `mypy`, `pytest`, `rg`
+- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `issue_read (user-github)`, `list_pull_requests (user-github)`, `mypy`, `pytest`, `rg`
 - **Yellow (review before running):** `docker compose build`, `rm <single file>`, `git rebase`
 - **Red (never):** `rm -rf`, `git push --force`, `git push origin dev`, `docker system prune`
 
@@ -1076,7 +1076,7 @@ STEP 1 — DERIVE PATHS:
   export GH_REPO=cgcardona/agentception
 
   # ⚠️  VALIDATION — run this immediately to catch slug errors early:
-  # MCP: github_list_issues(state="open") → if it errors, GH_REPO is wrong. Stop and fix.
+  # MCP: list_issues (user-github)(state="open") → if it errors, GH_REPO is wrong. Stop and fix.
 
 STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
@@ -1118,8 +1118,8 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   #   body="🔖 **Claimed by agent**\n\n$CLAIM_FINGERPRINT")
 
   # 0. Is the issue itself already closed? (fastest exit — check this FIRST)
-  # MCP: github_get_issue(issue_number=N) → .state
-  ISSUE_STATE=<github_get_issue(N).state>
+  # MCP: issue_read (user-github)(issue_number=N) → .state
+  ISSUE_STATE=<issue_read (user-github)(N).state>
   if [ "$ISSUE_STATE" = "CLOSED" ]; then
     echo "⚠️  Issue #<N> is already CLOSED on GitHub. No work needed."
     # MCP: github_remove_label(issue_number=N, label="status/in-progress")
@@ -1187,9 +1187,9 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
     for DEP in "${DEP_NUMS[@]}"; do
       DEP=$(echo "$DEP" | tr -d '[:space:]')
       [ -z "$DEP" ] && continue
-      # MCP: github_get_issue(issue_number=DEP) → .state and .stateReason
-      DEP_STATE=<github_get_issue(DEP).state>
-      DEP_REASON=<github_get_issue(DEP).stateReason>
+      # MCP: issue_read (user-github)(issue_number=DEP) → .state and .stateReason
+      DEP_STATE=<issue_read (user-github)(DEP).state>
+      DEP_REASON=<issue_read (user-github)(DEP).stateReason>
       if [ "$DEP_STATE" != "CLOSED" ] || [ "$DEP_REASON" != "COMPLETED" ]; then
         echo "⚠️  Dependency #$DEP is $DEP_STATE (reason=$DEP_REASON) — not yet merged to dev. Note in PR body."
         ALL_DEPS_MET=false
@@ -1572,7 +1572,7 @@ STEP 5 — PUSH & CREATE PR:
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"
   # appears verbatim in the PR body. Verify now so you don't leave a ghost issue.
-  # MCP: github_get_pr(pr_number=MY_PR_NUM) → .body
+  # MCP: pull_request_read (user-github)(pr_number=MY_PR_NUM) → .body
   # Check: result.body must contain "Closes #<N>" (case-insensitive)
   # If missing → MCP: update_pull_request(owner=..., repo=..., pullNumber=MY_PR_NUM,
   #                      body=<existing body + "\n\nCloses #<N>">)
@@ -1602,12 +1602,12 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # resolve_arch.py will switch to --mode reviewer to load the checklist instead of
     # the implementer fragments.
     REVIEWER_ARCH="${COGNITIVE_ARCH:-knuth:python}"
-    # MCP: github_get_pr(pr_number=MY_PR) → use .title, .body, .headRefName
-    PR_TITLE_VAL=<github_get_pr(MY_PR).title>
+    # MCP: pull_request_read (user-github)(pr_number=MY_PR) → use .title, .body, .headRefName
+    PR_TITLE_VAL=<pull_request_read (user-github)(MY_PR).title>
     # MCP: pull_request_read(owner="cgcardona", repo="agentception",
     #      method="get_files", pullNumber=MY_PR) → join file paths with commas
     PR_FILES_VAL=<comma-separated file list from MCP pull_request_read get_files>
-    CLOSES_VAL=<parse "Closes #NNN" from github_get_pr(MY_PR).body, join with commas>
+    CLOSES_VAL=<parse "Closes #NNN" from pull_request_read (user-github)(MY_PR).body, join with commas>
     HAS_MIG=$(echo "$PR_FILES_VAL" | grep -c "alembic/versions/" || echo 0)
     [ "$HAS_MIG" -gt 0 ] && HAS_MIG_VAL=true || HAS_MIG_VAL=false
     cat > "$REVIEW_WORKTREE/.agent-task" <<TASK
@@ -1695,7 +1695,7 @@ Run this before touching the Setup script:
 
 ```
 # List every open issue for the current phase — this IS your candidate pool.
-# MCP: github_list_issues(state="open", label="phase-1")
+# MCP: list_issues (user-github)(state="open", label="phase-1")
 # → returns [{number, title, url, labels, ...}] — print each as "#N  title\n  url"
 ```
 
@@ -1712,7 +1712,7 @@ From the label audit output, choose issues that satisfy **both** criteria in
 candidate's body to identify affected files:
 
 ```
-# MCP: github_get_issue(issue_number=N) → .body and .title
+# MCP: issue_read (user-github)(issue_number=N) → .body and .title
 ```
 
 Confirm no two selected issues share a file. Document your selection in the
@@ -1735,8 +1735,8 @@ for num in <result from MCP list_pull_requests>; do
   #      method="get_files", pullNumber=num) → assign file paths to: files
   files=<file list from MCP pull_request_read get_files for PR num>
   if [ -n "$files" ]; then
-    # MCP: github_get_pr(pr_number=num) → .title
-    title=$(github_get_pr result .title)
+    # MCP: pull_request_read (user-github)(pr_number=num) → .title
+    title=$(pull_request_read (user-github) result .title)
     echo ""
     echo "PR #$num — $title:"
     echo "$files" | sed 's/^/  /'
@@ -2452,10 +2452,10 @@ writes — they add caching, structured output, and logging.
 
 | MCP tool | Replaces |
 |----------|---------|
-| `github_list_issues(state, label)` | `gh issue list --label X` |
-| `github_get_issue(issue_number)` | `gh issue view N --json ...` |
-| `github_list_prs(state)` | `gh pr list` |
-| `github_get_pr(pr_number)` | `gh pr view N --json ...` |
+| `list_issues (user-github)(state, label)` | `gh issue list --label X` |
+| `issue_read (user-github)(issue_number)` | `gh issue view N --json ...` |
+| `list_pull_requests (user-github)(state)` | `gh pr list` |
+| `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
 | `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
@@ -2480,7 +2480,7 @@ and all `git` commands.
 ### Command policy
 
 Consult `.agentception/agent-command-policy.md` for the full tier list. Summary:
-- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `github_get_issue`, `github_list_prs`, `mypy`, `pytest`, `rg`
+- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `issue_read (user-github)`, `list_pull_requests (user-github)`, `mypy`, `pytest`, `rg`
 - **Yellow (review before running):** `docker compose build`, `rm <single file>`, `git rebase`
 - **Red (never):** `rm -rf`, `git push --force`, `git push origin dev`, `docker system prune`
 
@@ -3080,8 +3080,8 @@ STEP 5.5 — MERGE ORDER GATE (sequential chain safety):
   DO NOT loop indefinitely — escalate and self-destruct instead.
 
     for i in $(seq 1 15); do
-      # MCP: github_get_pr(pr_number=MERGE_AFTER) → .state
-      STATE=<github_get_pr(MERGE_AFTER).state>
+      # MCP: pull_request_read (user-github)(pr_number=MERGE_AFTER) → .state
+      STATE=<pull_request_read (user-github)(MERGE_AFTER).state>
       echo "[$i/15] Gate PR #$MERGE_AFTER state: $STATE"
       if [ "$STATE" = "MERGED" ]; then
         echo "✅ Gate cleared — PR #$MERGE_AFTER is merged. Proceeding to merge."
@@ -3263,7 +3263,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
-         # MCP: github_get_pr(pr_number=N) → .body → parse "Closes #NNN" patterns
+         # MCP: pull_request_read (user-github)(pr_number=N) → .body → parse "Closes #NNN" patterns
          # Then for each parsed issue number, call MCP issue_write to close it.
          echo "Parse PR body for Closes #NNN patterns, then close each via MCP issue_write"
        fi
@@ -3405,7 +3405,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
        for label in ac-ui/0-critical-bugs ac-ui/1-design-tokens \
                         ac-ui/2-data-model ac-ui/3-core-pages \
                         ac-ui/4-controls-intelligence ac-ui/5-polish; do
-      # MCP: github_list_issues(label="$label", state="open") → .count
+      # MCP: list_issues (user-github)(label="$label", state="open") → .count
       COUNT=<count from MCP response>
       if [ "$COUNT" -gt 0 ]; then
         ACTIVE_LABEL="$label"
@@ -3419,7 +3419,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       TASK_BATCH_ID=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('pipeline',{}).get('batch_id',''))" 2>/dev/null || echo "")
       BATCH_LABEL_PREFIX=$(echo "$TASK_BATCH_ID" | grep -oE 'batch-[0-9]+' | head -1)
       if [ -n "$BATCH_LABEL_PREFIX" ]; then
-        # MCP: github_list_issues(label="$BATCH_LABEL_PREFIX", state="open") → .count
+        # MCP: list_issues (user-github)(label="$BATCH_LABEL_PREFIX", state="open") → .count
         BATCH_COUNT=<count from MCP response>
         if [ "$BATCH_COUNT" -gt 0 ]; then
           ACTIVE_LABEL="$BATCH_LABEL_PREFIX"
@@ -3432,7 +3432,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       echo "ℹ️  No open ac-ui/ or batch issues remain — chain complete."
     else
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
-      # MCP: github_list_issues(label="$ACTIVE_LABEL", state="open")
+      # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "agent:wip" (already claimed),
       # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
@@ -3442,14 +3442,14 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     # Dependency gate: only proceed if all "Depends on #NNN" references are CLOSED.
     if [ -n "$NEXT_ISSUE" ]; then
-      # MCP: github_get_issue(number=$NEXT_ISSUE) → .body
+      # MCP: issue_read (user-github)(number=$NEXT_ISSUE) → .body
       # Parse "Depends on #NNN" references from body text.
       # For each dependency:
-      #   MCP: github_get_issue(number=<dep>) → check .state and .state_reason
+      #   MCP: issue_read (user-github)(number=<dep>) → check .state and .state_reason
       #   If state != "closed" or state_reason != "completed" → skip this issue.
       DEPS=<parsed dependency issue numbers>
       for dep in $DEPS; do
-        # MCP: github_get_issue(number=$dep) → .state
+        # MCP: issue_read (user-github)(number=$dep) → .state
         DEP_STATE=<state from MCP>
         if [ "$DEP_STATE" != "closed" ]; then
           echo "ℹ️  Issue #$NEXT_ISSUE blocked by dependency #$dep (state=$DEP_STATE) — chain complete for now."
@@ -3477,7 +3477,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # MCP: github_claim_issue(issue_number=$NEXT_ISSUE)
 
       # Resolve the primary label so the engineer can route mypy/tests correctly.
-      # MCP: github_get_issue(number=$NEXT_ISSUE) → .labels
+      # MCP: issue_read (user-github)(number=$NEXT_ISSUE) → .labels
       # Pick the first label starting with "ac-ui/"
       NEXT_ISSUE_LABEL=<label from MCP response>
 
@@ -3537,12 +3537,12 @@ TASK
   else
     # ── POOL MODE: spawned by QA Coordinator; spawn the next REVIEWER for the next open PR ──
 
-    # MCP: github_list_prs(state="open") → filter out any with label "agent:wip"
+    # MCP: list_pull_requests (user-github)(state="open") → filter out any with label "agent:wip"
     # Take the first unclaimed PR targeting dev.
     NEXT_PR=<first unclaimed PR number from MCP response>
 
     if [ -n "$NEXT_PR" ]; then
-      # MCP: github_get_pr(pr_number=$NEXT_PR) → .headRefName, .title, .body
+      # MCP: pull_request_read (user-github)(pr_number=$NEXT_PR) → .headRefName, .title, .body
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
@@ -3686,7 +3686,7 @@ If two PRs in the batch share a file:
 ### Step 1 — Confirm PRs are open
 
 ```
-# MCP: github_list_prs(state="open")
+# MCP: list_pull_requests (user-github)(state="open")
 ```
 
 ### Step 2 — Confirm `dev` is up to date
@@ -3724,7 +3724,7 @@ docker compose exec agentception ls /worktrees/
 REPO=$(git rev-parse --show-toplevel)
 git -C "$REPO" fetch origin
 git -C "$REPO" merge origin/dev
-# MCP: github_list_prs(state="open")   # any PRs the batch failed to merge?
+# MCP: list_pull_requests (user-github)(state="open")   # any PRs the batch failed to merge?
 ```
 
 ### 2 — Worktree cleanup
@@ -3960,7 +3960,7 @@ SEED:
        MAIN_REPO="<repo-root>"
        git -C "$MAIN_REPO" worktree list --porcelain | grep "^worktree" | awk '{print $2}' \
          > /tmp/active_worktrees
-       # MCP: github_list_prs(state="open") → filter to those with label "agent:wip"
+       # MCP: list_pull_requests (user-github)(state="open") → filter to those with label "agent:wip"
        for pr in <PR numbers with agent:wip>; do
          grep -q "pr-$pr" /tmp/active_worktrees || \
            # MCP: github_remove_label(issue_number=pr, label="agent:wip")
@@ -3968,7 +3968,7 @@ SEED:
        done
 
   3. Query open unclaimed PRs:
-       # MCP: github_list_prs(state="open")
+       # MCP: list_pull_requests (user-github)(state="open")
        # → filter result to exclude PRs that already have the "agent:wip" label
      If empty → report "review queue clear." Stop.
 
@@ -3980,7 +3980,7 @@ SEED:
   5. Take the first 4 unclaimed PRs. For each:
        a. Claim:  MCP: github_add_label(issue_number=N, label="agent:wip")
        b. Get PR body and title:
-            # MCP: github_get_pr(pr_number=N) → use .body, .title, .headRefName
+            # MCP: pull_request_read (user-github)(pr_number=N) → use .body, .title, .headRefName
        c. Call ``build_spawn_child`` MCP tool to create the reviewer node atomically:
           ```
           build_spawn_child(
@@ -4027,7 +4027,7 @@ required fields including COGNITIVE_ARCH, BATCH_ID, lineage fields, and scope.
 You do NOT need to write `.agent-task` files manually.
 
 If a worktree is missing for a new PR:
-  `# MCP: github_get_pr(pr_number=N) → .headRefName`
+  `# MCP: pull_request_read (user-github)(pr_number=N) → .headRefName`
   `git -C "<repo-root>" worktree add "$HOME/.agentception/worktrees/agentception/pr-{N}" origin/$BRANCH`
 
 ## MERGE_AFTER protocol
@@ -4392,10 +4392,10 @@ writes — they add caching, structured output, and logging.
 
 | MCP tool | Replaces |
 |----------|---------|
-| `github_list_issues(state, label)` | `gh issue list --label X` |
-| `github_get_issue(issue_number)` | `gh issue view N --json ...` |
-| `github_list_prs(state)` | `gh pr list` |
-| `github_get_pr(pr_number)` | `gh pr view N --json ...` |
+| `list_issues (user-github)(state, label)` | `gh issue list --label X` |
+| `issue_read (user-github)(issue_number)` | `gh issue view N --json ...` |
+| `list_pull_requests (user-github)(state)` | `gh pr list` |
+| `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
 | `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
@@ -4420,7 +4420,7 @@ and all `git` commands.
 ### Command policy
 
 Consult `.agentception/agent-command-policy.md` for the full tier list. Summary:
-- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `github_get_issue`, `github_list_prs`, `mypy`, `pytest`, `rg`
+- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `issue_read (user-github)`, `list_pull_requests (user-github)`, `mypy`, `pytest`, `rg`
 - **Yellow (review before running):** `docker compose build`, `rm <single file>`, `git rebase`
 - **Red (never):** `rm -rf`, `git push --force`, `git push origin dev`, `docker system prune`
 
@@ -5020,8 +5020,8 @@ STEP 5.5 — MERGE ORDER GATE (sequential chain safety):
   DO NOT loop indefinitely — escalate and self-destruct instead.
 
     for i in $(seq 1 15); do
-      # MCP: github_get_pr(pr_number=MERGE_AFTER) → .state
-      STATE=<github_get_pr(MERGE_AFTER).state>
+      # MCP: pull_request_read (user-github)(pr_number=MERGE_AFTER) → .state
+      STATE=<pull_request_read (user-github)(MERGE_AFTER).state>
       echo "[$i/15] Gate PR #$MERGE_AFTER state: $STATE"
       if [ "$STATE" = "MERGED" ]; then
         echo "✅ Gate cleared — PR #$MERGE_AFTER is merged. Proceeding to merge."
@@ -5203,7 +5203,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
-         # MCP: github_get_pr(pr_number=N) → .body → parse "Closes #NNN" patterns
+         # MCP: pull_request_read (user-github)(pr_number=N) → .body → parse "Closes #NNN" patterns
          # Then for each parsed issue number, call MCP issue_write to close it.
          echo "Parse PR body for Closes #NNN patterns, then close each via MCP issue_write"
        fi
@@ -5345,7 +5345,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
        for label in ac-ui/0-critical-bugs ac-ui/1-design-tokens \
                         ac-ui/2-data-model ac-ui/3-core-pages \
                         ac-ui/4-controls-intelligence ac-ui/5-polish; do
-      # MCP: github_list_issues(label="$label", state="open") → .count
+      # MCP: list_issues (user-github)(label="$label", state="open") → .count
       COUNT=<count from MCP response>
       if [ "$COUNT" -gt 0 ]; then
         ACTIVE_LABEL="$label"
@@ -5359,7 +5359,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       TASK_BATCH_ID=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('pipeline',{}).get('batch_id',''))" 2>/dev/null || echo "")
       BATCH_LABEL_PREFIX=$(echo "$TASK_BATCH_ID" | grep -oE 'batch-[0-9]+' | head -1)
       if [ -n "$BATCH_LABEL_PREFIX" ]; then
-        # MCP: github_list_issues(label="$BATCH_LABEL_PREFIX", state="open") → .count
+        # MCP: list_issues (user-github)(label="$BATCH_LABEL_PREFIX", state="open") → .count
         BATCH_COUNT=<count from MCP response>
         if [ "$BATCH_COUNT" -gt 0 ]; then
           ACTIVE_LABEL="$BATCH_LABEL_PREFIX"
@@ -5372,7 +5372,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       echo "ℹ️  No open ac-ui/ or batch issues remain — chain complete."
     else
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
-      # MCP: github_list_issues(label="$ACTIVE_LABEL", state="open")
+      # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "agent:wip" (already claimed),
       # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
@@ -5382,14 +5382,14 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     # Dependency gate: only proceed if all "Depends on #NNN" references are CLOSED.
     if [ -n "$NEXT_ISSUE" ]; then
-      # MCP: github_get_issue(number=$NEXT_ISSUE) → .body
+      # MCP: issue_read (user-github)(number=$NEXT_ISSUE) → .body
       # Parse "Depends on #NNN" references from body text.
       # For each dependency:
-      #   MCP: github_get_issue(number=<dep>) → check .state and .state_reason
+      #   MCP: issue_read (user-github)(number=<dep>) → check .state and .state_reason
       #   If state != "closed" or state_reason != "completed" → skip this issue.
       DEPS=<parsed dependency issue numbers>
       for dep in $DEPS; do
-        # MCP: github_get_issue(number=$dep) → .state
+        # MCP: issue_read (user-github)(number=$dep) → .state
         DEP_STATE=<state from MCP>
         if [ "$DEP_STATE" != "closed" ]; then
           echo "ℹ️  Issue #$NEXT_ISSUE blocked by dependency #$dep (state=$DEP_STATE) — chain complete for now."
@@ -5417,7 +5417,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # MCP: github_claim_issue(issue_number=$NEXT_ISSUE)
 
       # Resolve the primary label so the engineer can route mypy/tests correctly.
-      # MCP: github_get_issue(number=$NEXT_ISSUE) → .labels
+      # MCP: issue_read (user-github)(number=$NEXT_ISSUE) → .labels
       # Pick the first label starting with "ac-ui/"
       NEXT_ISSUE_LABEL=<label from MCP response>
 
@@ -5477,12 +5477,12 @@ TASK
   else
     # ── POOL MODE: spawned by QA Coordinator; spawn the next REVIEWER for the next open PR ──
 
-    # MCP: github_list_prs(state="open") → filter out any with label "agent:wip"
+    # MCP: list_pull_requests (user-github)(state="open") → filter out any with label "agent:wip"
     # Take the first unclaimed PR targeting dev.
     NEXT_PR=<first unclaimed PR number from MCP response>
 
     if [ -n "$NEXT_PR" ]; then
-      # MCP: github_get_pr(pr_number=$NEXT_PR) → .headRefName, .title, .body
+      # MCP: pull_request_read (user-github)(pr_number=$NEXT_PR) → .headRefName, .title, .body
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
@@ -5626,7 +5626,7 @@ If two PRs in the batch share a file:
 ### Step 1 — Confirm PRs are open
 
 ```
-# MCP: github_list_prs(state="open")
+# MCP: list_pull_requests (user-github)(state="open")
 ```
 
 ### Step 2 — Confirm `dev` is up to date
@@ -5664,7 +5664,7 @@ docker compose exec agentception ls /worktrees/
 REPO=$(git rev-parse --show-toplevel)
 git -C "$REPO" fetch origin
 git -C "$REPO" merge origin/dev
-# MCP: github_list_prs(state="open")   # any PRs the batch failed to merge?
+# MCP: list_pull_requests (user-github)(state="open")   # any PRs the batch failed to merge?
 ```
 
 ### 2 — Worktree cleanup
@@ -6257,10 +6257,10 @@ writes — they add caching, structured output, and logging.
 
 | MCP tool | Replaces |
 |----------|---------|
-| `github_list_issues(state, label)` | `gh issue list --label X` |
-| `github_get_issue(issue_number)` | `gh issue view N --json ...` |
-| `github_list_prs(state)` | `gh pr list` |
-| `github_get_pr(pr_number)` | `gh pr view N --json ...` |
+| `list_issues (user-github)(state, label)` | `gh issue list --label X` |
+| `issue_read (user-github)(issue_number)` | `gh issue view N --json ...` |
+| `list_pull_requests (user-github)(state)` | `gh pr list` |
+| `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
 | `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
@@ -6285,7 +6285,7 @@ and all `git` commands.
 ### Command policy
 
 Consult `.agentception/agent-command-policy.md` for the full tier list. Summary:
-- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `github_get_issue`, `github_list_prs`, `mypy`, `pytest`, `rg`
+- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `issue_read (user-github)`, `list_pull_requests (user-github)`, `mypy`, `pytest`, `rg`
 - **Yellow (review before running):** `docker compose build`, `rm <single file>`, `git rebase`
 - **Red (never):** `rm -rf`, `git push --force`, `git push origin dev`, `docker system prune`
 
@@ -6403,7 +6403,7 @@ STEP 1 — DERIVE PATHS:
   export GH_REPO=cgcardona/agentception
 
   # ⚠️  VALIDATION — run this immediately to catch slug errors early:
-  # MCP: github_list_issues(state="open") → if it errors, GH_REPO is wrong. Stop and fix.
+  # MCP: list_issues (user-github)(state="open") → if it errors, GH_REPO is wrong. Stop and fix.
 
 STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
@@ -6445,8 +6445,8 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   #   body="🔖 **Claimed by agent**\n\n$CLAIM_FINGERPRINT")
 
   # 0. Is the issue itself already closed? (fastest exit — check this FIRST)
-  # MCP: github_get_issue(issue_number=N) → .state
-  ISSUE_STATE=<github_get_issue(N).state>
+  # MCP: issue_read (user-github)(issue_number=N) → .state
+  ISSUE_STATE=<issue_read (user-github)(N).state>
   if [ "$ISSUE_STATE" = "CLOSED" ]; then
     echo "⚠️  Issue #<N> is already CLOSED on GitHub. No work needed."
     # MCP: github_remove_label(issue_number=N, label="status/in-progress")
@@ -6514,9 +6514,9 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
     for DEP in "${DEP_NUMS[@]}"; do
       DEP=$(echo "$DEP" | tr -d '[:space:]')
       [ -z "$DEP" ] && continue
-      # MCP: github_get_issue(issue_number=DEP) → .state and .stateReason
-      DEP_STATE=<github_get_issue(DEP).state>
-      DEP_REASON=<github_get_issue(DEP).stateReason>
+      # MCP: issue_read (user-github)(issue_number=DEP) → .state and .stateReason
+      DEP_STATE=<issue_read (user-github)(DEP).state>
+      DEP_REASON=<issue_read (user-github)(DEP).stateReason>
       if [ "$DEP_STATE" != "CLOSED" ] || [ "$DEP_REASON" != "COMPLETED" ]; then
         echo "⚠️  Dependency #$DEP is $DEP_STATE (reason=$DEP_REASON) — not yet merged to dev. Note in PR body."
         ALL_DEPS_MET=false
@@ -6899,7 +6899,7 @@ STEP 5 — PUSH & CREATE PR:
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"
   # appears verbatim in the PR body. Verify now so you don't leave a ghost issue.
-  # MCP: github_get_pr(pr_number=MY_PR_NUM) → .body
+  # MCP: pull_request_read (user-github)(pr_number=MY_PR_NUM) → .body
   # Check: result.body must contain "Closes #<N>" (case-insensitive)
   # If missing → MCP: update_pull_request(owner=..., repo=..., pullNumber=MY_PR_NUM,
   #                      body=<existing body + "\n\nCloses #<N>">)
@@ -6929,12 +6929,12 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # resolve_arch.py will switch to --mode reviewer to load the checklist instead of
     # the implementer fragments.
     REVIEWER_ARCH="${COGNITIVE_ARCH:-knuth:python}"
-    # MCP: github_get_pr(pr_number=MY_PR) → use .title, .body, .headRefName
-    PR_TITLE_VAL=<github_get_pr(MY_PR).title>
+    # MCP: pull_request_read (user-github)(pr_number=MY_PR) → use .title, .body, .headRefName
+    PR_TITLE_VAL=<pull_request_read (user-github)(MY_PR).title>
     # MCP: pull_request_read(owner="cgcardona", repo="agentception",
     #      method="get_files", pullNumber=MY_PR) → join file paths with commas
     PR_FILES_VAL=<comma-separated file list from MCP pull_request_read get_files>
-    CLOSES_VAL=<parse "Closes #NNN" from github_get_pr(MY_PR).body, join with commas>
+    CLOSES_VAL=<parse "Closes #NNN" from pull_request_read (user-github)(MY_PR).body, join with commas>
     HAS_MIG=$(echo "$PR_FILES_VAL" | grep -c "alembic/versions/" || echo 0)
     [ "$HAS_MIG" -gt 0 ] && HAS_MIG_VAL=true || HAS_MIG_VAL=false
     cat > "$REVIEW_WORKTREE/.agent-task" <<TASK
@@ -7022,7 +7022,7 @@ Run this before touching the Setup script:
 
 ```
 # List every open issue for the current phase — this IS your candidate pool.
-# MCP: github_list_issues(state="open", label="phase-1")
+# MCP: list_issues (user-github)(state="open", label="phase-1")
 # → returns [{number, title, url, labels, ...}] — print each as "#N  title\n  url"
 ```
 
@@ -7039,7 +7039,7 @@ From the label audit output, choose issues that satisfy **both** criteria in
 candidate's body to identify affected files:
 
 ```
-# MCP: github_get_issue(issue_number=N) → .body and .title
+# MCP: issue_read (user-github)(issue_number=N) → .body and .title
 ```
 
 Confirm no two selected issues share a file. Document your selection in the
@@ -7062,8 +7062,8 @@ for num in <result from MCP list_pull_requests>; do
   #      method="get_files", pullNumber=num) → assign file paths to: files
   files=<file list from MCP pull_request_read get_files for PR num>
   if [ -n "$files" ]; then
-    # MCP: github_get_pr(pr_number=num) → .title
-    title=$(github_get_pr result .title)
+    # MCP: pull_request_read (user-github)(pr_number=num) → .title
+    title=$(pull_request_read (user-github) result .title)
     echo ""
     echo "PR #$num — $title:"
     echo "$files" | sed 's/^/  /'

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -79,13 +79,13 @@ SEED:
        # If the worktree exists AND has commits, the claim is ACTIVE — do NOT touch it.
        MAIN_REPO=$(git -C "<repo-root>" rev-parse --show-toplevel 2>/dev/null || echo "<repo-root>")
 
-       # MCP: github_list_issues(state="open", label="agent:wip")
+       # MCP: list_issues (user-github)(state="open", label="agent:wip")
        # → returns list of {number, title, labels, ...}; iterate each .number as NUM
-       for NUM in <numbers from github_list_issues result>; do
+       for NUM in <numbers from list_issues (user-github) result>; do
          # If an open PR already references this issue (via branch name or close keyword),
          # the claim is ACTIVE even if the implementer worktree was pruned. Never clear it.
-         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
-         OPEN_PR=<pr_number from github_list_prs result, or empty>
+         # MCP: list_pull_requests (user-github)(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
+         OPEN_PR=<pr_number from list_pull_requests (user-github) result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "Keeping agent:wip on #$NUM (open PR #$OPEN_PR exists — worktree pruning is expected)"
            continue
@@ -111,7 +111,7 @@ SEED:
        # NEVER query all ac-ui/* labels — you are scoped to exactly one label per coordinator run.
        # This prevents you from accidentally claiming issues from a later phase.
        ACTIVE_LABEL="<from dispatch prompt>"
-       # MCP: github_list_issues(state="open", label="$ACTIVE_LABEL")
+       # MCP: list_issues (user-github)(state="open", label="$ACTIVE_LABEL")
        # → filter result to exclude issues that have any of these labels:
        #     "agent:wip"  (already claimed by another agent)
        #     "blocked"            (phase-gated — prior phase not yet complete)
@@ -125,8 +125,8 @@ SEED:
        # the stale sweep to (incorrectly) clear agent:wip and expose the issue again.
        # Always re-verify before seeding — branch naming is the canonical signal.
        for NUM in <candidate numbers from step 3>; do
-         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
-         OPEN_PR=<pr_number from github_list_prs result, or empty>
+         # MCP: list_pull_requests (user-github)(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
+         OPEN_PR=<pr_number from list_pull_requests (user-github) result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "SKIP #$NUM — open PR #$OPEN_PR already exists for this issue"
            # Remove from candidate list
@@ -141,13 +141,13 @@ SEED:
      Secondary signal (belt-and-suspenders): parse "Blocked by #NNN" from the
      issue body and verify each dep is CLOSED. Skip if any dep is still OPEN.
        for NUM in <candidate numbers>; do
-         # MCP: github_get_issue(number=NUM) → .body
+         # MCP: issue_read (user-github)(number=NUM) → .body
          # Extract "Blocked by #NNN" patterns from .body, iterate each dep number.
-         DEPS=<dep numbers parsed from github_get_issue(NUM).body>
+         DEPS=<dep numbers parsed from issue_read (user-github)(NUM).body>
          ALL_MET=true
          for dep in $DEPS; do
-           # MCP: github_get_issue(number=dep) → .state
-           STATE=<github_get_issue(dep).state>
+           # MCP: issue_read (user-github)(number=dep) → .state
+           STATE=<issue_read (user-github)(dep).state>
            [ "$STATE" != "closed" ] && ALL_MET=false && break
          done
          [ "$ALL_MET" = "true" ] && echo "SEED $NUM" || echo "SKIP $NUM (deps unmet)"
@@ -161,7 +161,7 @@ SEED:
   5. Take the first 4 unclaimed issues. For each:
        a. Claim:  MCP: github_add_label(issue_number=N, label="agent:wip")
        b. Read the issue body:
-            # MCP: github_get_issue(number=N) → use .body and .title
+            # MCP: issue_read (user-github)(number=N) → use .body and .title
        c. Call ``build_spawn_child`` MCP tool to create the engineer node atomically:
           ```
           build_spawn_child(
@@ -671,10 +671,10 @@ writes — they add caching, structured output, and logging.
 
 | MCP tool | Replaces |
 |----------|---------|
-| `github_list_issues(state, label)` | `gh issue list --label X` |
-| `github_get_issue(issue_number)` | `gh issue view N --json ...` |
-| `github_list_prs(state)` | `gh pr list` |
-| `github_get_pr(pr_number)` | `gh pr view N --json ...` |
+| `list_issues (user-github)(state, label)` | `gh issue list --label X` |
+| `issue_read (user-github)(issue_number)` | `gh issue view N --json ...` |
+| `list_pull_requests (user-github)(state)` | `gh pr list` |
+| `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
 | `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
@@ -699,7 +699,7 @@ and all `git` commands.
 ### Command policy
 
 Consult `.agentception/agent-command-policy.md` for the full tier list. Summary:
-- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `github_get_issue`, `github_list_prs`, `mypy`, `pytest`, `rg`
+- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `issue_read (user-github)`, `list_pull_requests (user-github)`, `mypy`, `pytest`, `rg`
 - **Yellow (review before running):** `docker compose build`, `rm <single file>`, `git rebase`
 - **Red (never):** `rm -rf`, `git push --force`, `git push origin dev`, `docker system prune`
 
@@ -817,7 +817,7 @@ STEP 1 — DERIVE PATHS:
   export GH_REPO=cgcardona/agentception
 
   # ⚠️  VALIDATION — run this immediately to catch slug errors early:
-  # MCP: github_list_issues(state="open") → if it errors, GH_REPO is wrong. Stop and fix.
+  # MCP: list_issues (user-github)(state="open") → if it errors, GH_REPO is wrong. Stop and fix.
 
 STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
@@ -859,8 +859,8 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   #   body="🔖 **Claimed by agent**\n\n$CLAIM_FINGERPRINT")
 
   # 0. Is the issue itself already closed? (fastest exit — check this FIRST)
-  # MCP: github_get_issue(issue_number=N) → .state
-  ISSUE_STATE=<github_get_issue(N).state>
+  # MCP: issue_read (user-github)(issue_number=N) → .state
+  ISSUE_STATE=<issue_read (user-github)(N).state>
   if [ "$ISSUE_STATE" = "CLOSED" ]; then
     echo "⚠️  Issue #<N> is already CLOSED on GitHub. No work needed."
     # MCP: github_remove_label(issue_number=N, label="status/in-progress")
@@ -928,9 +928,9 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
     for DEP in "${DEP_NUMS[@]}"; do
       DEP=$(echo "$DEP" | tr -d '[:space:]')
       [ -z "$DEP" ] && continue
-      # MCP: github_get_issue(issue_number=DEP) → .state and .stateReason
-      DEP_STATE=<github_get_issue(DEP).state>
-      DEP_REASON=<github_get_issue(DEP).stateReason>
+      # MCP: issue_read (user-github)(issue_number=DEP) → .state and .stateReason
+      DEP_STATE=<issue_read (user-github)(DEP).state>
+      DEP_REASON=<issue_read (user-github)(DEP).stateReason>
       if [ "$DEP_STATE" != "CLOSED" ] || [ "$DEP_REASON" != "COMPLETED" ]; then
         echo "⚠️  Dependency #$DEP is $DEP_STATE (reason=$DEP_REASON) — not yet merged to dev. Note in PR body."
         ALL_DEPS_MET=false
@@ -1313,7 +1313,7 @@ STEP 5 — PUSH & CREATE PR:
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"
   # appears verbatim in the PR body. Verify now so you don't leave a ghost issue.
-  # MCP: github_get_pr(pr_number=MY_PR_NUM) → .body
+  # MCP: pull_request_read (user-github)(pr_number=MY_PR_NUM) → .body
   # Check: result.body must contain "Closes #<N>" (case-insensitive)
   # If missing → MCP: update_pull_request(owner=..., repo=..., pullNumber=MY_PR_NUM,
   #                      body=<existing body + "\n\nCloses #<N>">)
@@ -1343,12 +1343,12 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # resolve_arch.py will switch to --mode reviewer to load the checklist instead of
     # the implementer fragments.
     REVIEWER_ARCH="${COGNITIVE_ARCH:-knuth:python}"
-    # MCP: github_get_pr(pr_number=MY_PR) → use .title, .body, .headRefName
-    PR_TITLE_VAL=<github_get_pr(MY_PR).title>
+    # MCP: pull_request_read (user-github)(pr_number=MY_PR) → use .title, .body, .headRefName
+    PR_TITLE_VAL=<pull_request_read (user-github)(MY_PR).title>
     # MCP: pull_request_read(owner="cgcardona", repo="agentception",
     #      method="get_files", pullNumber=MY_PR) → join file paths with commas
     PR_FILES_VAL=<comma-separated file list from MCP pull_request_read get_files>
-    CLOSES_VAL=<parse "Closes #NNN" from github_get_pr(MY_PR).body, join with commas>
+    CLOSES_VAL=<parse "Closes #NNN" from pull_request_read (user-github)(MY_PR).body, join with commas>
     HAS_MIG=$(echo "$PR_FILES_VAL" | grep -c "alembic/versions/" || echo 0)
     [ "$HAS_MIG" -gt 0 ] && HAS_MIG_VAL=true || HAS_MIG_VAL=false
     cat > "$REVIEW_WORKTREE/.agent-task" <<TASK
@@ -1436,7 +1436,7 @@ Run this before touching the Setup script:
 
 ```
 # List every open issue for the current phase — this IS your candidate pool.
-# MCP: github_list_issues(state="open", label="phase-1")
+# MCP: list_issues (user-github)(state="open", label="phase-1")
 # → returns [{number, title, url, labels, ...}] — print each as "#N  title\n  url"
 ```
 
@@ -1453,7 +1453,7 @@ From the label audit output, choose issues that satisfy **both** criteria in
 candidate's body to identify affected files:
 
 ```
-# MCP: github_get_issue(issue_number=N) → .body and .title
+# MCP: issue_read (user-github)(issue_number=N) → .body and .title
 ```
 
 Confirm no two selected issues share a file. Document your selection in the
@@ -1476,8 +1476,8 @@ for num in <result from MCP list_pull_requests>; do
   #      method="get_files", pullNumber=num) → assign file paths to: files
   files=<file list from MCP pull_request_read get_files for PR num>
   if [ -n "$files" ]; then
-    # MCP: github_get_pr(pr_number=num) → .title
-    title=$(github_get_pr result .title)
+    # MCP: pull_request_read (user-github)(pr_number=num) → .title
+    title=$(pull_request_read (user-github) result .title)
     echo ""
     echo "PR #$num — $title:"
     echo "$files" | sed 's/^/  /'
@@ -2193,10 +2193,10 @@ writes — they add caching, structured output, and logging.
 
 | MCP tool | Replaces |
 |----------|---------|
-| `github_list_issues(state, label)` | `gh issue list --label X` |
-| `github_get_issue(issue_number)` | `gh issue view N --json ...` |
-| `github_list_prs(state)` | `gh pr list` |
-| `github_get_pr(pr_number)` | `gh pr view N --json ...` |
+| `list_issues (user-github)(state, label)` | `gh issue list --label X` |
+| `issue_read (user-github)(issue_number)` | `gh issue view N --json ...` |
+| `list_pull_requests (user-github)(state)` | `gh pr list` |
+| `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
 | `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
@@ -2221,7 +2221,7 @@ and all `git` commands.
 ### Command policy
 
 Consult `.agentception/agent-command-policy.md` for the full tier list. Summary:
-- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `github_get_issue`, `github_list_prs`, `mypy`, `pytest`, `rg`
+- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `issue_read (user-github)`, `list_pull_requests (user-github)`, `mypy`, `pytest`, `rg`
 - **Yellow (review before running):** `docker compose build`, `rm <single file>`, `git rebase`
 - **Red (never):** `rm -rf`, `git push --force`, `git push origin dev`, `docker system prune`
 
@@ -2821,8 +2821,8 @@ STEP 5.5 — MERGE ORDER GATE (sequential chain safety):
   DO NOT loop indefinitely — escalate and self-destruct instead.
 
     for i in $(seq 1 15); do
-      # MCP: github_get_pr(pr_number=MERGE_AFTER) → .state
-      STATE=<github_get_pr(MERGE_AFTER).state>
+      # MCP: pull_request_read (user-github)(pr_number=MERGE_AFTER) → .state
+      STATE=<pull_request_read (user-github)(MERGE_AFTER).state>
       echo "[$i/15] Gate PR #$MERGE_AFTER state: $STATE"
       if [ "$STATE" = "MERGED" ]; then
         echo "✅ Gate cleared — PR #$MERGE_AFTER is merged. Proceeding to merge."
@@ -3004,7 +3004,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
-         # MCP: github_get_pr(pr_number=N) → .body → parse "Closes #NNN" patterns
+         # MCP: pull_request_read (user-github)(pr_number=N) → .body → parse "Closes #NNN" patterns
          # Then for each parsed issue number, call MCP issue_write to close it.
          echo "Parse PR body for Closes #NNN patterns, then close each via MCP issue_write"
        fi
@@ -3146,7 +3146,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
        for label in ac-ui/0-critical-bugs ac-ui/1-design-tokens \
                         ac-ui/2-data-model ac-ui/3-core-pages \
                         ac-ui/4-controls-intelligence ac-ui/5-polish; do
-      # MCP: github_list_issues(label="$label", state="open") → .count
+      # MCP: list_issues (user-github)(label="$label", state="open") → .count
       COUNT=<count from MCP response>
       if [ "$COUNT" -gt 0 ]; then
         ACTIVE_LABEL="$label"
@@ -3160,7 +3160,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       TASK_BATCH_ID=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('pipeline',{}).get('batch_id',''))" 2>/dev/null || echo "")
       BATCH_LABEL_PREFIX=$(echo "$TASK_BATCH_ID" | grep -oE 'batch-[0-9]+' | head -1)
       if [ -n "$BATCH_LABEL_PREFIX" ]; then
-        # MCP: github_list_issues(label="$BATCH_LABEL_PREFIX", state="open") → .count
+        # MCP: list_issues (user-github)(label="$BATCH_LABEL_PREFIX", state="open") → .count
         BATCH_COUNT=<count from MCP response>
         if [ "$BATCH_COUNT" -gt 0 ]; then
           ACTIVE_LABEL="$BATCH_LABEL_PREFIX"
@@ -3173,7 +3173,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       echo "ℹ️  No open ac-ui/ or batch issues remain — chain complete."
     else
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
-      # MCP: github_list_issues(label="$ACTIVE_LABEL", state="open")
+      # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "agent:wip" (already claimed),
       # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
@@ -3183,14 +3183,14 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     # Dependency gate: only proceed if all "Depends on #NNN" references are CLOSED.
     if [ -n "$NEXT_ISSUE" ]; then
-      # MCP: github_get_issue(number=$NEXT_ISSUE) → .body
+      # MCP: issue_read (user-github)(number=$NEXT_ISSUE) → .body
       # Parse "Depends on #NNN" references from body text.
       # For each dependency:
-      #   MCP: github_get_issue(number=<dep>) → check .state and .state_reason
+      #   MCP: issue_read (user-github)(number=<dep>) → check .state and .state_reason
       #   If state != "closed" or state_reason != "completed" → skip this issue.
       DEPS=<parsed dependency issue numbers>
       for dep in $DEPS; do
-        # MCP: github_get_issue(number=$dep) → .state
+        # MCP: issue_read (user-github)(number=$dep) → .state
         DEP_STATE=<state from MCP>
         if [ "$DEP_STATE" != "closed" ]; then
           echo "ℹ️  Issue #$NEXT_ISSUE blocked by dependency #$dep (state=$DEP_STATE) — chain complete for now."
@@ -3218,7 +3218,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # MCP: github_claim_issue(issue_number=$NEXT_ISSUE)
 
       # Resolve the primary label so the engineer can route mypy/tests correctly.
-      # MCP: github_get_issue(number=$NEXT_ISSUE) → .labels
+      # MCP: issue_read (user-github)(number=$NEXT_ISSUE) → .labels
       # Pick the first label starting with "ac-ui/"
       NEXT_ISSUE_LABEL=<label from MCP response>
 
@@ -3278,12 +3278,12 @@ TASK
   else
     # ── POOL MODE: spawned by QA Coordinator; spawn the next REVIEWER for the next open PR ──
 
-    # MCP: github_list_prs(state="open") → filter out any with label "agent:wip"
+    # MCP: list_pull_requests (user-github)(state="open") → filter out any with label "agent:wip"
     # Take the first unclaimed PR targeting dev.
     NEXT_PR=<first unclaimed PR number from MCP response>
 
     if [ -n "$NEXT_PR" ]; then
-      # MCP: github_get_pr(pr_number=$NEXT_PR) → .headRefName, .title, .body
+      # MCP: pull_request_read (user-github)(pr_number=$NEXT_PR) → .headRefName, .title, .body
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
@@ -3427,7 +3427,7 @@ If two PRs in the batch share a file:
 ### Step 1 — Confirm PRs are open
 
 ```
-# MCP: github_list_prs(state="open")
+# MCP: list_pull_requests (user-github)(state="open")
 ```
 
 ### Step 2 — Confirm `dev` is up to date
@@ -3465,7 +3465,7 @@ docker compose exec agentception ls /worktrees/
 REPO=$(git rev-parse --show-toplevel)
 git -C "$REPO" fetch origin
 git -C "$REPO" merge origin/dev
-# MCP: github_list_prs(state="open")   # any PRs the batch failed to merge?
+# MCP: list_pull_requests (user-github)(state="open")   # any PRs the batch failed to merge?
 ```
 
 ### 2 — Worktree cleanup

--- a/.agentception/roles/qa-coordinator.md
+++ b/.agentception/roles/qa-coordinator.md
@@ -82,7 +82,7 @@ SEED:
        MAIN_REPO="<repo-root>"
        git -C "$MAIN_REPO" worktree list --porcelain | grep "^worktree" | awk '{print $2}' \
          > /tmp/active_worktrees
-       # MCP: github_list_prs(state="open") → filter to those with label "agent:wip"
+       # MCP: list_pull_requests (user-github)(state="open") → filter to those with label "agent:wip"
        for pr in <PR numbers with agent:wip>; do
          grep -q "pr-$pr" /tmp/active_worktrees || \
            # MCP: github_remove_label(issue_number=pr, label="agent:wip")
@@ -90,7 +90,7 @@ SEED:
        done
 
   3. Query open unclaimed PRs:
-       # MCP: github_list_prs(state="open")
+       # MCP: list_pull_requests (user-github)(state="open")
        # → filter result to exclude PRs that already have the "agent:wip" label
      If empty → report "review queue clear." Stop.
 
@@ -102,7 +102,7 @@ SEED:
   5. Take the first 4 unclaimed PRs. For each:
        a. Claim:  MCP: github_add_label(issue_number=N, label="agent:wip")
        b. Get PR body and title:
-            # MCP: github_get_pr(pr_number=N) → use .body, .title, .headRefName
+            # MCP: pull_request_read (user-github)(pr_number=N) → use .body, .title, .headRefName
        c. Call ``build_spawn_child`` MCP tool to create the reviewer node atomically:
           ```
           build_spawn_child(
@@ -149,7 +149,7 @@ required fields including COGNITIVE_ARCH, BATCH_ID, lineage fields, and scope.
 You do NOT need to write `.agent-task` files manually.
 
 If a worktree is missing for a new PR:
-  `# MCP: github_get_pr(pr_number=N) → .headRefName`
+  `# MCP: pull_request_read (user-github)(pr_number=N) → .headRefName`
   `git -C "<repo-root>" worktree add "$HOME/.agentception/worktrees/agentception/pr-{N}" origin/$BRANCH`
 
 ## MERGE_AFTER protocol
@@ -514,10 +514,10 @@ writes — they add caching, structured output, and logging.
 
 | MCP tool | Replaces |
 |----------|---------|
-| `github_list_issues(state, label)` | `gh issue list --label X` |
-| `github_get_issue(issue_number)` | `gh issue view N --json ...` |
-| `github_list_prs(state)` | `gh pr list` |
-| `github_get_pr(pr_number)` | `gh pr view N --json ...` |
+| `list_issues (user-github)(state, label)` | `gh issue list --label X` |
+| `issue_read (user-github)(issue_number)` | `gh issue view N --json ...` |
+| `list_pull_requests (user-github)(state)` | `gh pr list` |
+| `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
 | `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
@@ -542,7 +542,7 @@ and all `git` commands.
 ### Command policy
 
 Consult `.agentception/agent-command-policy.md` for the full tier list. Summary:
-- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `github_get_issue`, `github_list_prs`, `mypy`, `pytest`, `rg`
+- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `issue_read (user-github)`, `list_pull_requests (user-github)`, `mypy`, `pytest`, `rg`
 - **Yellow (review before running):** `docker compose build`, `rm <single file>`, `git rebase`
 - **Red (never):** `rm -rf`, `git push --force`, `git push origin dev`, `docker system prune`
 
@@ -1142,8 +1142,8 @@ STEP 5.5 — MERGE ORDER GATE (sequential chain safety):
   DO NOT loop indefinitely — escalate and self-destruct instead.
 
     for i in $(seq 1 15); do
-      # MCP: github_get_pr(pr_number=MERGE_AFTER) → .state
-      STATE=<github_get_pr(MERGE_AFTER).state>
+      # MCP: pull_request_read (user-github)(pr_number=MERGE_AFTER) → .state
+      STATE=<pull_request_read (user-github)(MERGE_AFTER).state>
       echo "[$i/15] Gate PR #$MERGE_AFTER state: $STATE"
       if [ "$STATE" = "MERGED" ]; then
         echo "✅ Gate cleared — PR #$MERGE_AFTER is merged. Proceeding to merge."
@@ -1325,7 +1325,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
-         # MCP: github_get_pr(pr_number=N) → .body → parse "Closes #NNN" patterns
+         # MCP: pull_request_read (user-github)(pr_number=N) → .body → parse "Closes #NNN" patterns
          # Then for each parsed issue number, call MCP issue_write to close it.
          echo "Parse PR body for Closes #NNN patterns, then close each via MCP issue_write"
        fi
@@ -1467,7 +1467,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
        for label in ac-ui/0-critical-bugs ac-ui/1-design-tokens \
                         ac-ui/2-data-model ac-ui/3-core-pages \
                         ac-ui/4-controls-intelligence ac-ui/5-polish; do
-      # MCP: github_list_issues(label="$label", state="open") → .count
+      # MCP: list_issues (user-github)(label="$label", state="open") → .count
       COUNT=<count from MCP response>
       if [ "$COUNT" -gt 0 ]; then
         ACTIVE_LABEL="$label"
@@ -1481,7 +1481,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       TASK_BATCH_ID=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('pipeline',{}).get('batch_id',''))" 2>/dev/null || echo "")
       BATCH_LABEL_PREFIX=$(echo "$TASK_BATCH_ID" | grep -oE 'batch-[0-9]+' | head -1)
       if [ -n "$BATCH_LABEL_PREFIX" ]; then
-        # MCP: github_list_issues(label="$BATCH_LABEL_PREFIX", state="open") → .count
+        # MCP: list_issues (user-github)(label="$BATCH_LABEL_PREFIX", state="open") → .count
         BATCH_COUNT=<count from MCP response>
         if [ "$BATCH_COUNT" -gt 0 ]; then
           ACTIVE_LABEL="$BATCH_LABEL_PREFIX"
@@ -1494,7 +1494,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       echo "ℹ️  No open ac-ui/ or batch issues remain — chain complete."
     else
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
-      # MCP: github_list_issues(label="$ACTIVE_LABEL", state="open")
+      # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "agent:wip" (already claimed),
       # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
@@ -1504,14 +1504,14 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     # Dependency gate: only proceed if all "Depends on #NNN" references are CLOSED.
     if [ -n "$NEXT_ISSUE" ]; then
-      # MCP: github_get_issue(number=$NEXT_ISSUE) → .body
+      # MCP: issue_read (user-github)(number=$NEXT_ISSUE) → .body
       # Parse "Depends on #NNN" references from body text.
       # For each dependency:
-      #   MCP: github_get_issue(number=<dep>) → check .state and .state_reason
+      #   MCP: issue_read (user-github)(number=<dep>) → check .state and .state_reason
       #   If state != "closed" or state_reason != "completed" → skip this issue.
       DEPS=<parsed dependency issue numbers>
       for dep in $DEPS; do
-        # MCP: github_get_issue(number=$dep) → .state
+        # MCP: issue_read (user-github)(number=$dep) → .state
         DEP_STATE=<state from MCP>
         if [ "$DEP_STATE" != "closed" ]; then
           echo "ℹ️  Issue #$NEXT_ISSUE blocked by dependency #$dep (state=$DEP_STATE) — chain complete for now."
@@ -1539,7 +1539,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # MCP: github_claim_issue(issue_number=$NEXT_ISSUE)
 
       # Resolve the primary label so the engineer can route mypy/tests correctly.
-      # MCP: github_get_issue(number=$NEXT_ISSUE) → .labels
+      # MCP: issue_read (user-github)(number=$NEXT_ISSUE) → .labels
       # Pick the first label starting with "ac-ui/"
       NEXT_ISSUE_LABEL=<label from MCP response>
 
@@ -1599,12 +1599,12 @@ TASK
   else
     # ── POOL MODE: spawned by QA Coordinator; spawn the next REVIEWER for the next open PR ──
 
-    # MCP: github_list_prs(state="open") → filter out any with label "agent:wip"
+    # MCP: list_pull_requests (user-github)(state="open") → filter out any with label "agent:wip"
     # Take the first unclaimed PR targeting dev.
     NEXT_PR=<first unclaimed PR number from MCP response>
 
     if [ -n "$NEXT_PR" ]; then
-      # MCP: github_get_pr(pr_number=$NEXT_PR) → .headRefName, .title, .body
+      # MCP: pull_request_read (user-github)(pr_number=$NEXT_PR) → .headRefName, .title, .body
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
@@ -1748,7 +1748,7 @@ If two PRs in the batch share a file:
 ### Step 1 — Confirm PRs are open
 
 ```
-# MCP: github_list_prs(state="open")
+# MCP: list_pull_requests (user-github)(state="open")
 ```
 
 ### Step 2 — Confirm `dev` is up to date
@@ -1786,7 +1786,7 @@ docker compose exec agentception ls /worktrees/
 REPO=$(git rev-parse --show-toplevel)
 git -C "$REPO" fetch origin
 git -C "$REPO" merge origin/dev
-# MCP: github_list_prs(state="open")   # any PRs the batch failed to merge?
+# MCP: list_pull_requests (user-github)(state="open")   # any PRs the batch failed to merge?
 ```
 
 ### 2 — Worktree cleanup
@@ -2379,10 +2379,10 @@ writes — they add caching, structured output, and logging.
 
 | MCP tool | Replaces |
 |----------|---------|
-| `github_list_issues(state, label)` | `gh issue list --label X` |
-| `github_get_issue(issue_number)` | `gh issue view N --json ...` |
-| `github_list_prs(state)` | `gh pr list` |
-| `github_get_pr(pr_number)` | `gh pr view N --json ...` |
+| `list_issues (user-github)(state, label)` | `gh issue list --label X` |
+| `issue_read (user-github)(issue_number)` | `gh issue view N --json ...` |
+| `list_pull_requests (user-github)(state)` | `gh pr list` |
+| `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
 | `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
@@ -2407,7 +2407,7 @@ and all `git` commands.
 ### Command policy
 
 Consult `.agentception/agent-command-policy.md` for the full tier list. Summary:
-- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `github_get_issue`, `github_list_prs`, `mypy`, `pytest`, `rg`
+- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `issue_read (user-github)`, `list_pull_requests (user-github)`, `mypy`, `pytest`, `rg`
 - **Yellow (review before running):** `docker compose build`, `rm <single file>`, `git rebase`
 - **Red (never):** `rm -rf`, `git push --force`, `git push origin dev`, `docker system prune`
 
@@ -2525,7 +2525,7 @@ STEP 1 — DERIVE PATHS:
   export GH_REPO=cgcardona/agentception
 
   # ⚠️  VALIDATION — run this immediately to catch slug errors early:
-  # MCP: github_list_issues(state="open") → if it errors, GH_REPO is wrong. Stop and fix.
+  # MCP: list_issues (user-github)(state="open") → if it errors, GH_REPO is wrong. Stop and fix.
 
 STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
@@ -2567,8 +2567,8 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   #   body="🔖 **Claimed by agent**\n\n$CLAIM_FINGERPRINT")
 
   # 0. Is the issue itself already closed? (fastest exit — check this FIRST)
-  # MCP: github_get_issue(issue_number=N) → .state
-  ISSUE_STATE=<github_get_issue(N).state>
+  # MCP: issue_read (user-github)(issue_number=N) → .state
+  ISSUE_STATE=<issue_read (user-github)(N).state>
   if [ "$ISSUE_STATE" = "CLOSED" ]; then
     echo "⚠️  Issue #<N> is already CLOSED on GitHub. No work needed."
     # MCP: github_remove_label(issue_number=N, label="status/in-progress")
@@ -2636,9 +2636,9 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
     for DEP in "${DEP_NUMS[@]}"; do
       DEP=$(echo "$DEP" | tr -d '[:space:]')
       [ -z "$DEP" ] && continue
-      # MCP: github_get_issue(issue_number=DEP) → .state and .stateReason
-      DEP_STATE=<github_get_issue(DEP).state>
-      DEP_REASON=<github_get_issue(DEP).stateReason>
+      # MCP: issue_read (user-github)(issue_number=DEP) → .state and .stateReason
+      DEP_STATE=<issue_read (user-github)(DEP).state>
+      DEP_REASON=<issue_read (user-github)(DEP).stateReason>
       if [ "$DEP_STATE" != "CLOSED" ] || [ "$DEP_REASON" != "COMPLETED" ]; then
         echo "⚠️  Dependency #$DEP is $DEP_STATE (reason=$DEP_REASON) — not yet merged to dev. Note in PR body."
         ALL_DEPS_MET=false
@@ -3021,7 +3021,7 @@ STEP 5 — PUSH & CREATE PR:
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"
   # appears verbatim in the PR body. Verify now so you don't leave a ghost issue.
-  # MCP: github_get_pr(pr_number=MY_PR_NUM) → .body
+  # MCP: pull_request_read (user-github)(pr_number=MY_PR_NUM) → .body
   # Check: result.body must contain "Closes #<N>" (case-insensitive)
   # If missing → MCP: update_pull_request(owner=..., repo=..., pullNumber=MY_PR_NUM,
   #                      body=<existing body + "\n\nCloses #<N>">)
@@ -3051,12 +3051,12 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # resolve_arch.py will switch to --mode reviewer to load the checklist instead of
     # the implementer fragments.
     REVIEWER_ARCH="${COGNITIVE_ARCH:-knuth:python}"
-    # MCP: github_get_pr(pr_number=MY_PR) → use .title, .body, .headRefName
-    PR_TITLE_VAL=<github_get_pr(MY_PR).title>
+    # MCP: pull_request_read (user-github)(pr_number=MY_PR) → use .title, .body, .headRefName
+    PR_TITLE_VAL=<pull_request_read (user-github)(MY_PR).title>
     # MCP: pull_request_read(owner="cgcardona", repo="agentception",
     #      method="get_files", pullNumber=MY_PR) → join file paths with commas
     PR_FILES_VAL=<comma-separated file list from MCP pull_request_read get_files>
-    CLOSES_VAL=<parse "Closes #NNN" from github_get_pr(MY_PR).body, join with commas>
+    CLOSES_VAL=<parse "Closes #NNN" from pull_request_read (user-github)(MY_PR).body, join with commas>
     HAS_MIG=$(echo "$PR_FILES_VAL" | grep -c "alembic/versions/" || echo 0)
     [ "$HAS_MIG" -gt 0 ] && HAS_MIG_VAL=true || HAS_MIG_VAL=false
     cat > "$REVIEW_WORKTREE/.agent-task" <<TASK
@@ -3144,7 +3144,7 @@ Run this before touching the Setup script:
 
 ```
 # List every open issue for the current phase — this IS your candidate pool.
-# MCP: github_list_issues(state="open", label="phase-1")
+# MCP: list_issues (user-github)(state="open", label="phase-1")
 # → returns [{number, title, url, labels, ...}] — print each as "#N  title\n  url"
 ```
 
@@ -3161,7 +3161,7 @@ From the label audit output, choose issues that satisfy **both** criteria in
 candidate's body to identify affected files:
 
 ```
-# MCP: github_get_issue(issue_number=N) → .body and .title
+# MCP: issue_read (user-github)(issue_number=N) → .body and .title
 ```
 
 Confirm no two selected issues share a file. Document your selection in the
@@ -3184,8 +3184,8 @@ for num in <result from MCP list_pull_requests>; do
   #      method="get_files", pullNumber=num) → assign file paths to: files
   files=<file list from MCP pull_request_read get_files for PR num>
   if [ -n "$files" ]; then
-    # MCP: github_get_pr(pr_number=num) → .title
-    title=$(github_get_pr result .title)
+    # MCP: pull_request_read (user-github)(pr_number=num) → .title
+    title=$(pull_request_read (user-github) result .title)
     echo ""
     echo "PR #$num — $title:"
     echo "$files" | sed 's/^/  /'

--- a/agentception/mcp/github_tools.py
+++ b/agentception/mcp/github_tools.py
@@ -2,19 +2,14 @@ from __future__ import annotations
 
 """AgentCeption MCP tools for GitHub operations.
 
-Exposes key ``readers.github`` functions as MCP tools so agents can query
-and mutate GitHub state through the same typed, cached, logged interface
-used by the UI — no raw ``gh`` subprocess calls in prompts needed.
+Exposes key ``readers.github`` functions as MCP tools so agents can
+atomically claim/label issues through the same typed, cached, logged
+interface used by the UI.
 
-All reads flow through the TTL cache in ``readers/github.py`` (default 10 s),
-so rapid successive calls from an agent cost nothing extra.  All writes
-automatically invalidate the cache so the next read reflects current state.
+Read operations (list_issues, issue_read, list_pull_requests, pull_request_read)
+are delegated to the ``user-github`` MCP server — use those tools directly.
 
 Tool catalogue:
-  github_list_issues   — list open or closed issues, optionally filtered by label
-  github_get_issue     — fetch full metadata + body for a single issue
-  github_list_prs      — list open, merged, or all PRs targeting dev
-  github_get_pr        — fetch full PR metadata including comments, reviews, checks
   github_add_label     — add a label to an issue (invalidates cache)
   github_remove_label  — remove a label from an issue (invalidates cache, idempotent)
   github_claim_issue   — add the agent:wip claim label to an issue
@@ -27,146 +22,10 @@ from agentception.readers.github import (
     add_label_to_issue,
     add_wip_label,
     clear_wip_label,
-    get_closed_issues,
-    get_issue,
-    get_issue_body,
-    get_issue_comments,
-    get_merged_prs_full,
-    get_open_issues,
-    get_open_prs,
-    get_pr_checks,
-    get_pr_comments,
-    get_pr_reviews,
     remove_label_from_issue,
 )
 
 logger = logging.getLogger(__name__)
-
-
-async def github_list_issues(
-    label: str | None = None,
-    state: str = "open",
-    limit: int = 100,
-) -> dict[str, object]:
-    """List GitHub issues, optionally filtered by label and state.
-
-    Args:
-        label: GitHub label to filter by (e.g. ``"ac-plan/phase-0"``).
-               Omit to return all issues in the given state.
-        state: ``"open"`` (default) or ``"closed"``.
-        limit: Maximum number of results (only applied to closed issues).
-
-    Returns:
-        ``{"issues": [...], "count": N, "label": label, "state": state}``
-    """
-    logger.info(
-        "🔍 github_list_issues: state=%r label=%r limit=%d", state, label, limit
-    )
-    try:
-        if state == "closed":
-            raw = await get_closed_issues(limit=limit)
-            if label:
-                def _has_label(issue: dict[str, object], target: str) -> bool:
-                    labels_raw = issue.get("labels")
-                    if not isinstance(labels_raw, list):
-                        return False
-                    for lbl in labels_raw:
-                        if isinstance(lbl, dict) and lbl.get("name") == target:
-                            return True
-                        if isinstance(lbl, str) and lbl == target:
-                            return True
-                    return False
-
-                raw = [issue for issue in raw if _has_label(issue, label)]
-        else:
-            raw = await get_open_issues(label=label)
-    except RuntimeError as exc:
-        logger.error("❌ github_list_issues: %s", exc)
-        return {"ok": False, "error": str(exc)}
-
-    logger.info("✅ github_list_issues: returned %d issues", len(raw))
-    return {"ok": True, "issues": raw, "count": len(raw), "label": label, "state": state}
-
-
-async def github_get_issue(number: int) -> dict[str, object]:
-    """Fetch full metadata and body for a single GitHub issue.
-
-    Args:
-        number: GitHub issue number.
-
-    Returns:
-        ``{"ok": True, "issue": {number, state, title, labels, body}}``
-        or ``{"ok": False, "error": "..."}`` when the issue is not found.
-    """
-    logger.info("🔍 github_get_issue: #%d", number)
-    try:
-        meta = await get_issue(number)
-        body = await get_issue_body(number)
-        comments = await get_issue_comments(number)
-    except RuntimeError as exc:
-        logger.error("❌ github_get_issue #%d: %s", number, exc)
-        return {"ok": False, "error": str(exc)}
-
-    issue: dict[str, object] = {**meta, "body": body, "comments": comments}
-    logger.info("✅ github_get_issue: #%d fetched", number)
-    return {"ok": True, "issue": issue}
-
-
-async def github_list_prs(state: str = "open") -> dict[str, object]:
-    """List pull requests targeting the dev branch.
-
-    Args:
-        state: ``"open"`` (default), ``"merged"``, or ``"all"``.
-               ``"all"`` returns both open and recently merged PRs.
-
-    Returns:
-        ``{"ok": True, "prs": [...], "count": N, "state": state}``
-    """
-    logger.info("🔍 github_list_prs: state=%r", state)
-    try:
-        if state == "open":
-            raw = await get_open_prs()
-        elif state == "merged":
-            raw = await get_merged_prs_full()
-        else:
-            open_prs = await get_open_prs()
-            merged_prs = await get_merged_prs_full()
-            raw = open_prs + merged_prs
-    except RuntimeError as exc:
-        logger.error("❌ github_list_prs: %s", exc)
-        return {"ok": False, "error": str(exc)}
-
-    logger.info("✅ github_list_prs: returned %d PRs", len(raw))
-    return {"ok": True, "prs": raw, "count": len(raw), "state": state}
-
-
-async def github_get_pr(number: int) -> dict[str, object]:
-    """Fetch full PR metadata including comments, reviews, and CI checks.
-
-    Args:
-        number: GitHub PR number.
-
-    Returns:
-        ``{"ok": True, "pr": {number, comments, reviews, checks}}``
-        or ``{"ok": False, "error": "..."}`` on failure.
-    """
-    logger.info("🔍 github_get_pr: #%d", number)
-    try:
-        comments = await get_pr_comments(number)
-        reviews = await get_pr_reviews(number)
-        checks = await get_pr_checks(number)
-    except RuntimeError as exc:
-        logger.error("❌ github_get_pr #%d: %s", number, exc)
-        return {"ok": False, "error": str(exc)}
-
-    pr: dict[str, object] = {
-        "number": number,
-        "comments": comments,
-        "reviews": reviews,
-        "checks": checks,
-    }
-    logger.info("✅ github_get_pr: #%d fetched", number)
-    return {"ok": True, "pr": pr}
 
 
 async def github_add_label(issue_number: int, label: str) -> dict[str, object]:

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -56,10 +56,6 @@ from agentception.mcp.query_tools import (
 from agentception.mcp.github_tools import (
     github_add_label,
     github_claim_issue,
-    github_get_issue,
-    github_get_pr,
-    github_list_issues,
-    github_list_prs,
     github_remove_label,
     github_unclaim_issue,
 )
@@ -217,87 +213,6 @@ TOOLS: list[ACToolDef] = [
         },
     ),
     # ── GitHub tools — cached reads + write-through mutations ────────────────
-    ACToolDef(
-        name="github_list_issues",
-        description=(
-            "List GitHub issues for the configured repository, optionally filtered "
-            "by label and state. Reads are cached (10 s TTL). "
-            "Returns {ok, issues: [{number, title, labels, body, state}], count, label, state}."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "label": {
-                    "type": "string",
-                    "description": "Label to filter by (e.g. 'ac-plan/phase-0'). Omit for all.",
-                },
-                "state": {
-                    "type": "string",
-                    "enum": ["open", "closed"],
-                    "description": "Issue state — 'open' (default) or 'closed'.",
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Max results (applies to closed issues only). Default 100.",
-                },
-            },
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="github_get_issue",
-        description=(
-            "Fetch full metadata and body for a single GitHub issue. "
-            "Returns {ok, issue: {number, state, title, labels, body, comments}}."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "number": {
-                    "type": "integer",
-                    "description": "GitHub issue number.",
-                },
-            },
-            "required": ["number"],
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="github_list_prs",
-        description=(
-            "List pull requests targeting the dev branch. "
-            "Returns {ok, prs: [{number, title, headRefName, labels, state}], count, state}."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "state": {
-                    "type": "string",
-                    "enum": ["open", "merged", "all"],
-                    "description": "PR state — 'open' (default), 'merged', or 'all'.",
-                },
-            },
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="github_get_pr",
-        description=(
-            "Fetch PR metadata including comments, review decisions, and CI checks. "
-            "Returns {ok, pr: {number, comments, reviews, checks}}."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "number": {
-                    "type": "integer",
-                    "description": "GitHub PR number.",
-                },
-            },
-            "required": ["number"],
-            "additionalProperties": False,
-        },
-    ),
     ACToolDef(
         name="github_add_label",
         description=(
@@ -958,10 +873,6 @@ def call_tool(name: str, arguments: dict[str, object]) -> ACToolResult:
         "log_run_decision",
         "log_run_message",
         # GitHub tools
-        "github_list_issues",
-        "github_get_issue",
-        "github_list_prs",
-        "github_get_pr",
         "github_add_label",
         "github_remove_label",
         "github_claim_issue",
@@ -1351,54 +1262,6 @@ async def call_tool_async(
         )
 
     # ── GitHub tools ─────────────────────────────────────────────────────────
-
-    if name == "github_list_issues":
-        label_raw = arguments.get("label")
-        label: str | None = str(label_raw) if isinstance(label_raw, str) else None
-        state_raw = arguments.get("state", "open")
-        state: str = str(state_raw) if isinstance(state_raw, str) else "open"
-        limit_raw = arguments.get("limit", 100)
-        limit: int = int(limit_raw) if isinstance(limit_raw, int) else 100
-        result = await github_list_issues(label=label, state=state, limit=limit)
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=not bool(result.get("ok", False)),
-        )
-
-    if name == "github_get_issue":
-        number = arguments.get("number")
-        if not isinstance(number, int):
-            return ACToolResult(
-                content=[ACToolContent(type="text", text='{"error":"number (int) is required"}')],
-                isError=True,
-            )
-        result = await github_get_issue(number)
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=not bool(result.get("ok", False)),
-        )
-
-    if name == "github_list_prs":
-        state_raw = arguments.get("state", "open")
-        pr_state: str = str(state_raw) if isinstance(state_raw, str) else "open"
-        result = await github_list_prs(state=pr_state)
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=not bool(result.get("ok", False)),
-        )
-
-    if name == "github_get_pr":
-        number = arguments.get("number")
-        if not isinstance(number, int):
-            return ACToolResult(
-                content=[ACToolContent(type="text", text='{"error":"number (int) is required"}')],
-                isError=True,
-            )
-        result = await github_get_pr(number)
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=not bool(result.get("ok", False)),
-        )
 
     if name == "github_add_label":
         issue_num = arguments.get("issue_number")

--- a/scripts/gen_prompts/templates/dispatcher.md.j2
+++ b/scripts/gen_prompts/templates/dispatcher.md.j2
@@ -57,10 +57,10 @@ to make and which children to spawn:
 
 | TIER | SCOPE_TYPE | What SCOPE_VALUE means | GitHub queries |
 |------|-----------|------------------------|----------------|
-| `executive` | `label` | GitHub label string | `github_list_issues` + `github_list_prs` filtered to the label |
-| `coordinator` | `label` | GitHub label string | `github_list_issues` only (engineering) or `github_list_prs` only (qa) |
-| `engineer` | `issue` | Issue number (string) | `github_get_issue(issue_number=SCOPE_VALUE)` |
-| `reviewer` | `pr` | PR number (string) | `github_get_pr(pr_number=SCOPE_VALUE)` |
+| `executive` | `label` | GitHub label string | `list_issues (user-github)` + `list_pull_requests (user-github)` filtered to the label |
+| `coordinator` | `label` | GitHub label string | `list_issues (user-github)` only (engineering) or `list_pull_requests (user-github)` only (qa) |
+| `engineer` | `issue` | Issue number (string) | `issue_read (user-github)(issue_number=SCOPE_VALUE)` |
+| `reviewer` | `pr` | PR number (string) | `pull_request_read (user-github)(pr_number=SCOPE_VALUE)` |
 
 The `.agent-task` file contains inline comments with the MCP tool calls
 for this tier — pass them verbatim to the spawned agent in the briefing below.
@@ -119,13 +119,13 @@ Step 2: Read your .agent-task file:
 Step 3: Run your tier's GitHub queries via MCP to discover what needs doing.
 
   executive tier — call BOTH MCP tools:
-    github_list_issues(label="{scope_value}", state="open")
-    github_list_prs(state="open")
+    list_issues (user-github)(label="{scope_value}", state="open")
+    list_pull_requests (user-github)(state="open")
   Then: spawn engineering-coordinator if open issues exist,
         spawn qa-coordinator if open PRs exist (cleanup sweep only).
 
   coordinator tier (engineering-coordinator role) — call:
-    github_list_issues(label="{scope_value}", state="open")
+    list_issues (user-github)(label="{scope_value}", state="open")
   Filter out any issues with label "{{ claim_label }}" (already claimed),
   "blocked" (phase-gated — prior phase not yet complete), or "ticket-blocked"
   (has unresolved ticket-level dependencies — do not dispatch until all are closed).
@@ -133,7 +133,7 @@ Step 3: Run your tier's GitHub queries via MCP to discover what needs doing.
   Then: spawn one engineer per eligible issue (all in parallel via Task calls).
 
   coordinator tier (qa-coordinator role) — call:
-    github_list_prs(state="open")
+    list_pull_requests (user-github)(state="open")
   Then: spawn one pr-reviewer per open PR (all in parallel via Task calls).
 
 Step 4: For each child you spawn:
@@ -172,8 +172,8 @@ Step 2: Read your .agent-task file:
   {host_worktree_path}/.agent-task
 
 Step 3: Read your assigned {scope_type} via MCP:
-  engineer  → github_get_issue(number={scope_value})
-  reviewer  → github_get_pr(number={scope_value})
+  engineer  → issue_read (user-github)(number={scope_value})
+  reviewer  → pull_request_read (user-github)(number={scope_value})
 
 Step 4: Follow your role instructions exactly.
   engineer  → implement the issue in your worktree, open a PR against dev.

--- a/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
+++ b/scripts/gen_prompts/templates/parallel-issue-to-pr.md.j2
@@ -437,7 +437,7 @@ STEP 1 — DERIVE PATHS:
   export GH_REPO={{ gh_repo }}
 
   # ⚠️  VALIDATION — run this immediately to catch slug errors early:
-  # MCP: github_list_issues(state="open") → if it errors, GH_REPO is wrong. Stop and fix.
+  # MCP: list_issues (user-github)(state="open") → if it errors, GH_REPO is wrong. Stop and fix.
 
 STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
@@ -454,8 +454,8 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   #   body="🔖 **Claimed by agent**\n\n$CLAIM_FINGERPRINT")
 
   # 0. Is the issue itself already closed? (fastest exit — check this FIRST)
-  # MCP: github_get_issue(issue_number=N) → .state
-  ISSUE_STATE=<github_get_issue(N).state>
+  # MCP: issue_read (user-github)(issue_number=N) → .state
+  ISSUE_STATE=<issue_read (user-github)(N).state>
   if [ "$ISSUE_STATE" = "CLOSED" ]; then
     echo "⚠️  Issue #<N> is already CLOSED on GitHub. No work needed."
     # MCP: github_remove_label(issue_number=N, label="status/in-progress")
@@ -523,9 +523,9 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
     for DEP in "${DEP_NUMS[@]}"; do
       DEP=$(echo "$DEP" | tr -d '[:space:]')
       [ -z "$DEP" ] && continue
-      # MCP: github_get_issue(issue_number=DEP) → .state and .stateReason
-      DEP_STATE=<github_get_issue(DEP).state>
-      DEP_REASON=<github_get_issue(DEP).stateReason>
+      # MCP: issue_read (user-github)(issue_number=DEP) → .state and .stateReason
+      DEP_STATE=<issue_read (user-github)(DEP).state>
+      DEP_REASON=<issue_read (user-github)(DEP).stateReason>
       if [ "$DEP_STATE" != "CLOSED" ] || [ "$DEP_REASON" != "COMPLETED" ]; then
         echo "⚠️  Dependency #$DEP is $DEP_STATE (reason=$DEP_REASON) — not yet merged to dev. Note in PR body."
         ALL_DEPS_MET=false
@@ -748,7 +748,7 @@ STEP 5 — PUSH & CREATE PR:
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"
   # appears verbatim in the PR body. Verify now so you don't leave a ghost issue.
-  # MCP: github_get_pr(pr_number=MY_PR_NUM) → .body
+  # MCP: pull_request_read (user-github)(pr_number=MY_PR_NUM) → .body
   # Check: result.body must contain "Closes #<N>" (case-insensitive)
   # If missing → MCP: update_pull_request(owner=..., repo=..., pullNumber=MY_PR_NUM,
   #                      body=<existing body + "\n\nCloses #<N>">)
@@ -778,12 +778,12 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # resolve_arch.py will switch to --mode reviewer to load the checklist instead of
     # the implementer fragments.
     REVIEWER_ARCH="${COGNITIVE_ARCH:-knuth:python}"
-    # MCP: github_get_pr(pr_number=MY_PR) → use .title, .body, .headRefName
-    PR_TITLE_VAL=<github_get_pr(MY_PR).title>
+    # MCP: pull_request_read (user-github)(pr_number=MY_PR) → use .title, .body, .headRefName
+    PR_TITLE_VAL=<pull_request_read (user-github)(MY_PR).title>
     # MCP: pull_request_read(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
     #      method="get_files", pullNumber=MY_PR) → join file paths with commas
     PR_FILES_VAL=<comma-separated file list from MCP pull_request_read get_files>
-    CLOSES_VAL=<parse "Closes #NNN" from github_get_pr(MY_PR).body, join with commas>
+    CLOSES_VAL=<parse "Closes #NNN" from pull_request_read (user-github)(MY_PR).body, join with commas>
     HAS_MIG=$(echo "$PR_FILES_VAL" | grep -c "alembic/versions/" || echo 0)
     [ "$HAS_MIG" -gt 0 ] && HAS_MIG_VAL=true || HAS_MIG_VAL=false
     cat > "$REVIEW_WORKTREE/.agent-task" <<TASK
@@ -867,7 +867,7 @@ Run this before touching the Setup script:
 
 ```
 # List every open issue for the current phase — this IS your candidate pool.
-# MCP: github_list_issues(state="open", label="phase-1")
+# MCP: list_issues (user-github)(state="open", label="phase-1")
 # → returns [{number, title, url, labels, ...}] — print each as "#N  title\n  url"
 ```
 
@@ -884,7 +884,7 @@ From the label audit output, choose issues that satisfy **both** criteria in
 candidate's body to identify affected files:
 
 ```
-# MCP: github_get_issue(issue_number=N) → .body and .title
+# MCP: issue_read (user-github)(issue_number=N) → .body and .title
 ```
 
 Confirm no two selected issues share a file. Document your selection in the
@@ -907,8 +907,8 @@ for num in <result from MCP list_pull_requests>; do
   #      method="get_files", pullNumber=num) → assign file paths to: files
   files=<file list from MCP pull_request_read get_files for PR num>
   if [ -n "$files" ]; then
-    # MCP: github_get_pr(pr_number=num) → .title
-    title=$(github_get_pr result .title)
+    # MCP: pull_request_read (user-github)(pr_number=num) → .title
+    title=$(pull_request_read (user-github) result .title)
     echo ""
     echo "PR #$num — $title:"
     echo "$files" | sed 's/^/  /'

--- a/scripts/gen_prompts/templates/parallel-pr-review.md.j2
+++ b/scripts/gen_prompts/templates/parallel-pr-review.md.j2
@@ -709,8 +709,8 @@ STEP 5.5 — MERGE ORDER GATE (sequential chain safety):
   DO NOT loop indefinitely — escalate and self-destruct instead.
 
     for i in $(seq 1 15); do
-      # MCP: github_get_pr(pr_number=MERGE_AFTER) → .state
-      STATE=<github_get_pr(MERGE_AFTER).state>
+      # MCP: pull_request_read (user-github)(pr_number=MERGE_AFTER) → .state
+      STATE=<pull_request_read (user-github)(MERGE_AFTER).state>
       echo "[$i/15] Gate PR #$MERGE_AFTER state: $STATE"
       if [ "$STATE" = "MERGED" ]; then
         echo "✅ Gate cleared — PR #$MERGE_AFTER is merged. Proceeding to merge."
@@ -842,7 +842,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
-         # MCP: github_get_pr(pr_number=N) → .body → parse "Closes #NNN" patterns
+         # MCP: pull_request_read (user-github)(pr_number=N) → .body → parse "Closes #NNN" patterns
          # Then for each parsed issue number, call MCP issue_write to close it.
          echo "Parse PR body for Closes #NNN patterns, then close each via MCP issue_write"
        fi
@@ -982,7 +982,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
     ACTIVE_LABEL=""
     # For each phase label in order, check if open issues exist:
 {{ phases_shell }}
-      # MCP: github_list_issues(label="$label", state="open") → .count
+      # MCP: list_issues (user-github)(label="$label", state="open") → .count
       COUNT=<count from MCP response>
       if [ "$COUNT" -gt 0 ]; then
         ACTIVE_LABEL="$label"
@@ -996,7 +996,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       TASK_BATCH_ID=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('pipeline',{}).get('batch_id',''))" 2>/dev/null || echo "")
       BATCH_LABEL_PREFIX=$(echo "$TASK_BATCH_ID" | grep -oE 'batch-[0-9]+' | head -1)
       if [ -n "$BATCH_LABEL_PREFIX" ]; then
-        # MCP: github_list_issues(label="$BATCH_LABEL_PREFIX", state="open") → .count
+        # MCP: list_issues (user-github)(label="$BATCH_LABEL_PREFIX", state="open") → .count
         BATCH_COUNT=<count from MCP response>
         if [ "$BATCH_COUNT" -gt 0 ]; then
           ACTIVE_LABEL="$BATCH_LABEL_PREFIX"
@@ -1009,7 +1009,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       echo "ℹ️  No open {{ active_label_prefix }} or batch issues remain — chain complete."
     else
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
-      # MCP: github_list_issues(label="$ACTIVE_LABEL", state="open")
+      # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "{{ claim_label }}" (already claimed),
       # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
@@ -1019,14 +1019,14 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
 
     # Dependency gate: only proceed if all "Depends on #NNN" references are CLOSED.
     if [ -n "$NEXT_ISSUE" ]; then
-      # MCP: github_get_issue(number=$NEXT_ISSUE) → .body
+      # MCP: issue_read (user-github)(number=$NEXT_ISSUE) → .body
       # Parse "Depends on #NNN" references from body text.
       # For each dependency:
-      #   MCP: github_get_issue(number=<dep>) → check .state and .state_reason
+      #   MCP: issue_read (user-github)(number=<dep>) → check .state and .state_reason
       #   If state != "closed" or state_reason != "completed" → skip this issue.
       DEPS=<parsed dependency issue numbers>
       for dep in $DEPS; do
-        # MCP: github_get_issue(number=$dep) → .state
+        # MCP: issue_read (user-github)(number=$dep) → .state
         DEP_STATE=<state from MCP>
         if [ "$DEP_STATE" != "closed" ]; then
           echo "ℹ️  Issue #$NEXT_ISSUE blocked by dependency #$dep (state=$DEP_STATE) — chain complete for now."
@@ -1054,7 +1054,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # MCP: github_claim_issue(issue_number=$NEXT_ISSUE)
 
       # Resolve the primary label so the engineer can route mypy/tests correctly.
-      # MCP: github_get_issue(number=$NEXT_ISSUE) → .labels
+      # MCP: issue_read (user-github)(number=$NEXT_ISSUE) → .labels
       # Pick the first label starting with "{{ active_label_prefix }}"
       NEXT_ISSUE_LABEL=<label from MCP response>
 
@@ -1114,12 +1114,12 @@ TASK
   else
     # ── POOL MODE: spawned by QA Coordinator; spawn the next REVIEWER for the next open PR ──
 
-    # MCP: github_list_prs(state="open") → filter out any with label "{{ claim_label }}"
+    # MCP: list_pull_requests (user-github)(state="open") → filter out any with label "{{ claim_label }}"
     # Take the first unclaimed PR targeting dev.
     NEXT_PR=<first unclaimed PR number from MCP response>
 
     if [ -n "$NEXT_PR" ]; then
-      # MCP: github_get_pr(pr_number=$NEXT_PR) → .headRefName, .title, .body
+      # MCP: pull_request_read (user-github)(pr_number=$NEXT_PR) → .headRefName, .title, .body
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
@@ -1259,7 +1259,7 @@ If two PRs in the batch share a file:
 ### Step 1 — Confirm PRs are open
 
 ```
-# MCP: github_list_prs(state="open")
+# MCP: list_pull_requests (user-github)(state="open")
 ```
 
 ### Step 2 — Confirm `dev` is up to date
@@ -1297,7 +1297,7 @@ docker compose exec agentception ls /worktrees/
 REPO=$(git rev-parse --show-toplevel)
 git -C "$REPO" fetch origin
 git -C "$REPO" merge origin/dev
-# MCP: github_list_prs(state="open")   # any PRs the batch failed to merge?
+# MCP: list_pull_requests (user-github)(state="open")   # any PRs the batch failed to merge?
 ```
 
 ### 2 — Worktree cleanup

--- a/scripts/gen_prompts/templates/roles/coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/coordinator.md.j2
@@ -4,9 +4,9 @@ You route work. You do not do work. You never implement features, write migratio
 
 ## Decision Hierarchy
 
-1. **GitHub state is truth.** Never assume readiness without querying. Use MCP tools (`github_list_issues`, `github_list_prs`, `github_get_pr`) — never assume state.
+1. **GitHub state is truth.** Never assume readiness without querying. Use MCP tools (`list_issues (user-github)`, `list_pull_requests (user-github)`, `pull_request_read (user-github)`) — never assume state.
 2. **Dependency order before parallelism.** Check `DEPENDS_ON` before dispatching. Starting before a dependency merges creates conflicts.
-3. **Artifact proof required.** "Done" without a PR URL is not done. Require the URL. Verify with MCP `github_get_pr` or `pull_request_read`.
+3. **Artifact proof required.** "Done" without a PR URL is not done. Require the URL. Verify with MCP `pull_request_read (user-github)` or `pull_request_read`.
 4. **Human gates before migration phases.** Any `phase-1/db-schema` or `security` work requires explicit human sign-off. Stop and ask.
 
 ## What You Dispatch

--- a/scripts/gen_prompts/templates/roles/cto.md.j2
+++ b/scripts/gen_prompts/templates/roles/cto.md.j2
@@ -94,12 +94,12 @@ LOOP:
        # worktree + open PR = active claim, not a stale one.
        MAIN_REPO="<repo-root>"
 
-       # MCP: github_list_issues(state="open", label="{{ claim_label }}")
+       # MCP: list_issues (user-github)(state="open", label="{{ claim_label }}")
        # → returns list of {number, title, labels, ...}; iterate each .number as NUM
-       for NUM in <numbers from github_list_issues result>; do
+       for NUM in <numbers from list_issues (user-github) result>; do
          # Open PR guard — branch name is the canonical link between issue and PR.
-         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
-         OPEN_PR=<pr_number from github_list_prs result, or empty>
+         # MCP: list_pull_requests (user-github)(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
+         OPEN_PR=<pr_number from list_pull_requests (user-github) result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "CTO preflight: keeping {{ claim_label }} on #$NUM (open PR #$OPEN_PR — worktree pruning expected)"
            continue
@@ -123,16 +123,16 @@ LOOP:
        # SCOPE_VALUE was loaded from .agent-task in Step 2 of your briefing.
        # Discover phase sub-labels dynamically from open issues — never hardcode.
 
-       # MCP: github_list_issues(state="open", label="$SCOPE_VALUE")
+       # MCP: list_issues (user-github)(state="open", label="$SCOPE_VALUE")
        # → from the result, collect all label names that start with "$SCOPE_VALUE/",
        #   deduplicate, and sort. These are your PHASES.
-       PHASES=<unique sorted sub-labels from github_list_issues result>
+       PHASES=<unique sorted sub-labels from list_issues (user-github) result>
 
        # Find the first phase with open issues (phases sort lexicographically).
        ACTIVE_LABEL=""
        for label in $PHASES; do
-         # MCP: github_list_issues(state="open", label="$label")
-         COUNT=<length of github_list_issues result>
+         # MCP: list_issues (user-github)(state="open", label="$label")
+         COUNT=<length of list_issues (user-github) result>
          if [ "$COUNT" -gt 0 ]; then
            ACTIVE_LABEL="$label"
            ISSUES=$COUNT
@@ -142,14 +142,14 @@ LOOP:
 
        # Fallback: no phase sub-labels found — use SCOPE_VALUE as the single label.
        if [ -z "$ACTIVE_LABEL" ]; then
-         # MCP: github_list_issues(state="open", label="$SCOPE_VALUE")
-         COUNT=<length of github_list_issues result>
+         # MCP: list_issues (user-github)(state="open", label="$SCOPE_VALUE")
+         COUNT=<length of list_issues (user-github) result>
          [ "$COUNT" -gt 0 ] && ACTIVE_LABEL="$SCOPE_VALUE" && ISSUES=$COUNT
        fi
 
        # PRs: all open PRs against dev are always in scope.
-       # MCP: github_list_prs(state="open") → filter where .baseRefName == "dev"
-       PRS=<count from github_list_prs result>
+       # MCP: list_pull_requests (user-github)(state="open") → filter where .baseRefName == "dev"
+       PRS=<count from list_pull_requests (user-github) result>
 
        # If no active label found, all issues are closed — check PRs only.
        [ -z "$ACTIVE_LABEL" ] && ISSUES=0

--- a/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
@@ -78,13 +78,13 @@ SEED:
        # If the worktree exists AND has commits, the claim is ACTIVE — do NOT touch it.
        MAIN_REPO=$(git -C "<repo-root>" rev-parse --show-toplevel 2>/dev/null || echo "<repo-root>")
 
-       # MCP: github_list_issues(state="open", label="{{ claim_label }}")
+       # MCP: list_issues (user-github)(state="open", label="{{ claim_label }}")
        # → returns list of {number, title, labels, ...}; iterate each .number as NUM
-       for NUM in <numbers from github_list_issues result>; do
+       for NUM in <numbers from list_issues (user-github) result>; do
          # If an open PR already references this issue (via branch name or close keyword),
          # the claim is ACTIVE even if the implementer worktree was pruned. Never clear it.
-         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
-         OPEN_PR=<pr_number from github_list_prs result, or empty>
+         # MCP: list_pull_requests (user-github)(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
+         OPEN_PR=<pr_number from list_pull_requests (user-github) result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "Keeping {{ claim_label }} on #$NUM (open PR #$OPEN_PR exists — worktree pruning is expected)"
            continue
@@ -110,7 +110,7 @@ SEED:
        # NEVER query all {{ active_label_prefix }}* labels — you are scoped to exactly one label per coordinator run.
        # This prevents you from accidentally claiming issues from a later phase.
        ACTIVE_LABEL="<from dispatch prompt>"
-       # MCP: github_list_issues(state="open", label="$ACTIVE_LABEL")
+       # MCP: list_issues (user-github)(state="open", label="$ACTIVE_LABEL")
        # → filter result to exclude issues that have any of these labels:
        #     "{{ claim_label }}"  (already claimed by another agent)
        #     "blocked"            (phase-gated — prior phase not yet complete)
@@ -124,8 +124,8 @@ SEED:
        # the stale sweep to (incorrectly) clear {{ claim_label }} and expose the issue again.
        # Always re-verify before seeding — branch naming is the canonical signal.
        for NUM in <candidate numbers from step 3>; do
-         # MCP: github_list_prs(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
-         OPEN_PR=<pr_number from github_list_prs result, or empty>
+         # MCP: list_pull_requests (user-github)(state="open") → filter where .headRefName startswith "feat/issue-${NUM}"
+         OPEN_PR=<pr_number from list_pull_requests (user-github) result, or empty>
          if [ -n "$OPEN_PR" ]; then
            echo "SKIP #$NUM — open PR #$OPEN_PR already exists for this issue"
            # Remove from candidate list
@@ -140,13 +140,13 @@ SEED:
      Secondary signal (belt-and-suspenders): parse "Blocked by #NNN" from the
      issue body and verify each dep is CLOSED. Skip if any dep is still OPEN.
        for NUM in <candidate numbers>; do
-         # MCP: github_get_issue(number=NUM) → .body
+         # MCP: issue_read (user-github)(number=NUM) → .body
          # Extract "Blocked by #NNN" patterns from .body, iterate each dep number.
-         DEPS=<dep numbers parsed from github_get_issue(NUM).body>
+         DEPS=<dep numbers parsed from issue_read (user-github)(NUM).body>
          ALL_MET=true
          for dep in $DEPS; do
-           # MCP: github_get_issue(number=dep) → .state
-           STATE=<github_get_issue(dep).state>
+           # MCP: issue_read (user-github)(number=dep) → .state
+           STATE=<issue_read (user-github)(dep).state>
            [ "$STATE" != "closed" ] && ALL_MET=false && break
          done
          [ "$ALL_MET" = "true" ] && echo "SEED $NUM" || echo "SKIP $NUM (deps unmet)"
@@ -160,7 +160,7 @@ SEED:
   5. Take the first 4 unclaimed issues. For each:
        a. Claim:  MCP: github_add_label(issue_number=N, label="{{ claim_label }}")
        b. Read the issue body:
-            # MCP: github_get_issue(number=N) → use .body and .title
+            # MCP: issue_read (user-github)(number=N) → use .body and .title
        c. Call ``build_spawn_child`` MCP tool to create the engineer node atomically:
           ```
           build_spawn_child(

--- a/scripts/gen_prompts/templates/roles/qa-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/qa-coordinator.md.j2
@@ -81,7 +81,7 @@ SEED:
        MAIN_REPO="<repo-root>"
        git -C "$MAIN_REPO" worktree list --porcelain | grep "^worktree" | awk '{print $2}' \
          > /tmp/active_worktrees
-       # MCP: github_list_prs(state="open") → filter to those with label "{{ claim_label }}"
+       # MCP: list_pull_requests (user-github)(state="open") → filter to those with label "{{ claim_label }}"
        for pr in <PR numbers with {{ claim_label }}>; do
          grep -q "pr-$pr" /tmp/active_worktrees || \
            # MCP: github_remove_label(issue_number=pr, label="{{ claim_label }}")
@@ -89,7 +89,7 @@ SEED:
        done
 
   3. Query open unclaimed PRs:
-       # MCP: github_list_prs(state="open")
+       # MCP: list_pull_requests (user-github)(state="open")
        # → filter result to exclude PRs that already have the "{{ claim_label }}" label
      If empty → report "review queue clear." Stop.
 
@@ -101,7 +101,7 @@ SEED:
   5. Take the first 4 unclaimed PRs. For each:
        a. Claim:  MCP: github_add_label(issue_number=N, label="{{ claim_label }}")
        b. Get PR body and title:
-            # MCP: github_get_pr(pr_number=N) → use .body, .title, .headRefName
+            # MCP: pull_request_read (user-github)(pr_number=N) → use .body, .title, .headRefName
        c. Call ``build_spawn_child`` MCP tool to create the reviewer node atomically:
           ```
           build_spawn_child(
@@ -148,7 +148,7 @@ required fields including COGNITIVE_ARCH, BATCH_ID, lineage fields, and scope.
 You do NOT need to write `.agent-task` files manually.
 
 If a worktree is missing for a new PR:
-  `# MCP: github_get_pr(pr_number=N) → .headRefName`
+  `# MCP: pull_request_read (user-github)(pr_number=N) → .headRefName`
   `git -C "<repo-root>" worktree add "$HOME/.agentception/worktrees/{{ repo_name }}/pr-{N}" origin/$BRANCH`
 
 ## MERGE_AFTER protocol

--- a/scripts/gen_prompts/templates/snippets/environment-setup.md.j2
+++ b/scripts/gen_prompts/templates/snippets/environment-setup.md.j2
@@ -57,7 +57,7 @@ the `dev` branch with uncommitted changes.
 ### Command policy
 
 Consult `.agentception/agent-command-policy.md` for the full tier list. Summary:
-- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `github_get_issue`, `github_list_prs`, `mypy`, `pytest`, `rg`
+- **Green (auto-allow):** `ls`, `git status/log/diff/fetch`, `issue_read (user-github)`, `list_pull_requests (user-github)`, `mypy`, `pytest`, `rg`
 - **Yellow (review before running):** `docker compose build`, `rm <single file>`, `git rebase`
 - **Red (never):** `rm -rf`, `git push --force`, `git push origin dev`, `docker system prune`
 

--- a/scripts/gen_prompts/templates/snippets/github-mcp-reference.md.j2
+++ b/scripts/gen_prompts/templates/snippets/github-mcp-reference.md.j2
@@ -5,10 +5,10 @@ writes — they add caching, structured output, and logging.
 
 | MCP tool | Replaces |
 |----------|---------|
-| `github_list_issues(state, label)` | `gh issue list --label X` |
-| `github_get_issue(issue_number)` | `gh issue view N --json ...` |
-| `github_list_prs(state)` | `gh pr list` |
-| `github_get_pr(pr_number)` | `gh pr view N --json ...` |
+| `list_issues (user-github)(state, label)` | `gh issue list --label X` |
+| `issue_read (user-github)(issue_number)` | `gh issue view N --json ...` |
+| `list_pull_requests (user-github)(state)` | `gh pr list` |
+| `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
 | `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |


### PR DESCRIPTION
## Summary

- Deletes 4 `github_*` read wrapper tools: `github_list_issues`, `github_get_issue`, `github_list_prs`, `github_get_pr`
- Keeps `github_add_label`, `github_remove_label`, `github_claim_issue`, `github_unclaim_issue` (no atomic equivalent in `user-github`)
- 9 template files updated to reference `list_issues (user-github)`, `issue_read (user-github)`, `list_pull_requests (user-github)`, `pull_request_read (user-github)`
- `generate.py` regenerated 7 output files

## Test plan

- [x] mypy clean
- [x] 993 tests passing (0 failures)
- [x] All 7 generated files updated and committed together with their templates
