### PR TITLE
feat: data store audit — drop dead tables, fix live GitHub call on agent detail

### DIFF
--- a/agentception/alembic/versions/0005_drop_dead_tables.py
+++ b/agentception/alembic/versions/0005_drop_dead_tables.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Drop dead tables: role_versions and task_runs.
+
+``role_versions`` was written to by ``persist_role_version()`` but was never
+read back by any query function — the A/B role-version tracking reads from the
+``role-versions.json`` filesystem file instead.
+
+``task_runs`` was defined for a cognitive-architecture enrichment pipeline that
+is no longer active.  No query functions, routes, or MCP tools ever read from
+it.
+
+Both tables are dropped in a single migration to keep the history clean.
+
+Revision ID: 0005
+Revises: 0004
+"""
+
+from alembic import op
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_table("role_versions")
+    op.drop_table("task_runs")
+
+
+def downgrade() -> None:
+    # Recreate role_versions
+    import sqlalchemy as sa
+
+    op.create_table(
+        "role_versions",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("role_name", sa.String(128), nullable=False),
+        sa.Column("content_hash", sa.String(64), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("first_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("role_name", "content_hash", name="uq_role_versions"),
+    )
+    op.create_index("ix_role_versions_role_name", "role_versions", ["role_name"])
+
+    # Recreate task_runs
+    op.create_table(
+        "task_runs",
+        sa.Column("id", sa.String(256), nullable=False),
+        sa.Column("task_type", sa.String(128), nullable=False),
+        sa.Column("branch", sa.String(256), nullable=True),
+        sa.Column("commit_sha", sa.String(40), nullable=True),
+        sa.Column("payload_json", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(32), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_task_runs_task_type", "task_runs", ["task_type"])
+    op.create_index("ix_task_runs_status", "task_runs", ["status"])

--- a/agentception/db/models.py
+++ b/agentception/db/models.py
@@ -22,19 +22,9 @@ ACAgentMessage
     One row per message in an agent's Cursor transcript.  Written async so it
     never blocks the tick loop.  Enables full-text search and heuristics.
 
-ACRoleVersion
-    Content-addressed snapshot of a role prompt file.  New row only when the
-    SHA-256 hash of the file content changes — tracks prompt evolution over time.
-
 ACPipelineSnapshot
     Time-series: one row per poller tick.  Lightweight (no text blobs).
     Enables trend charts, SLA analysis, and anomaly detection.
-
-ACTaskRun
-    One row per agent task dispatched outside the GitHub issue workflow
-    (e.g. cognitive-arch enrichment, batch file editing).  Created pending
-    when the task file is generated; updated to completed/failed when the
-    agent commits or times out.  Physical task file deleted on completion.
 """
 
 import datetime
@@ -301,33 +291,6 @@ class ACAgentMessage(Base):
 
 
 # ---------------------------------------------------------------------------
-# ACRoleVersion — content-addressed role prompt snapshots
-# ---------------------------------------------------------------------------
-
-
-class ACRoleVersion(Base):
-    """Content-addressed snapshot of a role prompt file.
-
-    A new row is inserted only when the SHA-256 hash of the file content
-    changes, making this a full audit trail of every prompt change over time.
-    """
-
-    __tablename__ = "role_versions"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    role_name: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
-    content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
-    content: Mapped[str] = mapped_column(Text, nullable=False)
-    first_seen_at: Mapped[datetime.datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False
-    )
-
-    __table_args__ = (
-        UniqueConstraint("role_name", "content_hash", name="uq_role_versions"),
-    )
-
-
-# ---------------------------------------------------------------------------
 # ACPipelineSnapshot — time-series tick state
 # ---------------------------------------------------------------------------
 
@@ -410,53 +373,6 @@ class ACInitiativePhase(Base):
 
     __table_args__ = (
         Index("ix_initiative_phases_repo_initiative", "repo", "initiative"),
-    )
-
-
-# ---------------------------------------------------------------------------
-# ACTaskRun — ephemeral agent task lifecycle record
-# ---------------------------------------------------------------------------
-
-
-class ACTaskRun(Base):
-    """One row per agent task dispatched outside the GitHub issue workflow.
-
-    Created when a task file is generated (status=pending), updated to
-    completed when the agent commits, or failed if the physical file is
-    found without a corresponding commit after a timeout.  The physical
-    .agent-task file is deleted on transition to completed/failed so the
-    tasks directory never accumulates stale files.
-
-    Intentionally separate from ACAgentRun, which is tightly coupled to
-    the GitHub issue/PR lifecycle.  ACTaskRun covers batch file-editing
-    jobs, cognitive-arch enrichment runs, and any future non-issue tasks.
-    """
-
-    __tablename__ = "task_runs"
-
-    id: Mapped[str] = mapped_column(String(256), primary_key=True)
-    """Stable task identifier, e.g. ``cog-arch-systems-language-designers``."""
-
-    task_type: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
-    """Category of task, e.g. ``cognitive-arch-enrichment``."""
-
-    branch: Mapped[str | None] = mapped_column(String(256), nullable=True)
-    """Git branch the agent committed to, e.g. ``agent/cog-arch-systems-language-designers``."""
-
-    commit_sha: Mapped[str | None] = mapped_column(String(40), nullable=True)
-    """SHA of the agent's commit when status=completed."""
-
-    payload_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
-    """Task-specific metadata as JSON (figures list, batch name, etc.)."""
-
-    status: Mapped[str] = mapped_column(String(32), nullable=False, default="pending", index=True)
-    """pending | completed | failed"""
-
-    created_at: Mapped[datetime.datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False
-    )
-    completed_at: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
     )
 
 

