### PR TITLE
Remove status/* labels from taxonomy

### DIFF
--- a/.agentception/agent-conductor.md
+++ b/.agentception/agent-conductor.md
@@ -54,8 +54,8 @@ Pipeline state lives entirely in GitHub. No external database, no sidecar files.
 | Open issues with `batch-NN` label | Issues not yet implemented — ready for ISSUE_TO_PR |
 | Open PRs linked to `batch-NN` issues | PRs awaiting review — ready for PR_REVIEW |
 | Closed issues | Implemented and merged |
-| Open issues with `status/in-progress` | ISSUE_TO_PR agent currently working |
-| Open PRs with `status/pr-open` | PR_REVIEW agent dispatched but not yet merged |
+| Open issues with `agent/wip` | Leaf agent currently working |
+| Open PRs linked to open issues | PR_REVIEW agent dispatched but not yet merged |
 | `conductor-reminder` issue open | Pipeline was incomplete on last conductor run |
 
 ### Phase dependency order

--- a/.agentception/agent-engineer.md
+++ b/.agentception/agent-engineer.md
@@ -571,9 +571,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
   you have confirmed no prior work exists. This is the idempotency gate.
 
-  # Mark issue as in-progress so the conductor and other agents see it's claimed.
-  # MCP: github_add_label(issue_number=N, label="status/in-progress")
-
   # Leave an audit trail: which cognitive identity claimed this issue.
   AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
   CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -646,7 +643,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   └──────────────────────────────────────────────────────────────────────────┘
 
   Self-destruct when stopping early:
-    # MCP: github_remove_label(issue_number=N, label="status/in-progress")
     # MCP: github_remove_label(issue_number=N, label="agent/wip")
     WORKTREE=$(pwd)
     cd "$REPO"
@@ -1053,10 +1049,6 @@ STEP 5 — PUSH & CREATE PR:
   fi
   # MCP: add_issue_comment(owner="cgcardona", repo="agentception", issue_number=N,
   #   body="🤖 **Implemented by agent** — PR #${MY_PR_NUM:-?}\n\n$IMPL_FINGERPRINT")
-
-  # Transition status label: in-progress → pr-open
-  # MCP: github_remove_label(issue_number=N, label="status/in-progress")
-  # MCP: github_add_label(issue_number=N, label="status/pr-open")
 
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"

--- a/.agentception/agent-reviewer.md
+++ b/.agentception/agent-reviewer.md
@@ -1134,9 +1134,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   CLOSES_ISSUES_FOR_LABEL=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(str(x) for x in d.get('target',{}).get('closes',[])))")
   if [ -n "$CLOSES_ISSUES_FOR_LABEL" ]; then
     # For each issue in CLOSES_ISSUES_FOR_LABEL:
-    # MCP: github_remove_label(issue_number=<N>, label="status/pr-open")
-    # MCP: github_add_label(issue_number=<N>, label="status/merged")
-    echo "Update issue labels via MCP github_remove_label + github_add_label"
+    echo "Issues closed automatically via PR merge (Closes #N in PR body)"
   fi
 
   # 9. Pull the merge into the main repo's local dev — so the coordinator's

--- a/.agentception/roles/ceo.md
+++ b/.agentception/roles/ceo.md
@@ -1334,9 +1334,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
   you have confirmed no prior work exists. This is the idempotency gate.
 
-  # Mark issue as in-progress so the conductor and other agents see it's claimed.
-  # MCP: github_add_label(issue_number=N, label="status/in-progress")
-
   # Leave an audit trail: which cognitive identity claimed this issue.
   AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
   CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -1409,7 +1406,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   └──────────────────────────────────────────────────────────────────────────┘
 
   Self-destruct when stopping early:
-    # MCP: github_remove_label(issue_number=N, label="status/in-progress")
     # MCP: github_remove_label(issue_number=N, label="agent/wip")
     WORKTREE=$(pwd)
     cd "$REPO"
@@ -1816,10 +1812,6 @@ STEP 5 — PUSH & CREATE PR:
   fi
   # MCP: add_issue_comment(owner="cgcardona", repo="agentception", issue_number=N,
   #   body="🤖 **Implemented by agent** — PR #${MY_PR_NUM:-?}\n\n$IMPL_FINGERPRINT")
-
-  # Transition status label: in-progress → pr-open
-  # MCP: github_remove_label(issue_number=N, label="status/in-progress")
-  # MCP: github_add_label(issue_number=N, label="status/pr-open")
 
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"
@@ -3563,9 +3555,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   CLOSES_ISSUES_FOR_LABEL=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(str(x) for x in d.get('target',{}).get('closes',[])))")
   if [ -n "$CLOSES_ISSUES_FOR_LABEL" ]; then
     # For each issue in CLOSES_ISSUES_FOR_LABEL:
-    # MCP: github_remove_label(issue_number=<N>, label="status/pr-open")
-    # MCP: github_add_label(issue_number=<N>, label="status/merged")
-    echo "Update issue labels via MCP github_remove_label + github_add_label"
+    echo "Issues closed automatically via PR merge (Closes #N in PR body)"
   fi
 
   # 9. Pull the merge into the main repo's local dev — so the coordinator's
@@ -5479,9 +5469,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   CLOSES_ISSUES_FOR_LABEL=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(str(x) for x in d.get('target',{}).get('closes',[])))")
   if [ -n "$CLOSES_ISSUES_FOR_LABEL" ]; then
     # For each issue in CLOSES_ISSUES_FOR_LABEL:
-    # MCP: github_remove_label(issue_number=<N>, label="status/pr-open")
-    # MCP: github_add_label(issue_number=<N>, label="status/merged")
-    echo "Update issue labels via MCP github_remove_label + github_add_label"
+    echo "Issues closed automatically via PR merge (Closes #N in PR body)"
   fi
 
   # 9. Pull the merge into the main repo's local dev — so the coordinator's
@@ -6659,9 +6647,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
   you have confirmed no prior work exists. This is the idempotency gate.
 
-  # Mark issue as in-progress so the conductor and other agents see it's claimed.
-  # MCP: github_add_label(issue_number=N, label="status/in-progress")
-
   # Leave an audit trail: which cognitive identity claimed this issue.
   AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
   CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -6734,7 +6719,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   └──────────────────────────────────────────────────────────────────────────┘
 
   Self-destruct when stopping early:
-    # MCP: github_remove_label(issue_number=N, label="status/in-progress")
     # MCP: github_remove_label(issue_number=N, label="agent/wip")
     WORKTREE=$(pwd)
     cd "$REPO"
@@ -7141,10 +7125,6 @@ STEP 5 — PUSH & CREATE PR:
   fi
   # MCP: add_issue_comment(owner="cgcardona", repo="agentception", issue_number=N,
   #   body="🤖 **Implemented by agent** — PR #${MY_PR_NUM:-?}\n\n$IMPL_FINGERPRINT")
-
-  # Transition status label: in-progress → pr-open
-  # MCP: github_remove_label(issue_number=N, label="status/in-progress")
-  # MCP: github_add_label(issue_number=N, label="status/pr-open")
 
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"

--- a/.agentception/roles/coordinator.md
+++ b/.agentception/roles/coordinator.md
@@ -132,16 +132,15 @@ Full schema, invariants, and API details: `docs/guides/integrate.md` (§ ENRICHE
 
 ## Pipeline State
 
-Read from GitHub labels only:
+Issue lifecycle is determined by GitHub state — not by labels:
 
-| Label | Meaning |
-|-------|---------|
-| `status/ready` | Queued, no agent started |
-| `status/in-progress` | Agent working — check for open PR |
-| `status/pr-open` | PR awaiting review |
-| `status/merged` | Done |
+| GitHub state | Meaning |
+|--------------|---------|
+| Open, no `agent/wip` | Queued — not yet claimed |
+| Open, has `agent/wip` | Claimed — agent running |
+| Closed via merged PR | Done |
 
-`status/in-progress` with no open PR and no recent activity = orphan. Remove the label and re-queue.
+Open issue with `agent/wip` but no recent agent activity = orphan. Remove `agent/wip` and re-queue.
 
 ## ATTEMPT_N Anti-Loop Guard
 

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -1096,9 +1096,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
   you have confirmed no prior work exists. This is the idempotency gate.
 
-  # Mark issue as in-progress so the conductor and other agents see it's claimed.
-  # MCP: github_add_label(issue_number=N, label="status/in-progress")
-
   # Leave an audit trail: which cognitive identity claimed this issue.
   AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
   CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -1171,7 +1168,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   └──────────────────────────────────────────────────────────────────────────┘
 
   Self-destruct when stopping early:
-    # MCP: github_remove_label(issue_number=N, label="status/in-progress")
     # MCP: github_remove_label(issue_number=N, label="agent/wip")
     WORKTREE=$(pwd)
     cd "$REPO"
@@ -1578,10 +1574,6 @@ STEP 5 — PUSH & CREATE PR:
   fi
   # MCP: add_issue_comment(owner="cgcardona", repo="agentception", issue_number=N,
   #   body="🤖 **Implemented by agent** — PR #${MY_PR_NUM:-?}\n\n$IMPL_FINGERPRINT")
-
-  # Transition status label: in-progress → pr-open
-  # MCP: github_remove_label(issue_number=N, label="status/in-progress")
-  # MCP: github_add_label(issue_number=N, label="status/pr-open")
 
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"
@@ -3325,9 +3317,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   CLOSES_ISSUES_FOR_LABEL=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(str(x) for x in d.get('target',{}).get('closes',[])))")
   if [ -n "$CLOSES_ISSUES_FOR_LABEL" ]; then
     # For each issue in CLOSES_ISSUES_FOR_LABEL:
-    # MCP: github_remove_label(issue_number=<N>, label="status/pr-open")
-    # MCP: github_add_label(issue_number=<N>, label="status/merged")
-    echo "Update issue labels via MCP github_remove_label + github_add_label"
+    echo "Issues closed automatically via PR merge (Closes #N in PR body)"
   fi
 
   # 9. Pull the merge into the main repo's local dev — so the coordinator's
@@ -5241,9 +5231,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   CLOSES_ISSUES_FOR_LABEL=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(str(x) for x in d.get('target',{}).get('closes',[])))")
   if [ -n "$CLOSES_ISSUES_FOR_LABEL" ]; then
     # For each issue in CLOSES_ISSUES_FOR_LABEL:
-    # MCP: github_remove_label(issue_number=<N>, label="status/pr-open")
-    # MCP: github_add_label(issue_number=<N>, label="status/merged")
-    echo "Update issue labels via MCP github_remove_label + github_add_label"
+    echo "Issues closed automatically via PR merge (Closes #N in PR body)"
   fi
 
   # 9. Pull the merge into the main repo's local dev — so the coordinator's
@@ -6421,9 +6409,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
   you have confirmed no prior work exists. This is the idempotency gate.
 
-  # Mark issue as in-progress so the conductor and other agents see it's claimed.
-  # MCP: github_add_label(issue_number=N, label="status/in-progress")
-
   # Leave an audit trail: which cognitive identity claimed this issue.
   AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
   CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -6496,7 +6481,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   └──────────────────────────────────────────────────────────────────────────┘
 
   Self-destruct when stopping early:
-    # MCP: github_remove_label(issue_number=N, label="status/in-progress")
     # MCP: github_remove_label(issue_number=N, label="agent/wip")
     WORKTREE=$(pwd)
     cd "$REPO"
@@ -6903,10 +6887,6 @@ STEP 5 — PUSH & CREATE PR:
   fi
   # MCP: add_issue_comment(owner="cgcardona", repo="agentception", issue_number=N,
   #   body="🤖 **Implemented by agent** — PR #${MY_PR_NUM:-?}\n\n$IMPL_FINGERPRINT")
-
-  # Transition status label: in-progress → pr-open
-  # MCP: github_remove_label(issue_number=N, label="status/in-progress")
-  # MCP: github_add_label(issue_number=N, label="status/pr-open")
 
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -821,9 +821,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
   you have confirmed no prior work exists. This is the idempotency gate.
 
-  # Mark issue as in-progress so the conductor and other agents see it's claimed.
-  # MCP: github_add_label(issue_number=N, label="status/in-progress")
-
   # Leave an audit trail: which cognitive identity claimed this issue.
   AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
   CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -896,7 +893,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   └──────────────────────────────────────────────────────────────────────────┘
 
   Self-destruct when stopping early:
-    # MCP: github_remove_label(issue_number=N, label="status/in-progress")
     # MCP: github_remove_label(issue_number=N, label="agent/wip")
     WORKTREE=$(pwd)
     cd "$REPO"
@@ -1303,10 +1299,6 @@ STEP 5 — PUSH & CREATE PR:
   fi
   # MCP: add_issue_comment(owner="cgcardona", repo="agentception", issue_number=N,
   #   body="🤖 **Implemented by agent** — PR #${MY_PR_NUM:-?}\n\n$IMPL_FINGERPRINT")
-
-  # Transition status label: in-progress → pr-open
-  # MCP: github_remove_label(issue_number=N, label="status/in-progress")
-  # MCP: github_add_label(issue_number=N, label="status/pr-open")
 
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"
@@ -3050,9 +3042,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   CLOSES_ISSUES_FOR_LABEL=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(str(x) for x in d.get('target',{}).get('closes',[])))")
   if [ -n "$CLOSES_ISSUES_FOR_LABEL" ]; then
     # For each issue in CLOSES_ISSUES_FOR_LABEL:
-    # MCP: github_remove_label(issue_number=<N>, label="status/pr-open")
-    # MCP: github_add_label(issue_number=<N>, label="status/merged")
-    echo "Update issue labels via MCP github_remove_label + github_add_label"
+    echo "Issues closed automatically via PR merge (Closes #N in PR body)"
   fi
 
   # 9. Pull the merge into the main repo's local dev — so the coordinator's

--- a/.agentception/roles/qa-coordinator.md
+++ b/.agentception/roles/qa-coordinator.md
@@ -1306,9 +1306,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   CLOSES_ISSUES_FOR_LABEL=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(str(x) for x in d.get('target',{}).get('closes',[])))")
   if [ -n "$CLOSES_ISSUES_FOR_LABEL" ]; then
     # For each issue in CLOSES_ISSUES_FOR_LABEL:
-    # MCP: github_remove_label(issue_number=<N>, label="status/pr-open")
-    # MCP: github_add_label(issue_number=<N>, label="status/merged")
-    echo "Update issue labels via MCP github_remove_label + github_add_label"
+    echo "Issues closed automatically via PR merge (Closes #N in PR body)"
   fi
 
   # 9. Pull the merge into the main repo's local dev — so the coordinator's
@@ -2486,9 +2484,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
   you have confirmed no prior work exists. This is the idempotency gate.
 
-  # Mark issue as in-progress so the conductor and other agents see it's claimed.
-  # MCP: github_add_label(issue_number=N, label="status/in-progress")
-
   # Leave an audit trail: which cognitive identity claimed this issue.
   AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
   CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -2561,7 +2556,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   └──────────────────────────────────────────────────────────────────────────┘
 
   Self-destruct when stopping early:
-    # MCP: github_remove_label(issue_number=N, label="status/in-progress")
     # MCP: github_remove_label(issue_number=N, label="agent/wip")
     WORKTREE=$(pwd)
     cd "$REPO"
@@ -2968,10 +2962,6 @@ STEP 5 — PUSH & CREATE PR:
   fi
   # MCP: add_issue_comment(owner="cgcardona", repo="agentception", issue_number=N,
   #   body="🤖 **Implemented by agent** — PR #${MY_PR_NUM:-?}\n\n$IMPL_FINGERPRINT")
-
-  # Transition status label: in-progress → pr-open
-  # MCP: github_remove_label(issue_number=N, label="status/in-progress")
-  # MCP: github_add_label(issue_number=N, label="status/pr-open")
 
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"

--- a/agentception/routes/api/control.py
+++ b/agentception/routes/api/control.py
@@ -657,7 +657,7 @@ async def spawn_coordinator(body: SpawnCoordinatorRequest) -> SpawnCoordinatorRe
     ``agent-triage.md``.  The agent will:
 
     1. Run the Phase Planner against the ``BRAIN_DUMP`` field.
-    2. Create required GitHub labels (phase-N/*, status/*, priority/*).
+    2. Create required GitHub labels (phase/*, priority/*, type/*, gate/*).
     3. Create one sub-worktree per phase-batch.
     4. Write ``.agent-task`` files for each sub-agent.
     5. Launch sub-agents via the Cursor Task tool.

--- a/scripts/gen_prompts/config.yaml
+++ b/scripts/gen_prompts/config.yaml
@@ -52,7 +52,6 @@ codebases:
 #   phase/N      → ordering (coordinator reads to find active phase)
 #   batch/X      → milestone / sprint grouping
 #   priority/X   → urgency within a phase
-#   status/X     → lifecycle state written by agents
 #   gate/X       → human approval required before dispatch
 #   type/X       → classification of work
 #
@@ -187,22 +186,6 @@ labels:
     - name: "priority/low"
       color: "a2eeef"
       description: "Nice to have — do after higher-priority items"
-
-  # ── Status namespace ─────────────────────────────────────────────────────────────
-  # Lifecycle state written by agents as work progresses.
-  statuses:
-    - name: "status/ready"
-      color: "ffffff"
-      description: "Queued and ready for dispatch — no agent working yet"
-    - name: "status/in-progress"
-      color: "0075ca"
-      description: "Agent implementation underway"
-    - name: "status/pr-open"
-      color: "e8a2f4"
-      description: "PR created — awaiting review"
-    - name: "status/merged"
-      color: "198754"
-      description: "PR merged and closed"
 
   # ── Gate namespace ─────────────────────────────────────────────────────────────
   # Human approval required before agents can dispatch these items.

--- a/scripts/gen_prompts/sync_labels.sh
+++ b/scripts/gen_prompts/sync_labels.sh
@@ -62,12 +62,6 @@ sync_label 'priority/high' 'e67e22' 'High priority — do this wave'
 sync_label 'priority/medium' 'f59f00' 'Normal priority'
 sync_label 'priority/low' 'a2eeef' 'Nice to have — do after higher-priority items'
 
-echo '── Statuses ────────────────────────────────────────────────'
-sync_label 'status/ready' 'ffffff' 'Queued and ready for dispatch — no agent working yet'
-sync_label 'status/in-progress' '0075ca' 'Agent implementation underway'
-sync_label 'status/pr-open' 'e8a2f4' 'PR created — awaiting review'
-sync_label 'status/merged' '198754' 'PR merged and closed'
-
 echo '── Gates ───────────────────────────────────────────────────'
 sync_label 'gate/db-migration' 'd63939' 'Human gate: Alembic migration — verify MERGE_AFTER chain first'
 sync_label 'gate/security' 'd73a4a' 'Human gate: security review required before dispatch'

--- a/scripts/gen_prompts/templates/agent-conductor.md.j2
+++ b/scripts/gen_prompts/templates/agent-conductor.md.j2
@@ -54,8 +54,8 @@ Pipeline state lives entirely in GitHub. No external database, no sidecar files.
 | Open issues with `batch-NN` label | Issues not yet implemented — ready for ISSUE_TO_PR |
 | Open PRs linked to `batch-NN` issues | PRs awaiting review — ready for PR_REVIEW |
 | Closed issues | Implemented and merged |
-| Open issues with `status/in-progress` | ISSUE_TO_PR agent currently working |
-| Open PRs with `status/pr-open` | PR_REVIEW agent dispatched but not yet merged |
+| Open issues with `agent/wip` | Leaf agent currently working |
+| Open PRs linked to open issues | PR_REVIEW agent dispatched but not yet merged |
 | `conductor-reminder` issue open | Pipeline was incomplete on last conductor run |
 
 ### Phase dependency order

--- a/scripts/gen_prompts/templates/agent-engineer.md.j2
+++ b/scripts/gen_prompts/templates/agent-engineer.md.j2
@@ -401,9 +401,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   ⚠️  Query GitHub first. Do NOT create a branch, write a file, or run mypy until
   you have confirmed no prior work exists. This is the idempotency gate.
 
-  # Mark issue as in-progress so the conductor and other agents see it's claimed.
-  # MCP: github_add_label(issue_number=N, label="status/in-progress")
-
   # Leave an audit trail: which cognitive identity claimed this issue.
   AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
   CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
@@ -451,7 +448,6 @@ STEP 2 — CHECK CANONICAL STATE BEFORE DOING ANY WORK:
   └──────────────────────────────────────────────────────────────────────────┘
 
   Self-destruct when stopping early:
-    # MCP: github_remove_label(issue_number=N, label="status/in-progress")
     # MCP: github_remove_label(issue_number=N, label="{{ claim_label }}")
     WORKTREE=$(pwd)
     cd "$REPO"
@@ -698,10 +694,6 @@ STEP 5 — PUSH & CREATE PR:
 {{ fingerprint_block("IMPL_FINGERPRINT", "python-developer", "$PR_CREATED_AT") }}
   # MCP: add_issue_comment(owner="cgcardona", repo="agentception", issue_number=N,
   #   body="🤖 **Implemented by agent** — PR #${MY_PR_NUM:-?}\n\n$IMPL_FINGERPRINT")
-
-  # Transition status label: in-progress → pr-open
-  # MCP: github_remove_label(issue_number=N, label="status/in-progress")
-  # MCP: github_add_label(issue_number=N, label="status/pr-open")
 
   ⚠️  VERIFY AUTO-CLOSE LINKAGE — verify immediately after PR creation:
   # GitHub auto-closes issue #<N> when the PR is merged ONLY if "Closes #<N>"

--- a/scripts/gen_prompts/templates/agent-reviewer.md.j2
+++ b/scripts/gen_prompts/templates/agent-reviewer.md.j2
@@ -810,9 +810,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   CLOSES_ISSUES_FOR_LABEL=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(','.join(str(x) for x in d.get('target',{}).get('closes',[])))")
   if [ -n "$CLOSES_ISSUES_FOR_LABEL" ]; then
     # For each issue in CLOSES_ISSUES_FOR_LABEL:
-    # MCP: github_remove_label(issue_number=<N>, label="status/pr-open")
-    # MCP: github_add_label(issue_number=<N>, label="status/merged")
-    echo "Update issue labels via MCP github_remove_label + github_add_label"
+    echo "Issues closed automatically via PR merge (Closes #N in PR body)"
   fi
 
   # 9. Pull the merge into the main repo's local dev — so the coordinator's

--- a/scripts/gen_prompts/templates/roles/coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/coordinator.md.j2
@@ -110,16 +110,15 @@ Full schema, invariants, and API details: `docs/guides/integrate.md` (§ ENRICHE
 
 ## Pipeline State
 
-Read from GitHub labels only:
+Issue lifecycle is determined by GitHub state — not by labels:
 
-| Label | Meaning |
-|-------|---------|
-| `status/ready` | Queued, no agent started |
-| `status/in-progress` | Agent working — check for open PR |
-| `status/pr-open` | PR awaiting review |
-| `status/merged` | Done |
+| GitHub state | Meaning |
+|--------------|---------|
+| Open, no `agent/wip` | Queued — not yet claimed |
+| Open, has `agent/wip` | Claimed — agent running |
+| Closed via merged PR | Done |
 
-`status/in-progress` with no open PR and no recent activity = orphan. Remove the label and re-queue.
+Open issue with `agent/wip` but no recent agent activity = orphan. Remove `agent/wip` and re-queue.
 
 ## ATTEMPT_N Anti-Loop Guard
 


### PR DESCRIPTION
## Summary
- Deleted `status/ready`, `status/in-progress`, `status/pr-open`, `status/merged` from `config.yaml` — they were redundant with the DB-computed Kanban lanes
- Removed all `status/*` label operations from `agent-engineer.md.j2`, `agent-reviewer.md.j2`, `agent-conductor.md.j2`, and `coordinator.md.j2`
- `coordinator.md.j2` pipeline state table now documents GitHub state (open/closed + `agent/wip`) as the signal, not labels
- `sync_labels.sh` regenerated — no `status/*` entries
- `control.py` docstring updated

## Why
The `status/*` labels were decorative — they mirrored what the DB already computes deterministically from agent run records, PR state, and issue closed state. Keeping them created an implicit dual-write contract that agents would eventually violate, causing label/lane divergence.

## Test plan
- [x] `mypy agentception/ tests/` — zero errors
- [x] `pytest tests/ -q` — 73 passed
- [x] `generate.py --check` — no drift