### PR TITLE
fix: move filing progress strip above the YAML editor

### DIFF
--- a/agentception/templates/plan.html
+++ b/agentception/templates/plan.html
@@ -239,14 +239,14 @@
       <span x-text="yamlValidationMsg"></span>
     </div>
 
-    {# CodeMirror 6 editor container #}
-    <div x-ref="yamlEditor" class="plan-yaml-editor"></div>
-
-    {# Filing progress strip — only visible during launching state #}
+    {# Filing progress strip — shown between validation and editor during launch #}
     <div class="plan-filing-progress" x-show="step === 'launching' && filingProgress" x-transition.opacity>
       <div class="plan-spinner plan-spinner--sm"></div>
       <span x-text="filingProgress"></span>
     </div>
+
+    {# CodeMirror 6 editor container #}
+    <div x-ref="yamlEditor" class="plan-yaml-editor"></div>
 
     <div class="plan-error" x-show="errorMsg" x-transition>
       <span x-text="errorMsg"></span>


### PR DESCRIPTION
## Summary

- The filing progress spinner/text was rendered below the CodeMirror block, requiring users to scroll past the entire YAML to see which issue was being filed
- Moves the element between the validation strip and the editor so it is always visible at a glance during the launch sequence

## Test plan

- [ ] Generate a plan, click Launch, confirm the "Issue N/N — ..." progress line appears above the YAML (not below it)
- [ ] Confirm spinner is left-aligned and text follows it inline
