### PR TITLE
docs(agent-tree): clarify two-type model, both pr-reviewer paths, optional CEO

### DIFF
--- a/docs/agent-tree-protocol.md
+++ b/docs/agent-tree-protocol.md
@@ -7,35 +7,66 @@ briefs agents must conform to this spec.
 
 ---
 
+## Two agent types
+
+Every agent in AgentCeption is exactly one of:
+
+| Type | Behaviour | May spawn |
+|------|-----------|-----------|
+| **Coordinator** | Surveys a scope (issues, PRs, or sub-label), dispatches children, loops until queue drains, produces no direct artifacts | Other coordinators **or** leaf nodes |
+| **Leaf node** | Claims a single unit of work (one issue or one PR), executes it, may chain-spawn one downstream leaf before reporting done | One downstream leaf node only — never a coordinator |
+
+Coordinator examples: `ceo`, `cto`, `engineering-coordinator`, `qa-coordinator`.  
+Leaf examples: `python-developer`, `frontend-developer`, `pr-reviewer`.
+
+---
+
 ## The tree
 
 ```
-root (CTO)
- └── engineering-coordinator
-      └── engineer  (leaf — one issue)
-           └── pr-reviewer  (leaf — chain-spawned by engineer after opening PR)
+[ceo]  ← optional; cto becomes root when absent
+ └── cto  (coordinator)
+      ├── engineering-coordinator  (coordinator)
+      │    └── engineer            (leaf — one issue)
+      │         └── pr-reviewer   (leaf — chain-spawned after engineer opens PR)
+      └── qa-coordinator           (coordinator — cleanup sweep only)
+           └── pr-reviewer         (leaf — one unreviewed PR)
 ```
 
-**Chain-spawn model:** engineers open their PR and then immediately spawn their
-own reviewer before exiting. There is no concurrent QA coordinator when issues
-remain — that was a race condition (the QA coordinator ran before PRs existed,
-found nothing, and exited). The QA coordinator is only spawned by the CTO as a
-cleanup sweep when all issues are closed but stale unreviewed PRs remain.
+`pr-reviewer` reaches the tree in **two independent paths**:
 
-Any node can be the entry point. When you launch at `coordinator`,
-there is no CTO above it — you prune the tree at that node.
+1. **Engineer chain-spawn** — after an engineer opens its PR it immediately
+   spawns a `pr-reviewer` leaf before exiting.  The reviewer's `PARENT_RUN_ID`
+   is the engineer's `RUN_ID` and its `ORG_DOMAIN` is `qa`.  No physical QA
+   coordinator node needs to be running for the reviewer to be placed correctly
+   in the hierarchy — `ORG_DOMAIN` alone is enough for the dashboard.
+2. **QA coordinator sweep** — the CTO spawns a `qa-coordinator` when issues
+   are exhausted but stale unreviewed PRs remain.  The QA coordinator spawns
+   one `pr-reviewer` leaf per unreviewed PR.
+
+**Chain-spawn constraint:** engineers must never spawn a QA coordinator; they
+spawn only the single `pr-reviewer` leaf that covers their own PR.  A
+concurrent QA coordinator launched while issues remain would race against
+chain-spawned reviewers and find no additional PRs to cover.
+
+Any node can be the entry point. When you launch at `engineering-coordinator`,
+there is no CTO or CEO above it — the tree is pruned at that node.
 
 ---
 
 ## Tiers
 
-| Tier | Role examples | GitHub scope | Can spawn |
-|------|--------------|--------------|-----------|
-| `root` | `cto` | issues **and** PRs filtered to `SCOPE_VALUE` | Eng coordinator (always); QA coordinator (cleanup only — see below) |
-| `coordinator` | `engineering-coordinator` | **issues only** filtered to `SCOPE_VALUE` | any engineering leaf role |
-| `coordinator` | `qa-coordinator` | **PRs only** — cleanup sweep when issues = 0 | `pr-reviewer` |
-| `engineer` | `python-developer`, `frontend-developer`, `devops-engineer`, … | **one issue** (`SCOPE_VALUE` = issue number) | `pr-reviewer` (immediately after opening PR) |
-| `reviewer` | `pr-reviewer` | **one PR** (`SCOPE_VALUE` = PR number) | nothing |
+Tiers are the runtime execution label written into every `.agent-task` file.
+They map directly onto the two agent types: coordinators are `root` or
+`coordinator`; leaf nodes are `engineer` or `reviewer`.
+
+| Tier | Agent type | Role examples | GitHub scope | Can spawn |
+|------|-----------|--------------|--------------|-----------|
+| `root` | coordinator | `ceo`, `cto` | issues **and** PRs filtered to `SCOPE_VALUE` | any coordinator or leaf |
+| `coordinator` | coordinator | `engineering-coordinator` | **issues only** filtered to `SCOPE_VALUE` | any engineering leaf role |
+| `coordinator` | coordinator | `qa-coordinator` | **PRs only** — cleanup sweep when issues = 0 | `pr-reviewer` |
+| `engineer` | leaf | `python-developer`, `frontend-developer`, `devops-engineer`, … | **one issue** (`SCOPE_VALUE` = issue number) | `pr-reviewer` (chain-spawn after opening PR) |
+| `reviewer` | leaf | `pr-reviewer` | **one PR** (`SCOPE_VALUE` = PR number) | nothing |
 
 ### CTO spawn decision
 
