### PR TITLE
Open unlocked phases by default, collapse locked phases

### DIFF
--- a/agentception/templates/_build_board.html
+++ b/agentception/templates/_build_board.html
@@ -189,7 +189,7 @@
     {%- elif not group.issues %} build-swimlane__row--empty
     {%- else %} build-swimlane__row--active
     {%- endif %}"
-    x-data="{ open: {{ 'true' if (not group.locked and not group.complete and group.issues) else 'false' }} }"
+    x-data="{ open: {{ 'false' if group.locked else 'true' }} }"
     x-init='(function(){
       var k = {{ ("phase:" + group.label) | tojson }};
       var s = sessionStorage.getItem(k);


### PR DESCRIPTION
## Summary

- Unlocked phases (active, complete, or empty) now expand by default so the board immediately shows all actionable content.
- Locked phases collapse by default — they can't be acted on yet, so hiding their empty lanes reduces noise.
- User manual toggles are still persisted via `sessionStorage` and take precedence on subsequent page loads.

## Test plan

- [x] `pytest agentception/tests/test_build_board_partial.py` — 23 passed