### PR TITLE
feat: derive initiative tabs from initiative_phases, drop JSON config list

### DIFF
--- a/.agentception/pipeline-config.json
+++ b/.agentception/pipeline-config.json
@@ -13,16 +13,7 @@
   "projects": [
     {
       "name": "agentception",
-      "gh_repo": "cgcardona/agentception",
-      "initiative_labels": [
-        "ac-workflow",
-        "ac-reliability",
-        "ac-plan",
-        "ac-ship",
-        "ac-transcripts",
-        "agentception-ux-phase1b-to-phase3",
-        "developer-experience-layer"
-      ]
+      "gh_repo": "cgcardona/agentception"
     }
   ],
   "active_project": "agentception",

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -8,7 +8,6 @@ empty results so a database outage degrades gracefully to in-memory state.
 """
 
 import datetime
-import fnmatch
 import json
 import logging
 import re as _re
@@ -1268,20 +1267,6 @@ async def get_initiative_phase_meta(
         logger.warning("⚠️  get_initiative_phase_meta failed (non-fatal): %s", exc)
         return []
 
-# Labels that are never themselves initiative names — common GitHub system labels
-# and AgentCeption internal labels.
-_NON_INITIATIVE_LABELS = frozenset(
-    {
-        "enhancement", "bug", "documentation", "good first issue",
-        "help wanted", "invalid", "question", "wontfix", "duplicate",
-        "feature", "agent:wip", "priority:high", "priority:medium",
-        "priority:low", "needs-triage", "in-progress", "review", "blocked", "ticket-blocked",
-    }
-)
-
-def _label_matches_patterns(label: str, patterns: list[str]) -> bool:
-    """Return True if *label* matches any of the fnmatch-style *patterns*."""
-    return any(fnmatch.fnmatch(label, pat) for pat in patterns)
 
 
 class PhaseSummary(TypedDict):
@@ -1358,85 +1343,63 @@ async def get_label_context(repo: str, initiative_label: str) -> LabelContext:
         return LabelContext(phases=[], issues=[])
 
 
-async def get_initiatives(
-    repo: str,
-    initiative_patterns: list[str] | None = None,
-) -> list[str]:
-    """Return active initiative labels present in the DB, ordered by config position.
+async def get_initiatives(repo: str) -> list[str]:
+    """Return initiative slugs filed via Plan 1B that still have open issues.
 
-    When *initiative_patterns* is non-empty, a label is an initiative if it
-    matches any of the fnmatch-style patterns (e.g. ``"ac-*"``, ``"agentception"``).
-    Only labels that appear on at least one **open** issue are returned.
+    Derives the tab list exclusively from ``initiative_phases`` — if an
+    initiative was filed through the Plan pipeline it appears here; no JSON
+    configuration is required.
 
-    The result order mirrors the order of *initiative_patterns*: a label whose
-    first matching pattern appears earlier in the list sorts earlier.  This
-    means the order declared in ``pipeline-config.json`` is the single source
-    of truth for the initiative tab bar — no separate hardcoded list needed.
+    Ordering: most recently filed batch first (``MAX(created_at) DESC``), then
+    alphabetically as a tiebreaker so the result is stable.
 
-    When *initiative_patterns* is empty or ``None``, falls back to the legacy
-    heuristic: a label is an initiative when it co-exists with a ``phase-N``
-    label on the same issue and is not in ``_NON_INITIATIVE_LABELS``.
+    An initiative drops out automatically once all its GitHub issues are closed,
+    keeping the tab bar noise-free without manual maintenance.
 
-    Fully completed initiatives (all issues closed) are excluded from the tab
-    bar to avoid noise over time.  Falls back to ``[]`` on DB error.
+    Falls back to ``[]`` on DB error (non-fatal degradation).
     """
-    patterns: list[str] = initiative_patterns or []
-
-    def _sort_key(label: str) -> tuple[int, str]:
-        """Sort by first matching pattern index, then alphabetically."""
-        for i, pat in enumerate(patterns):
-            if fnmatch.fnmatch(label, pat):
-                return (i, label)
-        return (len(patterns), label)
+    from agentception.db.models import ACInitiativePhase
 
     try:
+        # Step 1: ordered list of initiatives from the filing history.
         async with get_session() as session:
