### PR TITLE
docs(agent-tree): adopt coordinator/worker vocabulary throughout

### DIFF
--- a/docs/agent-tree-protocol.md
+++ b/docs/agent-tree-protocol.md
@@ -9,15 +9,17 @@ briefs agents must conform to this spec.
 
 ## Two agent types
 
-Every agent in AgentCeption is exactly one of:
+AgentCeption uses a multi-way tree structure. In CS terms the tree has
+**nodes** and **leaves**; in our domain those map to **coordinators** and
+**workers**:
 
-| Type | Behaviour | May spawn |
-|------|-----------|-----------|
-| **Coordinator** | Surveys a scope (issues, PRs, or sub-label), dispatches children, loops until queue drains, produces no direct artifacts | Other coordinators **or** leaf nodes |
-| **Leaf node** | Claims a single unit of work (one issue or one PR), executes it, may chain-spawn one downstream leaf before reporting done | One downstream leaf node only — never a coordinator |
+| Domain term | CS equivalent | Behaviour | May spawn |
+|-------------|--------------|-----------|-----------|
+| **Coordinator** | node | Surveys a scope (issues, PRs, or sub-label), dispatches children, loops until queue drains, produces no direct artifacts | Other coordinators **or** workers |
+| **Worker** | leaf | Claims a single unit of work (one issue or one PR), executes it, may chain-spawn one downstream worker before reporting done | One downstream worker only — never a coordinator |
 
 Coordinator examples: `ceo`, `cto`, `engineering-coordinator`, `qa-coordinator`.  
-Leaf examples: `python-developer`, `frontend-developer`, `pr-reviewer`.
+Worker examples: `python-developer`, `frontend-developer`, `pr-reviewer`.
 
 ---
 
@@ -27,46 +29,47 @@ Leaf examples: `python-developer`, `frontend-developer`, `pr-reviewer`.
 [ceo]  ← optional; cto becomes root when absent
  └── cto  (coordinator)
       ├── engineering-coordinator  (coordinator)
-      │    └── engineer            (leaf — one issue)
-      │         └── pr-reviewer   (leaf — chain-spawned after engineer opens PR)
+      │    └── engineer            (worker — one issue)
+      │         └── pr-reviewer   (worker — chain-spawned after engineer opens PR)
       └── qa-coordinator           (coordinator — cleanup sweep only)
-           └── pr-reviewer         (leaf — one unreviewed PR)
+           └── pr-reviewer         (worker — one unreviewed PR)
 ```
 
 `pr-reviewer` reaches the tree in **two independent paths**:
 
 1. **Engineer chain-spawn** — after an engineer opens its PR it immediately
-   spawns a `pr-reviewer` leaf before exiting.  The reviewer's `PARENT_RUN_ID`
+   spawns a `pr-reviewer` worker before exiting.  The reviewer's `PARENT_RUN_ID`
    is the engineer's `RUN_ID` and its `ORG_DOMAIN` is `qa`.  No physical QA
-   coordinator node needs to be running for the reviewer to be placed correctly
-   in the hierarchy — `ORG_DOMAIN` alone is enough for the dashboard.
+   coordinator needs to be running for the reviewer to be placed correctly in
+   the hierarchy — `ORG_DOMAIN` alone is enough for the dashboard.
 2. **QA coordinator sweep** — the CTO spawns a `qa-coordinator` when issues
    are exhausted but stale unreviewed PRs remain.  The QA coordinator spawns
-   one `pr-reviewer` leaf per unreviewed PR.
+   one `pr-reviewer` worker per unreviewed PR.
 
 **Chain-spawn constraint:** engineers must never spawn a QA coordinator; they
-spawn only the single `pr-reviewer` leaf that covers their own PR.  A
+spawn only the single `pr-reviewer` worker that covers their own PR.  A
 concurrent QA coordinator launched while issues remain would race against
 chain-spawned reviewers and find no additional PRs to cover.
 
-Any node can be the entry point. When you launch at `engineering-coordinator`,
-there is no CTO or CEO above it — the tree is pruned at that node.
+Any coordinator can be the entry point. When you launch at
+`engineering-coordinator`, there is no CTO or CEO above it — the tree is
+pruned at that coordinator.
 
 ---
 
 ## Tiers
 
 Tiers are the runtime execution label written into every `.agent-task` file.
-They map directly onto the two agent types: coordinators are `root` or
-`coordinator`; leaf nodes are `engineer` or `reviewer`.
+They map directly onto the two agent types: coordinators carry tier `root` or
+`coordinator`; workers carry tier `engineer` or `reviewer`.
 
 | Tier | Agent type | Role examples | GitHub scope | Can spawn |
 |------|-----------|--------------|--------------|-----------|
-| `root` | coordinator | `ceo`, `cto` | issues **and** PRs filtered to `SCOPE_VALUE` | any coordinator or leaf |
-| `coordinator` | coordinator | `engineering-coordinator` | **issues only** filtered to `SCOPE_VALUE` | any engineering leaf role |
+| `root` | coordinator | `ceo`, `cto` | issues **and** PRs filtered to `SCOPE_VALUE` | any coordinator or worker |
+| `coordinator` | coordinator | `engineering-coordinator` | **issues only** filtered to `SCOPE_VALUE` | any engineering worker role |
 | `coordinator` | coordinator | `qa-coordinator` | **PRs only** — cleanup sweep when issues = 0 | `pr-reviewer` |
-| `engineer` | leaf | `python-developer`, `frontend-developer`, `devops-engineer`, … | **one issue** (`SCOPE_VALUE` = issue number) | `pr-reviewer` (chain-spawn after opening PR) |
-| `reviewer` | leaf | `pr-reviewer` | **one PR** (`SCOPE_VALUE` = PR number) | nothing |
+| `engineer` | worker | `python-developer`, `frontend-developer`, `devops-engineer`, … | **one issue** (`SCOPE_VALUE` = issue number) | `pr-reviewer` (chain-spawn after opening PR) |
+| `reviewer` | worker | `pr-reviewer` | **one PR** (`SCOPE_VALUE` = PR number) | nothing |
 
 ### CTO spawn decision
 
@@ -96,8 +99,8 @@ ORG_DOMAIN    = "c-suite"          # UI hierarchy slot: c-suite|engineering|qa
 
 # ── Scope ─────────────────────────────────────────────────────────────────────
 # SCOPE_TYPE  label   → executive/coordinator tiers; SCOPE_VALUE is a GitHub label string
-# SCOPE_TYPE  issue   → engineer leaf; SCOPE_VALUE is the issue number (string)
-# SCOPE_TYPE  pr      → reviewer leaf; SCOPE_VALUE is the PR number (string)
+# SCOPE_TYPE  issue   → engineer worker; SCOPE_VALUE is the issue number (string)
+# SCOPE_TYPE  pr      → reviewer worker; SCOPE_VALUE is the PR number (string)
 SCOPE_TYPE    = "label"
 SCOPE_VALUE   = "AC-UI/0-CRITICAL-BUGS"
 
@@ -116,7 +119,7 @@ ROLE_FILE     = "<container-repo-root>/.agentception/roles/cto.md"
 HOST_ROLE_FILE = "<host-repo-root>/.agentception/roles/cto.md"
 ```
 
