### PR TITLE
Add comprehensive frontend test suite: Vitest unit + Playwright E2E

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -194,7 +194,7 @@ For SSE streams, use a typed parser (e.g. `parseSseEvent<T>`) that validates the
 
 **Verification:** `npm run type-check` (`tsc --noEmit`) must pass with zero errors before every commit. esbuild does **not** type-check — the type-check script is the only gate.
 
-## JS / CSS / TypeScript build discipline
+## JS / CSS / TypeScript build and test discipline
 
 The browser loads **compiled bundles**, not source files directly:
 
@@ -204,12 +204,31 @@ The browser loads **compiled bundles**, not source files directly:
 | `agentception/static/scss/**/*.scss` | `agentception/static/app.css` | `npm run build:css` |
 | both | both | `npm run build` |
 
-**Rules:**
+**Build rules:**
 - After editing any `.ts` file under `static/js/`, run `npm run type-check` then `npm run build:js` before committing.
 - After editing any `.scss` file under `static/scss/`, run `npm run build:css` before committing.
 - When in doubt, run `npm run type-check && npm run build` (type-checks then builds both).
 - Never commit source changes to `static/js/` or `static/scss/` without a matching update to the bundle. A stale bundle is a silent runtime bug.
 - **Convert `.js` → `.ts` for every file you touch.** Migration is piecemeal; if you open a file to edit it and it is still `.js`, rename it and add types in the same commit.
+
+**TypeScript test commands:**
+
+| Command | What it runs |
+|---------|--------------|
+| `npm run type-check` | `tsc --noEmit` — strict type check, zero errors required |
+| `npm test` | Vitest unit tests (`agentception/static/js/**/*.test.ts`) |
+| `npm run test:watch` | Vitest in watch mode (dev) |
+| `npm run test:coverage` | Vitest with V8 coverage report |
+| `npm run test:e2e` | Playwright E2E (requires `docker compose up -d` first) |
+| `npm run test:e2e:ui` | Playwright with interactive UI explorer |
+| `npm run test:all` | type-check + unit + E2E (full pre-PR gate) |
+
+**Testing rules:**
+- Every exported function in a `.ts` source file must have Vitest unit tests in a sibling `__tests__/*.test.ts` file.
+- Use `vi.mock(...)` at the top of test files (auto-hoisted by Vitest) to mock module-level dependencies.
+- E2E tests intercept SSE endpoints via `page.route()`; pure computation endpoints hit the real server.
+- Run `npm test` (unit tests) before every commit. Run `npm run test:e2e` before every PR.
+- All unit tests must pass before running E2E tests. Never open a PR with a known failing test.
 
 ## Anti-patterns (never do these)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,10 +300,19 @@ For SSE streams, use a typed parser (e.g. `parseSseEvent<T>`) that validates the
 
 | Layer | Command | Threshold |
 |-------|---------|-----------|
-| Local | `npm run type-check` | `tsc --noEmit`, 0 errors |
-| Build | `npm run build:js` | esbuild bundles (no type checking) |
+| Local type check | `npm run type-check` | `tsc --noEmit`, 0 errors |
+| Unit tests | `npm test` | Vitest, all green |
+| Build | `npm run build:js` | esbuild bundles (no type-checking) |
+| E2E | `npm run test:e2e` | Playwright, all green (requires `docker compose up -d`) |
+| Full gate | `npm run test:all` | type-check + unit + E2E |
 
-Note: esbuild does **not** type-check. `npm run type-check` is the only gate — always run it before committing any `.ts` change.
+Note: esbuild does **not** type-check. `npm run type-check` is the only type gate — run it before every commit. `npm test` runs the Vitest unit-test suite (jsdom, no browser required). `npm run test:e2e` runs Playwright against the live Docker server.
+
+**Testing rules for TypeScript:**
+- Every exported function in a `.ts` source file must have Vitest unit tests in a sibling `__tests__/*.test.ts` file.
+- Mock module-level dependencies at the top of the test file with `vi.mock(...)` (Vitest auto-hoists these above imports).
+- SSE endpoints are intercepted in E2E tests via `page.route()`; pure computation endpoints hit the real server for genuine confidence.
+- Never open a PR with a known failing unit or E2E test.
 
 ### Jinja2 + Alpine.js / HTMX: always single-quote attributes containing `tojson`
 
@@ -365,8 +374,9 @@ There is no third option. A codebase with known broken tests that everyone steps
 8. [ ] No secrets, no `print()`, no dead code, no `Any`, no bare collections, no `cast()`, no `# type: ignore` (Python)
 8a. [ ] No `any`, `object`, `{}`, untyped parameters, `as any`, or `// @ts-ignore` (TypeScript)
 8b. [ ] No legacy, no deprecated, no shims — if you touched a file with dead patterns, they are deleted in this PR
-9. [ ] If any `.ts` files changed: `npm run type-check` passes (zero errors), then `npm run build:js`
+9. [ ] If any `.ts` files changed: `npm run type-check` (zero errors), `npm test` (all green), then `npm run build:js`
 9a. [ ] If any `.js` source files were touched: rename to `.ts` and add types in this same commit
 9b. [ ] If any `.scss` files changed: `npm run build:css`
+9c. [ ] E2E tests pass: `npm run test:e2e` (requires `docker compose up -d`)
 10. [ ] If API contract changed → handoff prompt produced
 11. [ ] **Open PR and merge immediately** — do not wait for CI (it does not run on dev PRs)

