### PR TITLE
feat(mcp): remove 7 agent-facing HTTP routes; replace ac_url with mcp_server (PR 6)

### DIFF
--- a/.agentception/dispatcher.md
+++ b/.agentception/dispatcher.md
@@ -89,7 +89,7 @@ it was already claimed.
 cat {host_worktree_path}/.agent-task
 ```
 
-Extract: `TIER`, `SCOPE_TYPE`, `SCOPE_VALUE`, `GH_REPO`, `ROLE`, `ROLE_FILE`, `AC_URL`.
+Extract: `TIER`, `SCOPE_TYPE`, `SCOPE_VALUE`, `GH_REPO`, `ROLE`, `ROLE_FILE`.
 
 ### 3c. Spawn the agent via Task tool
 
@@ -108,7 +108,7 @@ RUN_ID:      {run_id}
 SCOPE_TYPE:  label
 SCOPE_VALUE: {scope_value}
 GH_REPO:     {gh_repo}
-AC_URL:      http://localhost:10003
+mcp_server:  user-agentception
 
 Step 1: Read your role file:
   {role_file}
@@ -163,7 +163,7 @@ RUN_ID:      {run_id}
 SCOPE_TYPE:  {scope_type}    (issue or pr)
 SCOPE_VALUE: {scope_value}   (issue or PR number)
 GH_REPO:     {gh_repo}
-AC_URL:      http://localhost:10003
+mcp_server:  user-agentception
 
 Step 1: Read your role file:
   {role_file}

--- a/agentception/config.py
+++ b/agentception/config.py
@@ -106,14 +106,6 @@ class AgentCeptionSettings(BaseSettings):
         to the IDE.
         """
         return self.repo_dir / ".agentception"
-    ac_url: str = "http://localhost:10003"
-    """Base URL at which the AgentCeption service is reachable from the host.
-
-    Embedded in ``.agent-task`` files and in the Dispatcher prompt so that
-    spawned agents can POST lifecycle events back via curl.  Defaults to the
-    standard local port; override via ``AC_URL`` env var in production or
-    when running behind a reverse proxy.
-    """
     poll_interval_seconds: int = 5
     github_cache_seconds: int = 10
     database_url: str | None = None

--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -207,7 +207,6 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
 
     logger.info("✅ dispatch: worktree created at %s", worktree_path)
 
-    ac_url = settings.ac_url
     role_file = str(Path(settings.repo_dir) / ".agentception" / "roles" / f"{req.role}.md")
     cognitive_arch = _resolve_cognitive_arch(req.issue_body, req.role)
     agent_task = _build_agent_task(
@@ -223,7 +222,7 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
         "meta": {
             "run_id": run_id,
             "role_file": role_file,
-            "ac_url": ac_url,
+            "mcp_server": "user-agentception",
             "spawn_mode": "dispatcher",
         },
     })
@@ -493,7 +492,6 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
 
     logger.info("✅ dispatch-label: worktree %s for label %r tier=%s", worktree_path, req.label, tier)
 
-    ac_url = settings.ac_url
     role_file = str(Path(settings.repo_dir) / ".agentception" / "roles" / f"{role}.md")
     host_role_file = str(Path(settings.host_repo_dir) / ".agentception" / "roles" / f"{role}.md")
     label_cognitive_arch = _resolve_cognitive_arch("", role)
@@ -531,7 +529,7 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
         },
         "meta": {
             "run_id": run_id,
-            "ac_url": ac_url,
+            "mcp_server": "user-agentception",
         },
     }
     if org_domain:

--- a/agentception/routes/api/runs.py
+++ b/agentception/routes/api/runs.py
@@ -1,25 +1,21 @@
 from __future__ import annotations
 
-"""Run lifecycle API routes — agent callbacks and run management.
+"""Run lifecycle API routes — UI-facing only.
 
-Two audiences:
+Agents interact with AgentCeption exclusively through the ``user-agentception``
+MCP server.  This HTTP surface is reserved for browser / UI interactions only.
 
-1. **The AgentCeption Coordinator / Dispatcher** — ``GET /api/runs/pending``
-   exposes the launch queue; ``POST /api/runs/{run_id}/acknowledge``
-   atomically claims a run; ``POST /api/runs/{parent_run_id}/children``
-   lets any manager agent create a child node atomically.
+UI surfaces retained:
+  POST /api/runs/{run_id}/message  — operator sends a message to an agent
+  POST /api/runs/{run_id}/cancel   — UI cancels a pending_launch before dispatch
+  POST /api/runs/{run_id}/stop     — UI marks a run stopped from the inspector
 
-2. **Running agents** — ``POST /api/runs/{run_id}/step|blocker|decision|done``
-   let agents push structured lifecycle events back to AgentCeption.
-
-3. **Ship UI operators** — ``POST /api/runs/{run_id}/message`` saves a user
-   message to the agent's transcript; ``POST /api/runs/{run_id}/stop``
-   marks a run DONE from the inspector panel.
-
-See ``docs/agent-tree-protocol.md`` for the full tier spec.
+Agent-facing routes (GET /pending, POST /acknowledge, /children, /step,
+/blocker, /decision, /done) have been removed.  Use the MCP equivalents:
+  query_pending_runs, build_claim_run, build_spawn_child_run,
+  log_run_step, log_run_blocker, log_run_decision, build_complete_run.
 """
 
-import asyncio
 import datetime
 import logging
 
@@ -27,255 +23,12 @@ from fastapi import APIRouter, HTTPException, Response
 from pydantic import BaseModel
 from sqlalchemy import func, select
 
-from typing import Literal
-
 from agentception.db.engine import get_session
 from agentception.db.models import ACAgentMessage, ACAgentRun
-from agentception.db.persist import acknowledge_agent_run, persist_agent_event
-from agentception.db.queries import get_agent_run_teardown, get_pending_launches
-from agentception.services.spawn_child import (
-    SpawnChildError,
-    Tier,
-    spawn_child,
-)
-from agentception.services.teardown import teardown_agent_worktree
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/runs", tags=["runs"])
-
-
-# ---------------------------------------------------------------------------
-# GET /api/runs/pending — Dispatcher reads this to know what to spawn
-# ---------------------------------------------------------------------------
-
-
-@router.get("/pending")
-async def list_pending_launches() -> dict[str, object]:
-    """Return all runs waiting to be claimed by the Dispatcher.
-
-    The AgentCeption Dispatcher calls this once at startup to discover what
-    the UI has queued.  Each item includes the run_id, role, issue number,
-    and host-side worktree path so the Dispatcher can spawn the right agent
-    at the right level of the tree (leaf worker, VP, or CTO).
-    """
-    launches = await get_pending_launches()
-    return {"pending": launches, "count": len(launches)}
-
-
-# ---------------------------------------------------------------------------
-# POST /api/runs/{run_id}/acknowledge — atomically claim a pending run
-# ---------------------------------------------------------------------------
-
-
-@router.post("/{run_id}/acknowledge")
-async def acknowledge_launch(run_id: str) -> dict[str, object]:
-    """Atomically claim a pending run before spawning its Task agent.
-
-    The Dispatcher calls this immediately before it spawns the Task so the
-    run cannot be double-claimed if two Dispatchers run concurrently.
-    Transitions the run from ``pending_launch`` → ``implementing``.
-
-    Returns ``{"ok": true}`` on success or ``{"ok": false, "reason": "..."}``
-    when the run was not found or already claimed (idempotency guard).
-    """
-    ok = await acknowledge_agent_run(run_id)
-    if not ok:
-        return {"ok": False, "reason": f"Run {run_id!r} not found or not in pending_launch state"}
-    logger.info("✅ acknowledge_launch: %s claimed", run_id)
-    return {"ok": True, "run_id": run_id}
-
-
-# ---------------------------------------------------------------------------
-# POST /api/runs/{parent_run_id}/children — spawn a child node
-# ---------------------------------------------------------------------------
-
-
-class SpawnChildRequest(BaseModel):
-    """Request body for ``POST /api/runs/{parent_run_id}/children``."""
-
-    role: str
-    """Child's role slug (e.g. ``"engineering-coordinator"``, ``"python-developer"``)."""
-    tier: Tier
-    """Behavioral execution tier: ``"executive"`` | ``"coordinator"`` | ``"engineer"`` | ``"reviewer"``."""
-    org_domain: str | None = None
-    """Organisational slot for UI hierarchy (``"c-suite"`` | ``"engineering"`` | ``"qa"``)."""
-    scope_type: Literal["label", "issue", "pr"]
-    """``"label"``, ``"issue"``, or ``"pr"``."""
-    scope_value: str
-    """Label string, issue number, or PR number (as string)."""
-    gh_repo: str
-    """``"owner/repo"`` string."""
-    issue_body: str = ""
-    """Issue body for COGNITIVE_ARCH skill extraction (issue-scoped children)."""
-    issue_title: str = ""
-    """Issue title written to ISSUE_TITLE field."""
-    skills_hint: list[str] | None = None
-    """Explicit skill list; bypasses keyword extraction when provided."""
-
-
-class SpawnChildResponse(BaseModel):
-    """Successful response from ``POST /api/runs/{parent_run_id}/children``."""
-
-    run_id: str
-    host_worktree_path: str
-    worktree_path: str
-    tier: str
-    org_domain: str | None = None
-    role: str
-    cognitive_arch: str
-    agent_task_path: str
-    scope_type: str
-    scope_value: str
-    status: str = "implementing"
-
-
-@router.post("/{parent_run_id}/children", response_model=SpawnChildResponse)
-async def spawn_child_node(
-    parent_run_id: str, req: SpawnChildRequest
-) -> SpawnChildResponse:
-    """Atomically create a child node in the agent tree.
-
-    Any manager agent (CTO, coordinator, or future tier) calls this endpoint
-    to create a child with a worktree, ``.agent-task``, DB record, and
-    auto-acknowledgement — all in a single atomic operation.
-
-    The caller receives ``host_worktree_path`` and ``run_id``, then
-    immediately fires a Task tool call with the briefing:
-
-        "Read your .agent-task file at {host_worktree_path}/.agent-task
-         and follow the instructions for your role."
-
-    Raises:
-        HTTPException 422: Invalid ``scope_type`` value.
-        HTTPException 500: Worktree creation or file I/O failure.
-    """
-    try:
-        result = await spawn_child(
-            parent_run_id=parent_run_id,
-            role=req.role,
-            tier=req.tier,
-            org_domain=req.org_domain,
-            scope_type=req.scope_type,
-            scope_value=req.scope_value,
-            gh_repo=req.gh_repo,
-            issue_body=req.issue_body,
-            issue_title=req.issue_title,
-            skills_hint=req.skills_hint,
-        )
-    except SpawnChildError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    return SpawnChildResponse(**result.to_dict(), status="implementing")
-
-
-# ---------------------------------------------------------------------------
-# Agent callbacks — POST /api/runs/{run_id}/step|blocker|decision|done
-# ---------------------------------------------------------------------------
-
-
-class StepReport(BaseModel):
-    """Body for ``POST /api/runs/{run_id}/step``."""
-
-    issue_number: int
-    step_name: str
-
-
-class BlockerReport(BaseModel):
-    """Body for ``POST /api/runs/{run_id}/blocker``."""
-
-    issue_number: int
-    description: str
-
-
-class DecisionReport(BaseModel):
-    """Body for ``POST /api/runs/{run_id}/decision``."""
-
-    issue_number: int
-    decision: str
-    rationale: str
-
-
-class DoneReport(BaseModel):
-    """Body for ``POST /api/runs/{run_id}/done``."""
-
-    issue_number: int
-    pr_url: str
-    summary: str = ""
-
-
-@router.post("/{run_id}/step")
-async def report_step(run_id: str, req: StepReport) -> dict[str, object]:
-    """Agent reports starting a named execution step."""
-    await persist_agent_event(
-        issue_number=req.issue_number,
-        event_type="step_start",
-        payload={"step": req.step_name},
-        agent_run_id=run_id,
-    )
-    logger.info("✅ report_step: run=%r issue=%d step=%r", run_id, req.issue_number, req.step_name)
-    return {"ok": True}
-
-
-@router.post("/{run_id}/blocker")
-async def report_blocker(run_id: str, req: BlockerReport) -> dict[str, object]:
-    """Agent reports being blocked."""
-    await persist_agent_event(
-        issue_number=req.issue_number,
-        event_type="blocker",
-        payload={"description": req.description},
-        agent_run_id=run_id,
-    )
-    logger.warning(
-        "⚠️ report_blocker: run=%r issue=%d — %s", run_id, req.issue_number, req.description
-    )
-    return {"ok": True}
-
-
-@router.post("/{run_id}/decision")
-async def report_decision(run_id: str, req: DecisionReport) -> dict[str, object]:
-    """Agent records an architectural decision."""
-    await persist_agent_event(
-        issue_number=req.issue_number,
-        event_type="decision",
-        payload={"decision": req.decision, "rationale": req.rationale},
-        agent_run_id=run_id,
-    )
-    logger.info(
-        "✅ report_decision: run=%r issue=%d decision=%r", run_id, req.issue_number, req.decision
-    )
-    return {"ok": True}
-
-
-async def _teardown_agent_worktree(run_id: str) -> None:
-    """Delegate to the shared teardown service.
-
-    Thin wrapper kept so the ``asyncio.create_task`` call below doesn't change.
-    All logic lives in ``agentception.services.teardown``.
-    """
-    await teardown_agent_worktree(run_id)
-
-
-@router.post("/{run_id}/done")
-async def report_done(run_id: str, req: DoneReport) -> dict[str, object]:
-    """Agent reports completion, links the PR, and tears down its worktree.
-
-    The worktree removal and remote branch deletion run as a background task
-    so the agent receives an immediate ``{"ok": True}`` response and is not
-    blocked waiting for git operations to complete.
-    """
-    await persist_agent_event(
-        issue_number=req.issue_number,
-        event_type="done",
-        payload={"pr_url": req.pr_url, "summary": req.summary},
-        agent_run_id=run_id,
-    )
-    logger.info("✅ report_done: run=%r issue=%d pr_url=%r", run_id, req.issue_number, req.pr_url)
-    asyncio.create_task(
-        _teardown_agent_worktree(run_id),
-        name=f"teardown-{run_id}",
-    )
-    return {"ok": True}
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/services/spawn_child.py
+++ b/agentception/services/spawn_child.py
@@ -221,7 +221,6 @@ def _build_child_task(
     batch_id: str,
     parent_run_id: str,
     cognitive_arch: str,
-    ac_url: str,
     coord_fingerprint: str | None = None,
     issue_title: str = "",
     issue_number: int | None = None,
@@ -266,7 +265,9 @@ def _build_child_task(
         "repo": {
             "gh_repo": gh_repo,
             "base": "dev",
-            "ac_url": ac_url,
+            # mcp_server: agents communicate exclusively via the user-agentception
+            # MCP server — no HTTP calls.  This comment is documentation only.
+            "mcp_server": "user-agentception",
         },
         "pipeline": {
             "batch_id": batch_id,
@@ -414,7 +415,6 @@ async def spawn_child(
 
     worktree_path = str(Path(settings.worktrees_dir) / run_id)
     host_worktree_path = str(Path(settings.host_worktrees_dir) / run_id)
-    ac_url = settings.ac_url
 
     # Derive issue/pr numbers for supplemental task fields
     issue_number: int | None = None
@@ -497,7 +497,6 @@ async def spawn_child(
         batch_id=batch_id,
         parent_run_id=parent_run_id,
         cognitive_arch=resolved_arch,
-        ac_url=ac_url,
         coord_fingerprint=coord_fingerprint,
         issue_title=issue_title,
         issue_number=issue_number,

--- a/agentception/tests/test_agentception_spawn.py
+++ b/agentception/tests/test_agentception_spawn.py
@@ -715,7 +715,6 @@ def test_build_child_task_issue_scope_emits_valid_toml(tmp_path: Path) -> None:
         batch_id="issue-48-20260306T120000Z-1234",
         parent_run_id="coord-xyz",
         cognitive_arch="von_neumann:python",
-        ac_url="http://localhost:10003",
         coord_fingerprint="Engineering Coordinator · batch-001",
         issue_title="Migrate parse_agent_task()",
         issue_number=48,
@@ -752,7 +751,6 @@ def test_build_child_task_pr_scope_emits_valid_toml() -> None:
         batch_id="pr-142-20260306T120000Z-5678",
         parent_run_id="coord-abc",
         cognitive_arch="hopper:python",
-        ac_url="http://localhost:10003",
         pr_number=142,
     )
     parsed = tomllib.loads(output)
@@ -778,7 +776,6 @@ def test_build_child_task_label_scope_emits_valid_toml() -> None:
         batch_id="label-ac-workflow-20260306T120000Z-9abc",
         parent_run_id="",
         cognitive_arch="von_neumann:python",
-        ac_url="http://localhost:10003",
     )
     parsed = tomllib.loads(output)
     assert parsed["task"]["workflow"] == "coordinator"

--- a/agentception/tests/test_agentception_spawn_child.py
+++ b/agentception/tests/test_agentception_spawn_child.py
@@ -102,7 +102,6 @@ def _make_task(
     batch_id: str = "label-ac-workflow-20260101T000000Z-abcd",
     parent_run_id: str = "label-cto-111111",
     cognitive_arch: str = "von_neumann:python",
-    ac_url: str = "http://localhost:10003",
     issue_title: str = "",
     issue_number: int | None = None,
     pr_number: int | None = None,
@@ -121,7 +120,6 @@ def _make_task(
         batch_id=batch_id,
         parent_run_id=parent_run_id,
         cognitive_arch=cognitive_arch,
-        ac_url=ac_url,
         issue_title=issue_title,
         issue_number=issue_number,
         pr_number=pr_number,
@@ -137,7 +135,6 @@ def test_build_child_task_required_fields_present() -> None:
     assert 'scope_value = "ac-workflow"' in task
     assert 'parent_run_id = "label-cto-111111"' in task
     assert 'cognitive_arch = "von_neumann:python"' in task
-    assert 'ac_url = "http://localhost:10003"' in task
     assert 'role_file = "' in task
     assert 'host_role_file = "' in task
 
@@ -248,7 +245,6 @@ def test_build_child_task_coord_fingerprint_present() -> None:
         batch_id="issue-42-20260305T000000Z-ab12",
         parent_run_id="coord-ac-xyz",
         cognitive_arch="ada_lovelace:python",
-        ac_url="http://localhost:10003",
         coord_fingerprint=fp,
         issue_number=42,
     )
@@ -543,127 +539,6 @@ def test_spawn_child_result_to_dict_org_domain_none() -> None:
 
 
 # ---------------------------------------------------------------------------
-# POST /api/runs/{parent_run_id}/children — HTTP endpoint
-# ---------------------------------------------------------------------------
-
-
-def test_spawn_child_endpoint_invalid_scope_type(client: TestClient) -> None:
-    """Invalid scope_type should return HTTP 422."""
-    response = client.post(
-        "/api/runs/cto-abc/children",
-        json={
-            "role": "engineering-coordinator",
-            "tier": "coordinator",
-            "scope_type": "invalid",
-            "scope_value": "ac-workflow",
-            "gh_repo": "owner/repo",
-        },
-    )
-    assert response.status_code == 422
-
-
-def test_spawn_child_endpoint_invalid_tier(client: TestClient) -> None:
-    """Invalid tier value should return HTTP 422."""
-    response = client.post(
-        "/api/runs/cto-abc/children",
-        json={
-            "role": "engineering-coordinator",
-            "tier": "manager",   # not a valid Tier — must be rejected
-            "scope_type": "label",
-            "scope_value": "ac-workflow",
-            "gh_repo": "owner/repo",
-        },
-    )
-    assert response.status_code == 422
-
-
-def test_spawn_child_endpoint_missing_tier(client: TestClient) -> None:
-    """Missing tier (now required) must return HTTP 422."""
-    response = client.post(
-        "/api/runs/cto-abc/children",
-        json={
-            "role": "engineering-coordinator",
-            # tier missing
-            "scope_type": "label",
-            "scope_value": "ac-workflow",
-            "gh_repo": "owner/repo",
-        },
-    )
-    assert response.status_code == 422
-
-
-def test_spawn_child_endpoint_missing_required_field(client: TestClient) -> None:
-    response = client.post(
-        "/api/runs/cto-abc/children",
-        json={
-            "role": "engineering-coordinator",
-            "tier": "coordinator",
-            # scope_type missing
-            "scope_value": "ac-workflow",
-            "gh_repo": "owner/repo",
-        },
-    )
-    assert response.status_code == 422
-
-
-def test_spawn_child_endpoint_happy_path(client: TestClient) -> None:
-    mock_result = SpawnChildResult(
-        run_id="coord-ac-workflow-abc123",
-        host_worktree_path="/host/worktrees/coord-ac-workflow-abc123",
-        worktree_path="/worktrees/coord-ac-workflow-abc123",
-        tier="coordinator",
-        org_domain="engineering",
-        role="engineering-coordinator",
-        cognitive_arch="von_neumann:python",
-        agent_task_path="/worktrees/coord-ac-workflow-abc123/.agent-task",
-        scope_type="label",
-        scope_value="ac-workflow",
-    )
-    with patch(
-        "agentception.routes.api.runs.spawn_child",
-        AsyncMock(return_value=mock_result),
-    ):
-        response = client.post(
-            "/api/runs/label-cto-abc123/children",
-            json={
-                "role": "engineering-coordinator",
-                "tier": "coordinator",
-                "org_domain": "engineering",
-                "scope_type": "label",
-                "scope_value": "ac-workflow",
-                "gh_repo": "owner/repo",
-            },
-        )
-    assert response.status_code == 200
-    data = response.json()
-    assert data["run_id"] == "coord-ac-workflow-abc123"
-    assert data["tier"] == "coordinator"
-    assert data["org_domain"] == "engineering"
-    assert "node_type" not in data, "Response must not contain old 'node_type' key"
-    assert data["cognitive_arch"] == "von_neumann:python"
-    assert data["status"] == "implementing"
-
-
-def test_spawn_child_endpoint_propagates_spawn_child_error(client: TestClient) -> None:
-    with patch(
-        "agentception.routes.api.runs.spawn_child",
-        AsyncMock(side_effect=SpawnChildError("git worktree add failed: branch exists")),
-    ):
-        response = client.post(
-            "/api/runs/cto-abc/children",
-            json={
-                "role": "python-developer",
-                "tier": "engineer",
-                "scope_type": "issue",
-                "scope_value": "42",
-                "gh_repo": "owner/repo",
-            },
-        )
-    assert response.status_code == 500
-    assert "git worktree add failed" in response.json()["detail"]
-
-
-# ---------------------------------------------------------------------------
 # Universal tree protocol — any node can be pruned as root
 # ---------------------------------------------------------------------------
 
@@ -691,7 +566,6 @@ def test_all_tiers_produce_valid_task_content() -> None:
         assert 'cognitive_arch = "' in task, f"Missing cognitive_arch for {role}"
         assert 'role_file = "' in task, f"Missing role_file for {role}"
         assert 'host_role_file = "' in task, f"Missing host_role_file for {role}"
-        assert 'ac_url = "' in task, f"Missing ac_url for {role}"
         assert 'scope_value = "' in task, f"Missing scope_value for {role}"
         assert 'workflow = "' in task, f"Missing workflow for {role}"
         # NODE_TYPE / node_type must be absent

--- a/agentception/tests/test_label_context_and_dispatch.py
+++ b/agentception/tests/test_label_context_and_dispatch.py
@@ -175,8 +175,7 @@ def test_dispatch_label_full_initiative_creates_coordinator(
         mock_settings.worktrees_dir = str(tmp_path / "worktrees")
         mock_settings.host_worktrees_dir = "/host/worktrees"
         mock_settings.repo_dir = str(tmp_path)
-        mock_settings.ac_url = "http://localhost:10003"
-
+    
         res = client.post(
             "/api/dispatch/label",
             json=_dispatch_label_body(scope="full_initiative"),
@@ -201,8 +200,7 @@ def test_dispatch_label_full_initiative_role_override(
         mock_settings.worktrees_dir = str(tmp_path / "worktrees2")
         mock_settings.host_worktrees_dir = "/host/worktrees"
         mock_settings.repo_dir = str(tmp_path)
-        mock_settings.ac_url = "http://localhost:10003"
-
+    
         res = client.post(
             "/api/dispatch/label",
             json=_dispatch_label_body(scope="full_initiative", role="engineering-coordinator"),
@@ -231,8 +229,7 @@ def test_dispatch_label_phase_scope_is_coordinator(
         mock_settings.worktrees_dir = str(tmp_path / "worktrees3")
         mock_settings.host_worktrees_dir = "/host/worktrees"
         mock_settings.repo_dir = str(tmp_path)
-        mock_settings.ac_url = "http://localhost:10003"
-
+    
         res = client.post(
             "/api/dispatch/label",
             json=_dispatch_label_body(
@@ -279,7 +276,6 @@ def test_dispatch_label_phase_scope_agent_task_scope_value(
         mock_settings.worktrees_dir = str(wt_dir)
         mock_settings.host_worktrees_dir = "/host/worktrees"
         mock_settings.repo_dir = str(tmp_path)
-        mock_settings.ac_url = "http://localhost:10003"
         mock_exec.return_value = _make_fake_proc()
 
         client.post(
@@ -315,8 +311,7 @@ def test_dispatch_label_issue_scope_is_leaf(
         mock_settings.worktrees_dir = str(tmp_path / "worktrees5")
         mock_settings.host_worktrees_dir = "/host/worktrees"
         mock_settings.repo_dir = str(tmp_path)
-        mock_settings.ac_url = "http://localhost:10003"
-
+    
         res = client.post(
             "/api/dispatch/label",
             json=_dispatch_label_body(
@@ -361,7 +356,6 @@ def test_dispatch_label_issue_scope_agent_task_fields(
         mock_settings.worktrees_dir = str(wt_dir)
         mock_settings.host_worktrees_dir = "/host/worktrees"
         mock_settings.repo_dir = str(tmp_path)
-        mock_settings.ac_url = "http://localhost:10003"
         mock_exec.return_value = _make_fake_proc()
 
         client.post(

--- a/scripts/gen_prompts/templates/dispatcher.md.j2
+++ b/scripts/gen_prompts/templates/dispatcher.md.j2
@@ -89,7 +89,7 @@ it was already claimed.
 cat {host_worktree_path}/.agent-task
 ```
 
