### PR TITLE
fix(health): fix docstring placement and supercharge health tests

### DIFF
--- a/agentception/models/health.py
+++ b/agentception/models/health.py
@@ -1,10 +1,9 @@
-from __future__ import annotations
-
 """HealthSnapshot — canonical shape for AgentCeption system health data.
 
 Every downstream component (health_collector, /api/health/detailed endpoint,
 dashboard poller, and tests) imports from here. Change this contract carefully.
 """
+from __future__ import annotations
 
 from pydantic import BaseModel, Field
 

--- a/agentception/routes/api/health.py
+++ b/agentception/routes/api/health.py
@@ -1,9 +1,8 @@
-from __future__ import annotations
-
 """API route: GET /api/health/detailed — detailed system health snapshot.
 
 Thin handler — all collection logic lives in ``agentception.services.health_collector``.
 """
+from __future__ import annotations
 
 import logging
 

--- a/agentception/routes/ui/health.py
+++ b/agentception/routes/ui/health.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """UI route: GET /ui/health/widget — HTMX-polled System Health card fragment.
 
 Calls ``health_collector.collect()`` and renders ``partials/health_card.html``
@@ -9,6 +7,7 @@ Thresholds (from issue #941):
   nominal   — github_api_latency_ms < 500 AND memory_rss_mb < 512
   elevated  — any threshold exceeded (or probe failed, i.e. latency == -1.0)
 """
+from __future__ import annotations
 
 import logging
 

--- a/agentception/services/health_collector.py
+++ b/agentception/services/health_collector.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """health_collector — gathers system health metrics with a 5-second result cache.
 
 Single public coroutine: ``collect() -> HealthSnapshot``.
@@ -15,6 +13,7 @@ Metrics gathered:
 - ``github_api_latency_ms`` — round-trip to ``https://api.github.com`` via httpx.
                                Returns -1.0 on any network or timeout error.
 """
+from __future__ import annotations
 
 import asyncio
 import logging

