### PR TITLE
fix(sweep): expand _AGENT_BRANCH_RE to cover agent/* and ac/* branches

### DIFF
--- a/agentception/readers/git.py
+++ b/agentception/readers/git.py
@@ -24,8 +24,11 @@ from agentception.config import settings
 
 logger = logging.getLogger(__name__)
 
-# Matches any branch created by AgentCeption: feat/issue-N or feat/brain-dump-*
-_AGENT_BRANCH_RE = re.compile(r"^feat/(issue-\d+|brain-dump-.+)$")
+# Matches any branch created by AgentCeption across all naming conventions:
+#   feat/issue-N, feat/brain-dump-*   — legacy Cursor-session branches
+#   agent/*                           — dispatcher-created top-level worktree branches
+#   ac/*                              — pipeline branches (engineer, coordinator, reviewer)
+_AGENT_BRANCH_RE = re.compile(r"^(feat/(issue-\d+|brain-dump-.+)|agent/.+|ac/.+)$")
 _ISSUE_N_RE = re.compile(r"^feat/issue-(\d+)$")
 
 

--- a/tests/test_git_reader.py
+++ b/tests/test_git_reader.py
@@ -1,0 +1,58 @@
+"""Tests for agentception.readers.git — branch classification logic."""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+# Import the compiled regex directly so the tests stay decoupled from the
+# git subprocess machinery (no live repo needed).
+from agentception.readers.git import _AGENT_BRANCH_RE
+
+
+# ---------------------------------------------------------------------------
+# is_agent_branch — parametrized truth table
+# ---------------------------------------------------------------------------
+
+_SHOULD_MATCH = [
+    # legacy Cursor-session branches
+    "feat/issue-1",
+    "feat/issue-42",
+    "feat/issue-999",
+    "feat/brain-dump-foo",
+    "feat/brain-dump-very-long-description",
+    # dispatcher-created top-level worktree branches
+    "agent/cognitive-arch-propagation-e072",
+    "agent/some-label-abc123",
+    # pipeline engineer / coordinator / reviewer branches
+    "ac/issue-176",
+    "ac/issue-1",
+    "ac/coord-cognitive-arch-propagation-81ac",
+    "ac/review-188-06dd",
+    "ac/issue-176-resolve",
+]
+
+_SHOULD_NOT_MATCH = [
+    "dev",
+    "main",
+    "feature/something",       # wrong prefix
+    "fix/something",           # Cursor fix branches are NOT agent branches
+    "feat/plain",              # feat/ but not issue-N or brain-dump-*
+    "feat/issue-",             # missing number
+    "feat/issue-abc",          # non-numeric
+    "",
+]
+
+
+@pytest.mark.parametrize("branch", _SHOULD_MATCH)
+def test_agent_branch_re_matches(branch: str) -> None:
+    assert _AGENT_BRANCH_RE.match(branch), (
+        f"Expected _AGENT_BRANCH_RE to match {branch!r} but it did not"
+    )
+
+
+@pytest.mark.parametrize("branch", _SHOULD_NOT_MATCH)
+def test_agent_branch_re_no_match(branch: str) -> None:
+    assert not _AGENT_BRANCH_RE.match(branch), (
+        f"Expected _AGENT_BRANCH_RE NOT to match {branch!r} but it did"
+    )


### PR DESCRIPTION
## Summary

- Expands `_AGENT_BRANCH_RE` in `agentception/readers/git.py` to match all branch naming conventions the pipeline uses, not just legacy `feat/*` branches.
- Adds `tests/test_git_reader.py` with a parametrized truth table covering every match and no-match case.

## Root cause

The regex `^feat/(issue-\d+|brain-dump-.+)$` only covered legacy Cursor-session branch names. Every branch the pipeline actually creates was invisible to it:

| Prefix | Example | Used for |
|--------|---------|----------|
| `agent/*` | `agent/cognitive-arch-propagation-e072` | Dispatcher top-level worktree branches |
| `ac/*` | `ac/issue-176`, `ac/coord-*`, `ac/review-*` | Engineer / coordinator / reviewer branches |

Both the `/control/sweep` endpoint and the poller's stale-branch pruner call `is_agent_branch` to decide what to delete. Branches that didn't match survived every cleanup pass, requiring manual `git branch -D`.

## Fix

```python
_AGENT_BRANCH_RE = re.compile(r"^(feat/(issue-\d+|brain-dump-.+)|agent/.+|ac/.+)$")
```

## Test plan

- [ ] 20/20 parametrized tests pass — match cases include all three prefixes, no-match cases include `dev`, `main`, `fix/*`, and malformed `feat/` names
- [ ] mypy strict — 0 errors