### PR TITLE
fix: read cognitive_arch from .agent-task in CTO prompt, not hardcoded

### DIFF
--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -44,19 +44,20 @@ starts. The pool stays at 4 concurrent workers continuously until the queue drai
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE (do this before the loop)
 
-Your cognitive architecture is `von_neumann` — systematic, architectural, throughput-obsessed.
-Load the full context block now:
+Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Load it as the very first thing you do.
 
 ```bash
-REPO=$(git rev-parse --show-toplevel 2>/dev/null || echo "<repo-root>")
-COGNITIVE_ARCH="von_neumann"
-ROLE="cto"
+REPO=$(git rev-parse --show-toplevel 2>/dev/null || git worktree list | head -1 | awk '{print $1}')
+COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['cognitive_arch'])")
+ROLE=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['role'])")
 RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
-if [ -f "$RESOLVE_ARCH" ]; then
+if [ -n "$COGNITIVE_ARCH" ] && [ -f "$RESOLVE_ARCH" ]; then
   ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode implementer 2>/dev/null)
   echo "$ARCH_CONTEXT"
 else
-  echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+  echo "⚠️  COGNITIVE_ARCH not set or resolve_arch.py missing — proceeding with default von_neumann persona."
+  COGNITIVE_ARCH="${COGNITIVE_ARCH:-von_neumann}"
 fi
 ```
 
@@ -71,7 +72,7 @@ output text in your reply message):
 **My name is:** [extract the figure display name from the first
   "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
 **My role:** CTO / Pipeline Orchestrator
-**My cognitive architecture string:** von_neumann
+**My cognitive architecture string:** [value of $COGNITIVE_ARCH]
 
 [Paste the full content of $ARCH_CONTEXT here verbatim]
 ---

--- a/scripts/gen_prompts/templates/roles/cto.md.j2
+++ b/scripts/gen_prompts/templates/roles/cto.md.j2
@@ -43,19 +43,20 @@ starts. The pool stays at 4 concurrent workers continuously until the queue drai
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE (do this before the loop)
 
-Your cognitive architecture is `von_neumann` — systematic, architectural, throughput-obsessed.
-Load the full context block now:
+Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Load it as the very first thing you do.
 
 ```bash
-REPO=$(git rev-parse --show-toplevel 2>/dev/null || echo "<repo-root>")
-COGNITIVE_ARCH="von_neumann"
-ROLE="cto"
+REPO=$(git rev-parse --show-toplevel 2>/dev/null || git worktree list | head -1 | awk '{print $1}')
+COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['cognitive_arch'])")
+ROLE=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['role'])")
 RESOLVE_ARCH="$REPO/scripts/gen_prompts/resolve_arch.py"
-if [ -f "$RESOLVE_ARCH" ]; then
+if [ -n "$COGNITIVE_ARCH" ] && [ -f "$RESOLVE_ARCH" ]; then
   ARCH_CONTEXT=$(python3 "$RESOLVE_ARCH" "$COGNITIVE_ARCH" --mode implementer 2>/dev/null)
   echo "$ARCH_CONTEXT"
 else
-  echo "⚠️  resolve_arch.py not found at $RESOLVE_ARCH — skipping context block."
+  echo "⚠️  COGNITIVE_ARCH not set or resolve_arch.py missing — proceeding with default von_neumann persona."
+  COGNITIVE_ARCH="${COGNITIVE_ARCH:-von_neumann}"
 fi
 ```
 
@@ -70,7 +71,7 @@ output text in your reply message):
 **My name is:** [extract the figure display name from the first
   "## Cognitive Architecture: <Name>" heading inside $ARCH_CONTEXT]
 **My role:** CTO / Pipeline Orchestrator
-**My cognitive architecture string:** von_neumann
+**My cognitive architecture string:** [value of $COGNITIVE_ARCH]
 
 [Paste the full content of $ARCH_CONTEXT here verbatim]
 ---


### PR DESCRIPTION
## Summary

- The CTO role template had `COGNITIVE_ARCH="von_neumann"` hardcoded, so every CTO agent ignored the value written into `.agent-task` by the dispatcher
- Now reads the value at runtime via `tomllib`, identical to the pattern already used in `engineering-coordinator.md.j2` and `qa-coordinator.md.j2`
- Regenerated `.agentception/roles/cto.md` from the updated template

## Root Cause

The `engineering-coordinator` and `qa-coordinator` templates both read:
```bash
COGNITIVE_ARCH=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['agent']['cognitive_arch'])")
```

But `cto.md.j2` had:
```bash
COGNITIVE_ARCH="von_neumann"
```

This meant the dispatcher could write `jeff_dean:python` into `.agent-task`, but the CTO would always boot as `von_neumann` regardless.

## Test plan
- [ ] Dispatch a CTO agent with a non-`von_neumann` cognitive arch in `.agent-task` and verify the reported arch matches the file value
- [ ] Verify the fallback (`von_neumann`) still applies when `.agent-task` is missing or malformed