--- a/agentception/tests/test_health_collector.py
+++ b/agentception/tests/test_health_collector.py
@@ -1,0 +1,196 @@
+"""Unit tests for agentception.services.health_collector.
+
+Covers the full service layer that backs the /api/health/detailed endpoint:
+
+  _memory_rss_mb()          — returns a non-negative float from the OS
+  _active_worktree_count()  — counts subdirectories; ignores files; 0 when absent
+  _probe_github_latency_ms() — returns -1.0 on any network/timeout error
+  collect()                  — returns HealthSnapshot; respects the 5-second cache
+
+All I/O is mocked so these tests run offline and without touching the filesystem
+beyond the tmp_path fixtures.
+
+Run targeted:
+    pytest agentception/tests/test_health_collector.py -v
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+import agentception.services.health_collector as hc
+from agentception.models.health import HealthSnapshot
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_SNAPSHOT = HealthSnapshot(
+    uptime_seconds=10.0,
+    memory_rss_mb=64.0,
+    active_worktree_count=2,
+    github_api_latency_ms=42.0,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_cache() -> None:
+    """Reset the module-level cache globals before every test.
+
+    Without this, a successful ``collect()`` in one test contaminates the next
+    by leaving a warm cache entry that prevents ``_gather`` from being called.
+    """
+    hc._cached = None
+    hc._cached_at = 0.0
+
+
+# ── _memory_rss_mb ────────────────────────────────────────────────────────────
+
+
+def test_memory_rss_mb_returns_nonneg_float() -> None:
+    """_memory_rss_mb() must return a float >= 0.0 using the real OS resource call."""
+    result = hc._memory_rss_mb()
+    assert isinstance(result, float)
+    assert result >= 0.0
+
+
+# ── _active_worktree_count ────────────────────────────────────────────────────
+
+
+def test_active_worktree_count_returns_zero_when_dir_absent(tmp_path: Path) -> None:
+    """_active_worktree_count() must return 0 when the worktrees directory does not exist."""
+    missing = tmp_path / "nonexistent-worktrees"
+    with patch("agentception.services.health_collector.settings") as mock_settings:
+        mock_settings.worktrees_dir = missing
+        assert hc._active_worktree_count() == 0
+
+
+def test_active_worktree_count_counts_subdirectories(tmp_path: Path) -> None:
+    """_active_worktree_count() must return the exact number of subdirectories."""
+    wt_dir = tmp_path / "worktrees"
+    wt_dir.mkdir()
+    (wt_dir / "issue-1").mkdir()
+    (wt_dir / "issue-2").mkdir()
+    (wt_dir / "issue-3").mkdir()
+    with patch("agentception.services.health_collector.settings") as mock_settings:
+        mock_settings.worktrees_dir = wt_dir
+        assert hc._active_worktree_count() == 3
+
+
+def test_active_worktree_count_ignores_plain_files(tmp_path: Path) -> None:
+    """_active_worktree_count() must count only directories, not regular files."""
+    wt_dir = tmp_path / "worktrees"
+    wt_dir.mkdir()
+    (wt_dir / "issue-1").mkdir()
+    (wt_dir / "README.md").write_text("not a worktree", encoding="utf-8")
+    with patch("agentception.services.health_collector.settings") as mock_settings:
+        mock_settings.worktrees_dir = wt_dir
+        assert hc._active_worktree_count() == 1
+
+
+# ── _probe_github_latency_ms ──────────────────────────────────────────────────
+
+
+def _mock_httpx_client(side_effect: Exception | None = None) -> MagicMock:
+    """Build a mock httpx.AsyncClient context-manager for async with usage."""
+    instance = AsyncMock()
+    if side_effect is not None:
+        instance.head.side_effect = side_effect
+    else:
+        instance.head.return_value = MagicMock()
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=instance)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+@pytest.mark.anyio
+async def test_probe_github_latency_ms_returns_minus_one_on_connect_error() -> None:
+    """-1.0 is returned when the GitHub probe raises a connection error."""
+    with patch(
+        "agentception.services.health_collector.httpx.AsyncClient",
+        return_value=_mock_httpx_client(httpx.ConnectError("refused")),
+    ):
+        result = await hc._probe_github_latency_ms()
+    assert result == -1.0
+
+
+@pytest.mark.anyio
+async def test_probe_github_latency_ms_returns_minus_one_on_timeout() -> None:
+    """-1.0 is returned when the GitHub probe times out."""
+    with patch(
+        "agentception.services.health_collector.httpx.AsyncClient",
+        return_value=_mock_httpx_client(httpx.ReadTimeout("timed out")),
+    ):
+        result = await hc._probe_github_latency_ms()
+    assert result == -1.0
+
+
+@pytest.mark.anyio
+async def test_probe_github_latency_ms_returns_positive_float_on_success() -> None:
+    """A successful probe must return a non-negative float (measured latency in ms)."""
+    with patch(
+        "agentception.services.health_collector.httpx.AsyncClient",
+        return_value=_mock_httpx_client(),
+    ):
+        result = await hc._probe_github_latency_ms()
+    assert isinstance(result, float)
+    assert result >= 0.0
+
+
+# ── collect ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_collect_returns_health_snapshot_instance() -> None:
+    """collect() must return a HealthSnapshot regardless of the gathered values."""
+    with patch.object(hc, "_gather", new_callable=AsyncMock, return_value=_SNAPSHOT):
+        result = await hc.collect()
+    assert isinstance(result, HealthSnapshot)
+
+
+@pytest.mark.anyio
+async def test_collect_hits_cache_within_ttl() -> None:
+    """collect() must not call _gather a second time when the cache is still fresh.
+
+    The cache is considered fresh when the elapsed time since the last gather is
+    less than _CACHE_TTL_SECONDS (5 s).  Two rapid back-to-back calls must
+    produce exactly one _gather invocation.
+    """
+    hc._cached = _SNAPSHOT
+    hc._cached_at = time.monotonic()  # just warmed — well within TTL
+
+    with patch.object(hc, "_gather", new_callable=AsyncMock, return_value=_SNAPSHOT) as mock_gather:
+        r1 = await hc.collect()
+        r2 = await hc.collect()
+
+    assert r1 is _SNAPSHOT
+    assert r2 is _SNAPSHOT
+    mock_gather.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_collect_refreshes_after_ttl_expires() -> None:
+    """collect() must call _gather again once the cache has aged past the TTL."""
+    stale = HealthSnapshot(
+        uptime_seconds=1.0,
+        memory_rss_mb=10.0,
+        active_worktree_count=0,
+        github_api_latency_ms=5.0,
+    )
+    fresh = HealthSnapshot(
+        uptime_seconds=100.0,
+        memory_rss_mb=20.0,
+        active_worktree_count=1,
+        github_api_latency_ms=12.0,
+    )
+    hc._cached = stale
+    hc._cached_at = time.monotonic() - (hc._CACHE_TTL_SECONDS + 1.0)  # expired
+
+    with patch.object(hc, "_gather", new_callable=AsyncMock, return_value=fresh) as mock_gather:
+        result = await hc.collect()
+
+    assert result is fresh
+    mock_gather.assert_awaited_once()

--- a/agentception/tests/test_health_endpoint.py
+++ b/agentception/tests/test_health_endpoint.py
@@ -1,16 +1,17 @@
-from __future__ import annotations
-
 """Tests for GET /api/health/detailed endpoint.
 
 Tests cover:
 - 200 status code returned.
 - Response body matches HealthSnapshot schema (all 4 fields present).
 - Each field is the correct type.