--- a/agentception/static/js/__tests__/plan.test.ts
+++ b/agentception/static/js/__tests__/plan.test.ts
@@ -1,0 +1,639 @@
+/**
+ * Vitest unit tests for plan.ts — the Alpine.js Plan page component.
+ *
+ * Strategy
+ * --------
+ * CodeMirror 6 requires a real DOM parent element that jsdom cannot provide
+ * reliably, so the @codemirror/* packages are mocked at the module boundary.
+ * Every component method that would touch CodeMirror directly (‌_mountEditor,
+ * _getEditorValue, _setEditorValue) is exercised via a lightweight mock editor
+ * object, letting us verify all state-machine logic without a real browser.
+ *
+ * Alpine.js magic properties ($refs, $nextTick) are injected into every test
+ * component via makeComponent() so method bodies have correct types.
+ *
+ * External I/O (fetch, localStorage) runs through jsdom's built-in
+ * implementations; fetch is stubbed per-test with vi.stubGlobal / vi.fn().
+ *
+ * Run:   npm test
+ * Watch: npm run test:watch
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mock CodeMirror 6 before importing plan.ts ────────────────────────────
+// Hoisted automatically by Vitest above all imports.
+
+vi.mock('@codemirror/view', () => {
+  const MockEditorView = class {
+    static updateListener = {
+      of: (fn: (update: { docChanged: boolean }) => void) => ({ __listener: fn }),
+    };
+    static lineWrapping = { __lineWrapping: true };
+    dispatch = vi.fn();
+    state = { doc: { toString: () => '', length: 0 } };
+    constructor(_opts: unknown) {}
+  };
+  return {
+    EditorView: MockEditorView,
+    keymap: { of: (maps: unknown[]) => maps },
+    lineNumbers: () => ({}),
+    highlightActiveLine: () => ({}),
+  };
+});
+
+vi.mock('@codemirror/state', () => ({
+  EditorState: {
+    create: (opts: { doc: string; extensions: unknown[] }) => ({
+      doc: { toString: () => opts.doc, length: opts.doc.length },
+    }),
+  },
+}));
+
+vi.mock('@codemirror/commands', () => ({
+  defaultKeymap: [],
+  history: () => ({}),
+  historyKeymap: [],
+}));
+
+vi.mock('@codemirror/lang-yaml', () => ({ yaml: () => ({}) }));
+vi.mock('@codemirror/theme-one-dark', () => ({ oneDark: {} }));
+
+// ── Import after mocks are in place ──────────────────────────────────────
+
+import type { EditorView } from '@codemirror/view';
+import { parseSseEvent, planForm } from '../plan';
+
+// ── Test helpers ─────────────────────────────────────────────────────────
+
+type PlanComponent = ReturnType<typeof planForm>;
+
+/** Lightweight mock editor that tracks its value through dispatch calls. */
+function makeMockEditor(initialValue = ''): EditorView {
+  let value = initialValue;
+  return {
+    state: { doc: { toString: () => value, length: value.length } },
+    dispatch: vi.fn((tr: { changes?: { from: number; to: number; insert: string } }) => {
+      if (tr.changes?.insert !== undefined) value = tr.changes.insert;
+    }),
+  } as unknown as EditorView;
+}
+
+/** Create a component with Alpine magics stubbed and DOM-heavy methods mocked. */
+function makeComponent(): PlanComponent {
+  const c = planForm();
+  c.$refs = { textarea: null, yamlEditor: null };
+  c.$nextTick = vi.fn().mockImplementation(async (cb?: () => void) => { if (cb) cb(); });
+  c._mountEditor = vi.fn();
+  c._validateYaml = vi.fn().mockResolvedValue(undefined);
+  return c;
+}
+
+/**
+ * Build a fake SSE Response whose body contains one Uint8Array chunk
+ * with all events joined together.  Our _readStream / _readFileStream
+ * implementations handle single-chunk delivery correctly.
+ */
+function makeSseResponse(events: object[]): Response {
+  const body = events.map(e => `data: ${JSON.stringify(e)}\n\n`).join('');
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+  return {
+    ok: true,
+    status: 200,
+    body: stream,
+    json: async () => ({}),
+  } as unknown as Response;
+}
+
+function makeErrorResponse(status: number, detail: string): Response {
+  return {
+    ok: false,
+    status,
+    json: async () => ({ detail }),
+    body: null,
+  } as unknown as Response;
+}
+
+// ── parseSseEvent ─────────────────────────────────────────────────────────
+
+describe('parseSseEvent', () => {
+  it('returns null for lines that do not start with "data: "', () => {
+    expect(parseSseEvent('')).toBeNull();
+    expect(parseSseEvent('event: chunk')).toBeNull();
+    expect(parseSseEvent(': comment')).toBeNull();
+    expect(parseSseEvent('id: 1')).toBeNull();
+  });
+
+  it('returns null when the payload is not valid JSON', () => {
+    expect(parseSseEvent('data: {not json')).toBeNull();
+    expect(parseSseEvent('data: undefined')).toBeNull();
+  });
+
+  it('returns null when the payload is JSON but not an object', () => {
+    expect(parseSseEvent('data: "string"')).toBeNull();
+    expect(parseSseEvent('data: 42')).toBeNull();
+    expect(parseSseEvent('data: null')).toBeNull();
+  });
+
+  it('returns null when the object has no "t" field', () => {
+    expect(parseSseEvent('data: {"x": "y"}')).toBeNull();
+  });
+
+  it('returns null when "t" is not a string', () => {
+    expect(parseSseEvent('data: {"t": 42}')).toBeNull();
+    expect(parseSseEvent('data: {"t": null}')).toBeNull();
+    expect(parseSseEvent('data: {"t": true}')).toBeNull();
+  });
+
+  it('returns the parsed object for a valid chunk event', () => {
+    const result = parseSseEvent('data: {"t":"chunk","text":"hello world"}');
+    expect(result).toEqual({ t: 'chunk', text: 'hello world' });
+  });
+
+  it('returns the parsed object for a valid done event', () => {
+    const payload = { t: 'done', yaml: 'init: x\n', initiative: 'x', phase_count: 1, issue_count: 2 };
+    const result = parseSseEvent(`data: ${JSON.stringify(payload)}`);
+    expect(result).toEqual(payload);
+  });
+
+  it('returns the parsed object for a valid error event', () => {
+    const result = parseSseEvent('data: {"t":"error","detail":"Plan failed."}');
+    expect(result).toEqual({ t: 'error', detail: 'Plan failed.' });
+  });
+});
+
+// ── Draft persistence (localStorage) ─────────────────────────────────────
+
+describe('draft persistence', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('_saveDraft stores the editor value in localStorage', () => {
+    const c = makeComponent();
+    c._editor = makeMockEditor('initiative: auth\n');
+    // Un-mock _getEditorValue so the real implementation runs.
+    c._getEditorValue = () => c._editor?.state.doc.toString() ?? '';
+    c._saveDraft();
+    expect(localStorage.getItem('ac_plan_draft_yaml')).toBe('initiative: auth\n');
+  });
+
+  it('_clearDraft removes the key from localStorage', () => {
+    localStorage.setItem('ac_plan_draft_yaml', 'some yaml');
+    const c = makeComponent();
+    c._clearDraft();
+    expect(localStorage.getItem('ac_plan_draft_yaml')).toBeNull();
+  });
+
+  it('_restoreDraft does nothing when localStorage is empty', () => {
+    const c = makeComponent();
+    c._restoreDraft();
+    expect(c.step).toBe('write');
+  });
+
+  it('_restoreDraft jumps to review and mounts editor when draft exists', async () => {
+    localStorage.setItem('ac_plan_draft_yaml', 'initiative: auth\n');
+    const c = makeComponent();
+    c._restoreDraft();
+    // The restore uses setTimeout(0) — flush via a short real wait.
+    await new Promise(r => setTimeout(r, 10));
+    expect(c.step).toBe('review');
+    expect(c._mountEditor).toHaveBeenCalledWith('initiative: auth\n');
+  });
+
+  it('reset() clears the draft and wipes all state', () => {
+    localStorage.setItem('ac_plan_draft_yaml', 'old yaml');
+    const c = makeComponent();
+    c.step = 'done';
+    c.text = 'some plan';
+    c.initiative = 'old-init';
+    c.batchId = 'batch-xyz';
+    c._editor = makeMockEditor('old yaml');
+    c.reset();
+    expect(c.step).toBe('write');
+    expect(c.text).toBe('');
+    expect(c.initiative).toBe('');
+    expect(c.batchId).toBe('');
+    expect(localStorage.getItem('ac_plan_draft_yaml')).toBeNull();
+  });
+});
+
+// ── State machine: cancel, editPlan, appendSeed ───────────────────────────
+
+describe('state machine basics', () => {
+  it('cancel() sets step to write and clears submitting', () => {
+    const c = makeComponent();
+    c.step = 'generating';
+    c.submitting = true;
+    const ctrl = new AbortController();
+    c._abortController = ctrl;
+    c.cancel();
+    expect(c.step).toBe('write');
+    expect(c.submitting).toBe(false);
+    expect(c._abortController).toBeNull();
+    expect(ctrl.signal.aborted).toBe(true);
+  });
+
+  it('cancel() clears errorMsg', () => {
+    const c = makeComponent();
+    c.errorMsg = 'old error';
+    c.cancel();
+    expect(c.errorMsg).toBe('');
+  });
+
+  it('editPlan() returns to write step', () => {
+    const c = makeComponent();
+    c.step = 'review';
+    c.errorMsg = 'some error';
+    c.editPlan();
+    expect(c.step).toBe('write');
+    expect(c.errorMsg).toBe('');
+  });
+
+  it('appendSeed() appends text to an empty textarea', () => {
+    const c = makeComponent();
+    c.text = '';
+    c.appendSeed('- Fix login bug');
+    expect(c.text).toBe('- Fix login bug');
+  });
+
+  it('appendSeed() appends text with a newline separator', () => {
+    const c = makeComponent();
+    c.text = '- Existing item';
+    c.appendSeed('- New item');
+    expect(c.text).toBe('- Existing item\n- New item');
+  });
+
+  it('submit() does nothing when text is empty', async () => {
+    const c = makeComponent();
+    c.text = '   ';
+    await c.submit();
+    expect(c.step).toBe('write');
+  });
+
+  it('launch() does nothing when YAML is empty', async () => {
+    const c = makeComponent();
+    c.step = 'review';
+    c.yamlValid = true;
+    c._editor = makeMockEditor('');
+    c._getEditorValue = () => '';
+    await c.launch();
+    expect(c.step).toBe('review');
+  });
+
+  it('launch() shows error when YAML is invalid', async () => {
+    const c = makeComponent();
+    c.step = 'review';
+    c.yamlValid = false;
+    c._editor = makeMockEditor('bad yaml');
+    c._getEditorValue = () => 'bad yaml';
+    await c.launch();
+    expect(c.errorMsg).toContain('Fix the YAML');
+    expect(c.step).toBe('review');
+  });
+});
+
+// ── _readStream — Phase 1A SSE processing ────────────────────────────────
+
+describe('_readStream (Phase 1A)', () => {
+  const VALID_YAML = [
+    'initiative: auth-rewrite',
+    'phases:',
+    '  - label: 0-foundation',
+    '    description: "Foundation"',
+    '    depends_on: []',
+    '    issues:',
+    '      - id: auth-rewrite-p0-001',
+    '        title: "Add user model"',
+    '        body: "## Context\\nDo it."',
+  ].join('\n') + '\n';
+
+  it('accumulates chunk events into streamingText', async () => {
+    const c = makeComponent();
+    const resp = makeSseResponse([
+      { t: 'chunk', text: 'initiative: ' },
+      { t: 'chunk', text: 'auth-rewrite\n' },
+      { t: 'done', yaml: VALID_YAML, initiative: 'auth-rewrite', phase_count: 1, issue_count: 1 },
+    ]);
+    await c._readStream(resp);
+    expect(c.streamingText).toBe('initiative: auth-rewrite\n');
+  });
+
+  it('transitions to review step on done event', async () => {
+    const c = makeComponent();
+    const resp = makeSseResponse([
+      { t: 'done', yaml: VALID_YAML, initiative: 'auth-rewrite', phase_count: 1, issue_count: 1 },
+    ]);
+    await c._readStream(resp);
+    expect(c.step).toBe('review');
+  });
+
+  it('populates initiative, phaseCount, issueCount from done event', async () => {
+    const c = makeComponent();
+    const resp = makeSseResponse([
+      { t: 'done', yaml: VALID_YAML, initiative: 'auth-rewrite', phase_count: 2, issue_count: 5 },
+    ]);
+    await c._readStream(resp);
+    expect(c.initiative).toBe('auth-rewrite');
+    expect(c.phaseCount).toBe(2);
+    expect(c.issueCount).toBe(5);
+  });
+
+  it('persists YAML to localStorage on done event', async () => {
+    localStorage.clear();
+    const c = makeComponent();
+    const resp = makeSseResponse([
+      { t: 'done', yaml: VALID_YAML, initiative: 'auth-rewrite', phase_count: 1, issue_count: 1 },
+    ]);
+    await c._readStream(resp);
+    expect(localStorage.getItem('ac_plan_draft_yaml')).toBe(VALID_YAML);
+  });
+
+  it('mounts the CodeMirror editor via $nextTick after done', async () => {
+    const c = makeComponent();
+    const resp = makeSseResponse([
+      { t: 'done', yaml: VALID_YAML, initiative: 'auth-rewrite', phase_count: 1, issue_count: 1 },
+    ]);
+    await c._readStream(resp);
+    expect(c._mountEditor).toHaveBeenCalledWith(VALID_YAML);
+  });
+
+  it('throws on error event so caller can show errorMsg', async () => {
+    const c = makeComponent();
+    const resp = makeSseResponse([
+      { t: 'error', detail: 'Input too vague.' },
+    ]);
+    await expect(c._readStream(resp)).rejects.toThrow('Input too vague.');
+  });
+
+  it('throws when stream ends with no done or error event', async () => {
+    const c = makeComponent();
+    // Emit only chunks — no done/error.
+    const resp = makeSseResponse([
+      { t: 'chunk', text: 'partial yaml...' },
+    ]);
+    c.step = 'generating';
+    await expect(c._readStream(resp)).rejects.toThrow(/without a result/);
+  });
+
+  it('throws when response body is null', async () => {
+    const c = makeComponent();
+    const resp = { ok: true, body: null } as unknown as Response;
+    await expect(c._readStream(resp)).rejects.toThrow('Response has no body');
+  });
+});
+
+// ── submit() — integration with _readStream ───────────────────────────────
+
+describe('submit()', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('sets errorMsg and returns to write when fetch returns non-ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeErrorResponse(422, 'Plan text must not be empty.')));
+    const c = makeComponent();
+    c.text = 'some plan text';
+    await c.submit();
+    expect(c.step).toBe('write');
+    expect(c.errorMsg).toContain('Plan text must not be empty.');
+  });
+
+  it('sends dump and label_prefix in the request body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeSseResponse([
+      { t: 'done', yaml: 'initiative: test\n', initiative: 'test', phase_count: 1, issue_count: 1 },
+    ]));
+    vi.stubGlobal('fetch', fetchMock);
+    const c = makeComponent();
+    c.text = 'Build auth';
+    c.labelPrefix = 'my-init';
+    await c.submit();
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(opts.body as string) as { dump: string; label_prefix: string };
+    expect(body.dump).toBe('Build auth');
+    expect(body.label_prefix).toBe('my-init');
+  });
+});
+
+// ── _readFileStream — Phase 1B SSE processing ────────────────────────────
+
+describe('_readFileStream (Phase 1B)', () => {
+  const ISSUES = [
+    { issue_id: 'auth-p0-001', number: 42, url: 'https://github.com/t/r/issues/42', title: 'Add user model', phase: '0-foundation' },
+    { issue_id: 'auth-p0-002', number: 43, url: 'https://github.com/t/r/issues/43', title: 'Add migration',  phase: '0-foundation' },
+    { issue_id: 'auth-p1-001', number: 44, url: 'https://github.com/t/r/issues/44', title: 'Add login route', phase: '1-api' },
+  ];
+
+  it('updates filingProgress from start event', async () => {
+    const c = makeComponent();
+    c.step = 'launching';
+    const resp = makeSseResponse([
+      { t: 'start', total: 3, initiative: 'auth-rewrite' },
+      { t: 'done', total: 3, batch_id: 'batch-001', initiative: 'auth-rewrite', issues: ISSUES },
+    ]);
+    await c._readFileStream(resp);
+    // filingProgress is overwritten by each event — just ensure no crash.
+    expect(c.step).toBe('done');
+  });
+
+  it('updates filingProgress from label event', async () => {
+    const c = makeComponent();
+    c.step = 'launching';
+    let capturedProgress = '';
+    Object.defineProperty(c, 'filingProgress', {
+      set: (v: string) => { capturedProgress = v; },
+      get: () => capturedProgress,
+    });
+    const resp = makeSseResponse([
+      { t: 'label', text: 'Ensuring labels exist in GitHub…' },
+      { t: 'done', total: 1, batch_id: 'b', initiative: 'x', issues: [ISSUES[0]] },
+    ]);
+    await c._readFileStream(resp);
+    expect(capturedProgress).toContain('Ensuring labels');
+  });
+
+  it('updates filingProgress with index/total from issue event', async () => {
+    const c = makeComponent();
+    c.step = 'launching';
+    const progress: string[] = [];
+    const origSet = Object.getOwnPropertyDescriptor(c, 'filingProgress');
+    let _fp = '';
+    Object.defineProperty(c, 'filingProgress', {
+      set: (v: string) => { _fp = v; progress.push(v); },
+      get: () => _fp,
+      configurable: true,
+    });
+    const resp = makeSseResponse([
+      { t: 'issue', index: 1, total: 2, number: 42, url: '...', title: 'Add user model', phase: '0-foundation' },
+      { t: 'done', total: 2, batch_id: 'b', initiative: 'x', issues: ISSUES.slice(0, 2) },
+    ]);
+    await c._readFileStream(resp);
+    expect(progress.some(p => p.includes('1/2'))).toBe(true);
+    if (origSet) Object.defineProperty(c, 'filingProgress', origSet);
+  });
+
+  it('shows blocked-by numbers in filingProgress', async () => {
+    const c = makeComponent();
+    c.step = 'launching';
+    const progress: string[] = [];
+    let _fp = '';
+    Object.defineProperty(c, 'filingProgress', {
+      set: (v: string) => { _fp = v; progress.push(v); },
+      get: () => _fp,
+      configurable: true,
+    });
+    const resp = makeSseResponse([
+      { t: 'blocked', number: 44, blocked_by: [42, 43] },
+      { t: 'done', total: 3, batch_id: 'b', initiative: 'x', issues: ISSUES },
+    ]);
+    await c._readFileStream(resp);
+    const blockedMsg = progress.find(p => p.includes('blocked'));
+    expect(blockedMsg).toMatch(/#44/);
+    expect(blockedMsg).toMatch(/#42/);
+  });
+
+  it('transitions to done step on done event', async () => {
+    const c = makeComponent();
+    c.step = 'launching';
+    const resp = makeSseResponse([
+      { t: 'done', total: 3, batch_id: 'batch-xyz', initiative: 'auth-rewrite', issues: ISSUES },
+    ]);
+    await c._readFileStream(resp);
+    expect(c.step).toBe('done');
+  });
+
+  it('sets batchId and issueCount from done event', async () => {
+    const c = makeComponent();
+    c.step = 'launching';
+    const resp = makeSseResponse([
+      { t: 'done', total: 3, batch_id: 'batch-xyz', initiative: 'auth-rewrite', issues: ISSUES },
+    ]);
+    await c._readFileStream(resp);
+    expect(c.batchId).toBe('batch-xyz');
+    expect(c.issueCount).toBe(3);
+  });
+
+  it('groups issues by phase preserving creation order', async () => {
+    const c = makeComponent();
+    c.step = 'launching';
+    const resp = makeSseResponse([
+      { t: 'done', total: 3, batch_id: 'b', initiative: 'auth-rewrite', issues: ISSUES },
+    ]);
+    await c._readFileStream(resp);
+    expect(c.result.phaseGroups).toHaveLength(2);
+    expect(c.result.phaseGroups[0]?.phase).toBe('0-foundation');
+    expect(c.result.phaseGroups[0]?.issues).toHaveLength(2);
+    expect(c.result.phaseGroups[1]?.phase).toBe('1-api');
+    expect(c.result.phaseGroups[1]?.issues).toHaveLength(1);
+  });
+
+  it('marks only the first phase as active', async () => {
+    const c = makeComponent();
+    c.step = 'launching';
+    const resp = makeSseResponse([
+      { t: 'done', total: 3, batch_id: 'b', initiative: 'auth-rewrite', issues: ISSUES },
+    ]);
+    await c._readFileStream(resp);
+    expect(c.result.phaseGroups[0]?.isActive).toBe(true);
+    expect(c.result.phaseGroups[1]?.isActive).toBe(false);
+  });
+
+  it('clears the draft from localStorage on done', async () => {
+    localStorage.setItem('ac_plan_draft_yaml', 'old yaml');
+    const c = makeComponent();
+    c.step = 'launching';
+    const resp = makeSseResponse([
+      { t: 'done', total: 1, batch_id: 'b', initiative: 'x', issues: [ISSUES[0]] },
+    ]);
+    await c._readFileStream(resp);
+    expect(localStorage.getItem('ac_plan_draft_yaml')).toBeNull();
+  });
+
+  it('throws on error event so caller can show errorMsg', async () => {
+    const c = makeComponent();
+    c.step = 'launching';
+    const resp = makeSseResponse([{ t: 'error', detail: 'Label API down.' }]);
+    await expect(c._readFileStream(resp)).rejects.toThrow('Label API down.');
+  });
+
+  it('throws when stream ends without a done event', async () => {
+    const c = makeComponent();
+    c.step = 'launching';
+    const resp = makeSseResponse([{ t: 'issue', index: 1, total: 2, number: 42, url: '', title: 'T', phase: 'p0' }]);
+    await expect(c._readFileStream(resp)).rejects.toThrow(/without a confirmation/);
+  });
+});
+
+// ── _validateYaml ─────────────────────────────────────────────────────────
+
+describe('_validateYaml', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  /** Create a component in review step with a real _validateYaml implementation. */
+  function makeReviewComponent(editorValue: string): PlanComponent {
+    const c = makeComponent();
+    // Un-mock _validateYaml so the real implementation runs.
+    c._validateYaml = planForm()._validateYaml.bind(c);
+    c.step = 'review';
+    c._editor = makeMockEditor(editorValue);
+    c._getEditorValue = () => c._editor?.state.doc.toString() ?? '';
+    return c;
+  }
+
+  it('does nothing when step is not review', async () => {
+    const c = makeReviewComponent('any yaml');
+    c.step = 'write';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    await c._validateYaml();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sets yamlValid=false and shows warning for empty YAML', async () => {
+    const c = makeReviewComponent('');
+    await c._validateYaml();
+    expect(c.yamlValid).toBe(false);
+    expect(c.yamlValidationMsg).toContain('empty');
+  });
+
+  it('shows valid message with correct pluralisation for 1 phase / 1 issue', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: async () => ({ valid: true, initiative: 'auth', phase_count: 1, issue_count: 1 }),
+    }));
+    const c = makeReviewComponent('some yaml');
+    await c._validateYaml();
+    expect(c.yamlValid).toBe(true);
+    expect(c.yamlValidationMsg).toContain('1 phase,');
+    expect(c.yamlValidationMsg).toContain('1 issue');
+  });
+
+  it('shows valid message with correct pluralisation for multiple phases / issues', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: async () => ({ valid: true, initiative: 'auth', phase_count: 2, issue_count: 5 }),
+    }));
+    const c = makeReviewComponent('some yaml');
+    await c._validateYaml();
+    expect(c.yamlValidationMsg).toContain('2 phases,');
+    expect(c.yamlValidationMsg).toContain('5 issues');
+  });
+
+  it('sets yamlValid=false and shows detail on invalid schema', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: async () => ({ valid: false, detail: 'Missing required field: initiative' }),
+    }));
+    const c = makeReviewComponent('some yaml');
+    await c._validateYaml();
+    expect(c.yamlValid).toBe(false);
+    expect(c.yamlValidationMsg).toContain('Missing required field');
+  });
+
+  it('clears validationMsg silently on fetch error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+    const c = makeReviewComponent('some yaml');
+    c.yamlValidationMsg = 'previous message';
+    await c._validateYaml();
+    expect(c.yamlValidationMsg).toBe('');
+  });
+});