@@ -128,8 +159,7 @@ HOST_ROLE_FILE = "<host-repo-root>/.agentception/roles/pr-reviewer.md"
 > `ORG_DOMAIN` is the organisational slot for the UI hierarchy (c-suite, engineering, qa).
 > A chain-spawned PR reviewer has `TIER=reviewer` and `ORG_DOMAIN=qa` even though its
 > `PARENT_RUN_ID` points to an engineer, so the dashboard nests it under the QA column
-> without requiring a
-> physical QA Coordinator node to be running.
+> without requiring a physical QA coordinator node to be running.
 
 > `<repo-root>` is the absolute path to the cloned repository on the host
 > machine — the value of `REPO_DIR` (defaults to `/app` inside the
@@ -186,9 +216,11 @@ github_get_issue(number=$SCOPE_VALUE)
 ```
 
 Implements the issue, opens a PR, then **immediately chain-spawns a
-`pr-reviewer` Task** (Step 6 in the engineering-coordinator role) before
-calling `report/done`. The reviewer's `PARENT_RUN_ID` is set to this
-engineer's `RUN_ID`, `TIER` is set to `reviewer`, and `ORG_DOMAIN` to `qa`.
+`pr-reviewer` Task** before calling `report/done`. The reviewer's
+`PARENT_RUN_ID` is set to this engineer's `RUN_ID`, `TIER` is set to
+`reviewer`, and `ORG_DOMAIN` to `qa`. This makes the reviewer a logical child
+of the engineer in the hierarchy even though no physical QA coordinator is
+running.
 
 ### `reviewer` (leaf)
 
@@ -198,6 +230,8 @@ github_get_pr(number=$SCOPE_VALUE)
 ```
 
 Reviews, requests changes or approves+merges, calls `report/done`, exits.
+Spawned by **either** an engineer (chain-spawn) **or** a `qa-coordinator`
+(cleanup sweep) — the reviewer itself behaves identically in both cases.
 
 ---
 
@@ -241,10 +275,11 @@ They do NOT call `build_report_done` — they exit naturally after their queue d
 
 ## Tier → Role mapping (for the dispatch UI)
 
-| Tier | Selectable roles | Spawned by |
-|------|-----------------|------------|
-| `root` | `cto` | dispatcher (AgentCeption UI / MCP) |
-| `coordinator` | `engineering-coordinator` | CTO (always when issues > 0) |
-| `coordinator` | `qa-coordinator` | CTO (cleanup sweep only — issues == 0, PRs > 0) |
-| `engineer` | `python-developer`, `frontend-developer`, `typescript-developer`, `react-developer`, `go-developer`, `rust-developer`, `api-developer`, `devops-engineer`, `data-engineer`, `site-reliability-engineer`, `security-engineer`, `mobile-developer`, `ios-developer`, `android-developer`, `full-stack-developer`, `architect`, `technical-writer`, `test-engineer`, `ml-engineer`, `systems-programmer`, `rails-developer`, `database-architect` | engineering-coordinator |
-| `reviewer` | `pr-reviewer` | engineer (chain-spawn after PR open) or qa-coordinator (cleanup) |
+| Tier | Agent type | Selectable roles | Spawned by |
+|------|-----------|-----------------|------------|
+| `root` | coordinator | `ceo` | dispatcher (AgentCeption UI / MCP) |
+| `root` | coordinator | `cto` | dispatcher, or CEO when present |
+| `coordinator` | coordinator | `engineering-coordinator` | CTO (always when issues > 0) |
+| `coordinator` | coordinator | `qa-coordinator` | CTO (cleanup sweep only — issues == 0, PRs > 0) |
+| `engineer` | leaf | `python-developer`, `frontend-developer`, `typescript-developer`, `react-developer`, `go-developer`, `rust-developer`, `api-developer`, `devops-engineer`, `data-engineer`, `site-reliability-engineer`, `security-engineer`, `mobile-developer`, `ios-developer`, `android-developer`, `full-stack-developer`, `architect`, `technical-writer`, `test-engineer`, `ml-engineer`, `systems-programmer`, `rails-developer`, `database-architect` | engineering-coordinator |
+| `reviewer` | leaf | `pr-reviewer` | engineer (chain-spawn after PR open) **or** qa-coordinator (cleanup sweep) |


### PR DESCRIPTION
## Summary

- Add **"Two agent types"** section as the canonical mental model: *coordinators* (survey scope, spawn children, produce no direct artifacts) vs *leaf nodes* (claim one unit of work, may chain-spawn one downstream leaf only)
- Rewrite the tree diagram to show the optional CEO above CTO and **both independent paths** to `pr-reviewer` (engineer chain-spawn and qa-coordinator cleanup sweep)
- Document the chain-spawn constraint explicitly: engineers spawn only the `pr-reviewer` leaf for their own PR — never a coordinator
- Update Tiers table with an **Agent type** column mapping each tier (`root`, `coordinator`, `engineer`, `reviewer`) to coordinator or leaf
- Update the Tier → Role mapping table: split the `root` row into CEO and CTO rows, add Agent type column, clarify that `pr-reviewer` is spawned by engineer **or** qa-coordinator
- Fix a dangling sentence fragment in the `TIER vs ORG_DOMAIN` callout
