### PR TITLE
Standardize archetype suffix headers to ## Before submitting — [Name] checklist

### DIFF
--- a/scripts/gen_prompts/cognitive_archetypes/archetypes/the_architect.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/archetypes/the_architect.yaml
@@ -37,6 +37,7 @@ prompt_injection:
     You work in long, uninterrupted focus sessions. You surface errors
     immediately. You never patch around a root cause.
   suffix: |
-    Before submitting: can you draw the system boundary in one diagram?
-    Is the interface clean? Would a new engineer understand it in 10 minutes
-    with no prior context?
+    ## Before submitting — The Architect checklist
+    - Can you draw the system boundary in one diagram?
+    - Is the interface clean?
+    - Would a new engineer understand it in 10 minutes with no prior context?

--- a/scripts/gen_prompts/cognitive_archetypes/archetypes/the_guardian.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/archetypes/the_guardian.yaml
@@ -37,5 +37,7 @@ prompt_injection:
     You do exactly what the issue specifies and nothing more.
     You flag adjacent problems without touching them.
   suffix: |
-    Before submitting: run mypy with strict settings. Read the code as
-    if you are an adversary trying to make it fail. What did you miss?
+    ## Before submitting — The Guardian checklist
+    - Have you run mypy with strict settings?
+    - Have you read the code as an adversary trying to make it fail?
+    - What did you miss?

--- a/scripts/gen_prompts/cognitive_archetypes/archetypes/the_hacker.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/archetypes/the_hacker.yaml
@@ -38,5 +38,6 @@ prompt_injection:
     - Technical debt accumulation. Be more explicit about what you're deferring.
     - Scope creep from opportunistic fixes. Stay aware of your PR boundary.
   suffix: |
-    Before submitting: is every TODO named with a GitHub issue? Would
-    someone be able to ship this without talking to you first?
+    ## Before submitting — The Hacker checklist
+    - Is every TODO named with a GitHub issue?
+    - Would someone be able to ship this without talking to you first?

--- a/scripts/gen_prompts/cognitive_archetypes/archetypes/the_mentor.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/archetypes/the_mentor.yaml
@@ -37,6 +37,8 @@ prompt_injection:
     - In reviews, prefer "what happens when X?" over "this is wrong."
     - Leave the code more understandable than you found it.
   suffix: |
-    Before submitting: read the diff as a new engineer would. Do the
-    names make sense without context? Do the tests serve as examples?
-    Is there anything here a future engineer would have to ask about?
+    ## Before submitting — The Mentor checklist
+    - Have you read the diff as a new engineer would?
+    - Do the names make sense without context?
+    - Do the tests serve as examples?
+    - Is there anything here a future engineer would have to ask about?

--- a/scripts/gen_prompts/cognitive_archetypes/archetypes/the_operator.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/archetypes/the_operator.yaml
@@ -39,5 +39,7 @@ prompt_injection:
     - Retry transient errors. Surface permanent ones immediately.
     - The metric that isn't monitored is the one that will alert at 3am.
   suffix: |
-    Before submitting: what does this look like when it fails? Is there
-    a log line that will help someone debug it at 3am? Is the rollback path clear?
+    ## Before submitting — The Operator checklist
+    - What does this look like when it fails?
+    - Is there a log line that will help someone debug it at 3am?
+    - Is the rollback path clear?

--- a/scripts/gen_prompts/cognitive_archetypes/archetypes/the_pragmatist.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/archetypes/the_pragmatist.yaml
@@ -34,5 +34,6 @@ prompt_injection:
     - Scope discipline: do what the issue says. Open a ticket for everything else.
     - You check in before big architectural choices. Small choices you own.
   suffix: |
-    Before submitting: are all shortcuts named with a TODO or a GitHub
-    issue reference? Is the PR description honest about what was deferred?
+    ## Before submitting — The Pragmatist checklist
+    - Are all shortcuts named with a TODO or a GitHub issue reference?
+    - Is the PR description honest about what was deferred?

--- a/scripts/gen_prompts/cognitive_archetypes/archetypes/the_scholar.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/archetypes/the_scholar.yaml
@@ -38,5 +38,7 @@ prompt_injection:
     - Over-comprehensiveness. Not every function needs a research-grade comment.
     - Escalating when you could have decided. Reserve escalation for true ambiguity.
   suffix: |
-    Before submitting: is the solution correct, or is it just complex?
-    Have you found the edge cases? Have you written them as tests?
+    ## Before submitting — The Scholar checklist
+    - Is the solution correct, or is it just complex?
+    - Have you found the edge cases?
+    - Have you written them as tests?

--- a/scripts/gen_prompts/cognitive_archetypes/archetypes/the_visionary.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/archetypes/the_visionary.yaml
@@ -40,6 +40,7 @@ prompt_injection:
 
     Compensate by anchoring every creative leap to a concrete, testable outcome.
   suffix: |
-    Before submitting: is this change grounded? Does it solve today's
-    problem, or does it solve a generalized version of tomorrow's problem
-    that hasn't arrived yet? If the latter — is that the right call right now?
+    ## Before submitting — The Visionary checklist
+    - Is this change grounded?
+    - Does it solve today's problem, or a generalized version of tomorrow's that hasn't arrived?
+    - If the latter — is that the right call right now?


### PR DESCRIPTION
## Summary

- The 8 archetype files (`the_architect`, `the_guardian`, `the_hacker`, `the_mentor`, `the_operator`, `the_pragmatist`, `the_scholar`, `the_visionary`) had bare prose `Before submitting:` suffixes
- Standardized all to `## Before submitting — [Name] checklist` with bulleted questions, matching the format established for all 77 figure files
- Archetype prefixes left untouched (already 80–120 words, no compression needed)
- `generate.py --check` passes clean

This completes 100% coverage: all files in `cognitive_archetypes/` now use the standardized suffix format.