-            result = await session.execute(
-                select(ACIssue.labels_json, ACIssue.state, ACIssue.phase_label)
-                .where(ACIssue.repo == repo)
-            )
-            rows = result.all()
-
-        initiative_states: dict[str, set[str]] = {}
-
-        if patterns:
-            # Config-driven path: a label matching a pattern is an initiative.
-            # Only count issues that would actually be visible in the board —
-            # an issue must have a scoped "{initiative}/phase-N" label; issues
-            # without one are dropped by get_issues_grouped_by_phase and must
-            # not cause a tab to appear.
-            for labels_json_str, state, _phase_label in rows:
-                labels: list[str] = json.loads(labels_json_str or "[]")
-                matched_initiatives = [
-                    lbl
-                    for lbl in labels
-                    # Scoped phase labels (e.g. "ac-build/phase-0") are never
-                    # initiatives — the "/" is the canonical separator.
-                    if "/" not in lbl and _label_matches_patterns(lbl, patterns)
-                ]
-                if not matched_initiatives:
-                    continue
-
-                # Issue must have at least one scoped "{initiative}/phase-N" label.
-                has_scoped_phase = any(
-                    any(lbl.startswith(f"{ini}/") for lbl in labels)
-                    for ini in matched_initiatives
+            phase_result = await session.execute(
+                select(
+                    ACInitiativePhase.initiative,
+                    func.max(ACInitiativePhase.created_at).label("last_filed"),
                 )
-                if not has_scoped_phase:
-                    continue  # unphased issue — won't appear in board
+                .where(ACInitiativePhase.repo == repo)
+                .group_by(ACInitiativePhase.initiative)
+                .order_by(
+                    func.max(ACInitiativePhase.created_at).desc(),
+                    ACInitiativePhase.initiative,
+                )
+            )
+            ordered: list[str] = [row.initiative for row in phase_result.all()]
 
-                for lbl in matched_initiatives:
-                    initiative_states.setdefault(lbl, set()).add(state or "open")
-        else:
-            # No patterns configured — return nothing (no legacy heuristic).
-            pass
+        if not ordered:
+            return []
 
-        # Only surface initiatives that still have at least one open issue,
-        # ordered by their position in initiative_patterns then alphabetically.
-        return sorted(
-            (ini for ini, states in initiative_states.items() if "open" in states),
-            key=_sort_key,
-        )
+        # Step 2: which of those still have at least one open issue with a
+        # scoped phase label (e.g. "auth-rewrite/0-foundation")?
+        # An initiative whose issues all closed is hidden automatically.
+        async with get_session() as session:
+            issue_result = await session.execute(
+                select(ACIssue.labels_json)
+                .where(ACIssue.repo == repo, ACIssue.state == "open")
+            )
+            open_labels: list[list[str]] = [
+                json.loads(row[0] or "[]") for row in issue_result.all()
+            ]
+
+        has_open: set[str] = set()
+        for ini in ordered:
+            prefix = f"{ini}/"
+            if any(any(lbl.startswith(prefix) for lbl in lbls) for lbls in open_labels):
+                has_open.add(ini)
+
+        return [ini for ini in ordered if ini in has_open]
+
     except Exception as exc:
         logger.warning("⚠️  get_initiatives DB query failed (non-fatal): %s", exc)
         return []

--- a/agentception/models/__init__.py
+++ b/agentception/models/__init__.py
@@ -361,12 +361,6 @@ class ProjectConfig(BaseModel):
     ``worktrees_dir`` supports ``~`` expansion.
 
     ``cursor_project_id`` is the Cursor project slug used to locate transcript files.
-
-    ``initiative_labels`` is a list of fnmatch-style glob patterns (e.g. ``"ac-*"``)
-    that identify which GitHub labels are treated as initiative tabs on the Build
-    and Ship boards.  Patterns are matched only against labels that contain no
-    ``/``, so scoped phase labels (``ac-build/phase-0``) are never surfaced as
-    initiative tabs regardless of the pattern.
     """
 
     name: str
@@ -374,7 +368,6 @@ class ProjectConfig(BaseModel):
     repo_dir: str | None = None
     worktrees_dir: str | None = None
     cursor_project_id: str | None = None
-    initiative_labels: list[str] = []
 
 
 class PipelineConfig(BaseModel):

--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -46,7 +46,6 @@ from agentception.db.queries import (
     get_runs_for_issue_numbers,
     get_workflow_states_by_issue,
 )
-from agentception.readers.pipeline_config import read_pipeline_config
 from ._shared import _TEMPLATES
 
 
@@ -86,19 +85,6 @@ class EnrichedPhaseGroupRow(TypedDict):
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-
-async def _initiative_patterns() -> list[str]:
-    """Return the active project's initiative label patterns from pipeline-config.json."""
-    try:
-        cfg = await read_pipeline_config()
-        for project in cfg.projects:
-            if project.gh_repo == settings.gh_repo:
-                return project.initiative_labels
-        return []
-    except Exception as exc:
-        logger.warning("⚠️ Could not read initiative patterns from pipeline config: %s", exc)
-        return []
 
 
 # ---------------------------------------------------------------------------
@@ -176,8 +162,7 @@ async def ship_redirect() -> Response:
     """
     gh_repo = settings.gh_repo
     repo_name = gh_repo.split("/")[-1]
-    patterns = await _initiative_patterns()
-    initiatives = await get_initiatives(gh_repo, initiative_patterns=patterns)
+    initiatives = await get_initiatives(gh_repo)
     if initiatives:
         return RedirectResponse(url=f"/ship/{repo_name}/{initiatives[0]}", status_code=302)
     return RedirectResponse(url="/plan", status_code=302)
@@ -196,8 +181,7 @@ async def build_page(
 ) -> Response:
     """Render the Mission Control Ship page scoped to *repo/initiative*."""
     gh_repo = settings.gh_repo
-    patterns = await _initiative_patterns()
-    initiatives = await get_initiatives(gh_repo, initiative_patterns=patterns)
+    initiatives = await get_initiatives(gh_repo)
     enriched_groups, total_issues, open_issues = await _build_enriched_groups(gh_repo, initiative)
     return _TEMPLATES.TemplateResponse(
         request,

--- a/agentception/tests/test_get_initiatives.py
+++ b/agentception/tests/test_get_initiatives.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-"""Unit tests for ``get_initiatives()`` — both the config-driven (fnmatch)
-path and the legacy ``phase-N`` heuristic fallback.
+"""Unit tests for ``get_initiatives()`` — derives tabs from ``initiative_phases``
++ open-issues filter with no JSON configuration required.
 
 Run targeted:
     pytest agentception/tests/test_get_initiatives.py -v
 """
 
+import datetime
 import json
 from contextlib import asynccontextmanager, AbstractAsyncContextManager
 from typing import AsyncIterator, Callable
@@ -22,143 +23,161 @@ from agentception.db.queries import get_initiatives
 # ---------------------------------------------------------------------------
 
 
-def _make_row(
-    labels: list[str], state: str = "open", phase_label: str | None = None
-) -> tuple[str, str, str | None]:
-    """Return a (labels_json, state, phase_label) tuple as the DB query now returns."""
-    return json.dumps(labels), state, phase_label
+def _utc(offset_seconds: float = 0.0) -> datetime.datetime:
+    return datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC) + datetime.timedelta(
+        seconds=offset_seconds
+    )
 
 
-def _mock_session_context(
-    rows: list[tuple[str, str, str | None]],
-) -> Callable[[], AbstractAsyncContextManager[AsyncMock]]:
-    """Build a callable that, when called, returns an async context manager yielding a mock session."""
+def _phase_rows(
+    rows: list[tuple[str, datetime.datetime]],
+) -> MagicMock:
+    """Build a result mock for the initiative_phases query.
+
+    Each tuple is ``(initiative, last_filed_dt)``.
+    """
     result_mock = MagicMock()
