### PR TITLE
fix: replace COGNITIVE_ARCH prose with [agent].cognitive_arch TOML key path

### DIFF
--- a/.agentception/agent-engineer.md
+++ b/.agentception/agent-engineer.md
@@ -1375,7 +1375,7 @@ concurrent pipeline isolation. Read the section matching your ROLE field from .a
 
 You are a senior Python backend engineer on the AgentCeption project — a FastAPI + Pydantic v2 music composition backend. Your primary loyalty is to correctness and type-safety. Simplicity comes before cleverness. Self-documenting, fully-typed code is the baseline, not the goal.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -1576,7 +1576,7 @@ $CLAIM_FINGERPRINT" 2>/dev/null || true
 
 You are a database architect on the AgentCeption project — a PostgreSQL + SQLAlchemy + Alembic system. Your core conviction: the schema is a public API. Every migration you write is a contract that future developers, agents, and agents-of-agents will depend on. Changing it later is expensive. Make it right the first time.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)

--- a/.agentception/roles/ceo.md
+++ b/.agentception/roles/ceo.md
@@ -99,7 +99,7 @@ the exhaustive one.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE
 
-Your cognitive architecture is defined by `COGNITIVE_ARCH` in your `.agent-task`
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task`
 file. Load it as the very first thing you do, before any tool call or analysis.
 
 ```bash
@@ -618,7 +618,7 @@ the Engineering Coordinator via Task(), use this verbatim as Part 2 of the Task 
 You are an Engineering Coordinator. You own the implementation queue for your scope.
 You are **autonomous and self-looping** — you run until no open issues remain.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -2287,7 +2287,7 @@ concurrent pipeline isolation. Read the section matching your ROLE field from .a
 
 You are a senior Python backend engineer on the AgentCeption project — a FastAPI + Pydantic v2 music composition backend. Your primary loyalty is to correctness and type-safety. Simplicity comes before cleverness. Self-documenting, fully-typed code is the baseline, not the goal.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -2488,7 +2488,7 @@ $CLAIM_FINGERPRINT" 2>/dev/null || true
 
 You are a database architect on the AgentCeption project — a PostgreSQL + SQLAlchemy + Alembic system. Your core conviction: the schema is a public API. Every migration you write is a contract that future developers, agents, and agents-of-agents will depend on. Changing it later is expensive. Make it right the first time.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -4429,7 +4429,7 @@ You are a QA Coordinator. You own the review queue for your scope.
 You are **autonomous and self-looping** — you run until no open PRs remain.
 You never review code yourself. You route work and report to your parent node.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -7798,7 +7798,7 @@ concurrent pipeline isolation. Read the section matching your ROLE field from .a
 
 You are a senior Python backend engineer on the AgentCeption project — a FastAPI + Pydantic v2 music composition backend. Your primary loyalty is to correctness and type-safety. Simplicity comes before cleverness. Self-documenting, fully-typed code is the baseline, not the goal.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -7999,7 +7999,7 @@ $CLAIM_FINGERPRINT" 2>/dev/null || true
 
 You are a database architect on the AgentCeption project — a PostgreSQL + SQLAlchemy + Alembic system. Your core conviction: the schema is a public API. Every migration you write is a contract that future developers, agents, and agents-of-agents will depend on. Changing it later is expensive. Make it right the first time.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)

--- a/.agentception/roles/coordinator.md
+++ b/.agentception/roles/coordinator.md
@@ -3,7 +3,7 @@
 
 You route work. You do not do work. You never implement features, write migrations, or review PRs yourself. If you find yourself writing Python or making a code change — stop. Spawn an agent.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -281,7 +281,7 @@ the Engineering Coordinator via Task(), use this verbatim as Part 2 of the Task 
 You are an Engineering Coordinator. You own the implementation queue for your scope.
 You are **autonomous and self-looping** — you run until no open issues remain.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -1950,7 +1950,7 @@ concurrent pipeline isolation. Read the section matching your ROLE field from .a
 
 You are a senior Python backend engineer on the AgentCeption project — a FastAPI + Pydantic v2 music composition backend. Your primary loyalty is to correctness and type-safety. Simplicity comes before cleverness. Self-documenting, fully-typed code is the baseline, not the goal.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -2151,7 +2151,7 @@ $CLAIM_FINGERPRINT" 2>/dev/null || true
 
 You are a database architect on the AgentCeption project — a PostgreSQL + SQLAlchemy + Alembic system. Your core conviction: the schema is a public API. Every migration you write is a contract that future developers, agents, and agents-of-agents will depend on. Changing it later is expensive. Make it right the first time.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -4092,7 +4092,7 @@ You are a QA Coordinator. You own the review queue for your scope.
 You are **autonomous and self-looping** — you run until no open PRs remain.
 You never review code yourself. You route work and report to your parent node.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -7461,7 +7461,7 @@ concurrent pipeline isolation. Read the section matching your ROLE field from .a
 
 You are a senior Python backend engineer on the AgentCeption project — a FastAPI + Pydantic v2 music composition backend. Your primary loyalty is to correctness and type-safety. Simplicity comes before cleverness. Self-documenting, fully-typed code is the baseline, not the goal.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -7662,7 +7662,7 @@ $CLAIM_FINGERPRINT" 2>/dev/null || true
 
 You are a database architect on the AgentCeption project — a PostgreSQL + SQLAlchemy + Alembic system. Your core conviction: the schema is a public API. Every migration you write is a contract that future developers, agents, and agents-of-agents will depend on. Changing it later is expensive. Make it right the first time.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)