+- Sentinel value -1.0 for github_api_latency_ms is preserved verbatim.
+- Response contains no unexpected fields beyond the four declared ones.
 - health_collector.collect() is the sole delegate (no business logic in route).
 
 Run targeted:
     pytest agentception/tests/test_health_endpoint.py -v
 """
+from __future__ import annotations
 
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
@@ -109,3 +110,38 @@ def test_health_detailed_returns_collect_values(client: TestClient) -> None:
     assert body["memory_rss_mb"] == _MOCK_SNAPSHOT.memory_rss_mb
     assert body["active_worktree_count"] == _MOCK_SNAPSHOT.active_worktree_count
     assert body["github_api_latency_ms"] == _MOCK_SNAPSHOT.github_api_latency_ms
+
+
+# ── Sentinel value ─────────────────────────────────────────────────────────────
+
+
+def test_health_detailed_sentinel_value_minus_one_preserved(client: TestClient) -> None:
+    """github_api_latency_ms == -1.0 (failed probe) must be preserved through serialisation.
+
+    The endpoint contract promises -1.0 as the sentinel for a failed GitHub
+    probe.  This verifies the value survives the Pydantic → JSON round-trip
+    without being coerced, rounded, or dropped.
+    """
+    sentinel_snapshot = HealthSnapshot(
+        uptime_seconds=10.0,
+        memory_rss_mb=64.0,
+        active_worktree_count=0,
+        github_api_latency_ms=-1.0,
+    )
+    with patch(
+        "agentception.routes.api.health.health_collector.collect",
+        new_callable=AsyncMock,
+        return_value=sentinel_snapshot,
+    ):
+        body = client.get("/api/health/detailed").json()
+    assert body["github_api_latency_ms"] == -1.0
+
+
+# ── Schema exactness ───────────────────────────────────────────────────────────
+
+
+def test_health_detailed_response_has_no_extra_fields(client: TestClient) -> None:
+    """The response body must contain exactly the four HealthSnapshot fields — no more."""
+    body = client.get("/api/health/detailed").json()
+    expected_keys = {"uptime_seconds", "memory_rss_mb", "active_worktree_count", "github_api_latency_ms"}
+    assert set(body.keys()) == expected_keys

--- a/agentception/tests/test_health_ui.py
+++ b/agentception/tests/test_health_ui.py
@@ -1,0 +1,156 @@
+"""Unit and integration tests for agentception.routes.ui.health.
+
+Covers:
+
+  _fmt_uptime()           — pure formatter for the uptime duration display
+  GET /ui/health/widget   — HTMX fragment: 200, HTML content-type, is_nominal logic
+
+``_fmt_uptime`` has three branches (seconds / minutes / hours) that are each
+thoroughly exercised including exact boundary values.
+
+The widget endpoint is tested for status code, content-type, and the
+``is_nominal`` flag that drives the status-dot BEM modifier.  Template content
+is intentionally not asserted verbatim to avoid brittle string matching.
+
+Run targeted:
+    pytest agentception/tests/test_health_ui.py -v
+"""
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+from agentception.models.health import HealthSnapshot
+from agentception.routes.ui.health import _fmt_uptime
+
+
+# ── _fmt_uptime ───────────────────────────────────────────────────────────────
+
+
+class TestFmtUptime:
+    """All branches and boundary conditions for _fmt_uptime."""
+
+    # seconds branch (< 60)
+    def test_zero_seconds(self) -> None:
+        assert _fmt_uptime(0.0) == "0s"
+
+    def test_one_second(self) -> None:
+        assert _fmt_uptime(1.0) == "1s"
+
+    def test_59_seconds(self) -> None:
+        assert _fmt_uptime(59.9) == "59s"
+
+    # minutes branch (60 ≤ seconds < 3600)
+    def test_exactly_60_seconds(self) -> None:
+        assert _fmt_uptime(60.0) == "1m 0s"
+
+    def test_90_seconds(self) -> None:
+        assert _fmt_uptime(90.0) == "1m 30s"
+
+    def test_119_seconds(self) -> None:
+        assert _fmt_uptime(119.0) == "1m 59s"
+
+    def test_3599_seconds(self) -> None:
+        assert _fmt_uptime(3599.0) == "59m 59s"
+
+    # hours branch (≥ 3600)
+    def test_exactly_one_hour(self) -> None:
+        assert _fmt_uptime(3600.0) == "1h 0m"
+
+    def test_one_hour_30_minutes(self) -> None:
+        assert _fmt_uptime(5400.0) == "1h 30m"
+
+    def test_two_hours_one_minute(self) -> None:
+        assert _fmt_uptime(7260.0) == "2h 1m"
+
+    def test_large_duration(self) -> None:
+        # 25 h 0 m (90 000 s) — verify no integer overflow or format break
+        assert _fmt_uptime(90_000.0) == "25h 0m"
+
+
+# ── GET /ui/health/widget ─────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def client() -> Generator[TestClient, None, None]:
+    """Module-scoped test client to avoid repeated lifespan startup."""
+    with TestClient(app) as c:
+        yield c
+
+
+_COLLECT_PATH = "agentception.routes.ui.health.health_collector.collect"
+
+
+def test_health_widget_returns_200(client: TestClient) -> None:
+    """GET /ui/health/widget must always return HTTP 200."""
+    snapshot = HealthSnapshot(
+        uptime_seconds=60.0, memory_rss_mb=128.0,
+        active_worktree_count=1, github_api_latency_ms=80.0,
+    )
+    with patch(_COLLECT_PATH, new_callable=AsyncMock, return_value=snapshot):
+        response = client.get("/ui/health/widget")
+    assert response.status_code == 200
+
+
+def test_health_widget_returns_html_content_type(client: TestClient) -> None:
+    """GET /ui/health/widget must return text/html content-type."""
+    snapshot = HealthSnapshot(
+        uptime_seconds=60.0, memory_rss_mb=128.0,
+        active_worktree_count=1, github_api_latency_ms=80.0,
+    )
+    with patch(_COLLECT_PATH, new_callable=AsyncMock, return_value=snapshot):
+        response = client.get("/ui/health/widget")
+    assert "text/html" in response.headers["content-type"]
+
+
+def test_health_widget_is_nominal_when_all_thresholds_ok(client: TestClient) -> None:
+    """Widget body must include 'nominal' state indicator when latency and memory are within limits."""
+    snapshot = HealthSnapshot(
+        uptime_seconds=120.0,
+        memory_rss_mb=256.0,        # < 512 MB threshold
+        active_worktree_count=2,
+        github_api_latency_ms=200.0,  # < 500 ms threshold
+    )
+    with patch(_COLLECT_PATH, new_callable=AsyncMock, return_value=snapshot):
+        response = client.get("/ui/health/widget")
+    assert "nominal" in response.text
+
+
+def test_health_widget_is_elevated_when_probe_failed(client: TestClient) -> None:
+    """Widget body must include 'elevated' state indicator when the GitHub probe returned -1.0."""
+    snapshot = HealthSnapshot(
+        uptime_seconds=5.0, memory_rss_mb=128.0,
+        active_worktree_count=0,
+        github_api_latency_ms=-1.0,  # probe failure sentinel
+    )
+    with patch(_COLLECT_PATH, new_callable=AsyncMock, return_value=snapshot):
+        response = client.get("/ui/health/widget")
+    assert "elevated" in response.text
+
+
+def test_health_widget_is_elevated_when_memory_exceeds_threshold(client: TestClient) -> None:
+    """Widget body must include 'elevated' when memory_rss_mb >= 512."""
+    snapshot = HealthSnapshot(
+        uptime_seconds=200.0,
+        memory_rss_mb=513.0,        # over threshold
+        active_worktree_count=0, github_api_latency_ms=50.0,
+    )
+    with patch(_COLLECT_PATH, new_callable=AsyncMock, return_value=snapshot):
+        response = client.get("/ui/health/widget")
+    assert "elevated" in response.text
+
+
+def test_health_widget_is_elevated_when_latency_exceeds_threshold(client: TestClient) -> None:
+    """Widget body must include 'elevated' when github_api_latency_ms >= 500."""
+    snapshot = HealthSnapshot(
+        uptime_seconds=300.0, memory_rss_mb=100.0,
+        active_worktree_count=1,
+        github_api_latency_ms=600.0,  # over threshold
+    )
+    with patch(_COLLECT_PATH, new_callable=AsyncMock, return_value=snapshot):
+        response = client.get("/ui/health/widget")
+    assert "elevated" in response.text


### PR DESCRIPTION
## Summary
- Fix `from __future__ import annotations` placement (must follow, not precede, the module docstring) in all four health source files and the existing test file
- Add 2 missing tests to `test_health_endpoint.py`: sentinel -1.0 round-trip and exact schema shape
- Create `test_health_collector.py` (10 tests): `_memory_rss_mb`, `_active_worktree_count`, `_probe_github_latency_ms`, and `collect()` cache behaviour
- Create `test_health_ui.py` (17 tests): all `_fmt_uptime` branches and widget nominal/elevated threshold logic

## Test plan
- [x] mypy strict — 0 errors across all 7 changed files
- [x] 37 new/updated health tests — all green
- [x] Full suite — 1188 passed, 0 failures