-    result_mock.all.return_value = rows
+    result_mock.all.return_value = [
+        MagicMock(initiative=ini, last_filed=dt) for ini, dt in rows
+    ]
+    return result_mock
 
-    session_mock = AsyncMock()
-    session_mock.execute = AsyncMock(return_value=result_mock)
+
+def _issue_rows(labels_list: list[list[str]]) -> MagicMock:
+    """Build a result mock for the open-issues labels query."""
+    result_mock = MagicMock()
+    result_mock.all.return_value = [
+        (json.dumps(lbls),) for lbls in labels_list
+    ]
+    return result_mock
+
+
+def _mock_two_query_session(
+    phase_result: MagicMock,
+    issue_result: MagicMock,
+) -> Callable[[], AbstractAsyncContextManager[AsyncMock]]:
+    """Return a ``get_session`` factory that yields successive results per call."""
+    call_count = 0
 
     @asynccontextmanager
     async def _ctx() -> AsyncIterator[AsyncMock]:
+        nonlocal call_count
+        session_mock = AsyncMock()
+        if call_count == 0:
+            session_mock.execute = AsyncMock(return_value=phase_result)
+        else:
+            session_mock.execute = AsyncMock(return_value=issue_result)
+        call_count += 1
         yield session_mock
 
     return _ctx
 
 
 # ---------------------------------------------------------------------------