--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -8,7 +8,6 @@ ACPipelineSnapshot  — one row per tick, always (lightweight scalars only).
 ACIssue / ACPullRequest — upsert on hash-diff: only write when content changes.
 ACAgentRun          — upsert on every tick so status transitions are recorded.
 ACAgentMessage      — fire-and-forget async task, never blocks the tick loop.
-ACRoleVersion       — insert-if-not-exists on role file content hash.
 
 All writes are wrapped in a single ``try/except`` so a DB outage never takes
 down the poller — the dashboard degrades gracefully to filesystem-only mode.
@@ -36,7 +35,6 @@ from agentception.db.models import (
     ACPipelineSnapshot,
     ACPRIssueLink,
     ACPullRequest,
-    ACRoleVersion,
     ACWave,
 )
 
@@ -882,42 +880,6 @@ async def _upsert_agent_runs(
             stale_pending.id,
             stale_pending.spawned_at,
         )
-
-
-# ---------------------------------------------------------------------------
-# Role version snapshot (content-addressed insert-if-new)
-# ---------------------------------------------------------------------------
-
-
-async def persist_role_version(role_name: str, content: str) -> None:
-    """Snapshot a role file if its content has changed since last seen.
-
-    Called at startup and whenever a role file is read.  Safe to call
-    concurrently — the unique constraint on (role_name, content_hash) acts
-    as the idempotency guard.
-    """
-    content_hash = _hash(content)
-    try:
-        async with get_session() as session:
-            result = await session.execute(
-                select(ACRoleVersion).where(
-                    ACRoleVersion.role_name == role_name,
-                    ACRoleVersion.content_hash == content_hash,
-                )
-            )
-            if result.scalar_one_or_none() is None:
-                session.add(
-                    ACRoleVersion(
-                        role_name=role_name,
-                        content_hash=content_hash,
-                        content=content,
-                        first_seen_at=_now(),
-                    )
-                )
-                await session.commit()
-                logger.info("📸 Role version snapshot: %s (%s…)", role_name, content_hash[:8])
-    except Exception as exc:
-        logger.warning("⚠️  persist_role_version failed (non-fatal): %s", exc)
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/routes/ui/agents.py
+++ b/agentception/routes/ui/agents.py
@@ -18,7 +18,9 @@ from agentception.db.queries import (
     AgentRunDetail,
     AgentRunRow,
     BoardIssueRow,
+    IssueDetailRow,
     SiblingRunRow,
+    get_issue_detail,
 )
 from agentception.models import AgentNode, PipelineState, VALID_ROLES
 from agentception.poller import get_state
@@ -622,13 +624,6 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
     pr_number: int | None = node.pr_number if node else None
     batch_id: str | None = node.batch_id if node else None
 
-    async def _safe_get_issue(n: int) -> dict[str, object]:
-        try:
-            from agentception.readers.github import get_issue as _get_issue
-            return await _get_issue(n)
-        except Exception:
-            return {}
-
     async def _safe_get_pr_checks(n: int) -> list[dict[str, object]]:
         try:
             from agentception.readers.github import get_pr_checks as _get_pr_checks
@@ -649,8 +644,8 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
         except Exception:
             return []
 
-    async def _noop_dict() -> dict[str, object]:
-        return {}
+    async def _noop_none() -> IssueDetailRow | None:
+        return None
 
     async def _noop_list_dict() -> list[dict[str, object]]:
         return []
@@ -666,12 +661,19 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
             return None
 
     events: list[AgentEventRow]
-    issue_detail: dict[str, object]
+    issue_detail: IssueDetailRow | None
     pr_checks: list[dict[str, object]]
     pr_reviews: list[dict[str, object]]
     siblings: list[SiblingRunRow]
 
     parent_run_id: str | None = node.parent_run_id if node else None
+
+    async def _safe_get_issue_from_db(n: int) -> IssueDetailRow | None:
+        try:
+            from agentception.config import settings as _settings
+            return await get_issue_detail(_settings.gh_repo, n)
+        except Exception:
+            return None
 
     (
         events,
@@ -681,7 +683,7 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
         siblings,
     ) = await asyncio.gather(
         get_agent_events_tail(agent_id),
-        _safe_get_issue(issue_number) if issue_number else _noop_dict(),
+        _safe_get_issue_from_db(issue_number) if issue_number else _noop_none(),
         _safe_get_pr_checks(pr_number) if pr_number else _noop_list_dict(),
         _safe_get_pr_reviews(pr_number) if pr_number else _noop_list_dict(),
         _safe_get_siblings(batch_id) if batch_id else _noop_list_sibling(),


### PR DESCRIPTION
## Summary

- **Drop `ac_role_versions`** — this table was write-only. `read_role_versions()` reads `.agentception/role-versions.json` from the filesystem, not the DB. Zero query functions ever read from it.
- **Drop `ac_task_runs`** — defined for a cognitive-arch enrichment pipeline that is no longer active. No routes, query functions, or MCP tools ever read from it.
- **Fix agent detail page** — replaces the live `get_issue()` GitHub API call with `get_issue_detail()` from Postgres. `ac_issues.body` is already synced every 5 s by the poller. PR CI checks and reviews stay as live calls since CI status is legitimately real-time.

Alembic migration `0005_drop_dead_tables` drops both tables from the live database.

## Test plan

- [x] `mypy` — zero errors (182 files)
- [x] `typing_audit --max-any 0` — passes
- [x] `pytest` — 1183 passed
- [x] `generate.py --check` — no drift
- [x] `alembic upgrade head` — migration applied cleanly