### PR TITLE
docs: simplify root annotation in agent tree diagram

### DIFF
--- a/docs/agent-tree-protocol.md
+++ b/docs/agent-tree-protocol.md
@@ -26,9 +26,7 @@ Worker examples: `python-developer`, `frontend-developer`, `pr-reviewer`.
 ## The tree
 
 ```
-[any coordinator]  ← any coordinator can be root; the tree is pruned at the entry point
-      │
-[ceo] (optional)
+[ceo]  ← example root; any coordinator can be root — tree is pruned at the entry point
  └── cto  (coordinator)
       ├── engineering-coordinator  (coordinator)
       │    └── engineer            (worker — one issue)


### PR DESCRIPTION
Collapses the two-line root annotation into a single line using CEO as a concrete example, with an inline note that any coordinator can be root.