### PR TITLE
fix: exclude taxonomy namespaces from initiative slug extraction

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -24,6 +24,13 @@ from typing import TYPE_CHECKING, TypedDict
 
 from sqlalchemy import select
 
+# Label namespace prefixes that are part of the taxonomy and must never be
+# interpreted as initiative slugs.  Any label whose prefix-before-"/" matches
+# one of these is a taxonomy label, not a plan-pipeline initiative.
+_TAXONOMY_NAMESPACES: frozenset[str] = frozenset(
+    {"agent", "batch", "gate", "phase", "priority", "team", "type"}
+)
+
 from agentception.db.engine import get_session
 from agentception.db.models import (
     ACAgentEvent,
@@ -629,14 +636,16 @@ async def _recompute_workflow_state(session: object, repo: str) -> list[str]:
         issue_num = issue.github_number
         issue_labels: list[str] = json.loads(issue.labels_json or "[]")
 
-        # Derive initiative and phase from labels.
+        # Derive initiative and phase from labels — skip taxonomy namespaces.
         initiative: str | None = None
         phase_key: str | None = None
         for lbl in issue_labels:
             if "/" in lbl:
-                initiative = lbl.split("/")[0]
-                phase_key = lbl
-                break
+                slug = lbl.split("/")[0]
+                if slug not in _TAXONOMY_NAMESPACES:
+                    initiative = slug
+                    phase_key = lbl
+                    break
 
         # Get best PR for this issue.
         issue_candidates = [c for c in all_candidates if c["issue_number"] == issue_num]
@@ -1338,7 +1347,8 @@ async def reseed_missing_initiative_phases(repo: str) -> None:
                 for lbl in labels:
                     if "/" in lbl:
                         slug, _, _ = lbl.partition("/")
-                        initiative_phase_labels.setdefault(slug, set()).add(lbl)
+                        if slug not in _TAXONOMY_NAMESPACES:
+                            initiative_phase_labels.setdefault(slug, set()).add(lbl)
 
             for initiative, phase_label_set in initiative_phase_labels.items():
                 # Skip if the dep graph already exists for this repo+initiative.

--- a/agentception/tests/test_reseed_initiative_phases.py
+++ b/agentception/tests/test_reseed_initiative_phases.py
@@ -162,3 +162,36 @@ async def test_reseed_skips_initiative_with_no_scoped_labels() -> None:
         await reseed_missing_initiative_phases("owner/repo")
 
     assert captured == [], "No scoped labels → nothing to reseed"
+
+
+@pytest.mark.anyio
+async def test_reseed_ignores_taxonomy_namespace_labels() -> None:
+    """Taxonomy labels (team/*, phase/*, priority/*, type/*, etc.) must never
+    be treated as initiative slugs even when they contain a '/'."""
+    issues = [
+        # issue #285-style: taxonomy labels only, no plan-pipeline initiative label
+        _mock_issue(
+            ["team/engineering", "phase/0", "priority/medium", "type/testing", "smoke-test"]
+        ),
+    ]
+    captured: list[str] = []
+
+    async def fake_persist(
+        repo: str, initiative: str, batch_id: str, phases: list[PhaseEntry]
+    ) -> None:
+        captured.append(initiative)
+
+    ctx = _make_session_ctx(issues, has_existing_phase=False)
+    with (
+        patch("agentception.db.persist.get_session", return_value=ctx),
+        patch(
+            "agentception.db.persist.persist_initiative_phases",
+            side_effect=fake_persist,
+        ),
+    ):
+        await reseed_missing_initiative_phases("owner/repo")
+
+    assert captured == [], (
+        "team/*, phase/*, priority/*, type/* are taxonomy labels — "
+        "they must not be registered as initiative slugs"
+    )


### PR DESCRIPTION
## Summary
- `team/*`, `phase/*`, `priority/*`, `type/*`, `gate/*`, `agent/*`, `batch/*` are taxonomy labels — not plan-pipeline initiatives
- `reseed_missing_initiative_phases` was treating any label containing `/` as an initiative slug, so `team/engineering` → `team`, `phase/0` → `phase`, etc. got registered in `ACInitiativePhase`
- This polluted the Mission Control tab bar with spurious namespace tabs (`type | team | priority | phase | …`)
- Fix: add `_TAXONOMY_NAMESPACES` constant and guard both label-extraction sites in `persist.py`
- Regression test added: `test_reseed_ignores_taxonomy_namespace_labels`
- Also deleted the 4 bad rows already in the live DB via direct SQL

## Test plan
- [ ] Navigate to `/ship` — tab bar shows only legitimate initiative slugs, no `type`/`team`/`phase`/`priority` tabs