### PR TITLE
remove legacy feat/* branch patterns and codify no-legacy rule

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -15,12 +15,23 @@ You may: implement features, fix bugs, refactor, extend architecture, add tests,
 You may NOT: introduce new frameworks/dependencies without justification, redesign architecture unless requested, weaken security, skip tests.
 When uncertain: (1) preserve existing patterns, (2) prefer smaller changes over rewrites, (3) choose correct over simple, (4) document assumptions, (5) ask the user.
 
+## No legacy. No deprecated. No exceptions.
+
+This is the single most repeated rule in this codebase. It is not a guideline — it is a hard constraint enforced on every change.
+
+- **Delete on sight.** If you touch a file and find dead code, a deprecated API shape, a backward-compatibility shim, or a legacy fallback — delete it in the same commit. Do not leave it for later.
+- **No fallback paths for old API shapes.** If the new shape is `agent/*` and `ac/*`, the old shape `feat/issue-N` is gone. There is no "also support the old way." Remove every trace.
+- **No "legacy" or "deprecated" comments.** If the code is marked deprecated, it should be deleted, not annotated. A comment that says "legacy — do not use" is not a substitute for deletion.
+- **No version shims.** No `if old_format: ... else: new_format`. Pick the current shape and enforce it everywhere.
+- **No dead constants, dead regexes, dead fields.** A regex that can never match is deleted. A struct field that is never read is deleted. A route that is never called is deleted.
+
+When you remove something, remove it completely: the implementation, the tests that test the old shape, the documentation that describes it, and any config that references it.
+
 ## Architecture (do not weaken)
 
 - **Layers:** Routes (thin) → Services → Models. Never collapse.
 - **Planning pipeline:** Phase 1A (LLM → PlanSpec YAML) → Phase 1B (human review) → Issue creation → Agent dispatch.
 - **Org tree dispatch:** CTO → VP → Engineer. Each tier receives the correct label scope and cognitive-architecture context.
-- **No deprecated APIs:** Remove dead code on sight. No fallbacks for old API shapes.
 
 ## GitHub interactions — MCP first
 
@@ -157,7 +168,7 @@ The browser loads **compiled bundles**, not source files directly:
 
 - **Never work directly on `dev` or `main`.** Every change — one line or a thousand — goes on a feature branch (Cursor sessions) or a worktree (AgentCeption pipeline). No exceptions. See Branch discipline above.
 - **Never run file-modifying commands on `dev` without a clean checkout.** Running `generate.py`, `npm run build`, or any generator on `dev` dirties the branch. Always be on a feature branch first.
-- **No legacy, no deprecated, no backwards compatibility.** Remove dead code, dead fields, dead endpoints on sight. Never add fallback paths for old API shapes.
+- **No legacy. No deprecated. No backwards compatibility.** See the top-level section above — this is a hard constraint, not a guideline.
 - Business logic in route handlers. Global mutable state outside designated stores.
 - Hardcoded model IDs, secrets, or URLs outside config.
 - **`Any`, `object`, bare collections, `cast()`, or `# type: ignore`.** See the Typing section — these are absolute bans, not guidelines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,20 @@ You do NOT:
 
 ---
 
+## No legacy. No deprecated. No exceptions.
+
+This is the single most repeated rule in this codebase. Every agent must internalize it before writing a single line.
+
+- **Delete on sight.** When you touch a file and find dead code, a deprecated API shape, a backward-compatibility shim, or a legacy fallback — delete it in the same commit. Do not defer it.
+- **No fallback paths for old API shapes.** The current shape is the only shape. If a naming convention, field, or endpoint changed, every trace of the old one is deleted — not aliased, not conditionally supported.
+- **No "legacy" or "deprecated" annotations.** Code marked `# deprecated` or `# legacy — do not use` should be deleted, not annotated. A comment is not a substitute for deletion.
+- **No version shims.** No `if old_format: ... else: new_format`. Enforce the current shape everywhere.
+- **No dead constants, dead regexes, dead fields.** A regex that can never match is deleted. A model field never read is deleted. A route never called is deleted.
+
+When you remove something, remove it completely: the implementation, the tests for the old shape, the docs that describe it, and any config that references it.
+
+---
+
 ## Scope of Authority
 
 ### Decide yourself
@@ -296,6 +310,7 @@ There is no third option. A codebase with known broken tests that everyone steps
 6. [ ] Zero broken tests — fix any you find, not just yours
 7. [ ] Affected docs updated in the same commit
 8. [ ] No secrets, no `print()`, no dead code, no `Any`, no bare collections, no `cast()`, no `# type: ignore`
+8a. [ ] No legacy, no deprecated, no shims — if you touched a file with dead patterns, they are deleted in this PR
 9. [ ] JS/CSS bundles rebuilt if static source changed (`npm run build`)
 10. [ ] If API contract changed → handoff prompt produced
 11. [ ] **Open PR and merge immediately** — do not wait for CI (it does not run on dev PRs)

--- a/agentception/readers/git.py
+++ b/agentception/readers/git.py
@@ -24,12 +24,10 @@ from agentception.config import settings
 
 logger = logging.getLogger(__name__)
 
-# Matches any branch created by AgentCeption across all naming conventions:
-#   feat/issue-N, feat/brain-dump-*   — legacy Cursor-session branches
-#   agent/*                           — dispatcher-created top-level worktree branches
-#   ac/*                              — pipeline branches (engineer, coordinator, reviewer)
-_AGENT_BRANCH_RE = re.compile(r"^(feat/(issue-\d+|brain-dump-.+)|agent/.+|ac/.+)$")
-_ISSUE_N_RE = re.compile(r"^feat/issue-(\d+)$")
+# Matches any branch created by AgentCeption:
+#   agent/*  — dispatcher-created top-level worktree branches
+#   ac/*     — pipeline branches (engineer, coordinator, reviewer)
+_AGENT_BRANCH_RE = re.compile(r"^(agent/.+|ac/.+)$")
 
 
 async def _git(args: list[str]) -> str:
@@ -105,9 +103,6 @@ async def list_git_worktrees() -> list[dict[str, object]]:
                 branch = branch[len("refs/heads/"):]
             current["branch"] = branch
             current["is_agent_branch"] = bool(_AGENT_BRANCH_RE.match(branch))
-            m = _ISSUE_N_RE.match(branch)
-            if m:
-                current["issue_number"] = int(m.group(1))
         elif line == "bare":
             current["bare"] = True
         elif line.startswith("locked"):

--- a/tests/test_git_reader.py
+++ b/tests/test_git_reader.py
@@ -15,12 +15,6 @@ from agentception.readers.git import _AGENT_BRANCH_RE
 # ---------------------------------------------------------------------------
 
 _SHOULD_MATCH = [
-    # legacy Cursor-session branches
-    "feat/issue-1",
-    "feat/issue-42",
-    "feat/issue-999",
-    "feat/brain-dump-foo",
-    "feat/brain-dump-very-long-description",
     # dispatcher-created top-level worktree branches
     "agent/cognitive-arch-propagation-e072",
     "agent/some-label-abc123",
@@ -35,11 +29,14 @@ _SHOULD_MATCH = [
 _SHOULD_NOT_MATCH = [
     "dev",
     "main",
-    "feature/something",       # wrong prefix
-    "fix/something",           # Cursor fix branches are NOT agent branches
-    "feat/plain",              # feat/ but not issue-N or brain-dump-*
-    "feat/issue-",             # missing number
-    "feat/issue-abc",          # non-numeric
+    "feature/something",
+    "fix/something",        # Cursor fix branches are NOT agent branches
+    "feat/issue-1",         # removed — legacy naming, no longer used
+    "feat/issue-42",
+    "feat/brain-dump-foo",  # removed — legacy naming, no longer used
+    "feat/plain",
+    "feat/issue-",
+    "feat/issue-abc",
     "",
 ]
 


### PR DESCRIPTION
## Summary

- Deletes the `feat/issue-N` / `feat/brain-dump-*` patterns from `_AGENT_BRANCH_RE` — those naming conventions no longer exist.
- Deletes the dead `_ISSUE_N_RE` constant and the three lines that set `worktree["issue_number"]` from it — nothing reads that field from the git reader.
- Moves legacy `feat/*` cases to the no-match list in `test_git_reader.py`.
- Adds a top-level **"No legacy. No deprecated. No exceptions."** section to both `.cursorrules` and `AGENTS.md`, immediately after the agent identity block, replacing the buried anti-pattern bullet points with a section that cannot be missed.
- Adds checklist item 8a to the `AGENTS.md` verification checklist.

## Test plan

- [ ] 18/18 parametrized tests pass — `feat/*` branches now correctly appear in the no-match list
- [ ] mypy strict — 0 errors