### PR TITLE
Fix plan done-state UX, stale comments, and broken E2E selectors

### DIFF
--- a/agentception/templates/plan.html
+++ b/agentception/templates/plan.html
@@ -4,15 +4,17 @@
 {#
   Plan — Step 1.A + 1.B
   ─────────────────────────────────────────────────────────────────────────────
-  Three states managed by Alpine (planForm in plan.js):
-    write    — textarea input, seeds, submit
-    review   — Monaco YAML editor, editable, validate + launch
-    done     — success summary, batch ID, next steps
+  Five states managed by Alpine (planForm in plan.ts):
+    write      — textarea input, seeds, submit
+    generating — SSE stream live-preview, cancel button
+    review     — CodeMirror 6 YAML editor, editable, validate + launch
+    launching  — issue-filing SSE in progress, progress strip
+    done       — success summary, batch ID, next steps
 
   No right sidebar. The coordinator pipeline happens after Submit — it's not
   a UI step, so we don't show it here.
 
-  JS     : plan.js  →  planForm()
+  JS     : plan.ts  →  planForm()
   CSS    : app.css  §  Plan
   ─────────────────────────────────────────────────────────────────────────────
 #}
@@ -75,7 +77,7 @@
   {# ══════════════════════════════════════════════════════════════════════
      WRITE state — free-form text input
      ══════════════════════════════════════════════════════════════════════ #}
-  <div class="plan-write" x-show="step === 'write'" x-transition.opacity>
+  <div id="plan-write" class="plan-write" x-show="step === 'write'" x-transition.opacity>
 
     <h1 class="plan-title">The Singularity is here.</h1>
     <p class="plan-sub">Paste anything — a rough idea, a wall of text, a list of tasks, a complaint about what's broken. AgentCeption structures it into a phase-gated plan of GitHub issues.</p>
@@ -172,7 +174,7 @@
   {# ══════════════════════════════════════════════════════════════════════
      GENERATING state — spinner while LLM works
      ══════════════════════════════════════════════════════════════════════ #}
-  <div class="plan-generating" x-show="step === 'generating'">
+  <div id="plan-generating" class="plan-generating" x-show="step === 'generating'">
     <div class="plan-gen-header">
       <div class="plan-spinner"></div>
       <div>
@@ -197,7 +199,7 @@
   {# ══════════════════════════════════════════════════════════════════════
      REVIEW state — CodeMirror 6 YAML editor
      ══════════════════════════════════════════════════════════════════════ #}
-  <div class="plan-review" x-show="step === 'review' || step === 'launching'">
+  <div id="plan-review" class="plan-review" x-show="step === 'review' || step === 'launching'">
 
     <div class="plan-review-header">
       <div>
@@ -213,7 +215,7 @@
           class="btn btn-secondary"
           @click="editPlan()"
           :disabled="step === 'launching'"
-        >← Edit</button>
+        >← Edit plan</button>
         <button
           class="btn btn-primary"
           @click="launch()"
@@ -237,7 +239,7 @@
       <span x-text="yamlValidationMsg"></span>
     </div>
 
-    {# Monaco editor container #}
+    {# CodeMirror 6 editor container #}
     <div x-ref="yamlEditor" class="plan-yaml-editor"></div>
 
     {# Filing progress strip — only visible during launching state #}
@@ -253,9 +255,9 @@
   </div>
 
   {# ══════════════════════════════════════════════════════════════════════
-     DONE state — coordinator launched, batch and worktree shown
+     DONE state — issues filed, summary + next steps
      ══════════════════════════════════════════════════════════════════════ #}
-  <div class="plan-done" x-show="step === 'done'" x-transition.opacity>
+  <div id="plan-done" class="plan-done" x-show="step === 'done'" x-transition.opacity>
 
     {# ── Hero ──────────────────────────────────────────────────────────── #}
     <div class="plan-done-hero">
@@ -267,7 +269,8 @@
         <span x-text="issueCount"></span>
         <span x-text="issueCount === 1 ? 'issue' : 'issues'"></span>
         <span class="plan-done-sep">·</span>
-        <span class="plan-done-active-dot"></span> phase 0 active
+        <span class="plan-done-active-dot"></span>
+        <span x-text="(result.phaseGroups[0]?.phase ?? 'phase 0') + ' active'"></span>
       </div>
     </div>
 
@@ -316,13 +319,13 @@
       </div>
 
       <div class="plan-done-actions">
-        <a href="/" class="btn btn-primary">Build Board →</a>
+        <a href="/" class="btn btn-primary">Dispatch agents →</a>
         <a
           :href="'https://github.com/{{ gh_repo }}/issues?q=is%3Aopen+label%3A' + encodeURIComponent(initiative)"
           target="_blank" rel="noopener noreferrer"
           class="btn btn-secondary"
         >View on GitHub ↗</a>
-        <button class="btn btn-ghost" @click="reset()">← New plan</button>
+        <button class="btn btn-ghost" @click="reset()">New plan</button>
       </div>
     </div>
 

--- a/tests/e2e/plan.spec.ts
+++ b/tests/e2e/plan.spec.ts
@@ -23,6 +23,13 @@
  * This means the validate endpoint exercises the full Python stack including
  * Pydantic model validation, giving genuine confidence that the schema is
  * correct end-to-end.
+ *
+ * Selector strategy
+ * -----------------
+ * State containers are targeted by their `id` attributes (e.g. #plan-review).
+ * Interactive elements use Playwright's :has-text() for resilience against
+ * minor copy changes.  SCSS class selectors are used only for presentational
+ * elements where the class is stable (e.g. .plan-done-batch-id).
  */
 
 import { expect, Page, test } from '@playwright/test';
@@ -71,13 +78,13 @@ function buildPreviewSse(yaml: string, initiative = 'auth-rewrite', phases = 1, 
   ].join('\n');
 }
 
-const ISSUES_SINGLE_PHASE = [
+const FILED_ISSUES = [
   { issue_id: 'auth-rewrite-p0-001', number: 101, url: 'https://github.com/test/repo/issues/101', title: 'Add SQLAlchemy User model', phase: '0-foundation' },
   { issue_id: 'auth-rewrite-p0-002', number: 102, url: 'https://github.com/test/repo/issues/102', title: 'Add Alembic migration', phase: '0-foundation' },
   { issue_id: 'auth-rewrite-p1-001', number: 103, url: 'https://github.com/test/repo/issues/103', title: 'Add login endpoint', phase: '1-api' },
 ];
 
-function buildFileIssuesSse(issues: typeof ISSUES_SINGLE_PHASE, batchId = 'batch-abc123'): string {
+function buildFileIssuesSse(issues: typeof FILED_ISSUES, batchId = 'batch-abc123'): string {
   const events: string[] = [
     `data: {"t":"start","total":${issues.length},"initiative":"auth-rewrite"}\n`,
     `data: {"t":"label","text":"Ensuring labels exist in GitHub\\u2026"}\n`,
@@ -88,7 +95,7 @@ function buildFileIssuesSse(issues: typeof ISSUES_SINGLE_PHASE, batchId = 'batch
     );
   });
   events.push(
-    `data: {"t":"done","total":${issues.length},"batch_id":${JSON.stringify(batchId)},"initiative":"auth-rewrite","issues":${JSON.stringify(issues)},"coordinator_arch":{}}\n`,
+    `data: {"t":"done","total":${issues.length},"batch_id":${JSON.stringify(batchId)},"initiative":"auth-rewrite","issues":${JSON.stringify(issues)}}\n`,
     '\n',
   );
   return events.join('\n');
@@ -106,7 +113,7 @@ async function mockPreview(page: Page, yaml = VALID_YAML, phases = 1, issues = 1
   });
 }
 
-async function mockFileIssues(page: Page, issues = ISSUES_SINGLE_PHASE): Promise<void> {
+async function mockFileIssues(page: Page, issues = FILED_ISSUES): Promise<void> {
   await page.route('**/api/plan/file-issues', async route => {
     await route.fulfill({
       status: 200,
@@ -128,13 +135,14 @@ async function goToPlan(page: Page): Promise<void> {
 test.describe('Plan page — initial load', () => {
   test('loads in write state with textarea visible', async ({ page }) => {
     await goToPlan(page);
+    await expect(page.locator('#plan-write')).toBeVisible();
     await expect(page.locator('[x-ref="textarea"]')).toBeVisible();
-    await expect(page.locator('button', { hasText: 'Generate plan' })).toBeVisible();
+    await expect(page.locator('button:has-text("Generate plan")')).toBeVisible();
   });
 
-  test('seed pills are visible and clickable', async ({ page }) => {
+  test('seed chips are visible and clickable', async ({ page }) => {
     await goToPlan(page);
-    const firstSeed = page.locator('.plan-seed').first();
+    const firstSeed = page.locator('.plan-seed-chip').first();
     await expect(firstSeed).toBeVisible();
     await firstSeed.click();
     // After clicking, the textarea should contain text.
@@ -176,18 +184,18 @@ test.describe('Phase 1A — plan generation', () => {
     await page.fill('[x-ref="textarea"]', 'Build auth');
     await page.click('button:has-text("Generate plan")');
     await expect(page.locator('#plan-review')).toBeVisible({ timeout: 10_000 });
-    // CodeMirror renders a .cm-editor div.
+    // CodeMirror renders a .cm-editor div inside the .plan-yaml-editor container.
     await expect(page.locator('.cm-editor')).toBeVisible();
   });
 
-  test('phase/issue counts are shown in review state', async ({ page }) => {
+  test('phase/issue counts are shown in the review meta line', async ({ page }) => {
     await mockPreview(page, TWO_PHASE_YAML, 2, 3);
     await goToPlan(page);
     await page.fill('[x-ref="textarea"]', 'Build auth with multiple phases');
     await page.click('button:has-text("Generate plan")');
     await expect(page.locator('#plan-review')).toBeVisible({ timeout: 10_000 });
-    // Count display reflects the done event values (before live validation runs).
-    const meta = page.locator('.plan-yaml-meta').first();
+    // .plan-review-meta shows "initiative · N phases · N issues".
+    const meta = page.locator('.plan-review-meta').first();
     await expect(meta).toContainText('2', { timeout: 5000 });
     await expect(meta).toContainText('3');
   });
@@ -206,7 +214,7 @@ test.describe('Phase 1A — plan generation', () => {
 
     // Should land back on write state with the error visible.
     await expect(page.locator('#plan-write')).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('.plan-error, [x-text="errorMsg"]')).toContainText(/vague|detail/i, { timeout: 5000 });
+    await expect(page.locator('.plan-error')).toContainText(/vague|detail/i, { timeout: 5000 });
   });
 });
 
@@ -223,15 +231,16 @@ test.describe('Review state — YAML validation', () => {
 
   test('valid YAML shows a green validation message', async ({ page }) => {
     // Wait for the validate call (triggered by CodeMirror mount) to settle.
-    await expect(page.locator('.plan-yaml-status')).toContainText('Valid', { timeout: 8000 });
+    // .plan-yaml-validation strips show success/error text.
+    await expect(page.locator('.plan-yaml-validation')).toContainText('Valid', { timeout: 8000 });
   });
 
   test('Launch button is enabled for valid YAML', async ({ page }) => {
-    await expect(page.locator('.plan-yaml-status')).toContainText('Valid', { timeout: 8000 });
+    await expect(page.locator('.plan-yaml-validation')).toContainText('Valid', { timeout: 8000 });
     await expect(page.locator('button:has-text("Launch")')).toBeEnabled();
   });
 
-  test('"Edit plan" returns to write state', async ({ page }) => {
+  test('"← Edit plan" returns to write state', async ({ page }) => {
     await page.click('button:has-text("Edit plan")');
     await expect(page.locator('#plan-write')).toBeVisible();
   });
@@ -268,15 +277,16 @@ test.describe('Phase 1B — file issues', () => {
     await page.fill('[x-ref="textarea"]', 'Build auth');
     await page.click('button:has-text("Generate plan")');
     await expect(page.locator('#plan-review')).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('.plan-yaml-status')).toContainText('Valid', { timeout: 8000 });
+    // Wait for the real validate endpoint to confirm YAML is valid.
+    await expect(page.locator('.plan-yaml-validation')).toContainText('Valid', { timeout: 8000 });
   });
 
   test('launching shows progress and transitions to done state', async ({ page }) => {
     await mockFileIssues(page);
     await page.click('button:has-text("Launch")');
 
-    // Launching state briefly visible.
-    await expect(page.locator('#plan-launching')).toBeVisible({ timeout: 5000 });
+    // Launching state briefly visible (the review div is still shown during launching).
+    await expect(page.locator('.plan-filing-progress')).toBeVisible({ timeout: 5000 });
 
     // Done state after stream completes.
     await expect(page.locator('#plan-done')).toBeVisible({ timeout: 10_000 });
@@ -289,13 +299,28 @@ test.describe('Phase 1B — file issues', () => {
     await expect(page.locator('.plan-done-batch-id')).toContainText('batch-abc123');
   });
 
+  test('done state shows the active phase label dynamically', async ({ page }) => {
+    await mockFileIssues(page);
+    await page.click('button:has-text("Launch")');
+    await expect(page.locator('#plan-done')).toBeVisible({ timeout: 10_000 });
+    // Hero stats line should show the actual first phase slug, not "phase 0".
+    await expect(page.locator('.plan-done-hero-stats')).toContainText('0-foundation active');
+  });
+
   test('done state shows GitHub issue links', async ({ page }) => {
     await mockFileIssues(page);
     await page.click('button:has-text("Launch")');
     await expect(page.locator('#plan-done')).toBeVisible({ timeout: 10_000 });
-    // Each created issue should have a link.
-    const issueLinks = page.locator('.plan-done-issue a, #plan-done a[href*="github.com"]');
+    // Each created issue should have a link to GitHub.
+    const issueLinks = page.locator('#plan-done a[href*="github.com"]');
     await expect(issueLinks.first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('"Dispatch agents →" primary action link exists', async ({ page }) => {
+    await mockFileIssues(page);
+    await page.click('button:has-text("Launch")');
+    await expect(page.locator('#plan-done')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('#plan-done a:has-text("Dispatch agents")')).toBeVisible();
   });
 
   test('error during launch shows error message and returns to review', async ({ page }) => {
@@ -308,7 +333,7 @@ test.describe('Phase 1B — file issues', () => {
     });
     await page.click('button:has-text("Launch")');
     await expect(page.locator('#plan-review')).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('.plan-error, [x-text="errorMsg"]')).toContainText(/rate limited/i, { timeout: 5000 });
+    await expect(page.locator('.plan-error')).toContainText(/rate limited/i, { timeout: 5000 });
   });
 
   test('"New plan" button from done state resets to write', async ({ page }) => {


### PR DESCRIPTION
## Summary

- **UX**: Rename `Build Board →` to `Dispatch agents →` — action-oriented label makes the next step obvious without needing to know internal page names
- **UX**: Remove `←` from `← New plan` button — it reads as "go backwards" which conflicts with `Build Board →` making them look like a pair; it's an escape hatch, not a back button
- **UX**: Rename `← Edit` button to `← Edit plan` for clarity
- **Bug**: Fix hardcoded `phase 0 active` text in the hero stats — now dynamic `x-text` that shows the actual first phase slug (e.g. `0-foundation active`, `0-scope active`)
- **Bug**: Add `id=` attributes to all four Alpine state containers (`plan-write`, `plan-generating`, `plan-review`, `plan-done`) — E2E tests were referencing `#plan-review` etc. which did not exist in the DOM, making every Playwright test silently broken
- **Bug**: Fix five broken E2E selectors (`.plan-seed`, `.plan-yaml-meta`, `.plan-yaml-status`, issue link selector, edit button text)
- **Hygiene**: Update stale template comments (`plan.js` → `plan.ts`, `Monaco` → `CodeMirror 6`)
- **Tests**: Two new E2E tests: dynamic active-phase label and `Dispatch agents →` link presence

## Test plan

- [x] `tsc --noEmit` — zero errors (both tsconfigs)
- [x] `npm test` — 48/48 Vitest unit tests pass
- [x] `mypy agentception/ tests/` — zero errors
- [ ] `npm run test:e2e` — run with `docker compose up -d`