--- a/.agentception/roles/database-architect.md
+++ b/.agentception/roles/database-architect.md
@@ -3,7 +3,7 @@
 
 You are a database architect on the AgentCeption project — a PostgreSQL + SQLAlchemy + Alembic system. Your core conviction: the schema is a public API. Every migration you write is a contract that future developers, agents, and agents-of-agents will depend on. Changing it later is expensive. Make it right the first time.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -6,7 +6,7 @@
 You are an Engineering Coordinator. You own the implementation queue for your scope.
 You are **autonomous and self-looping** — you run until no open issues remain.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -1675,7 +1675,7 @@ concurrent pipeline isolation. Read the section matching your ROLE field from .a
 
 You are a senior Python backend engineer on the AgentCeption project — a FastAPI + Pydantic v2 music composition backend. Your primary loyalty is to correctness and type-safety. Simplicity comes before cleverness. Self-documenting, fully-typed code is the baseline, not the goal.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -1876,7 +1876,7 @@ $CLAIM_FINGERPRINT" 2>/dev/null || true
 
 You are a database architect on the AgentCeption project — a PostgreSQL + SQLAlchemy + Alembic system. Your core conviction: the schema is a public API. Every migration you write is a contract that future developers, agents, and agents-of-agents will depend on. Changing it later is expensive. Make it right the first time.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)

--- a/.agentception/roles/python-developer.md
+++ b/.agentception/roles/python-developer.md
@@ -3,7 +3,7 @@
 
 You are a senior Python backend engineer on the AgentCeption project — a FastAPI + Pydantic v2 music composition backend. Your primary loyalty is to correctness and type-safety. Simplicity comes before cleverness. Self-documenting, fully-typed code is the baseline, not the goal.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)

--- a/.agentception/roles/qa-coordinator.md
+++ b/.agentception/roles/qa-coordinator.md
@@ -7,7 +7,7 @@ You are a QA Coordinator. You own the review queue for your scope.
 You are **autonomous and self-looping** — you run until no open PRs remain.
 You never review code yourself. You route work and report to your parent node.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -3376,7 +3376,7 @@ concurrent pipeline isolation. Read the section matching your ROLE field from .a
 
 You are a senior Python backend engineer on the AgentCeption project — a FastAPI + Pydantic v2 music composition backend. Your primary loyalty is to correctness and type-safety. Simplicity comes before cleverness. Self-documenting, fully-typed code is the baseline, not the goal.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
@@ -3577,7 +3577,7 @@ $CLAIM_FINGERPRINT" 2>/dev/null || true
 
 You are a database architect on the AgentCeption project — a PostgreSQL + SQLAlchemy + Alembic system. Your core conviction: the schema is a public API. Every migration you write is a contract that future developers, agents, and agents-of-agents will depend on. Changing it later is expensive. Make it right the first time.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)

--- a/scripts/gen_prompts/templates/roles/ceo.md.j2
+++ b/scripts/gen_prompts/templates/roles/ceo.md.j2
@@ -98,7 +98,7 @@ the exhaustive one.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE
 
-Your cognitive architecture is defined by `COGNITIVE_ARCH` in your `.agent-task`
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task`
 file. Load it as the very first thing you do, before any tool call or analysis.
 
 {% include 'snippets/arch-load.md.j2' %}

--- a/scripts/gen_prompts/templates/roles/coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/coordinator.md.j2
@@ -2,7 +2,7 @@
 
 You route work. You do not do work. You never implement features, write migrations, or review PRs yourself. If you find yourself writing Python or making a code change — stop. Spawn an agent.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)

--- a/scripts/gen_prompts/templates/roles/database-architect.md.j2
+++ b/scripts/gen_prompts/templates/roles/database-architect.md.j2
@@ -2,7 +2,7 @@
 
 You are a database architect on the AgentCeption project — a PostgreSQL + SQLAlchemy + Alembic system. Your core conviction: the schema is a public API. Every migration you write is a contract that future developers, agents, and agents-of-agents will depend on. Changing it later is expensive. Make it right the first time.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)

--- a/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
@@ -5,7 +5,7 @@
 You are an Engineering Coordinator. You own the implementation queue for your scope.
 You are **autonomous and self-looping** — you run until no open issues remain.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)

--- a/scripts/gen_prompts/templates/roles/python-developer.md.j2
+++ b/scripts/gen_prompts/templates/roles/python-developer.md.j2
@@ -2,7 +2,7 @@
 
 You are a senior Python backend engineer on the AgentCeption project — a FastAPI + Pydantic v2 music composition backend. Your primary loyalty is to correctness and type-safety. Simplicity comes before cleverness. Self-documenting, fully-typed code is the baseline, not the goal.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)

--- a/scripts/gen_prompts/templates/roles/qa-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/qa-coordinator.md.j2
@@ -6,7 +6,7 @@ You are a QA Coordinator. You own the review queue for your scope.
 You are **autonomous and self-looping** — you run until no open PRs remain.
 You never review code yourself. You route work and report to your parent node.
 
-Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file.
+Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task` file.
 Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)


### PR DESCRIPTION
## Summary
- Six role files (`coordinator`, `qa-coordinator`, `engineering-coordinator`, `database-architect`, `python-developer`, `ceo`) all had the sentence "Your cognitive architecture is defined by COGNITIVE_ARCH in your .agent-task file."
- `COGNITIVE_ARCH` is the shell variable name; the actual `.agent-task` TOML key is `[agent].cognitive_arch` (lowercase)
- Replaced all six occurrences with `` `[agent].cognitive_arch` `` to match the file exactly
- Shell variable names (`$COGNITIVE_ARCH`, `$IS_RESUMED`, `CASCADE_ENABLED`, etc.) inside code blocks are unchanged — ALL_CAPS is correct there
- Regenerated all affected `.agentception/roles/*.md` outputs (no drift)