### PR TITLE
fix: use single-quoted attribute for Design org tojson dispatch

### DIFF
--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -27,7 +27,7 @@
           <span class="build-header__stat-total">{{ total_issues }} total</span>
         </span>
         <button class="build-header__design-btn"
-                @click="$dispatch('open-org-designer', { label: '{{ initiative }}', repo: {{ repo | tojson }}, figures: window._orgFigures })">
+                @click='$dispatch("open-org-designer", { label: {{ initiative | tojson }}, repo: {{ repo | tojson }}, figures: window._orgFigures })'>
           Design org →
         </button>
         <span class="build-header__live" title="Board refreshes every 5 s">● LIVE</span>


### PR DESCRIPTION
## Summary

- `{{ repo | tojson }}` emits `"cgcardona/agentception"` (double-quoted JSON). Wrapping it in a double-quoted HTML attribute caused Alpine to see a truncated expression and throw `Unexpected token }`, so the overlay never opened.
- Fixed by switching the `@click` attribute to single quotes, with `tojson` for both `label` and `initiative` — exactly the pattern required by our standing rule.

## Test plan

- [x] `mypy` — 0 errors
- [x] `npm run build:css` — clean
- [x] Click "Design org →" in browser — overlay opens, D3 tree renders