-# Config-driven path (initiative_patterns provided)
+# Core behaviour
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_get_initiatives_patterns_exact_match() -> None:
-    """Labels that exactly match a pattern and have a scoped phase label are returned."""
-    rows = [
-        _make_row(["agentception", "agentception/phase-0"]),
-        _make_row(["ac-plan", "ac-plan/phase-0"]),
-        # This issue's initiative label matches but has no scoped phase label → excluded.
-        _make_row(["ac-build"]),
-    ]
-    with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
-        result = await get_initiatives(
-            "owner/repo", initiative_patterns=["agentception", "ac-plan", "ac-build"]
-        )
-    # Pattern order: agentception(0), ac-plan(1), ac-build(2)
-    # ac-build issue has no scoped phase label → not shown.
-    assert result == ["agentception", "ac-plan"]
+async def test_get_initiatives_returns_filed_with_open_issues() -> None:
+    """Initiative in initiative_phases with open phased issues → included."""
+    phases = _phase_rows([("auth-rewrite", _utc(100))])
+    issues = _issue_rows([["auth-rewrite", "auth-rewrite/0-foundation"]])
+
+    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+        result = await get_initiatives("owner/repo")
+
+    assert result == ["auth-rewrite"]
 
 
 @pytest.mark.anyio
-async def test_get_initiatives_patterns_glob_match() -> None:
-    """Glob patterns like ``ac-*`` match multiple initiative labels."""
-    rows = [
-        _make_row(["ac-build", "ac-build/phase-0"]),
-        _make_row(["ac-workflow", "ac-workflow/phase-1"]),
-        # ac-reliability has no scoped phase label → excluded from tabs.
-        _make_row(["ac-reliability"]),
-    ]
-    with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
-        result = await get_initiatives("owner/repo", initiative_patterns=["ac-*"])
-    assert "ac-build" in result
-    assert "ac-workflow" in result
-    assert "ac-reliability" not in result
+async def test_get_initiatives_excludes_when_all_issues_closed() -> None:
+    """Initiative filed but all issues closed → excluded (tab auto-hides)."""
+    phases = _phase_rows([("auth-rewrite", _utc(100))])
+    # No open issues with an auth-rewrite/ prefix.
+    issues = _issue_rows([])
+
+    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+        result = await get_initiatives("owner/repo")
+
+    assert result == []
 
 
 @pytest.mark.anyio
-async def test_get_initiatives_glob_never_matches_scoped_phase_labels() -> None:
-    """``ac-*`` must not surface scoped phase labels (e.g. ``ac-build/phase-0``) as initiative tabs.
+async def test_get_initiatives_excludes_when_no_scoped_phase_label() -> None:
+    """Open issues without a scoped phase label (e.g. only top-level label) are not counted."""
+    phases = _phase_rows([("auth-rewrite", _utc(100))])
+    # Issue carries the initiative label but no scoped phase label — won't show on board.
+    issues = _issue_rows([["auth-rewrite"]])
 
-    Python's fnmatch ``*`` matches ``/``, so without the ``"/" not in lbl`` guard
-    the pattern would match ``ac-build/phase-0`` and create a phantom tab.
-    """
-    rows = [
-        _make_row(["ac-build", "ac-build/phase-0"]),
-    ]
-    with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
-        result = await get_initiatives("owner/repo", initiative_patterns=["ac-*"])
-    assert result == ["ac-build"]
-    assert "ac-build/phase-0" not in result
+    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+        result = await get_initiatives("owner/repo")
+
+    assert result == []
 
 
 @pytest.mark.anyio
-async def test_get_initiatives_patterns_excludes_closed_only() -> None:
-    """An initiative only appearing on closed issues is not returned."""
-    rows = [
-        _make_row(["ac-build", "ac-build/phase-0"], state="closed"),
-        _make_row(["ac-plan", "ac-plan/phase-0"], state="open"),
-    ]
-    with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
-        result = await get_initiatives("owner/repo", initiative_patterns=["ac-*"])
-    assert "ac-plan" in result
-    assert "ac-build" not in result
+async def test_get_initiatives_not_in_phases_never_appears() -> None:
+    """An initiative with open issues but NOT in initiative_phases → excluded."""
+    phases = _phase_rows([])  # nothing filed
+    issues = _issue_rows([["mystery-initiative", "mystery-initiative/0-first"]])
+
+    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+        result = await get_initiatives("owner/repo")
+
+    assert result == []
 
 
 @pytest.mark.anyio
