### PR TITLE
feat: add cascade_enabled flag for incremental CEO smoke-test mode

### DIFF
--- a/.agentception/roles/ceo.md
+++ b/.agentception/roles/ceo.md
@@ -176,6 +176,54 @@ Never loop a stuck agent.
 - Assuming GitHub state without querying it.
 
 
+## STEP 0.5 — CHECK CASCADE MODE
+
+```bash
+CASCADE_ENABLED=$(python3 -c "
+import tomllib
+d = tomllib.loads(open('.agent-task').read())
+print(str(d.get('spawn', {}).get('cascade_enabled', True)).lower())
+" 2>/dev/null || echo "true")
+RUN_ID=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('meta', {}).get('run_id', ''))" 2>/dev/null || echo "")
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+```
+
+If `CASCADE_ENABLED` is **`false`** — this is a diagnostic smoke-test run.
+**Do NOT query GitHub. Do NOT dispatch any children.** Instead:
+
+1. Output this block verbatim as visible text:
+
+```
+✅ CEO smoke test — pipeline node verified.
+
+  Role:              $ROLE
+  Cognitive arch:    $COGNITIVE_ARCH
+  Run ID:            $RUN_ID
+  Timestamp:         $TIMESTAMP
+  cascade_enabled:   false — no children dispatched.
+```
+
+2. Call the AgentCeption MCP tools (server: `agentception`):
+
+```
+log_run_step(
+  issue_number=0,
+  step_name="CEO smoke test — cognitive arch loaded: {COGNITIVE_ARCH} at {TIMESTAMP}",
+  agent_run_id="{RUN_ID}"
+)
+
+build_complete_run(
+  issue_number=0,
+  pr_url="",
+  summary="CEO smoke test complete. Role={ROLE} Arch={COGNITIVE_ARCH} Timestamp={TIMESTAMP}",
+  agent_run_id="{RUN_ID}"
+)
+```
+
+3. **Stop here.** Do not proceed to STEP 1.
+
+---
+
 ## STEP 1 — SURVEY: Discover Active Teams
 
 ```

--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -417,6 +417,15 @@ class LabelDispatchRequest(BaseModel):
     the launched agent knows the exact hierarchy it is expected to spawn.
     When absent the agent infers its own team structure from the ticket list.
     """
+    cascade_enabled: bool = True
+    """When False the launched agent must not spawn any child agents.
+
+    Used for incremental smoke-testing: prove one tier works before wiring it
+    to the next.  The agent reads this flag from ``[spawn].cascade_enabled``
+    in its ``.agent-task`` and, if False, outputs its self-introduction,
+    calls ``log_run_step`` + ``build_complete_run`` via MCP, and exits without
+    querying GitHub or dispatching children.
+    """
 
 
 class LabelDispatchResponse(BaseModel):
@@ -564,6 +573,9 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
         "worktree": {
             "path": host_worktree_path,
             "branch": branch,
+        },
+        "spawn": {
+            "cascade_enabled": req.cascade_enabled,
         },
         "meta": {
             "run_id": run_id,

--- a/agentception/tests/test_label_context_and_dispatch.py
+++ b/agentception/tests/test_label_context_and_dispatch.py
@@ -370,3 +370,89 @@ def test_dispatch_label_issue_scope_agent_task_fields(
     assert task_data["target"]["scope_value"] == "42"
     assert task_data["target"]["initiative_label"] == "ac-workflow"
     assert task_data["agent"]["tier"] == "engineer"
+
+
+# ---------------------------------------------------------------------------
+# cascade_enabled field — smoke-test mode
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_enabled_defaults_to_true_in_agent_task(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """cascade_enabled must be True in .agent-task when not specified in request."""
+    written_text: list[str] = []
+    original_write_text = Path.write_text
+
+    def _capture(
+        self: Path,
+        data: str,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ) -> int:
+        if self.name == ".agent-task":
+            written_text.append(data)
+        return original_write_text(self, data, encoding=encoding, errors=errors, newline=newline)
+
+    with (
+        patch("agentception.routes.api.dispatch.settings") as mock_settings,
+        patch("agentception.routes.api.dispatch.asyncio.create_subprocess_exec", new=_make_worktree_exec()),
+        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
+        patch.object(Path, "write_text", _capture),
+    ):
+        mock_settings.worktrees_dir = str(tmp_path / "worktrees7")
+        mock_settings.host_worktrees_dir = "/host/worktrees"
+        mock_settings.repo_dir = str(tmp_path)
+
+        client.post(
+            "/api/dispatch/label",
+            json=_dispatch_label_body(scope="full_initiative"),
+        )
+
+    import tomllib
+    assert written_text, "No .agent-task file was written"
+    task_data = tomllib.loads(written_text[0])
+    assert task_data["spawn"]["cascade_enabled"] is True
+
+
+def test_cascade_enabled_false_written_to_agent_task(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """cascade_enabled=False must propagate into [spawn].cascade_enabled in .agent-task."""
+    written_text: list[str] = []
+    original_write_text = Path.write_text
+
+    def _capture(
+        self: Path,
+        data: str,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ) -> int:
+        if self.name == ".agent-task":
+            written_text.append(data)
+        return original_write_text(self, data, encoding=encoding, errors=errors, newline=newline)
+
+    with (
+        patch("agentception.routes.api.dispatch.settings") as mock_settings,
+        patch("agentception.routes.api.dispatch.asyncio.create_subprocess_exec", new=_make_worktree_exec()),
+        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
+        patch.object(Path, "write_text", _capture),
+    ):
+        mock_settings.worktrees_dir = str(tmp_path / "worktrees8")
+        mock_settings.host_worktrees_dir = "/host/worktrees"
+        mock_settings.repo_dir = str(tmp_path)
+
+        res = client.post(
+            "/api/dispatch/label",
+            json=_dispatch_label_body(scope="full_initiative", cascade_enabled=False),
+        )
+
+    assert res.status_code == 200
+    import tomllib
+    assert written_text, "No .agent-task file was written"
+    task_data = tomllib.loads(written_text[0])
+    assert task_data["spawn"]["cascade_enabled"] is False

--- a/scripts/gen_prompts/templates/roles/ceo.md.j2
+++ b/scripts/gen_prompts/templates/roles/ceo.md.j2
@@ -105,6 +105,54 @@ file. Load it as the very first thing you do, before any tool call or analysis.
 
 {% include 'snippets/coordinator-base.md.j2' %}
 
+## STEP 0.5 — CHECK CASCADE MODE
+
+```bash
+CASCADE_ENABLED=$(python3 -c "
+import tomllib
+d = tomllib.loads(open('.agent-task').read())
+print(str(d.get('spawn', {}).get('cascade_enabled', True)).lower())
+" 2>/dev/null || echo "true")
+RUN_ID=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d.get('meta', {}).get('run_id', ''))" 2>/dev/null || echo "")
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+```
+
+If `CASCADE_ENABLED` is **`false`** — this is a diagnostic smoke-test run.
+**Do NOT query GitHub. Do NOT dispatch any children.** Instead:
+
+1. Output this block verbatim as visible text:
+
+```
+✅ CEO smoke test — pipeline node verified.
+
+  Role:              $ROLE
+  Cognitive arch:    $COGNITIVE_ARCH
+  Run ID:            $RUN_ID
+  Timestamp:         $TIMESTAMP
+  cascade_enabled:   false — no children dispatched.
+```
+
+2. Call the AgentCeption MCP tools (server: `agentception`):
+
+```
+log_run_step(
+  issue_number=0,
+  step_name="CEO smoke test — cognitive arch loaded: {COGNITIVE_ARCH} at {TIMESTAMP}",
+  agent_run_id="{RUN_ID}"
+)
+
+build_complete_run(
+  issue_number=0,
+  pr_url="",
+  summary="CEO smoke test complete. Role={ROLE} Arch={COGNITIVE_ARCH} Timestamp={TIMESTAMP}",
+  agent_run_id="{RUN_ID}"
+)
+```
+
+3. **Stop here.** Do not proceed to STEP 1.
+
+---
+
 ## STEP 1 — SURVEY: Discover Active Teams
 
 ```


### PR DESCRIPTION
## Summary
- Adds `cascade_enabled: bool = True` to `LabelDispatchRequest` — when False the launched agent must not spawn children
- `dispatch_label_agent` writes `[spawn].cascade_enabled` into `.agent-task` so every role can read it
- `ceo.md.j2` gains **STEP 0.5**: if `cascade_enabled = false`, CEO outputs self-intro + timestamp, calls `log_run_step` + `build_complete_run` via MCP, and stops — no GitHub survey, no child dispatch
- Two regression tests: default `True` and explicit `False` both round-trip correctly through the TOML file

## Test plan
- [ ] `mypy` clean (185 files, 0 errors)
- [ ] 15 dispatch tests pass
- [ ] `generate.py --check` shows 0 drift
- [ ] Launch CEO with `cascade_enabled=false` from org designer → card moves TODO → ACTIVE → DONE, no children spawned