### PR TITLE
fix(control): hoist deferred imports and supercharge control tests

### DIFF
--- a/agentception/routes/api/control.py
+++ b/agentception/routes/api/control.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -16,6 +17,7 @@ from starlette.responses import Response
 
 from agentception.config import settings
 from agentception.models import (
+    VALID_ROLES,
     SpawnConductorRequest,
     SpawnConductorResult,
     SpawnCoordinatorRequest,
@@ -148,8 +150,6 @@ async def _do_spawn(body: SpawnRequest) -> SpawnResult:
     HTTPException(500)
         When ``git worktree add`` fails.
     """
-    import re as _re
-
     issue_number = body.issue_number
 
     # ── 1. Fetch issue state from GitHub ──────────────────────────────────────
@@ -261,7 +261,7 @@ async def _do_spawn(body: SpawnRequest) -> SpawnResult:
         issue_body = ""
 
     # Extract "Depends on #NNN" patterns as a list of ints for the TOML builder.
-    dep_matches = _re.findall(r"[Dd]epends\s+on\s+#(\d+)", issue_body)
+    dep_matches = re.findall(r"[Dd]epends\s+on\s+#(\d+)", issue_body)
     depends_on: list[int] = [int(m) for m in dep_matches]
 
     # Derive COGNITIVE_ARCH from issue body so the agent gets the right persona.
@@ -381,7 +381,6 @@ async def spawn_wave(role: str = "python-developer") -> WaveSpawnResult:
     HTTP 422
         When ``role`` is not a recognised role slug.
     """
-    from agentception.models import VALID_ROLES
     if role not in VALID_ROLES:
         raise HTTPException(
             status_code=422,

--- a/agentception/tests/test_agentception_controls.py
+++ b/agentception/tests/test_agentception_controls.py
@@ -1,28 +1,38 @@
-from __future__ import annotations
+"""Tests for the AgentCeption pipeline control endpoints.
 
-"""Tests for the AgentCeption pipeline pause/resume control endpoints (AC-102).
+Covers every endpoint in ``agentception/routes/api/control.py``:
 
-Covers:
-  POST /api/control/pause   → creates sentinel, returns {paused: true}
-  POST /api/control/resume  → deletes sentinel, returns {paused: false}
-  GET  /api/control/status  → reflects current sentinel state
+  POST /api/control/pause            → creates sentinel, toast header
+  POST /api/control/resume           → removes sentinel, toast header
+  GET  /api/control/status           → reflects sentinel state
+  POST /api/control/trigger-poll     → fires async tick
+  GET  /api/control/active-label     → returns label / pinned / pin
+  PUT  /api/control/active-label     → pin a label; 400 for invalid label
+  DELETE /api/control/active-label   → clear pin
+  POST /api/control/spawn-wave       → 422 for unknown role
+  POST /api/control/sweep            → dry-run and live paths
+  POST /api/control/spawn-coordinator → 422 for empty text; success path
+  GET  /api/control/conductor-history → returns entries
+  POST /api/control/spawn-conductor  → 422 for empty phases; success path
 
-All tests are synchronous and use a temporary directory for the sentinel file
-so they never touch the real repository filesystem.
+All tests are synchronous and use temporary directories / mock patches so
+they never touch the real repository filesystem or any live GitHub API.
 
 Run targeted:
     pytest agentception/tests/test_agentception_controls.py -v
 """
+from __future__ import annotations
 
-import importlib
+import json
 from collections.abc import Generator
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from agentception.app import app
+from agentception.models import PipelineConfig
 
 
 @pytest.fixture(scope="module")
@@ -86,6 +96,18 @@ def test_pause_idempotent(tmp_path: Path, client_paused: TestClient) -> None:
     assert response.json() == {"paused": True}
 
 
+def test_pause_returns_hx_trigger_toast_header(tmp_path: Path, client: TestClient) -> None:
+    """POST /api/control/pause must emit an HX-Trigger toast header for HTMX."""
+    sentinel = tmp_path / ".pipeline-pause"
+    with patch("agentception.routes.api.control._SENTINEL", sentinel):
+        response = client.post("/api/control/pause")
+    assert response.status_code == 200
+    raw = response.headers.get("hx-trigger", "")
+    payload = json.loads(raw)
+    assert payload["toast"]["type"] == "warning"
+    assert "paused" in payload["toast"]["message"].lower()
+
+
 # ── POST /api/control/resume ──────────────────────────────────────────────────
 
 
@@ -117,6 +139,18 @@ def test_resume_idempotent_when_not_paused(tmp_path: Path, client: TestClient) -
         response = client.post("/api/control/resume")
     assert response.status_code == 200
     assert response.json() == {"paused": False}
+
+
+def test_resume_returns_hx_trigger_toast_header(tmp_path: Path, client_paused: TestClient) -> None:
+    """POST /api/control/resume must emit an HX-Trigger toast header for HTMX."""
+    sentinel = tmp_path / ".pipeline-pause"
+    with patch("agentception.routes.api.control._SENTINEL", sentinel):
+        response = client_paused.post("/api/control/resume")
+    assert response.status_code == 200
+    raw = response.headers.get("hx-trigger", "")
+    payload = json.loads(raw)
+    assert payload["toast"]["type"] == "success"
+    assert "resumed" in payload["toast"]["message"].lower()
 
 
 # ── GET /api/control/status ───────────────────────────────────────────────────
@@ -170,9 +204,433 @@ def test_trigger_poll_returns_triggered_true(client: TestClient) -> None:
     The actual poll tick runs asynchronously; we verify only the HTTP response
     shape and that the endpoint does not raise.
     """
-    with patch("agentception.routes.api.control.trigger_poll.__wrapped__", None, create=True):
-        pass
-    with patch("agentception.poller.tick", return_value=None) as mock_tick:  # noqa: F841
+    with patch("agentception.poller.tick", return_value=None):
         response = client.post("/api/control/trigger-poll")
     assert response.status_code == 200
     assert response.json() == {"triggered": True}
+
+
+# ── GET /api/control/active-label ─────────────────────────────────────────────
+
+
+def test_active_label_get_returns_auto_resolved_label(client: TestClient) -> None:
+    """GET /api/control/active-label must return the auto-resolved label when no pin is set."""
+    with (
+        patch("agentception.routes.api.control.get_pin", return_value=None),
+        patch(
+            "agentception.routes.api.control.get_active_label",
+            new_callable=AsyncMock,
+            return_value="ac/5-plan",
+        ),
+    ):
+        response = client.get("/api/control/active-label")
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"label": "ac/5-plan", "pinned": False, "pin": None}
+
+
+def test_active_label_get_returns_pinned_label(client: TestClient) -> None:
+    """GET /api/control/active-label must report pinned=true and the pin value when a pin is active."""
+    with (
+        patch("agentception.routes.api.control.get_pin", return_value="ac/3-implement"),
+        patch(
+            "agentception.routes.api.control.get_active_label",
+            new_callable=AsyncMock,
+            return_value="ac/3-implement",
+        ),
+    ):
+        response = client.get("/api/control/active-label")
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"label": "ac/3-implement", "pinned": True, "pin": "ac/3-implement"}
+
+
+# ── PUT /api/control/active-label ─────────────────────────────────────────────
+
+
+def test_active_label_pin_valid_label_returns_200(client: TestClient) -> None:
+    """PUT /api/control/active-label must set the pin and return the pinned status."""
+    config = PipelineConfig(active_labels_order=["ac/5-plan", "ac/3-implement"])
+    with (
+        patch(
+            "agentception.routes.api.control.read_pipeline_config",
+            new_callable=AsyncMock,
+            return_value=config,
+        ),
+        patch("agentception.routes.api.control.set_pin") as mock_set,
+    ):
+        response = client.put("/api/control/active-label", json={"label": "ac/5-plan"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["label"] == "ac/5-plan"
+    assert data["pinned"] is True
+    assert data["pin"] == "ac/5-plan"
+    mock_set.assert_called_once_with("ac/5-plan")
+
+
+def test_active_label_pin_invalid_label_returns_400(client: TestClient) -> None:
+    """PUT /api/control/active-label must return 400 when the label is not in active_labels_order."""
+    config = PipelineConfig(active_labels_order=["ac/5-plan"])
+    with patch(
+        "agentception.routes.api.control.read_pipeline_config",
+        new_callable=AsyncMock,
+        return_value=config,
+    ):
+        response = client.put("/api/control/active-label", json={"label": "ac/9-unknown"})
+    assert response.status_code == 400
+    assert "ac/9-unknown" in response.json()["detail"]
+
+
+# ── DELETE /api/control/active-label ──────────────────────────────────────────
+
+
+def test_active_label_unpin_returns_auto_resolved(client: TestClient) -> None:
+    """DELETE /api/control/active-label must clear the pin and return the auto-resolved label."""
+    with (
+        patch("agentception.routes.api.control.clear_pin") as mock_clear,
+        patch(
+            "agentception.routes.api.control.get_active_label",
+            new_callable=AsyncMock,
+            return_value="ac/5-plan",
+        ),
+    ):
+        response = client.delete("/api/control/active-label")
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"label": "ac/5-plan", "pinned": False, "pin": None}
+    mock_clear.assert_called_once()
+
+
+# ── POST /api/control/spawn-wave ─────────────────────────────────────────────
+
+
+def test_spawn_wave_invalid_role_returns_422(client: TestClient) -> None:
+    """POST /api/control/spawn-wave with an unknown role must return 422."""
+    response = client.post("/api/control/spawn-wave?role=time-traveller")
+    assert response.status_code == 422
+    assert "time-traveller" in response.json()["detail"]
+
+
+# ── POST /api/control/sweep ───────────────────────────────────────────────────
+
+
+def _make_async_subprocess_noop() -> MagicMock:
+    """Return a mock for asyncio.create_subprocess_exec that always succeeds."""
+    async def _noop(*_args: str, **_kwargs: object) -> AsyncMock:
+        proc = AsyncMock()
+        proc.returncode = 0
+        proc.communicate.return_value = (b"", b"")
+        return proc
+
+    return MagicMock(side_effect=_noop)
+
+
+def test_sweep_clean_state_returns_empty_results(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """POST /api/control/sweep with no stale branches or claims must return all-empty lists."""
+    with (
+        patch(
+            "agentception.readers.git.list_git_worktrees",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.readers.git.list_git_branches",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.readers.github.get_wip_issues",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.intelligence.guards.detect_stale_claims",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("agentception.routes.api.control.asyncio.create_subprocess_exec", _make_async_subprocess_noop()),
+        patch("agentception.routes.api.control.settings") as mock_settings,
+    ):
+        mock_settings.repo_dir = tmp_path
+        mock_settings.worktrees_dir = tmp_path / "worktrees"
+        response = client.post("/api/control/sweep")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["deleted_branches"] == []
+    assert data["cleared_wip_labels"] == []
+    assert data["errors"] == []
+
+
+def test_sweep_dry_run_reports_stale_branch_without_deleting(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """POST /api/control/sweep?dry_run=true must report stale branches but not run git branch -D."""
+    exec_mock = _make_async_subprocess_noop()
+    with (
+        patch(
+            "agentception.readers.git.list_git_worktrees",
+            new_callable=AsyncMock,
+            return_value=[],  # no live worktrees → every agent branch is stale
+        ),
+        patch(
+            "agentception.readers.git.list_git_branches",
+            new_callable=AsyncMock,
+            return_value=[{"name": "agent/issue-42", "is_agent_branch": True}],
+        ),
+        patch(
+            "agentception.readers.github.get_wip_issues",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.intelligence.guards.detect_stale_claims",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("agentception.routes.api.control.asyncio.create_subprocess_exec", exec_mock),
+        patch("agentception.routes.api.control.settings") as mock_settings,
+    ):
+        mock_settings.repo_dir = tmp_path
+        mock_settings.worktrees_dir = tmp_path / "worktrees"
+        response = client.post("/api/control/sweep?dry_run=true")
+    assert response.status_code == 200
+    data = response.json()
+    assert "agent/issue-42" in data["deleted_branches"]
+    # dry_run=True → subprocess must NOT have been called to delete the branch
+    exec_mock.assert_not_called()
+
+
+def test_sweep_live_branch_not_included_in_deleted(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """POST /api/control/sweep must skip branches that have a live worktree checked out."""
+    with (
+        patch(
+            "agentception.readers.git.list_git_worktrees",
+            new_callable=AsyncMock,
+            return_value=[{"branch": "agent/issue-7", "is_main": False}],
+        ),
+        patch(
+            "agentception.readers.git.list_git_branches",
+            new_callable=AsyncMock,
+            return_value=[{"name": "agent/issue-7", "is_agent_branch": True}],
+        ),
+        patch(
+            "agentception.readers.github.get_wip_issues",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.intelligence.guards.detect_stale_claims",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("agentception.routes.api.control.asyncio.create_subprocess_exec", _make_async_subprocess_noop()),
+        patch("agentception.routes.api.control.settings") as mock_settings,
+    ):
+        mock_settings.repo_dir = tmp_path
+        mock_settings.worktrees_dir = tmp_path / "worktrees"
+        response = client.post("/api/control/sweep")
+    assert response.status_code == 200
+    assert response.json()["deleted_branches"] == []
+
+
+def test_sweep_clears_stale_wip_labels(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    """POST /api/control/sweep must call clear_wip_label for each stale claim."""
+
+    class _FakeClaim:
+        issue_number: int = 99
+
+    with (
+        patch(
+            "agentception.readers.git.list_git_worktrees",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.readers.git.list_git_branches",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.readers.github.get_wip_issues",
+            new_callable=AsyncMock,
+            return_value=[{"number": 99}],
+        ),
+        patch(
+            "agentception.intelligence.guards.detect_stale_claims",
+            new_callable=AsyncMock,
+            return_value=[_FakeClaim()],
+        ),
+        patch(
+            "agentception.readers.github.clear_wip_label",
+            new_callable=AsyncMock,
+        ) as mock_clear,
+        patch("agentception.routes.api.control.asyncio.create_subprocess_exec", _make_async_subprocess_noop()),
+        patch("agentception.routes.api.control.settings") as mock_settings,
+    ):
+        mock_settings.repo_dir = tmp_path
+        mock_settings.worktrees_dir = tmp_path / "worktrees"
+        response = client.post("/api/control/sweep")
+    assert response.status_code == 200
+    data = response.json()
+    assert 99 in data["cleared_wip_labels"]
+    mock_clear.assert_called_once_with(99)
+
+
+# ── POST /api/control/spawn-coordinator ──────────────────────────────────────
+
+
+def test_spawn_coordinator_empty_plan_text_returns_422(client: TestClient) -> None:
+    """POST /api/control/spawn-coordinator with blank plan_text must return 422."""
+    response = client.post(
+        "/api/control/spawn-coordinator",
+        json={"plan_text": "   ", "label_prefix": ""},
+    )
+    assert response.status_code == 422
+    assert "plan_text" in response.json()["detail"].lower()
+
+
+def test_spawn_coordinator_success(client: TestClient, tmp_path: Path) -> None:
+    """POST /api/control/spawn-coordinator must return slug, worktree, and branch on success."""
+    wt_root = tmp_path / "worktrees"
+    wt_root.mkdir()
+
+    async def _git_worktree_add(*args: str, **_: object) -> AsyncMock:
+        """Simulate git worktree add by creating the target directory."""
+        args_list = list(args)
+        if "add" in args_list:
+            add_idx = args_list.index("add")
+            # git -C repo worktree add -b branch <path> origin/dev → path at add_idx+3
+            if add_idx + 3 < len(args_list):
+                Path(args_list[add_idx + 3]).mkdir(parents=True, exist_ok=True)
+        proc = AsyncMock()
+        proc.returncode = 0
+        proc.communicate.return_value = (b"", b"")
+        return proc
+
+    with (
+        patch("agentception.routes.api.control.settings") as mock_settings,
+        patch(
+            "agentception.routes.api.control.asyncio.create_subprocess_exec",
+            MagicMock(side_effect=_git_worktree_add),
+        ),
+    ):
+        mock_settings.worktrees_dir = wt_root
+        mock_settings.host_worktrees_dir = wt_root
+        mock_settings.repo_dir = tmp_path
+        response = client.post(
+            "/api/control/spawn-coordinator",
+            json={"plan_text": "Build an amazing feature", "label_prefix": "test"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["slug"].startswith("plan-")
+    assert data["branch"].startswith("feat/plan-")
+    assert "agent_task" in data
+    assert "worktree" in data
+
+
+# ── GET /api/control/conductor-history ───────────────────────────────────────
+
+
+def test_conductor_history_returns_empty_list_when_no_history(client: TestClient) -> None:
+    """GET /api/control/conductor-history must return [] when the DB has no conductor rows."""
+    with patch(
+        "agentception.db.queries.get_conductor_history",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        response = client.get("/api/control/conductor-history")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_conductor_history_returns_entries(client: TestClient) -> None:
+    """GET /api/control/conductor-history must return deserialized ConductorHistoryEntry rows."""
+    rows = [
+        {
+            "wave_id": "conductor-20260303-120000",
+            "worktree": "/worktrees/conductor-20260303-120000",
+            "host_worktree": "~/.agentception/worktrees/conductor-20260303-120000",
+            "started_at": "2026-03-03 12:00:00+00:00",
+            "status": "completed",
+        }
+    ]
+    with patch(
+        "agentception.db.queries.get_conductor_history",
+        new_callable=AsyncMock,
+        return_value=rows,
+    ):
+        response = client.get("/api/control/conductor-history")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["wave_id"] == "conductor-20260303-120000"
+    assert data[0]["status"] == "completed"
+
+
+# ── POST /api/control/spawn-conductor ────────────────────────────────────────
+
+
+def test_spawn_conductor_empty_phases_returns_422(client: TestClient) -> None:
+    """POST /api/control/spawn-conductor with an empty phases list must return 422."""
+    response = client.post(
+        "/api/control/spawn-conductor",
+        json={"phases": []},
+    )
+    assert response.status_code == 422
+    assert "phases" in response.json()["detail"].lower()
+
+
+def test_spawn_conductor_success(client: TestClient, tmp_path: Path) -> None:
+    """POST /api/control/spawn-conductor must return wave_id, worktree, and branch on success."""
+    wt_root = tmp_path / "worktrees"
+    wt_root.mkdir()
+
+    async def _git_worktree_add(*args: str, **_: object) -> AsyncMock:
+        args_list = list(args)
+        if "add" in args_list:
+            add_idx = args_list.index("add")
+            if add_idx + 3 < len(args_list):
+                Path(args_list[add_idx + 3]).mkdir(parents=True, exist_ok=True)
+        proc = AsyncMock()
+        proc.returncode = 0
+        proc.communicate.return_value = (b"", b"")
+        return proc
+
+    with (
+        patch("agentception.routes.api.control.settings") as mock_settings,
+        patch(
+            "agentception.routes.api.control.asyncio.create_subprocess_exec",
+            MagicMock(side_effect=_git_worktree_add),
+        ),
+        patch(
+            "agentception.db.persist.persist_wave_start",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        mock_settings.worktrees_dir = wt_root
+        mock_settings.host_worktrees_dir = wt_root
+        mock_settings.repo_dir = tmp_path
+        response = client.post(
+            "/api/control/spawn-conductor",
+            json={"phases": ["ac/5-plan", "ac/3-implement"], "org": None},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["wave_id"].startswith("conductor-")
+    assert data["branch"].startswith("feat/conductor-")
+    assert "agent_task" in data
+    assert "worktree" in data


### PR DESCRIPTION
## Summary
- Move `import re` and `VALID_ROLES` from deferred function-body imports to module-level in `routes/api/control.py`
- Expand `test_agentception_controls.py` from 11 to 29 tests, covering every endpoint in the control plane
- All 73 tests pass; mypy strict clean

## Test plan
- [x] `docker compose exec agentception mypy agentception/routes/api/control.py agentception/tests/test_agentception_controls.py` — 0 errors
- [x] `docker compose exec agentception pytest tests/ -q` — 73 passed