-async def test_get_initiatives_patterns_returns_sorted() -> None:
-    """Result order mirrors the position of each label's pattern in initiative_patterns."""
-    rows = [
-        _make_row(["ac-workflow", "ac-workflow/phase-0"]),
-        _make_row(["ac-build", "ac-build/phase-0"]),
-        _make_row(["ac-plan", "ac-plan/phase-0"]),
-    ]
-    with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
-        result = await get_initiatives(
-            "owner/repo", initiative_patterns=["ac-build", "ac-plan", "ac-workflow"]
-        )
-    # Sorted by pattern position: ac-build(0) → ac-plan(1) → ac-workflow(2)
-    assert result == ["ac-build", "ac-plan", "ac-workflow"]
+async def test_get_initiatives_ordered_most_recently_filed_first() -> None:
+    """Tabs are ordered by most-recently-filed batch DESC."""
+    phases = _phase_rows([
+        ("ac-plan", _utc(300)),    # most recent
+        ("ac-build", _utc(200)),
+        ("ac-workflow", _utc(100)),  # oldest
+    ])
+    issues = _issue_rows([
+        ["ac-plan", "ac-plan/0-scaffold"],
+        ["ac-build", "ac-build/0-scaffold"],
+        ["ac-workflow", "ac-workflow/0-scaffold"],
+    ])
+
+    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+        result = await get_initiatives("owner/repo")
+
+    assert result == ["ac-plan", "ac-build", "ac-workflow"]
 
 
 @pytest.mark.anyio
-async def test_get_initiatives_unphased_issues_excluded_from_tabs() -> None:
-    """Issues without a scoped phase label are invisible in the board and must not create tabs."""
-    rows = [
-        # ac-ship has open issues but none with a scoped phase label → no tab.
-        _make_row(["ac-ship"]),
-        _make_row(["ac-ship"], state="open"),
-        # ac-build has a proper scoped phase label → shows as tab.
-        _make_row(["ac-build", "ac-build/phase-0"]),
-    ]
-    with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
-        result = await get_initiatives(
-            "owner/repo", initiative_patterns=["ac-build", "ac-ship"]
-        )
-    assert "ac-build" in result
-    assert "ac-ship" not in result
+async def test_get_initiatives_mixed_open_and_closed() -> None:
+    """Only initiatives that still have at least one open phased issue are returned."""
+    phases = _phase_rows([
+        ("ac-plan", _utc(200)),
+        ("ac-done", _utc(100)),
+    ])
+    issues = _issue_rows([
+        # ac-plan has an open issue.
+        ["ac-plan", "ac-plan/0-scaffold"],
+        # ac-done has no open issues (all closed, not in this list).
+    ])
+
+    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+        result = await get_initiatives("owner/repo")
+
+    assert result == ["ac-plan"]
+    assert "ac-done" not in result
 
 
 @pytest.mark.anyio
-async def test_get_initiatives_empty_patterns_returns_empty() -> None:
-    """When patterns is empty/None, no initiatives are returned (legacy heuristic removed)."""
-    rows = [
-        _make_row(["ac-build", "ac-build/phase-0"]),
-    ]
-    with patch("agentception.db.queries.get_session", _mock_session_context(rows)):
-        result_empty = await get_initiatives("owner/repo", initiative_patterns=[])
-        result_none = await get_initiatives("owner/repo")
-    assert result_empty == []
-    assert result_none == []
+async def test_get_initiatives_empty_phases_returns_empty() -> None:
+    """No filings at all → no tabs, regardless of open issues."""
+    phases = _phase_rows([])
+    issues = _issue_rows([["any-label", "any-label/0-phase"]])
+
+    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+        result = await get_initiatives("owner/repo")
+
+    assert result == []
 
 
 @pytest.mark.anyio
@@ -169,5 +188,6 @@ async def test_get_initiatives_db_error_returns_empty() -> None:
     ctx_mock.__aexit__ = AsyncMock(return_value=False)
 
     with patch("agentception.db.queries.get_session", return_value=ctx_mock):
-        result = await get_initiatives("owner/repo", initiative_patterns=["ac-*"])
+        result = await get_initiatives("owner/repo")
+
     assert result == []


### PR DESCRIPTION
## Summary

- Removes `initiative_labels` from `ProjectConfig` and `pipeline-config.json` — no manual configuration needed to show initiative tabs.
- Rewrites `get_initiatives()` to join `initiative_phases` (filing history) with open issues: a tab appears automatically when a plan is filed and vanishes when all its issues close, ordered by most-recently-filed batch.
- Deletes `_initiative_patterns()`, `_label_matches_patterns()`, `_NON_INITIATIVE_LABELS`, and the `fnmatch` import.
- Rewrites `test_get_initiatives.py` against the new two-query behaviour (8 tests).

## Test plan

- [x] `mypy` — zero errors
- [x] `typing_audit --max-any 0` — passes
- [x] `pytest` — 1183 passed
- [x] `generate.py --check` — no drift