-### Leaf engineer example
+### Worker engineer example
 
 ```toml
 RUN_ID        = "issue-42-20260303T200100Z-c3d4"
@@ -155,11 +158,12 @@ HOST_ROLE_FILE = "<host-repo-root>/.agentception/roles/pr-reviewer.md"
 ```
 
 > **`TIER` vs `ORG_DOMAIN`:** `TIER` is the behavioral execution tier —
-> it tells the agent what kind of work it does (survey+spawn vs implement vs review).
+> it tells the agent what kind of work it does (coordinator: survey+spawn vs
+> worker: implement or review).
 > `ORG_DOMAIN` is the organisational slot for the UI hierarchy (c-suite, engineering, qa).
 > A chain-spawned PR reviewer has `TIER=reviewer` and `ORG_DOMAIN=qa` even though its
-> `PARENT_RUN_ID` points to an engineer, so the dashboard nests it under the QA column
-> without requiring a physical QA coordinator node to be running.
+> `PARENT_RUN_ID` points to an engineer worker, so the dashboard nests it under the QA
+> column without requiring a physical QA coordinator to be running.
 
 > `<repo-root>` is the absolute path to the cloned repository on the host
 > machine — the value of `REPO_DIR` (defaults to `/app` inside the
@@ -208,7 +212,7 @@ github_list_prs(state="open")
 Spawns one `reviewer` Task per unreviewed PR, up to 3 concurrently.
 Only spawned by the CTO when `ISSUES == 0` and stale unreviewed PRs remain.
 
-### `engineer` (leaf)
+### `engineer` (worker)
 
 ```
 # Read the single assigned issue
@@ -222,7 +226,7 @@ Implements the issue, opens a PR, then **immediately chain-spawns a
 of the engineer in the hierarchy even though no physical QA coordinator is
 running.
 
-### `reviewer` (leaf)
+### `reviewer` (worker)
 
 ```
 # Read the single assigned PR
@@ -231,7 +235,7 @@ github_get_pr(number=$SCOPE_VALUE)
 
 Reviews, requests changes or approves+merges, calls `report/done`, exits.
 Spawned by **either** an engineer (chain-spawn) **or** a `qa-coordinator`
-(cleanup sweep) — the reviewer itself behaves identically in both cases.
+(cleanup sweep) — the reviewer worker itself behaves identically in both cases.
 
 ---
 
@@ -240,7 +244,7 @@ Spawned by **either** an engineer (chain-spawn) **or** a `qa-coordinator`
 - **Spawn all child Tasks simultaneously in a single message** — there is no concurrency limit.
 - **Always `subagent_type="generalPurpose"`** — never `shell`. Only
   `generalPurpose` agents have access to the Task tool.
-- **Claim before spawning**: manager tiers call
+- **Claim before spawning**: coordinator tiers call
   `POST /api/runs/{run_id}/acknowledge` for each child run_id before
   spawning its Task, preventing double-dispatch.
 - **PARENT_RUN_ID propagation**: every child task receives its physical
@@ -248,12 +252,13 @@ Spawned by **either** an engineer (chain-spawn) **or** a `qa-coordinator`
   `RUN_ID`, not the coordinator's.
 - **ORG_DOMAIN propagation**: every child task should include an
   `ORG_DOMAIN` field (c-suite | engineering | qa). The UI uses this
-  field to place nodes in the hierarchy without requiring a physical parent
-  node to be running. Chain-spawned reviewers must pass `org_domain="qa"`.
+  field to place workers and coordinators in the hierarchy without requiring a
+  physical parent coordinator to be running. Chain-spawned reviewers must pass
+  `org_domain="qa"`.
 - **No concurrent QA coordinator when issues remain**: the CTO must never
-  spawn a QA coordinator when `ISSUES > 0`. Engineers chain-spawn their own
-  reviewers; a concurrent QA coordinator would race against them and find
-  no PRs to review.
+  spawn a QA coordinator when `ISSUES > 0`. Engineer workers chain-spawn their
+  own reviewer workers; a concurrent QA coordinator would race against them and
+  find no PRs to review.
 
 ---
 
@@ -265,10 +270,10 @@ All tiers report progress via MCP tools (never HTTP directly):
 build_report_step(issue_number, step_name, agent_run_id?)
 build_report_blocker(issue_number, description, agent_run_id?)
 build_report_decision(issue_number, decision, rationale, agent_run_id?)
-build_report_done(issue_number, pr_url, summary?, agent_run_id?)  ← leaf tiers only
+build_report_done(issue_number, pr_url, summary?, agent_run_id?)  ← worker tiers only
 ```
 
-Manager tiers call `build_report_step` at each phase of their loop.
+Coordinator tiers call `build_report_step` at each phase of their loop.
 They do NOT call `build_report_done` — they exit naturally after their queue drains.
 
 ---
@@ -278,8 +283,8 @@ They do NOT call `build_report_done` — they exit naturally after their queue d
 | Tier | Agent type | Selectable roles | Spawned by |
 |------|-----------|-----------------|------------|
 | `root` | coordinator | `ceo` | dispatcher (AgentCeption UI / MCP) |
-| `root` | coordinator | `cto` | dispatcher, or CEO when present |
+| `root` | coordinator | `cto` | dispatcher, or CEO coordinator when present |
 | `coordinator` | coordinator | `engineering-coordinator` | CTO (always when issues > 0) |
 | `coordinator` | coordinator | `qa-coordinator` | CTO (cleanup sweep only — issues == 0, PRs > 0) |
-| `engineer` | leaf | `python-developer`, `frontend-developer`, `typescript-developer`, `react-developer`, `go-developer`, `rust-developer`, `api-developer`, `devops-engineer`, `data-engineer`, `site-reliability-engineer`, `security-engineer`, `mobile-developer`, `ios-developer`, `android-developer`, `full-stack-developer`, `architect`, `technical-writer`, `test-engineer`, `ml-engineer`, `systems-programmer`, `rails-developer`, `database-architect` | engineering-coordinator |
-| `reviewer` | leaf | `pr-reviewer` | engineer (chain-spawn after PR open) **or** qa-coordinator (cleanup sweep) |
+| `engineer` | worker | `python-developer`, `frontend-developer`, `typescript-developer`, `react-developer`, `go-developer`, `rust-developer`, `api-developer`, `devops-engineer`, `data-engineer`, `site-reliability-engineer`, `security-engineer`, `mobile-developer`, `ios-developer`, `android-developer`, `full-stack-developer`, `architect`, `technical-writer`, `test-engineer`, `ml-engineer`, `systems-programmer`, `rails-developer`, `database-architect` | engineering-coordinator |
+| `reviewer` | worker | `pr-reviewer` | engineer worker (chain-spawn after PR open) **or** qa-coordinator (cleanup sweep) |


### PR DESCRIPTION
## Summary

Establishes the canonical domain vocabulary: **coordinator** (CS: node) and **worker** (CS: leaf).

- The two-type table now leads with domain terms and notes CS equivalents parenthetically in a dedicated column
- Every occurrence of "leaf node", "leaf tier", "manager tier", and "leaf engineer" in domain-facing prose is replaced with the correct domain term
- The sole remaining use of `leaf` is in the CS-equivalent column of the types table — the intentional and correct location
- No logic changes; documentation only