--- a/agentception/static/js/plan.ts
+++ b/agentception/static/js/plan.ts
@@ -196,7 +196,7 @@ interface PlanFormComponent extends AlpineMagics {
 // Individual field access is safe because TypeScript narrows T on each `t`
 // branch in the caller.
 
-function parseSseEvent<T extends { t: string }>(line: string): T | null {
+export function parseSseEvent<T extends { t: string }>(line: string): T | null {
   if (!line.startsWith('data: ')) return null;
   let raw: unknown;
   try {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,14 @@
     "build:js": "esbuild agentception/static/js/app.js --bundle --format=iife --minify --outfile=agentception/static/app.js",
     "build:css": "sass --style=compressed --no-source-map agentception/static/scss/app.scss agentception/static/app.css",
     "build": "npm run build:js && npm run build:css",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit && tsc --noEmit --project tsconfig.node.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:all": "npm run type-check && npm test && npm run test:e2e"
   },
   "devDependencies": {
     "@codemirror/commands": "*",
@@ -15,8 +22,13 @@
     "@codemirror/state": "*",
     "@codemirror/theme-one-dark": "*",
     "@codemirror/view": "*",
+    "@playwright/test": "^1.50.1",
+    "@types/node": "^25.3.5",
+    "@vitest/coverage-v8": "^3.1.3",
     "esbuild": "^0.27.3",
+    "jsdom": "^26.1.0",
     "marked": "^17.0.4",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^3.1.3"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E configuration.
+ *
+ * Targets the AgentCeption server running in Docker at localhost:10003.
+ * Start the stack first:  docker compose up -d
+ *
+ * Run all E2E tests:      npm run test:e2e
+ * Run with UI explorer:   npm run test:e2e:ui
+ *
+ * All external dependencies (OpenRouter, GitHub) are intercepted via
+ * page.route() in each test — no real API keys are required.
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  // Retry flaky tests once in CI; never locally (fail fast for dev).
+  retries: process.env['CI'] ? 2 : 0,
+  // Run tests sequentially to avoid port contention with the shared server.
+  workers: process.env['CI'] ? 1 : undefined,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: 'http://localhost:10003',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tests/e2e/plan.spec.ts
+++ b/tests/e2e/plan.spec.ts
@@ -1,0 +1,322 @@
+/**
+ * Playwright E2E tests for the Plan page — Phases 1A and 1B.
+ *
+ * Prerequisites
+ * -------------
+ * The AgentCeption stack must be running before these tests execute:
+ *
+ *   docker compose up -d
+ *   npm run test:e2e
+ *
+ * External dependencies (OpenRouter LLM, GitHub gh CLI) are fully intercepted
+ * via page.route() so no real API keys or network access are required.  The
+ * tests exercise the real FastAPI server, real Jinja2 templates, real Alpine.js
+ * component, and real HTMX — only the slow/external SSE endpoints are stubbed.
+ *
+ * Network mocking strategy
+ * ------------------------
+ * - POST /api/plan/preview  → fake SSE stream (avoids OpenRouter call)
+ * - POST /api/plan/file-issues → fake SSE stream (avoids gh CLI)
+ * - POST /api/plan/validate → hits the REAL backend (pure YAML computation)
+ * - GET  /plan, /plan/recent-runs → hits the REAL backend
+ *
+ * This means the validate endpoint exercises the full Python stack including
+ * Pydantic model validation, giving genuine confidence that the schema is
+ * correct end-to-end.
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+// ── SSE fixture helpers ────────────────────────────────────────────────────
+
+const VALID_YAML = [
+  'initiative: auth-rewrite',
+  'phases:',
+  '  - label: 0-foundation',
+  '    description: "Add User model and migration"',
+  '    depends_on: []',
+  '    issues:',
+  '      - id: auth-rewrite-p0-001',
+  '        title: "Add SQLAlchemy User model"',
+  '        body: "## Context\\nAdd a User model with id, email, hashed_password."',
+].join('\n') + '\n';
+
+const TWO_PHASE_YAML = [
+  'initiative: auth-rewrite',
+  'phases:',
+  '  - label: 0-foundation',
+  '    description: "Foundation"',
+  '    depends_on: []',
+  '    issues:',
+  '      - id: auth-rewrite-p0-001',
+  '        title: "Add SQLAlchemy User model"',
+  '        body: "## Context\\nAdd a User model."',
+  '      - id: auth-rewrite-p0-002',
+  '        title: "Add Alembic migration"',
+  '        body: "## Context\\nAdd migration."',
+  '  - label: 1-api',
+  '    description: "API layer"',
+  '    depends_on: ["0-foundation"]',
+  '    issues:',
+  '      - id: auth-rewrite-p1-001',
+  '        title: "Add login endpoint"',
+  '        body: "## Context\\nAdd /auth/login."',
+].join('\n') + '\n';
+
+function buildPreviewSse(yaml: string, initiative = 'auth-rewrite', phases = 1, issues = 1): string {
+  return [
+    `data: {"t":"chunk","text":"${yaml.slice(0, 20).replace(/\n/g, '\\n')}"}\n`,
+    `data: {"t":"done","yaml":${JSON.stringify(yaml)},"initiative":${JSON.stringify(initiative)},"phase_count":${phases},"issue_count":${issues}}\n`,
+    '\n',
+  ].join('\n');
+}
+
+const ISSUES_SINGLE_PHASE = [
+  { issue_id: 'auth-rewrite-p0-001', number: 101, url: 'https://github.com/test/repo/issues/101', title: 'Add SQLAlchemy User model', phase: '0-foundation' },
+  { issue_id: 'auth-rewrite-p0-002', number: 102, url: 'https://github.com/test/repo/issues/102', title: 'Add Alembic migration', phase: '0-foundation' },
+  { issue_id: 'auth-rewrite-p1-001', number: 103, url: 'https://github.com/test/repo/issues/103', title: 'Add login endpoint', phase: '1-api' },
+];
+
+function buildFileIssuesSse(issues: typeof ISSUES_SINGLE_PHASE, batchId = 'batch-abc123'): string {
+  const events: string[] = [
+    `data: {"t":"start","total":${issues.length},"initiative":"auth-rewrite"}\n`,
+    `data: {"t":"label","text":"Ensuring labels exist in GitHub\\u2026"}\n`,
+  ];
+  issues.forEach((iss, idx) => {
+    events.push(
+      `data: {"t":"issue","index":${idx + 1},"total":${issues.length},"number":${iss.number},"url":${JSON.stringify(iss.url)},"title":${JSON.stringify(iss.title)},"phase":${JSON.stringify(iss.phase)}}\n`,
+    );
+  });
+  events.push(
+    `data: {"t":"done","total":${issues.length},"batch_id":${JSON.stringify(batchId)},"initiative":"auth-rewrite","issues":${JSON.stringify(issues)},"coordinator_arch":{}}\n`,
+    '\n',
+  );
+  return events.join('\n');
+}
+
+// ── Shared route-mocking helpers ──────────────────────────────────────────
+
+async function mockPreview(page: Page, yaml = VALID_YAML, phases = 1, issues = 1): Promise<void> {
+  await page.route('**/api/plan/preview', async route => {
+    await route.fulfill({
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+      body: buildPreviewSse(yaml, 'auth-rewrite', phases, issues),
+    });
+  });
+}
+
+async function mockFileIssues(page: Page, issues = ISSUES_SINGLE_PHASE): Promise<void> {
+  await page.route('**/api/plan/file-issues', async route => {
+    await route.fulfill({
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+      body: buildFileIssuesSse(issues),
+    });
+  });
+}
+
+// ── Shared navigation helper ──────────────────────────────────────────────
+
+async function goToPlan(page: Page): Promise<void> {
+  await page.goto('/plan');
+  await page.waitForLoadState('networkidle');
+}
+
+// ── Page load ─────────────────────────────────────────────────────────────
+
+test.describe('Plan page — initial load', () => {
+  test('loads in write state with textarea visible', async ({ page }) => {
+    await goToPlan(page);
+    await expect(page.locator('[x-ref="textarea"]')).toBeVisible();
+    await expect(page.locator('button', { hasText: 'Generate plan' })).toBeVisible();
+  });
+
+  test('seed pills are visible and clickable', async ({ page }) => {
+    await goToPlan(page);
+    const firstSeed = page.locator('.plan-seed').first();
+    await expect(firstSeed).toBeVisible();
+    await firstSeed.click();
+    // After clicking, the textarea should contain text.
+    const value = await page.locator('[x-ref="textarea"]').inputValue();
+    expect(value.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Phase 1A: Generate plan ───────────────────────────────────────────────
+
+test.describe('Phase 1A — plan generation', () => {
+  test('typing text and submitting shows generating state then review state', async ({ page }) => {
+    await mockPreview(page);
+    await goToPlan(page);
+
+    await page.fill('[x-ref="textarea"]', 'Build user authentication with JWT tokens');
+    await page.click('button:has-text("Generate plan")');
+
+    // Generating state appears briefly.
+    await expect(page.locator('#plan-generating')).toBeVisible({ timeout: 3000 });
+
+    // Review state appears after SSE stream completes.
+    await expect(page.locator('#plan-review')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('Cmd+Enter keyboard shortcut submits the form', async ({ page }) => {
+    await mockPreview(page);
+    await goToPlan(page);
+
+    await page.fill('[x-ref="textarea"]', 'Build payment integration');
+    await page.keyboard.press('Meta+Enter');
+
+    await expect(page.locator('#plan-review')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('CodeMirror editor is present in review state', async ({ page }) => {
+    await mockPreview(page);
+    await goToPlan(page);
+    await page.fill('[x-ref="textarea"]', 'Build auth');
+    await page.click('button:has-text("Generate plan")');
+    await expect(page.locator('#plan-review')).toBeVisible({ timeout: 10_000 });
+    // CodeMirror renders a .cm-editor div.
+    await expect(page.locator('.cm-editor')).toBeVisible();
+  });
+
+  test('phase/issue counts are shown in review state', async ({ page }) => {
+    await mockPreview(page, TWO_PHASE_YAML, 2, 3);
+    await goToPlan(page);
+    await page.fill('[x-ref="textarea"]', 'Build auth with multiple phases');
+    await page.click('button:has-text("Generate plan")');
+    await expect(page.locator('#plan-review')).toBeVisible({ timeout: 10_000 });
+    // Count display reflects the done event values (before live validation runs).
+    const meta = page.locator('.plan-yaml-meta').first();
+    await expect(meta).toContainText('2', { timeout: 5000 });
+    await expect(meta).toContainText('3');
+  });
+
+  test('error SSE event shows error message and returns to write state', async ({ page }) => {
+    await page.route('**/api/plan/preview', async route => {
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+        body: 'data: {"t":"error","detail":"Input too vague — please add more detail."}\n\n',
+      });
+    });
+    await goToPlan(page);
+    await page.fill('[x-ref="textarea"]', '?');
+    await page.click('button:has-text("Generate plan")');
+
+    // Should land back on write state with the error visible.
+    await expect(page.locator('#plan-write')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.plan-error, [x-text="errorMsg"]')).toContainText(/vague|detail/i, { timeout: 5000 });
+  });
+});
+
+// ── Review state: YAML editor + validation ────────────────────────────────
+
+test.describe('Review state — YAML validation', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockPreview(page);
+    await goToPlan(page);
+    await page.fill('[x-ref="textarea"]', 'Build auth');
+    await page.click('button:has-text("Generate plan")');
+    await expect(page.locator('#plan-review')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('valid YAML shows a green validation message', async ({ page }) => {
+    // Wait for the validate call (triggered by CodeMirror mount) to settle.
+    await expect(page.locator('.plan-yaml-status')).toContainText('Valid', { timeout: 8000 });
+  });
+
+  test('Launch button is enabled for valid YAML', async ({ page }) => {
+    await expect(page.locator('.plan-yaml-status')).toContainText('Valid', { timeout: 8000 });
+    await expect(page.locator('button:has-text("Launch")')).toBeEnabled();
+  });
+
+  test('"Edit plan" returns to write state', async ({ page }) => {
+    await page.click('button:has-text("Edit plan")');
+    await expect(page.locator('#plan-write')).toBeVisible();
+  });
+});
+
+// ── Draft persistence ─────────────────────────────────────────────────────
+
+test.describe('Draft persistence', () => {
+  test('hard refresh restores review state from localStorage draft', async ({ page }) => {
+    await mockPreview(page);
+    await goToPlan(page);
+
+    await page.fill('[x-ref="textarea"]', 'Build auth');
+    await page.click('button:has-text("Generate plan")');
+    await expect(page.locator('#plan-review')).toBeVisible({ timeout: 10_000 });
+
+    // Hard refresh — the draft is stored in localStorage.
+    await mockPreview(page);   // re-install mock for next navigation
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Should restore to review, not write.
+    await expect(page.locator('#plan-review')).toBeVisible({ timeout: 8000 });
+    await expect(page.locator('.cm-editor')).toBeVisible();
+  });
+});
+
+// ── Phase 1B: File issues ─────────────────────────────────────────────────
+
+test.describe('Phase 1B — file issues', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockPreview(page, TWO_PHASE_YAML, 2, 3);
+    await goToPlan(page);
+    await page.fill('[x-ref="textarea"]', 'Build auth');
+    await page.click('button:has-text("Generate plan")');
+    await expect(page.locator('#plan-review')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.plan-yaml-status')).toContainText('Valid', { timeout: 8000 });
+  });
+
+  test('launching shows progress and transitions to done state', async ({ page }) => {
+    await mockFileIssues(page);
+    await page.click('button:has-text("Launch")');
+
+    // Launching state briefly visible.
+    await expect(page.locator('#plan-launching')).toBeVisible({ timeout: 5000 });
+
+    // Done state after stream completes.
+    await expect(page.locator('#plan-done')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('done state displays the batch ID', async ({ page }) => {
+    await mockFileIssues(page);
+    await page.click('button:has-text("Launch")');
+    await expect(page.locator('#plan-done')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.plan-done-batch-id')).toContainText('batch-abc123');
+  });
+
+  test('done state shows GitHub issue links', async ({ page }) => {
+    await mockFileIssues(page);
+    await page.click('button:has-text("Launch")');
+    await expect(page.locator('#plan-done')).toBeVisible({ timeout: 10_000 });
+    // Each created issue should have a link.
+    const issueLinks = page.locator('.plan-done-issue a, #plan-done a[href*="github.com"]');
+    await expect(issueLinks.first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('error during launch shows error message and returns to review', async ({ page }) => {
+    await page.route('**/api/plan/file-issues', async route => {
+      await route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+        body: 'data: {"t":"start","total":3,"initiative":"auth-rewrite"}\n\ndata: {"t":"error","detail":"GitHub rate limited."}\n\n',
+      });
+    });
+    await page.click('button:has-text("Launch")');
+    await expect(page.locator('#plan-review')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.plan-error, [x-text="errorMsg"]')).toContainText(/rate limited/i, { timeout: 5000 });
+  });
+
+  test('"New plan" button from done state resets to write', async ({ page }) => {
+    await mockFileIssues(page);
+    await page.click('button:has-text("Launch")');
+    await expect(page.locator('#plan-done')).toBeVisible({ timeout: 10_000 });
+    await page.click('button:has-text("New plan")');
+    await expect(page.locator('#plan-write')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[x-ref="textarea"]')).toHaveValue('');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022", "ESNext", "DOM"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "ESNext"],
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": [
+    "vitest.config.ts",
+    "playwright.config.ts",
+    "tests/e2e/**/*.ts"
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // jsdom gives us localStorage, ReadableStream, TextEncoder, etc.
+    environment: 'jsdom',
+    include: ['agentception/static/js/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      include: ['agentception/static/js/**/*.ts'],
+      exclude: ['agentception/static/js/**/*.test.ts'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds **48 Vitest unit tests** for `plan.ts` covering `parseSseEvent`, draft persistence, state machine transitions, Phase 1A/1B SSE stream parsing, and `_validateYaml` — runs in jsdom with no browser required
- Adds **13 Playwright E2E tests** covering the full Plan page flow (page load → generate → review → launch → done), draft persistence across hard refresh, and error paths — intercepts SSE endpoints via `page.route()` while hitting the real validate endpoint
- Exports `parseSseEvent` from `plan.ts` for isolated unit testing
- Adds `vitest.config.ts`, `playwright.config.ts`, `tsconfig.node.json`
- Updates `tsconfig.json` with `ESNext` lib for `Symbol.asyncDispose` compatibility
- Installs `vitest`, `@vitest/coverage-v8`, `jsdom`, `@playwright/test`, `@types/node`
- Adds `npm run test`, `test:watch`, `test:coverage`, `test:e2e`, `test:all` scripts
- Updates `.cursorrules` and `AGENTS.md` with test commands and rules

## Test plan

- [x] `npm run type-check` — zero errors (both browser + node tsconfigs)
- [x] `npm test` — 48/48 Vitest unit tests pass
- [ ] `npm run test:e2e` — run with `docker compose up -d` (requires live server)
