### PR TITLE
Remove hardcoded von Neumann persona from CTO Identity section

### DIFF
--- a/.agentception/roles/ceo.md
+++ b/.agentception/roles/ceo.md
@@ -245,10 +245,10 @@ You are the CTO of the AgentCeption engineering pipeline. You are **autonomous a
 self-looping**. You run until GitHub shows zero open issues (across your team labels)
 and zero open PRs. You see the entire board. You dispatch coordinators. You never touch code.
 
-You think like von Neumann — you hold the full system state in your head,
-cross-reference implementation queue against review queue on every wave, and
-optimise throughput at the pipeline level, not the ticket level. You are
-relentlessly systematic and never make allocation decisions from intuition alone.
+Your cognitive architecture — who you think like and what mental models you bring to every
+decision — is loaded from your `.agent-task` file in STEP 0. Do not assume a persona
+before reading it. The architecture determines how you reason about the pipeline, not
+the role description above.
 
 ## Quality bar (propagates to all agents you dispatch)
 

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -7,10 +7,10 @@ You are the CTO of the AgentCeption engineering pipeline. You are **autonomous a
 self-looping**. You run until GitHub shows zero open issues (across your team labels)
 and zero open PRs. You see the entire board. You dispatch coordinators. You never touch code.
 
-You think like von Neumann — you hold the full system state in your head,
-cross-reference implementation queue against review queue on every wave, and
-optimise throughput at the pipeline level, not the ticket level. You are
-relentlessly systematic and never make allocation decisions from intuition alone.
+Your cognitive architecture — who you think like and what mental models you bring to every
+decision — is loaded from your `.agent-task` file in STEP 0. Do not assume a persona
+before reading it. The architecture determines how you reason about the pipeline, not
+the role description above.
 
 ## Quality bar (propagates to all agents you dispatch)
 

--- a/scripts/gen_prompts/templates/roles/cto.md.j2
+++ b/scripts/gen_prompts/templates/roles/cto.md.j2
@@ -6,10 +6,10 @@ You are the CTO of the AgentCeption engineering pipeline. You are **autonomous a
 self-looping**. You run until GitHub shows zero open issues (across your team labels)
 and zero open PRs. You see the entire board. You dispatch coordinators. You never touch code.
 
-You think like von Neumann — you hold the full system state in your head,
-cross-reference implementation queue against review queue on every wave, and
-optimise throughput at the pipeline level, not the ticket level. You are
-relentlessly systematic and never make allocation decisions from intuition alone.
+Your cognitive architecture — who you think like and what mental models you bring to every
+decision — is loaded from your `.agent-task` file in STEP 0. Do not assume a persona
+before reading it. The architecture determines how you reason about the pipeline, not
+the role description above.
 
 ## Quality bar (propagates to all agents you dispatch)
 


### PR DESCRIPTION
## Summary

The CTO `Identity` block contained a hardcoded `"You think like von Neumann"` sentence — cognitive architecture bleed where the figure was baked into the prompt text rather than being injected through `COGNITIVE_ARCH` at runtime.

This is the same pattern every other role avoids: persona is loaded from `.agent-task` via the `arch-load` snippet in STEP 0, not declared in the static Identity section.

## What changed

- `cto.md.j2`: replaced 4-line hardcoded von Neumann persona with a forward reference to STEP 0, making explicit that `.agent-task` determines reasoning style
- Regenerated `.agentception/roles/cto.md` and `.agentception/roles/ceo.md` (which embeds the CTO role)

## Test plan

- [x] `generate.py --check` — 0 drift
- [x] No other templates have this pattern (searched all `.j2` files)