-Extract: `TIER`, `SCOPE_TYPE`, `SCOPE_VALUE`, `GH_REPO`, `ROLE`, `ROLE_FILE`, `AC_URL`.
+Extract: `TIER`, `SCOPE_TYPE`, `SCOPE_VALUE`, `GH_REPO`, `ROLE`, `ROLE_FILE`.
 
 ### 3c. Spawn the agent via Task tool
 
@@ -108,7 +108,7 @@ RUN_ID:      {run_id}
 SCOPE_TYPE:  label
 SCOPE_VALUE: {scope_value}
 GH_REPO:     {gh_repo}
-AC_URL:      http://localhost:10003
+mcp_server:  user-agentception
 
 Step 1: Read your role file:
   {role_file}
@@ -163,7 +163,7 @@ RUN_ID:      {run_id}
 SCOPE_TYPE:  {scope_type}    (issue or pr)
 SCOPE_VALUE: {scope_value}   (issue or PR number)
 GH_REPO:     {gh_repo}
-AC_URL:      http://localhost:10003
+mcp_server:  user-agentception
 
 Step 1: Read your role file:
   {role_file}


### PR DESCRIPTION
## Summary

Completes the MCP architecture consolidation. Agents communicate exclusively through `user-agentception` MCP — no HTTP.

- **Deleted 7 agent-facing HTTP routes** — MCP equivalents in parentheses:
  - `GET /pending` → `query_pending_runs`
  - `POST /{id}/acknowledge` → `build_claim_run`
  - `POST /{parent}/children` → `build_spawn_child_run`
  - `POST /{id}/step` → `log_run_step`
  - `POST /{id}/blocker` → `log_run_blocker`
  - `POST /{id}/decision` → `log_run_decision`
  - `POST /{id}/done` → `build_complete_run`
- **Retained UI-only routes**: `/message`, `/cancel`, `/stop`
- **Removed `ac_url`** from `config.py`, `spawn_child.py`, `dispatch.py`; replaced with `mcp_server = "user-agentception"` in `.agent-task` `[repo]` section
- **Dispatcher template** updated: `AC_URL` field removed from example `.agent-task` blocks

## Test plan

- [x] mypy: 0 errors across 175 files
- [x] 987 tests passing (0 failures)
- [x] 6 obsolete HTTP endpoint tests removed (route deleted)
- [x] All `ac_url` references purged from non-test code
