### PR TITLE
refactor: rename pipeline labels to slash-convention

### DIFF
--- a/.agentception/agent-engineer.md
+++ b/.agentception/agent-engineer.md
@@ -143,9 +143,9 @@ Before finalising your four, confirm each pair is independent:
 
 If issues are **dependent** (B cannot ship without A):
 1. State it in the issue body: `**Depends on #A** — implement after #A is merged.`
-2. Label it `ticket-blocked` (distinct from `blocked`, which is the phase-gate label).
+2. Label it `blocked/deps` (distinct from `pipeline/gated`, which is the phase-gate label).
 3. Do **not** assign it to a parallel agent until #A is merged.
-4. The poller automatically removes `ticket-blocked` once all dependencies close.
+4. The poller automatically removes `blocked/deps` once all dependencies close.
 5. Only then is it safe for the coordinator to pick it up in the next dispatch cycle.
 
 ---
@@ -685,7 +685,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
       echo "   A) If the dependency's code is NOT needed to implement this issue → proceed."
       echo "      Note unmet deps in the PR body. Use TYPE_CHECKING guards for any missing imports."
       echo "   B) If the dependency's code IS required (e.g. imports a module that doesn't exist yet)"
-      echo "      → clean abort: remove agent:wip, remove this worktree, and skip this issue."
+      echo "      → clean abort: remove agent/wip, remove this worktree, and skip this issue."
       echo "      CLEAN ABORT sequence:"
       echo "        MCP: github_remove_label(issue_number=N, label=\"agent/wip\")"
       echo "        MCP: github_remove_label(issue_number=N, label=\"status/in-progress\")"
@@ -1008,7 +1008,7 @@ STEP 5 — PUSH & CREATE PR:
   if [ -n "$MY_PR_NUM" ]; then
     sed -i '' "s/^LINKED_PR=.*/LINKED_PR=$MY_PR_NUM/" .agent-task 2>/dev/null || true
     echo "✅ LINKED_PR=$MY_PR_NUM written back to .agent-task"
-    # ⚠️  Do NOT add agent:wip to the PR here. agent:wip on a PR means
+    # ⚠️  Do NOT add agent/wip to the PR here. agent/wip on a PR means
     # "a reviewer is actively working on this." The reviewer claims it in STEP 3
     # of agent-reviewer.md after its idempotency gate passes. The idempotency
     # gate (reviewDecision = APPROVED check) already prevents double-reviews without
@@ -1070,7 +1070,7 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # Create a fresh review worktree at the PR branch tip.
     REVIEW_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$MY_PR"
     git -C "$REPO" worktree add "$REVIEW_WORKTREE" "origin/$MY_BRANCH"
-    # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+    # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
     # after passing the idempotency gate. Adding it here causes stale labels when the
     # reviewer is never launched or crashes before claiming.
 
@@ -1236,8 +1236,8 @@ same parallel batch.
 
 **Dependency detection:** If issue B cannot function without A's code:
 1. Note `**Depends on #A**` in B's issue body.
-2. Label B as `ticket-blocked` (NOT `blocked` — `blocked` is for phase-gating only).
-3. The poller removes `ticket-blocked` automatically once A is closed.
+2. Label B as `blocked/deps` (NOT `pipeline/gated` — `pipeline/gated` is for phase-gating only).
+3. The poller removes `blocked/deps` automatically once A is closed.
 4. Merge A first; the coordinator will pick up B on the next dispatch cycle.
 
 ### Step C — Confirm `dev` is up to date

--- a/.agentception/agent-reviewer.md
+++ b/.agentception/agent-reviewer.md
@@ -1027,8 +1027,8 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   │ URL and the exact error, and let the user merge manually.                  │
   └─────────────────────────────────────────────────────────────────────────────
 
-  # 6. Clear agent:wip now that the PR is merged — it must not persist on closed PRs.
-       # MCP: github_remove_label(issue_number=N, label="agent:wip")
+  # 6. Clear agent/wip now that the PR is merged — it must not persist on closed PRs.
+       # MCP: github_remove_label(issue_number=N, label="agent/wip")
 
   # 7. Delete the remote branch — CHECK EXISTENCE FIRST.
   # GitHub auto-delete-head-branches is ENABLED on this repo, so the branch is
@@ -1120,7 +1120,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          #       issue_number=<N>, state="closed", state_reason="completed")
          # MCP: add_issue_comment(owner="cgcardona", repo="agentception",
          #       issue_number=<N>, body="$CLOSE_COMMENT")
-         # MCP: github_remove_label(issue_number=<N>, label="agent:wip")
+         # MCP: github_remove_label(issue_number=<N>, label="agent/wip")
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
@@ -1291,7 +1291,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "agent/wip" (already claimed),
-      # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
+      # "pipeline/gated" (phase-gated), or "blocked/deps" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
       # Take the lowest-numbered remaining issue.
       NEXT_ISSUE=<lowest unclaimed issue number from MCP response>
@@ -1403,7 +1403,7 @@ TASK
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
-      # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+      # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
       # after passing the idempotency gate. Adding it here causes stale labels when the
       # reviewer is never launched or crashes before claiming.
 
@@ -1476,7 +1476,7 @@ TASK
   fi
 
 STEP 9 — SELF-DESTRUCT (always run this after STEP 8, merge or not, early stop or not):
-  # Unconditionally clear agent:wip — covers D/F grade, merge failure, and timeout paths
+  # Unconditionally clear agent/wip — covers D/F grade, merge failure, and timeout paths
   # where STEP 6 was never reached. Removing a non-existent label is a no-op.
   # MCP: github_remove_label(issue_number=N, label="agent/wip")
   WORKTREE=$(pwd)

--- a/.agentception/dispatcher.md
+++ b/.agentception/dispatcher.md
@@ -150,7 +150,7 @@ Step 3: Run your tier's GitHub queries via MCP to discover what needs doing.
   coordinator (engineering-coordinator role) — call:
     list_issues (user-github)(label="{scope_value}", state="open")
   Filter out any issues with label "agent/wip" (already claimed),
-  "blocked" (phase-gated — prior phase not yet complete), or "ticket-blocked"
+  "pipeline/gated" (phase-gated — prior phase not yet complete), or "blocked/deps"
   (has unresolved ticket-level dependencies — do not dispatch until all are closed).
   Only work on issues with none of these three labels.
   Then: spawn one engineer per eligible issue (all in parallel via Task calls).

--- a/.agentception/pipeline-config.json
+++ b/.agentception/pipeline-config.json
@@ -22,6 +22,6 @@
     "security",
     "api-contract"
   ],
-  "phase_advance_blocked_label": "blocked",
-  "phase_advance_active_label": "pipeline-active"
+  "phase_advance_blocked_label": "pipeline/gated",
+  "phase_advance_active_label": "pipeline/active"
 }

--- a/.agentception/roles/ceo.md
+++ b/.agentception/roles/ceo.md
@@ -775,8 +775,8 @@ SEED:
          # MCP: list_issues (user-github)(state="open", labels=["$TEAM_LABEL", "$ACTIVE_PHASE"])
          # → filter result to exclude issues that have any of these labels:
          #     "agent/wip"  (already claimed by another agent)
-         #     "blocked"            (phase-gated — prior phase not yet complete)
-         #     "ticket-blocked"     (has unresolved ticket-level dependency — the
+         #     "pipeline/gated"     (phase-gated — prior phase not yet complete)
+         #     "blocked/deps"       (has unresolved ticket-level dependency — the
          #                           poller removes this label automatically once
          #                           all deps close; never dispatch these manually)
          # → append remaining to CANDIDATES
@@ -799,8 +799,8 @@ SEED:
        done
 
   3.6 Dependency gate — CRITICAL for sequential issues:
-     Primary signal: if an issue has the "ticket-blocked" label (already filtered
-     out in step 3), it must NOT be seeded. The poller removes "ticket-blocked"
+     Primary signal: if an issue has the "blocked/deps" label (already filtered
+     out in step 3), it must NOT be seeded. The poller removes "blocked/deps"
      automatically once all deps close, so by the time this coordinator runs, any
      issue without that label has met its ticket-level deps.
      Secondary signal (belt-and-suspenders): parse "Blocked by #NNN" from the
@@ -1055,9 +1055,9 @@ Before finalising your four, confirm each pair is independent:
 
 If issues are **dependent** (B cannot ship without A):
 1. State it in the issue body: `**Depends on #A** — implement after #A is merged.`
-2. Label it `ticket-blocked` (distinct from `blocked`, which is the phase-gate label).
+2. Label it `blocked/deps` (distinct from `pipeline/gated`, which is the phase-gate label).
 3. Do **not** assign it to a parallel agent until #A is merged.
-4. The poller automatically removes `ticket-blocked` once all dependencies close.
+4. The poller automatically removes `blocked/deps` once all dependencies close.
 5. Only then is it safe for the coordinator to pick it up in the next dispatch cycle.
 
 ---
@@ -1597,7 +1597,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
       echo "   A) If the dependency's code is NOT needed to implement this issue → proceed."
       echo "      Note unmet deps in the PR body. Use TYPE_CHECKING guards for any missing imports."
       echo "   B) If the dependency's code IS required (e.g. imports a module that doesn't exist yet)"
-      echo "      → clean abort: remove agent:wip, remove this worktree, and skip this issue."
+      echo "      → clean abort: remove agent/wip, remove this worktree, and skip this issue."
       echo "      CLEAN ABORT sequence:"
       echo "        MCP: github_remove_label(issue_number=N, label=\"agent/wip\")"
       echo "        MCP: github_remove_label(issue_number=N, label=\"status/in-progress\")"
@@ -1920,7 +1920,7 @@ STEP 5 — PUSH & CREATE PR:
   if [ -n "$MY_PR_NUM" ]; then
     sed -i '' "s/^LINKED_PR=.*/LINKED_PR=$MY_PR_NUM/" .agent-task 2>/dev/null || true
     echo "✅ LINKED_PR=$MY_PR_NUM written back to .agent-task"
-    # ⚠️  Do NOT add agent:wip to the PR here. agent:wip on a PR means
+    # ⚠️  Do NOT add agent/wip to the PR here. agent/wip on a PR means
     # "a reviewer is actively working on this." The reviewer claims it in STEP 3
     # of agent-reviewer.md after its idempotency gate passes. The idempotency
     # gate (reviewDecision = APPROVED check) already prevents double-reviews without
@@ -1982,7 +1982,7 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # Create a fresh review worktree at the PR branch tip.
     REVIEW_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$MY_PR"
     git -C "$REPO" worktree add "$REVIEW_WORKTREE" "origin/$MY_BRANCH"
-    # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+    # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
     # after passing the idempotency gate. Adding it here causes stale labels when the
     # reviewer is never launched or crashes before claiming.
 
@@ -2148,8 +2148,8 @@ same parallel batch.
 
 **Dependency detection:** If issue B cannot function without A's code:
 1. Note `**Depends on #A**` in B's issue body.
-2. Label B as `ticket-blocked` (NOT `blocked` — `blocked` is for phase-gating only).
-3. The poller removes `ticket-blocked` automatically once A is closed.
+2. Label B as `blocked/deps` (NOT `pipeline/gated` — `pipeline/gated` is for phase-gating only).
+3. The poller removes `blocked/deps` automatically once A is closed.
 4. Merge A first; the coordinator will pick up B on the next dispatch cycle.
 
 ### Step C — Confirm `dev` is up to date
@@ -3670,8 +3670,8 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   │ URL and the exact error, and let the user merge manually.                  │
   └─────────────────────────────────────────────────────────────────────────────
 
-  # 6. Clear agent:wip now that the PR is merged — it must not persist on closed PRs.
-       # MCP: github_remove_label(issue_number=N, label="agent:wip")
+  # 6. Clear agent/wip now that the PR is merged — it must not persist on closed PRs.
+       # MCP: github_remove_label(issue_number=N, label="agent/wip")
 
   # 7. Delete the remote branch — CHECK EXISTENCE FIRST.
   # GitHub auto-delete-head-branches is ENABLED on this repo, so the branch is
@@ -3763,7 +3763,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          #       issue_number=<N>, state="closed", state_reason="completed")
          # MCP: add_issue_comment(owner="cgcardona", repo="agentception",
          #       issue_number=<N>, body="$CLOSE_COMMENT")
-         # MCP: github_remove_label(issue_number=<N>, label="agent:wip")
+         # MCP: github_remove_label(issue_number=<N>, label="agent/wip")
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
@@ -3934,7 +3934,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "agent/wip" (already claimed),
-      # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
+      # "pipeline/gated" (phase-gated), or "blocked/deps" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
       # Take the lowest-numbered remaining issue.
       NEXT_ISSUE=<lowest unclaimed issue number from MCP response>
@@ -4046,7 +4046,7 @@ TASK
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
-      # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+      # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
       # after passing the idempotency gate. Adding it here causes stale labels when the
       # reviewer is never launched or crashes before claiming.
 
@@ -4119,7 +4119,7 @@ TASK
   fi
 
 STEP 9 — SELF-DESTRUCT (always run this after STEP 8, merge or not, early stop or not):
-  # Unconditionally clear agent:wip — covers D/F grade, merge failure, and timeout paths
+  # Unconditionally clear agent/wip — covers D/F grade, merge failure, and timeout paths
   # where STEP 6 was never reached. Removing a non-existent label is a no-op.
   # MCP: github_remove_label(issue_number=N, label="agent/wip")
   WORKTREE=$(pwd)
@@ -5672,8 +5672,8 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   │ URL and the exact error, and let the user merge manually.                  │
   └─────────────────────────────────────────────────────────────────────────────
 
-  # 6. Clear agent:wip now that the PR is merged — it must not persist on closed PRs.
-       # MCP: github_remove_label(issue_number=N, label="agent:wip")
+  # 6. Clear agent/wip now that the PR is merged — it must not persist on closed PRs.
+       # MCP: github_remove_label(issue_number=N, label="agent/wip")
 
   # 7. Delete the remote branch — CHECK EXISTENCE FIRST.
   # GitHub auto-delete-head-branches is ENABLED on this repo, so the branch is
@@ -5765,7 +5765,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          #       issue_number=<N>, state="closed", state_reason="completed")
          # MCP: add_issue_comment(owner="cgcardona", repo="agentception",
          #       issue_number=<N>, body="$CLOSE_COMMENT")
-         # MCP: github_remove_label(issue_number=<N>, label="agent:wip")
+         # MCP: github_remove_label(issue_number=<N>, label="agent/wip")
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
@@ -5936,7 +5936,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "agent/wip" (already claimed),
-      # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
+      # "pipeline/gated" (phase-gated), or "blocked/deps" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
       # Take the lowest-numbered remaining issue.
       NEXT_ISSUE=<lowest unclaimed issue number from MCP response>
@@ -6048,7 +6048,7 @@ TASK
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
-      # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+      # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
       # after passing the idempotency gate. Adding it here causes stale labels when the
       # reviewer is never launched or crashes before claiming.
 
@@ -6121,7 +6121,7 @@ TASK
   fi
 
 STEP 9 — SELF-DESTRUCT (always run this after STEP 8, merge or not, early stop or not):
-  # Unconditionally clear agent:wip — covers D/F grade, merge failure, and timeout paths
+  # Unconditionally clear agent/wip — covers D/F grade, merge failure, and timeout paths
   # where STEP 6 was never reached. Removing a non-existent label is a no-op.
   # MCP: github_remove_label(issue_number=N, label="agent/wip")
   WORKTREE=$(pwd)
@@ -6566,9 +6566,9 @@ Before finalising your four, confirm each pair is independent:
 
 If issues are **dependent** (B cannot ship without A):
 1. State it in the issue body: `**Depends on #A** — implement after #A is merged.`
-2. Label it `ticket-blocked` (distinct from `blocked`, which is the phase-gate label).
+2. Label it `blocked/deps` (distinct from `pipeline/gated`, which is the phase-gate label).
 3. Do **not** assign it to a parallel agent until #A is merged.
-4. The poller automatically removes `ticket-blocked` once all dependencies close.
+4. The poller automatically removes `blocked/deps` once all dependencies close.
 5. Only then is it safe for the coordinator to pick it up in the next dispatch cycle.
 
 ---
@@ -7108,7 +7108,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
       echo "   A) If the dependency's code is NOT needed to implement this issue → proceed."
       echo "      Note unmet deps in the PR body. Use TYPE_CHECKING guards for any missing imports."
       echo "   B) If the dependency's code IS required (e.g. imports a module that doesn't exist yet)"
-      echo "      → clean abort: remove agent:wip, remove this worktree, and skip this issue."
+      echo "      → clean abort: remove agent/wip, remove this worktree, and skip this issue."
       echo "      CLEAN ABORT sequence:"
       echo "        MCP: github_remove_label(issue_number=N, label=\"agent/wip\")"
       echo "        MCP: github_remove_label(issue_number=N, label=\"status/in-progress\")"
@@ -7431,7 +7431,7 @@ STEP 5 — PUSH & CREATE PR:
   if [ -n "$MY_PR_NUM" ]; then
     sed -i '' "s/^LINKED_PR=.*/LINKED_PR=$MY_PR_NUM/" .agent-task 2>/dev/null || true
     echo "✅ LINKED_PR=$MY_PR_NUM written back to .agent-task"
-    # ⚠️  Do NOT add agent:wip to the PR here. agent:wip on a PR means
+    # ⚠️  Do NOT add agent/wip to the PR here. agent/wip on a PR means
     # "a reviewer is actively working on this." The reviewer claims it in STEP 3
     # of agent-reviewer.md after its idempotency gate passes. The idempotency
     # gate (reviewDecision = APPROVED check) already prevents double-reviews without
@@ -7493,7 +7493,7 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # Create a fresh review worktree at the PR branch tip.
     REVIEW_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$MY_PR"
     git -C "$REPO" worktree add "$REVIEW_WORKTREE" "origin/$MY_BRANCH"
-    # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+    # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
     # after passing the idempotency gate. Adding it here causes stale labels when the
     # reviewer is never launched or crashes before claiming.
 
@@ -7659,8 +7659,8 @@ same parallel batch.
 
 **Dependency detection:** If issue B cannot function without A's code:
 1. Note `**Depends on #A**` in B's issue body.
-2. Label B as `ticket-blocked` (NOT `blocked` — `blocked` is for phase-gating only).
-3. The poller removes `ticket-blocked` automatically once A is closed.
+2. Label B as `blocked/deps` (NOT `pipeline/gated` — `pipeline/gated` is for phase-gating only).
+3. The poller removes `blocked/deps` automatically once A is closed.
 4. Merge A first; the coordinator will pick up B on the next dispatch cycle.
 
 ### Step C — Confirm `dev` is up to date

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -438,8 +438,8 @@ SEED:
          # MCP: list_issues (user-github)(state="open", labels=["$TEAM_LABEL", "$ACTIVE_PHASE"])
          # → filter result to exclude issues that have any of these labels:
          #     "agent/wip"  (already claimed by another agent)
-         #     "blocked"            (phase-gated — prior phase not yet complete)
-         #     "ticket-blocked"     (has unresolved ticket-level dependency — the
+         #     "pipeline/gated"     (phase-gated — prior phase not yet complete)
+         #     "blocked/deps"       (has unresolved ticket-level dependency — the
          #                           poller removes this label automatically once
          #                           all deps close; never dispatch these manually)
          # → append remaining to CANDIDATES
@@ -462,8 +462,8 @@ SEED:
        done
 
   3.6 Dependency gate — CRITICAL for sequential issues:
-     Primary signal: if an issue has the "ticket-blocked" label (already filtered
-     out in step 3), it must NOT be seeded. The poller removes "ticket-blocked"
+     Primary signal: if an issue has the "blocked/deps" label (already filtered
+     out in step 3), it must NOT be seeded. The poller removes "blocked/deps"
      automatically once all deps close, so by the time this coordinator runs, any
      issue without that label has met its ticket-level deps.
      Secondary signal (belt-and-suspenders): parse "Blocked by #NNN" from the
@@ -718,9 +718,9 @@ Before finalising your four, confirm each pair is independent:
 
 If issues are **dependent** (B cannot ship without A):
 1. State it in the issue body: `**Depends on #A** — implement after #A is merged.`
-2. Label it `ticket-blocked` (distinct from `blocked`, which is the phase-gate label).
+2. Label it `blocked/deps` (distinct from `pipeline/gated`, which is the phase-gate label).
 3. Do **not** assign it to a parallel agent until #A is merged.
-4. The poller automatically removes `ticket-blocked` once all dependencies close.
+4. The poller automatically removes `blocked/deps` once all dependencies close.
 5. Only then is it safe for the coordinator to pick it up in the next dispatch cycle.
 
 ---
@@ -1260,7 +1260,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
       echo "   A) If the dependency's code is NOT needed to implement this issue → proceed."
       echo "      Note unmet deps in the PR body. Use TYPE_CHECKING guards for any missing imports."
       echo "   B) If the dependency's code IS required (e.g. imports a module that doesn't exist yet)"
-      echo "      → clean abort: remove agent:wip, remove this worktree, and skip this issue."
+      echo "      → clean abort: remove agent/wip, remove this worktree, and skip this issue."
       echo "      CLEAN ABORT sequence:"
       echo "        MCP: github_remove_label(issue_number=N, label=\"agent/wip\")"
       echo "        MCP: github_remove_label(issue_number=N, label=\"status/in-progress\")"
@@ -1583,7 +1583,7 @@ STEP 5 — PUSH & CREATE PR:
   if [ -n "$MY_PR_NUM" ]; then
     sed -i '' "s/^LINKED_PR=.*/LINKED_PR=$MY_PR_NUM/" .agent-task 2>/dev/null || true
     echo "✅ LINKED_PR=$MY_PR_NUM written back to .agent-task"
-    # ⚠️  Do NOT add agent:wip to the PR here. agent:wip on a PR means
+    # ⚠️  Do NOT add agent/wip to the PR here. agent/wip on a PR means
     # "a reviewer is actively working on this." The reviewer claims it in STEP 3
     # of agent-reviewer.md after its idempotency gate passes. The idempotency
     # gate (reviewDecision = APPROVED check) already prevents double-reviews without
@@ -1645,7 +1645,7 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # Create a fresh review worktree at the PR branch tip.
     REVIEW_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$MY_PR"
     git -C "$REPO" worktree add "$REVIEW_WORKTREE" "origin/$MY_BRANCH"
-    # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+    # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
     # after passing the idempotency gate. Adding it here causes stale labels when the
     # reviewer is never launched or crashes before claiming.
 
@@ -1811,8 +1811,8 @@ same parallel batch.
 
 **Dependency detection:** If issue B cannot function without A's code:
 1. Note `**Depends on #A**` in B's issue body.
-2. Label B as `ticket-blocked` (NOT `blocked` — `blocked` is for phase-gating only).
-3. The poller removes `ticket-blocked` automatically once A is closed.
+2. Label B as `blocked/deps` (NOT `pipeline/gated` — `pipeline/gated` is for phase-gating only).
+3. The poller removes `blocked/deps` automatically once A is closed.
 4. Merge A first; the coordinator will pick up B on the next dispatch cycle.
 
 ### Step C — Confirm `dev` is up to date
@@ -3333,8 +3333,8 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   │ URL and the exact error, and let the user merge manually.                  │
   └─────────────────────────────────────────────────────────────────────────────
 
-  # 6. Clear agent:wip now that the PR is merged — it must not persist on closed PRs.
-       # MCP: github_remove_label(issue_number=N, label="agent:wip")
+  # 6. Clear agent/wip now that the PR is merged — it must not persist on closed PRs.
+       # MCP: github_remove_label(issue_number=N, label="agent/wip")
 
   # 7. Delete the remote branch — CHECK EXISTENCE FIRST.
   # GitHub auto-delete-head-branches is ENABLED on this repo, so the branch is
@@ -3426,7 +3426,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          #       issue_number=<N>, state="closed", state_reason="completed")
          # MCP: add_issue_comment(owner="cgcardona", repo="agentception",
          #       issue_number=<N>, body="$CLOSE_COMMENT")
-         # MCP: github_remove_label(issue_number=<N>, label="agent:wip")
+         # MCP: github_remove_label(issue_number=<N>, label="agent/wip")
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
@@ -3597,7 +3597,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "agent/wip" (already claimed),
-      # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
+      # "pipeline/gated" (phase-gated), or "blocked/deps" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
       # Take the lowest-numbered remaining issue.
       NEXT_ISSUE=<lowest unclaimed issue number from MCP response>
@@ -3709,7 +3709,7 @@ TASK
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
-      # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+      # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
       # after passing the idempotency gate. Adding it here causes stale labels when the
       # reviewer is never launched or crashes before claiming.
 
@@ -3782,7 +3782,7 @@ TASK
   fi
 
 STEP 9 — SELF-DESTRUCT (always run this after STEP 8, merge or not, early stop or not):
-  # Unconditionally clear agent:wip — covers D/F grade, merge failure, and timeout paths
+  # Unconditionally clear agent/wip — covers D/F grade, merge failure, and timeout paths
   # where STEP 6 was never reached. Removing a non-existent label is a no-op.
   # MCP: github_remove_label(issue_number=N, label="agent/wip")
   WORKTREE=$(pwd)
@@ -5335,8 +5335,8 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   │ URL and the exact error, and let the user merge manually.                  │
   └─────────────────────────────────────────────────────────────────────────────
 
-  # 6. Clear agent:wip now that the PR is merged — it must not persist on closed PRs.
-       # MCP: github_remove_label(issue_number=N, label="agent:wip")
+  # 6. Clear agent/wip now that the PR is merged — it must not persist on closed PRs.
+       # MCP: github_remove_label(issue_number=N, label="agent/wip")
 
   # 7. Delete the remote branch — CHECK EXISTENCE FIRST.
   # GitHub auto-delete-head-branches is ENABLED on this repo, so the branch is
@@ -5428,7 +5428,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          #       issue_number=<N>, state="closed", state_reason="completed")
          # MCP: add_issue_comment(owner="cgcardona", repo="agentception",
          #       issue_number=<N>, body="$CLOSE_COMMENT")
-         # MCP: github_remove_label(issue_number=<N>, label="agent:wip")
+         # MCP: github_remove_label(issue_number=<N>, label="agent/wip")
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
@@ -5599,7 +5599,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "agent/wip" (already claimed),
-      # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
+      # "pipeline/gated" (phase-gated), or "blocked/deps" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
       # Take the lowest-numbered remaining issue.
       NEXT_ISSUE=<lowest unclaimed issue number from MCP response>
@@ -5711,7 +5711,7 @@ TASK
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
-      # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+      # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
       # after passing the idempotency gate. Adding it here causes stale labels when the
       # reviewer is never launched or crashes before claiming.
 
@@ -5784,7 +5784,7 @@ TASK
   fi
 
 STEP 9 — SELF-DESTRUCT (always run this after STEP 8, merge or not, early stop or not):
-  # Unconditionally clear agent:wip — covers D/F grade, merge failure, and timeout paths
+  # Unconditionally clear agent/wip — covers D/F grade, merge failure, and timeout paths
   # where STEP 6 was never reached. Removing a non-existent label is a no-op.
   # MCP: github_remove_label(issue_number=N, label="agent/wip")
   WORKTREE=$(pwd)
@@ -6229,9 +6229,9 @@ Before finalising your four, confirm each pair is independent:
 
 If issues are **dependent** (B cannot ship without A):
 1. State it in the issue body: `**Depends on #A** — implement after #A is merged.`
-2. Label it `ticket-blocked` (distinct from `blocked`, which is the phase-gate label).
+2. Label it `blocked/deps` (distinct from `pipeline/gated`, which is the phase-gate label).
 3. Do **not** assign it to a parallel agent until #A is merged.
-4. The poller automatically removes `ticket-blocked` once all dependencies close.
+4. The poller automatically removes `blocked/deps` once all dependencies close.
 5. Only then is it safe for the coordinator to pick it up in the next dispatch cycle.
 
 ---
@@ -6771,7 +6771,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
       echo "   A) If the dependency's code is NOT needed to implement this issue → proceed."
       echo "      Note unmet deps in the PR body. Use TYPE_CHECKING guards for any missing imports."
       echo "   B) If the dependency's code IS required (e.g. imports a module that doesn't exist yet)"
-      echo "      → clean abort: remove agent:wip, remove this worktree, and skip this issue."
+      echo "      → clean abort: remove agent/wip, remove this worktree, and skip this issue."
       echo "      CLEAN ABORT sequence:"
       echo "        MCP: github_remove_label(issue_number=N, label=\"agent/wip\")"
       echo "        MCP: github_remove_label(issue_number=N, label=\"status/in-progress\")"
@@ -7094,7 +7094,7 @@ STEP 5 — PUSH & CREATE PR:
   if [ -n "$MY_PR_NUM" ]; then
     sed -i '' "s/^LINKED_PR=.*/LINKED_PR=$MY_PR_NUM/" .agent-task 2>/dev/null || true
     echo "✅ LINKED_PR=$MY_PR_NUM written back to .agent-task"
-    # ⚠️  Do NOT add agent:wip to the PR here. agent:wip on a PR means
+    # ⚠️  Do NOT add agent/wip to the PR here. agent/wip on a PR means
     # "a reviewer is actively working on this." The reviewer claims it in STEP 3
     # of agent-reviewer.md after its idempotency gate passes. The idempotency
     # gate (reviewDecision = APPROVED check) already prevents double-reviews without
@@ -7156,7 +7156,7 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # Create a fresh review worktree at the PR branch tip.
     REVIEW_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$MY_PR"
     git -C "$REPO" worktree add "$REVIEW_WORKTREE" "origin/$MY_BRANCH"
-    # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+    # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
     # after passing the idempotency gate. Adding it here causes stale labels when the
     # reviewer is never launched or crashes before claiming.
 
@@ -7322,8 +7322,8 @@ same parallel batch.
 
 **Dependency detection:** If issue B cannot function without A's code:
 1. Note `**Depends on #A**` in B's issue body.
-2. Label B as `ticket-blocked` (NOT `blocked` — `blocked` is for phase-gating only).
-3. The poller removes `ticket-blocked` automatically once A is closed.
+2. Label B as `blocked/deps` (NOT `pipeline/gated` — `pipeline/gated` is for phase-gating only).
+3. The poller removes `blocked/deps` automatically once A is closed.
 4. Merge A first; the coordinator will pick up B on the next dispatch cycle.
 
 ### Step C — Confirm `dev` is up to date

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -163,8 +163,8 @@ SEED:
          # MCP: list_issues (user-github)(state="open", labels=["$TEAM_LABEL", "$ACTIVE_PHASE"])
          # → filter result to exclude issues that have any of these labels:
          #     "agent/wip"  (already claimed by another agent)
-         #     "blocked"            (phase-gated — prior phase not yet complete)
-         #     "ticket-blocked"     (has unresolved ticket-level dependency — the
+         #     "pipeline/gated"     (phase-gated — prior phase not yet complete)
+         #     "blocked/deps"       (has unresolved ticket-level dependency — the
          #                           poller removes this label automatically once
          #                           all deps close; never dispatch these manually)
          # → append remaining to CANDIDATES
@@ -187,8 +187,8 @@ SEED:
        done
 
   3.6 Dependency gate — CRITICAL for sequential issues:
-     Primary signal: if an issue has the "ticket-blocked" label (already filtered
-     out in step 3), it must NOT be seeded. The poller removes "ticket-blocked"
+     Primary signal: if an issue has the "blocked/deps" label (already filtered
+     out in step 3), it must NOT be seeded. The poller removes "blocked/deps"
      automatically once all deps close, so by the time this coordinator runs, any
      issue without that label has met its ticket-level deps.
      Secondary signal (belt-and-suspenders): parse "Blocked by #NNN" from the
@@ -443,9 +443,9 @@ Before finalising your four, confirm each pair is independent:
 
 If issues are **dependent** (B cannot ship without A):
 1. State it in the issue body: `**Depends on #A** — implement after #A is merged.`
-2. Label it `ticket-blocked` (distinct from `blocked`, which is the phase-gate label).
+2. Label it `blocked/deps` (distinct from `pipeline/gated`, which is the phase-gate label).
 3. Do **not** assign it to a parallel agent until #A is merged.
-4. The poller automatically removes `ticket-blocked` once all dependencies close.
+4. The poller automatically removes `blocked/deps` once all dependencies close.
 5. Only then is it safe for the coordinator to pick it up in the next dispatch cycle.
 
 ---
@@ -985,7 +985,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
       echo "   A) If the dependency's code is NOT needed to implement this issue → proceed."
       echo "      Note unmet deps in the PR body. Use TYPE_CHECKING guards for any missing imports."
       echo "   B) If the dependency's code IS required (e.g. imports a module that doesn't exist yet)"
-      echo "      → clean abort: remove agent:wip, remove this worktree, and skip this issue."
+      echo "      → clean abort: remove agent/wip, remove this worktree, and skip this issue."
       echo "      CLEAN ABORT sequence:"
       echo "        MCP: github_remove_label(issue_number=N, label=\"agent/wip\")"
       echo "        MCP: github_remove_label(issue_number=N, label=\"status/in-progress\")"
@@ -1308,7 +1308,7 @@ STEP 5 — PUSH & CREATE PR:
   if [ -n "$MY_PR_NUM" ]; then
     sed -i '' "s/^LINKED_PR=.*/LINKED_PR=$MY_PR_NUM/" .agent-task 2>/dev/null || true
     echo "✅ LINKED_PR=$MY_PR_NUM written back to .agent-task"
-    # ⚠️  Do NOT add agent:wip to the PR here. agent:wip on a PR means
+    # ⚠️  Do NOT add agent/wip to the PR here. agent/wip on a PR means
     # "a reviewer is actively working on this." The reviewer claims it in STEP 3
     # of agent-reviewer.md after its idempotency gate passes. The idempotency
     # gate (reviewDecision = APPROVED check) already prevents double-reviews without
@@ -1370,7 +1370,7 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # Create a fresh review worktree at the PR branch tip.
     REVIEW_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$MY_PR"
     git -C "$REPO" worktree add "$REVIEW_WORKTREE" "origin/$MY_BRANCH"
-    # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+    # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
     # after passing the idempotency gate. Adding it here causes stale labels when the
     # reviewer is never launched or crashes before claiming.
 
@@ -1536,8 +1536,8 @@ same parallel batch.
 
 **Dependency detection:** If issue B cannot function without A's code:
 1. Note `**Depends on #A**` in B's issue body.
-2. Label B as `ticket-blocked` (NOT `blocked` — `blocked` is for phase-gating only).
-3. The poller removes `ticket-blocked` automatically once A is closed.
+2. Label B as `blocked/deps` (NOT `pipeline/gated` — `pipeline/gated` is for phase-gating only).
+3. The poller removes `blocked/deps` automatically once A is closed.
 4. Merge A first; the coordinator will pick up B on the next dispatch cycle.
 
 ### Step C — Confirm `dev` is up to date
@@ -3058,8 +3058,8 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   │ URL and the exact error, and let the user merge manually.                  │
   └─────────────────────────────────────────────────────────────────────────────
 
-  # 6. Clear agent:wip now that the PR is merged — it must not persist on closed PRs.
-       # MCP: github_remove_label(issue_number=N, label="agent:wip")
+  # 6. Clear agent/wip now that the PR is merged — it must not persist on closed PRs.
+       # MCP: github_remove_label(issue_number=N, label="agent/wip")
 
   # 7. Delete the remote branch — CHECK EXISTENCE FIRST.
   # GitHub auto-delete-head-branches is ENABLED on this repo, so the branch is
@@ -3151,7 +3151,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          #       issue_number=<N>, state="closed", state_reason="completed")
          # MCP: add_issue_comment(owner="cgcardona", repo="agentception",
          #       issue_number=<N>, body="$CLOSE_COMMENT")
-         # MCP: github_remove_label(issue_number=<N>, label="agent:wip")
+         # MCP: github_remove_label(issue_number=<N>, label="agent/wip")
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
@@ -3322,7 +3322,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "agent/wip" (already claimed),
-      # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
+      # "pipeline/gated" (phase-gated), or "blocked/deps" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
       # Take the lowest-numbered remaining issue.
       NEXT_ISSUE=<lowest unclaimed issue number from MCP response>
@@ -3434,7 +3434,7 @@ TASK
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
-      # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+      # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
       # after passing the idempotency gate. Adding it here causes stale labels when the
       # reviewer is never launched or crashes before claiming.
 
@@ -3507,7 +3507,7 @@ TASK
   fi
 
 STEP 9 — SELF-DESTRUCT (always run this after STEP 8, merge or not, early stop or not):
-  # Unconditionally clear agent:wip — covers D/F grade, merge failure, and timeout paths
+  # Unconditionally clear agent/wip — covers D/F grade, merge failure, and timeout paths
   # where STEP 6 was never reached. Removing a non-existent label is a no-op.
   # MCP: github_remove_label(issue_number=N, label="agent/wip")
   WORKTREE=$(pwd)

--- a/.agentception/roles/qa-coordinator.md
+++ b/.agentception/roles/qa-coordinator.md
@@ -1250,8 +1250,8 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   │ URL and the exact error, and let the user merge manually.                  │
   └─────────────────────────────────────────────────────────────────────────────
 
-  # 6. Clear agent:wip now that the PR is merged — it must not persist on closed PRs.
-       # MCP: github_remove_label(issue_number=N, label="agent:wip")
+  # 6. Clear agent/wip now that the PR is merged — it must not persist on closed PRs.
+       # MCP: github_remove_label(issue_number=N, label="agent/wip")
 
   # 7. Delete the remote branch — CHECK EXISTENCE FIRST.
   # GitHub auto-delete-head-branches is ENABLED on this repo, so the branch is
@@ -1343,7 +1343,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          #       issue_number=<N>, state="closed", state_reason="completed")
          # MCP: add_issue_comment(owner="cgcardona", repo="agentception",
          #       issue_number=<N>, body="$CLOSE_COMMENT")
-         # MCP: github_remove_label(issue_number=<N>, label="agent:wip")
+         # MCP: github_remove_label(issue_number=<N>, label="agent/wip")
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
@@ -1514,7 +1514,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "agent/wip" (already claimed),
-      # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
+      # "pipeline/gated" (phase-gated), or "blocked/deps" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
       # Take the lowest-numbered remaining issue.
       NEXT_ISSUE=<lowest unclaimed issue number from MCP response>
@@ -1626,7 +1626,7 @@ TASK
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
-      # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+      # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
       # after passing the idempotency gate. Adding it here causes stale labels when the
       # reviewer is never launched or crashes before claiming.
 
@@ -1699,7 +1699,7 @@ TASK
   fi
 
 STEP 9 — SELF-DESTRUCT (always run this after STEP 8, merge or not, early stop or not):
-  # Unconditionally clear agent:wip — covers D/F grade, merge failure, and timeout paths
+  # Unconditionally clear agent/wip — covers D/F grade, merge failure, and timeout paths
   # where STEP 6 was never reached. Removing a non-existent label is a no-op.
   # MCP: github_remove_label(issue_number=N, label="agent/wip")
   WORKTREE=$(pwd)
@@ -2144,9 +2144,9 @@ Before finalising your four, confirm each pair is independent:
 
 If issues are **dependent** (B cannot ship without A):
 1. State it in the issue body: `**Depends on #A** — implement after #A is merged.`
-2. Label it `ticket-blocked` (distinct from `blocked`, which is the phase-gate label).
+2. Label it `blocked/deps` (distinct from `pipeline/gated`, which is the phase-gate label).
 3. Do **not** assign it to a parallel agent until #A is merged.
-4. The poller automatically removes `ticket-blocked` once all dependencies close.
+4. The poller automatically removes `blocked/deps` once all dependencies close.
 5. Only then is it safe for the coordinator to pick it up in the next dispatch cycle.
 
 ---
@@ -2686,7 +2686,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
       echo "   A) If the dependency's code is NOT needed to implement this issue → proceed."
       echo "      Note unmet deps in the PR body. Use TYPE_CHECKING guards for any missing imports."
       echo "   B) If the dependency's code IS required (e.g. imports a module that doesn't exist yet)"
-      echo "      → clean abort: remove agent:wip, remove this worktree, and skip this issue."
+      echo "      → clean abort: remove agent/wip, remove this worktree, and skip this issue."
       echo "      CLEAN ABORT sequence:"
       echo "        MCP: github_remove_label(issue_number=N, label=\"agent/wip\")"
       echo "        MCP: github_remove_label(issue_number=N, label=\"status/in-progress\")"
@@ -3009,7 +3009,7 @@ STEP 5 — PUSH & CREATE PR:
   if [ -n "$MY_PR_NUM" ]; then
     sed -i '' "s/^LINKED_PR=.*/LINKED_PR=$MY_PR_NUM/" .agent-task 2>/dev/null || true
     echo "✅ LINKED_PR=$MY_PR_NUM written back to .agent-task"
-    # ⚠️  Do NOT add agent:wip to the PR here. agent:wip on a PR means
+    # ⚠️  Do NOT add agent/wip to the PR here. agent/wip on a PR means
     # "a reviewer is actively working on this." The reviewer claims it in STEP 3
     # of agent-reviewer.md after its idempotency gate passes. The idempotency
     # gate (reviewDecision = APPROVED check) already prevents double-reviews without
@@ -3071,7 +3071,7 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # Create a fresh review worktree at the PR branch tip.
     REVIEW_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$MY_PR"
     git -C "$REPO" worktree add "$REVIEW_WORKTREE" "origin/$MY_BRANCH"
-    # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+    # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
     # after passing the idempotency gate. Adding it here causes stale labels when the
     # reviewer is never launched or crashes before claiming.
 
@@ -3237,8 +3237,8 @@ same parallel batch.
 
 **Dependency detection:** If issue B cannot function without A's code:
 1. Note `**Depends on #A**` in B's issue body.
-2. Label B as `ticket-blocked` (NOT `blocked` — `blocked` is for phase-gating only).
-3. The poller removes `ticket-blocked` automatically once A is closed.
+2. Label B as `blocked/deps` (NOT `pipeline/gated` — `pipeline/gated` is for phase-gating only).
+3. The poller removes `blocked/deps` automatically once A is closed.
 4. Merge A first; the coordinator will pick up B on the next dispatch cycle.
 
 ### Step C — Confirm `dev` is up to date

--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -28,7 +28,7 @@ from sqlalchemy import select
 # interpreted as initiative slugs.  Any label whose prefix-before-"/" matches
 # one of these is a taxonomy label, not a plan-pipeline initiative.
 _TAXONOMY_NAMESPACES: frozenset[str] = frozenset(
-    {"agent", "batch", "gate", "phase", "priority", "team", "type"}
+    {"agent", "batch", "blocked", "gate", "phase", "pipeline", "priority", "team", "type"}
 )
 
 from agentception.db.engine import get_session

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -2042,17 +2042,17 @@ async def get_pending_launches() -> list[PendingLaunchRow]:
         return []
 
 
-class TicketBlockedRow(TypedDict):
-    """One open issue that carries the ``ticket-blocked`` label and has dependencies."""
+class BlockedDepsRow(TypedDict):
+    """One open issue that carries the ``blocked/deps`` label and has dependencies."""
 
     github_number: int
     dep_numbers: list[int]
 
 
-async def get_ticket_blocked_open_issues(repo: str) -> list[TicketBlockedRow]:
-    """Return open issues that still carry the ``ticket-blocked`` label.
+async def get_blocked_deps_open_issues(repo: str) -> list[BlockedDepsRow]:
+    """Return open issues that still carry the ``blocked/deps`` label.
 
-    Used by the poller to decide which ``ticket-blocked`` labels can be
+    Used by the poller to decide which ``blocked/deps`` labels can be
     removed because all ticket-level dependencies have since closed.
 
     Falls back to ``[]`` on DB error.
@@ -2067,30 +2067,30 @@ async def get_ticket_blocked_open_issues(repo: str) -> list[TicketBlockedRow]:
             )
             rows = result.scalars().all()
 
-        out: list[TicketBlockedRow] = []
+        out: list[BlockedDepsRow] = []
         for row in rows:
             labels: list[str] = json.loads(row.labels_json or "[]")
-            if "ticket-blocked" not in labels:
+            if "blocked/deps" not in labels:
                 continue
             dep_numbers: list[int] = json.loads(row.depends_on_json or "[]")
             if not dep_numbers:
                 continue
             out.append(
-                TicketBlockedRow(
+                BlockedDepsRow(
                     github_number=row.github_number,
                     dep_numbers=dep_numbers,
                 )
             )
         return out
     except Exception as exc:
-        logger.warning("❌ get_ticket_blocked_open_issues failed: %s", exc)
+        logger.warning("❌ get_blocked_deps_open_issues failed: %s", exc)
         return []
 
 
-async def get_issues_missing_ticket_blocked(repo: str) -> list[TicketBlockedRow]:
-    """Return open issues that have deps recorded but are missing the ``ticket-blocked`` label.
+async def get_issues_missing_blocked_deps(repo: str) -> list[BlockedDepsRow]:
+    """Return open issues that have deps recorded but are missing the ``blocked/deps`` label.
 
-    Used by the poller's ``_stamp_missing_ticket_blocked`` to re-apply the label
+    Used by the poller's ``_stamp_missing_blocked_deps`` to re-apply the label
     when the initial stamp in ``file_issues`` failed silently (e.g. a transient
     GitHub API error caught by the old shared try/except).  Only issues whose
     ``depends_on_json`` is non-empty are considered — the body-based backfill in
@@ -2109,23 +2109,23 @@ async def get_issues_missing_ticket_blocked(repo: str) -> list[TicketBlockedRow]
             )
             rows = result.scalars().all()
 
-        out: list[TicketBlockedRow] = []
+        out: list[BlockedDepsRow] = []
         for row in rows:
             dep_numbers: list[int] = json.loads(row.depends_on_json or "[]")
             if not dep_numbers:
                 continue
             labels: list[str] = json.loads(row.labels_json or "[]")
-            if "ticket-blocked" in labels:
+            if "blocked/deps" in labels:
                 continue
             out.append(
-                TicketBlockedRow(
+                BlockedDepsRow(
                     github_number=row.github_number,
                     dep_numbers=dep_numbers,
                 )
             )
         return out
     except Exception as exc:
-        logger.warning("❌ get_issues_missing_ticket_blocked failed: %s", exc)
+        logger.warning("❌ get_issues_missing_blocked_deps failed: %s", exc)
         return []
 
 

--- a/agentception/mcp/plan_advance_phase.py
+++ b/agentception/mcp/plan_advance_phase.py
@@ -9,9 +9,9 @@ removing the configured blocked label and adding the configured active label.
 Label names are read from ``pipeline-config.json`` so they remain configurable
 without a code change:
 
-- ``phase_advance_blocked_label`` (default ``"blocked"``) — removed from
+- ``phase_advance_blocked_label`` (default ``"pipeline/gated"``) — removed from
   to-phase issues that were waiting on the previous phase.
-- ``phase_advance_active_label`` (default ``"pipeline-active"``) — added to
+- ``phase_advance_active_label`` (default ``"pipeline/active"``) — added to
   to-phase issues to signal they are ready for dispatch.
 
 This function is async and must be called from the ``call_tool_async``
@@ -184,8 +184,8 @@ async def _unlock_issue(
 
     Args:
         issue_number:  GitHub issue number.
-        blocked_label: Label name to remove (e.g. ``"blocked"``).
-        active_label:  Label name to add (e.g. ``"pipeline-active"``).
+        blocked_label: Label name to remove (e.g. ``"pipeline/gated"``).
+        active_label:  Label name to add (e.g. ``"pipeline/active"``).
     """
     await remove_label_from_issue(issue_number, blocked_label)
     await add_label_to_issue(issue_number, active_label)

--- a/agentception/models/__init__.py
+++ b/agentception/models/__init__.py
@@ -404,9 +404,9 @@ class PipelineConfig(BaseModel):
     active_project: str | None = None
     approval_required_labels: list[str] = ["db-schema", "security", "api-contract"]
     #: Label removed from to_phase issues when advancing a phase gate.
-    phase_advance_blocked_label: str = "blocked"
+    phase_advance_blocked_label: str = "pipeline/gated"
     #: Label added to to_phase issues when they become eligible for dispatch.
-    phase_advance_active_label: str = "pipeline-active"
+    phase_advance_active_label: str = "pipeline/active"
 
 
 class SpawnRequest(BaseModel):

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -499,7 +499,7 @@ async def _build_board_issues(
 
 
 async def _auto_advance_phases(repo: str) -> None:
-    """Automatically remove the ``blocked`` label and add ``pipeline-active`` when a phase gate opens.
+    """Automatically remove the ``pipeline/gated`` label and add ``pipeline/active`` when a phase gate opens.
 
     Called on every tick after ``persist_tick`` and ``reseed_missing_initiative_phases``.
     Reads the DB-computed phase completion state, finds any phases whose
@@ -578,11 +578,11 @@ async def _auto_advance_phases(repo: str) -> None:
                     )
 
 
-async def _auto_unblock_ticket_deps(repo: str) -> None:
-    """Remove ``ticket-blocked`` from issues whose all ticket-level deps have closed.
+async def _auto_unblock_deps(repo: str) -> None:
+    """Remove ``blocked/deps`` from issues whose all ticket-level deps have closed.
 
     Called on every tick after ``_auto_advance_phases``.  For each open issue
-    that still carries the ``ticket-blocked`` label, checks whether every issue
+    that still carries the ``blocked/deps`` label, checks whether every issue
     in its ``depends_on_json`` list is now ``closed`` in the DB.  If so,
     removes the label so the engineering coordinator will pick it up on the
     next dispatch.
@@ -590,50 +590,50 @@ async def _auto_unblock_ticket_deps(repo: str) -> None:
     DB is the source of truth here — the poller has already written the latest
     GitHub state into ``ACIssue.state`` before this function runs.
     """
-    from agentception.db.queries import get_closed_issue_numbers, get_ticket_blocked_open_issues
+    from agentception.db.queries import get_blocked_deps_open_issues, get_closed_issue_numbers
     from agentception.readers.github import remove_label_from_issue
 
     try:
-        candidates = await get_ticket_blocked_open_issues(repo)
+        candidates = await get_blocked_deps_open_issues(repo)
         if not candidates:
             return
         closed = await get_closed_issue_numbers(repo)
         for row in candidates:
             if all(dep in closed for dep in row["dep_numbers"]):
                 try:
-                    await remove_label_from_issue(row["github_number"], "ticket-blocked")
+                    await remove_label_from_issue(row["github_number"], "blocked/deps")
                     logger.info(
-                        "✅ _auto_unblock_ticket_deps: #%d all deps closed — removed ticket-blocked",
+                        "✅ _auto_unblock_deps: #%d all deps closed — removed blocked/deps",
                         row["github_number"],
                     )
                 except Exception as exc:
                     logger.warning(
-                        "⚠️  _auto_unblock_ticket_deps: could not remove label from #%d: %s",
+                        "⚠️  _auto_unblock_deps: could not remove label from #%d: %s",
                         row["github_number"],
                         exc,
                     )
     except Exception as exc:
-        logger.warning("⚠️  _auto_unblock_ticket_deps: failed: %s", exc)
+        logger.warning("⚠️  _auto_unblock_deps: failed: %s", exc)
 
 
-async def _stamp_missing_ticket_blocked(repo: str) -> None:
-    """Re-apply ``ticket-blocked`` to issues whose deps are recorded but the label is absent.
+async def _stamp_missing_blocked_deps(repo: str) -> None:
+    """Re-apply ``blocked/deps`` to issues whose deps are recorded but the label is absent.
 
     This is the server-side safety net for a silent failure mode in
     ``file_issues``: if ``add_label_to_issue`` threw a ``RuntimeError`` that was
     caught by the (now-fixed) shared try/except, the body was edited but the
     label was never applied.  On the next poller tick this function detects the
-    gap — ``depends_on_json`` non-empty but ``ticket-blocked`` missing — and
+    gap — ``depends_on_json`` non-empty but ``blocked/deps`` missing — and
     re-stamps the label provided at least one dep is still open.
 
-    Called on every tick immediately before ``_auto_unblock_ticket_deps`` so the
+    Called on every tick immediately before ``_auto_unblock_deps`` so the
     unblock pass always operates on a correct label set.
     """
-    from agentception.db.queries import get_closed_issue_numbers, get_issues_missing_ticket_blocked
+    from agentception.db.queries import get_closed_issue_numbers, get_issues_missing_blocked_deps
     from agentception.readers.github import add_label_to_issue
 
     try:
-        candidates = await get_issues_missing_ticket_blocked(repo)
+        candidates = await get_issues_missing_blocked_deps(repo)
         if not candidates:
             return
         closed = await get_closed_issue_numbers(repo)
@@ -641,20 +641,20 @@ async def _stamp_missing_ticket_blocked(repo: str) -> None:
             if all(dep in closed for dep in row["dep_numbers"]):
                 continue  # All deps already closed — no need to block
             try:
-                await add_label_to_issue(row["github_number"], "ticket-blocked")
+                await add_label_to_issue(row["github_number"], "blocked/deps")
                 logger.info(
-                    "✅ _stamp_missing_ticket_blocked: re-stamped ticket-blocked on #%d (deps: %s)",
+                    "✅ _stamp_missing_blocked_deps: re-stamped blocked/deps on #%d (deps: %s)",
                     row["github_number"],
                     row["dep_numbers"],
                 )
             except Exception as exc:
                 logger.warning(
-                    "⚠️  _stamp_missing_ticket_blocked: could not stamp #%d: %s",
+                    "⚠️  _stamp_missing_blocked_deps: could not stamp #%d: %s",
                     row["github_number"],
                     exc,
                 )
     except Exception as exc:
-        logger.warning("⚠️  _stamp_missing_ticket_blocked: failed: %s", exc)
+        logger.warning("⚠️  _stamp_missing_blocked_deps: failed: %s", exc)
 
 
 async def tick() -> PipelineState:
@@ -713,12 +713,12 @@ async def tick() -> PipelineState:
         await reseed_missing_initiative_phases(settings.gh_repo)
         # Auto-unblock next-phase issues whenever a phase gate closes.
         await _auto_advance_phases(settings.gh_repo)
-        # Re-stamp ticket-blocked on issues whose label was lost (e.g. silent
-        # API failure during file_issues).  Must run before _auto_unblock so
+        # Re-stamp blocked/deps on issues whose label was lost (e.g. silent
+        # API failure during file_issues).  Must run before _auto_unblock_deps so
         # the unblock pass always sees a correct label set.
-        await _stamp_missing_ticket_blocked(settings.gh_repo)
-        # Auto-remove ticket-blocked label when all ticket-level deps have closed.
-        await _auto_unblock_ticket_deps(settings.gh_repo)
+        await _stamp_missing_blocked_deps(settings.gh_repo)
+        # Auto-remove blocked/deps label when all ticket-level deps have closed.
+        await _auto_unblock_deps(settings.gh_repo)
     except Exception as exc:
         logger.warning("⚠️  DB persist skipped (non-fatal): %s", exc)
 

--- a/agentception/readers/issue_creator.py
+++ b/agentception/readers/issue_creator.py
@@ -9,7 +9,7 @@ that the user reviewed in the CodeMirror editor and creates real GitHub issues
 Execution order
 ---------------
 1. Ensure all required labels exist (initiative label + scoped phase labels +
-   pipeline-active + blocked).
+   pipeline/active + pipeline/gated).
 2. Iterate phases in order.  Within each phase, create issues concurrently.
 3. After all issues are created and GitHub numbers are known, edit any issue
    whose ``depends_on`` list is non-empty to append a "Blocked by: #X" line.
@@ -18,12 +18,12 @@ Labels applied to every issue
 ------------------------------
 - ``{spec.initiative}``               e.g. ``ac-build``
 - ``{spec.initiative}/{phase.label}`` e.g. ``ac-build/phase-0``
-- ``pipeline-active``                 phase 0 (first phase) only — ready for dispatch
-- ``blocked``                         phase 1+ — phase-gated until prior phase closes
+- ``pipeline/active``                 phase 0 (first phase) only — ready for dispatch
+- ``pipeline/gated``                  phase 1+ — phase-gated until prior phase closes
 
-When ``plan_advance_phase`` runs it removes ``blocked`` and adds
-``pipeline-active`` to the newly unlocked phase, so the pipeline-active /
-blocked labels always reflect the live execution frontier.
+When ``plan_advance_phase`` runs it removes ``pipeline/gated`` and adds
+``pipeline/active`` to the newly unlocked phase, so the pipeline/active /
+pipeline/gated labels always reflect the live execution frontier.
 """
 
 import asyncio
@@ -182,8 +182,8 @@ async def _gh_edit_body(repo: str, number: int, new_body: str) -> None:
 async def _bootstrap_labels(spec: PlanSpec) -> None:
     """Ensure all required labels exist in the repo.
 
-    Creates the initiative label, all scoped phase labels, and the two
-    pipeline-gate labels (``pipeline-active`` / ``blocked``).  Labels are
+    Creates the initiative label, all scoped phase labels, and the three
+    pipeline-gate labels (``pipeline/active`` / ``pipeline/gated`` / ``blocked/deps``).  Labels are
     namespaced per initiative — no bare global phase-N labels are created.
     Phase colors are assigned by position (``_PHASE_PALETTE[idx % len]``) so
     any slug convention and any number of phases receives a distinct color.
@@ -195,19 +195,19 @@ async def _bootstrap_labels(spec: PlanSpec) -> None:
             f"Initiative: {spec.initiative}",
         ),
         ensure_label_exists(
-            "pipeline-active",
+            "pipeline/active",
             "0E8A16",
-            "Issue is in the active phase — ready for agent dispatch",
+            "Ready for agent dispatch — phase gate is open",
         ),
         ensure_label_exists(
-            "blocked",
+            "pipeline/gated",
             "B60205",
-            "Issue is blocked — waiting for a prior phase to complete",
+            "Phase gate closed — prior phase must complete before dispatch",
         ),
         ensure_label_exists(
-            "ticket-blocked",
+            "blocked/deps",
             "E4B429",
-            "Issue has unresolved ticket-level dependencies — do not dispatch until all are closed",
+            "Has open ticket dependencies — poller removes once all deps close",
         ),
     ]
     for idx, phase in enumerate(spec.phases):
@@ -325,7 +325,7 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
     index = 0
     for phase_idx, phase in enumerate(spec.phases):
         # Phase 0 is immediately workable; all later phases are phase-gated.
-        gate_label = "pipeline-active" if phase_idx == 0 else "blocked"
+        gate_label = "pipeline/active" if phase_idx == 0 else "pipeline/gated"
         labels = [spec.initiative, f"{spec.initiative}/{phase.label}", gate_label]
         # For phase 1+ embed the blocking phase label into the issue body so
         # agents reading the ticket immediately know what must complete first.
@@ -410,21 +410,21 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
                 logger.warning("⚠️ Could not edit body of #%d for depends_on: %s", our_number, exc)
                 continue
 
-            # Stamp ticket-blocked so coordinators can filter this issue out
+            # Stamp blocked/deps so coordinators can filter this issue out
             # until all its deps are closed.  Separated from the body edit so a
             # label-API failure never silently leaves an issue unblocked: the
-            # poller's _stamp_missing_ticket_blocked will re-apply it next tick.
+            # poller's _stamp_missing_blocked_deps will re-apply it next tick.
             try:
-                await add_label_to_issue(our_number, "ticket-blocked")
+                await add_label_to_issue(our_number, "blocked/deps")
             except RuntimeError as exc:
                 logger.error(
-                    "❌ #%d body edited but ticket-blocked stamp failed — poller will re-stamp: %s",
+                    "❌ #%d body edited but blocked/deps stamp failed — poller will re-stamp: %s",
                     our_number,
                     exc,
                 )
             else:
                 logger.info(
-                    "✅ #%d blocked_by %s — ticket-blocked label added",
+                    "✅ #%d blocked_by %s — blocked/deps label added",
                     our_number,
                     [f"#{n}" for n in blocker_numbers],
                 )
@@ -435,7 +435,7 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
                 blocked_by=blocker_numbers,
             )
 
-    # Persist ticket-level deps to DB so the Build board can display them.
+    # Persist dep relationships to DB so the Build board can display them.
     await persist_issue_depends_on(repo, issue_deps)
 
     # ── 4. Persist phase DAG and display order ────────────────────────────

--- a/agentception/services/spawn_child.py
+++ b/agentception/services/spawn_child.py
@@ -335,7 +335,7 @@ def _mcp_hints(scope_type: ScopeType, scope_value: str, tier: Tier) -> str:
         lines += [
             f"# MCP: github_list_issues(label='{scope_value}', state='open')",
             "# MCP: github_list_prs(state='open')",
-            "# NOTE: exclude issues labelled 'agent/wip' (claimed) or 'blocked' (phase-gated)",
+            "# NOTE: exclude issues labelled 'agent/wip' (claimed) or 'pipeline/gated' (phase-gated)",
         ]
     elif node_type == "leaf" and scope_type == "issue":
         lines.append(f"# MCP: github_get_issue(number={scope_value})")

--- a/agentception/services/task_builders.py
+++ b/agentception/services/task_builders.py
@@ -79,7 +79,7 @@ def _build_agent_task(
         },
         "agent": {
             "role": role,
-            "tier": "engineer",
+            "tier": "worker",
             "org_domain": "engineering",
             "cognitive_arch": cognitive_arch,
         },

--- a/agentception/tests/test_agentception_poller.py
+++ b/agentception/tests/test_agentception_poller.py
@@ -764,9 +764,9 @@ async def test_auto_advance_phases_does_not_advance_complete_phase() -> None:
 
 
 @pytest.mark.anyio
-async def test_auto_unblock_ticket_deps_removes_label_when_all_deps_closed() -> None:
-    """ticket-blocked is removed when every dep issue is closed in the DB."""
-    from agentception.poller import _auto_unblock_ticket_deps
+async def test_auto_unblock_deps_removes_label_when_all_deps_closed() -> None:
+    """blocked/deps is removed when every dep issue is closed in the DB."""
+    from agentception.poller import _auto_unblock_deps
 
     candidates = [{"github_number": 177, "dep_numbers": [175]}]
     closed = {175}
@@ -774,7 +774,7 @@ async def test_auto_unblock_ticket_deps_removes_label_when_all_deps_closed() -> 
 
     with (
         patch(
-            "agentception.db.queries.get_ticket_blocked_open_issues",
+            "agentception.db.queries.get_blocked_deps_open_issues",
             new=AsyncMock(return_value=candidates),
         ),
         patch(
@@ -786,15 +786,15 @@ async def test_auto_unblock_ticket_deps_removes_label_when_all_deps_closed() -> 
             remove_mock,
         ),
     ):
-        await _auto_unblock_ticket_deps("cgcardona/agentception")
+        await _auto_unblock_deps("cgcardona/agentception")
 
-    remove_mock.assert_awaited_once_with(177, "ticket-blocked")
+    remove_mock.assert_awaited_once_with(177, "blocked/deps")
 
 
 @pytest.mark.anyio
-async def test_auto_unblock_ticket_deps_skips_when_dep_still_open() -> None:
-    """ticket-blocked is NOT removed when any dep issue is still open."""
-    from agentception.poller import _auto_unblock_ticket_deps
+async def test_auto_unblock_deps_skips_when_dep_still_open() -> None:
+    """blocked/deps is NOT removed when any dep issue is still open."""
+    from agentception.poller import _auto_unblock_deps
 
     candidates = [{"github_number": 177, "dep_numbers": [175]}]
     closed: set[int] = set()  # 175 still open
@@ -802,7 +802,7 @@ async def test_auto_unblock_ticket_deps_skips_when_dep_still_open() -> None:
 
     with (
         patch(
-            "agentception.db.queries.get_ticket_blocked_open_issues",
+            "agentception.db.queries.get_blocked_deps_open_issues",
             new=AsyncMock(return_value=candidates),
         ),
         patch(
@@ -814,22 +814,22 @@ async def test_auto_unblock_ticket_deps_skips_when_dep_still_open() -> None:
             remove_mock,
         ),
     ):
-        await _auto_unblock_ticket_deps("cgcardona/agentception")
+        await _auto_unblock_deps("cgcardona/agentception")
 
     remove_mock.assert_not_awaited()
 
 
 @pytest.mark.anyio
-async def test_auto_unblock_ticket_deps_skips_when_no_candidates() -> None:
+async def test_auto_unblock_deps_skips_when_no_candidates() -> None:
     """No GitHub calls made when queue is empty."""
-    from agentception.poller import _auto_unblock_ticket_deps
+    from agentception.poller import _auto_unblock_deps
 
     remove_mock = AsyncMock()
     closed_mock = AsyncMock(return_value=set())
 
     with (
         patch(
-            "agentception.db.queries.get_ticket_blocked_open_issues",
+            "agentception.db.queries.get_blocked_deps_open_issues",
             new=AsyncMock(return_value=[]),
         ),
         patch(
@@ -841,25 +841,25 @@ async def test_auto_unblock_ticket_deps_skips_when_no_candidates() -> None:
             remove_mock,
         ),
     ):
-        await _auto_unblock_ticket_deps("cgcardona/agentception")
+        await _auto_unblock_deps("cgcardona/agentception")
 
     closed_mock.assert_not_awaited()
     remove_mock.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
-# _stamp_missing_ticket_blocked — regression for silent label-stamp failure
+# _stamp_missing_blocked_deps — regression for silent label-stamp failure
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_stamp_missing_ticket_blocked_restamps_when_dep_open() -> None:
-    """ticket-blocked is applied when depends_on_json has an open dep but label is absent.
+async def test_stamp_missing_blocked_deps_restamps_when_dep_open() -> None:
+    """blocked/deps is applied when depends_on_json has an open dep but label is absent.
 
     Regression: issue_creator used a shared try/except that silently swallowed
     add_label_to_issue failures, leaving issues dispatchable despite open blockers.
     """
-    from agentception.poller import _stamp_missing_ticket_blocked
+    from agentception.poller import _stamp_missing_blocked_deps
 
     candidates = [{"github_number": 177, "dep_numbers": [175]}]
     closed: set[int] = set()  # 175 still open
@@ -867,7 +867,7 @@ async def test_stamp_missing_ticket_blocked_restamps_when_dep_open() -> None:
 
     with (
         patch(
-            "agentception.db.queries.get_issues_missing_ticket_blocked",
+            "agentception.db.queries.get_issues_missing_blocked_deps",
             new=AsyncMock(return_value=candidates),
         ),
         patch(
@@ -879,15 +879,15 @@ async def test_stamp_missing_ticket_blocked_restamps_when_dep_open() -> None:
             add_mock,
         ),
     ):
-        await _stamp_missing_ticket_blocked("cgcardona/agentception")
+        await _stamp_missing_blocked_deps("cgcardona/agentception")
 
-    add_mock.assert_awaited_once_with(177, "ticket-blocked")
+    add_mock.assert_awaited_once_with(177, "blocked/deps")
 
 
 @pytest.mark.anyio
-async def test_stamp_missing_ticket_blocked_skips_when_all_deps_closed() -> None:
+async def test_stamp_missing_blocked_deps_skips_when_all_deps_closed() -> None:
     """No label is added when every dep is already closed (issue is about to be unblocked)."""
-    from agentception.poller import _stamp_missing_ticket_blocked
+    from agentception.poller import _stamp_missing_blocked_deps
 
     candidates = [{"github_number": 177, "dep_numbers": [175]}]
     closed = {175}  # dep already closed
@@ -895,7 +895,7 @@ async def test_stamp_missing_ticket_blocked_skips_when_all_deps_closed() -> None
 
     with (
         patch(
-            "agentception.db.queries.get_issues_missing_ticket_blocked",
+            "agentception.db.queries.get_issues_missing_blocked_deps",
             new=AsyncMock(return_value=candidates),
         ),
         patch(
@@ -907,22 +907,22 @@ async def test_stamp_missing_ticket_blocked_skips_when_all_deps_closed() -> None
             add_mock,
         ),
     ):
-        await _stamp_missing_ticket_blocked("cgcardona/agentception")
+        await _stamp_missing_blocked_deps("cgcardona/agentception")
 
     add_mock.assert_not_awaited()
 
 
 @pytest.mark.anyio
-async def test_stamp_missing_ticket_blocked_skips_when_no_candidates() -> None:
-    """No GitHub calls when every issue already has ticket-blocked or has no deps."""
-    from agentception.poller import _stamp_missing_ticket_blocked
+async def test_stamp_missing_blocked_deps_skips_when_no_candidates() -> None:
+    """No GitHub calls when every issue already has blocked/deps or has no deps."""
+    from agentception.poller import _stamp_missing_blocked_deps
 
     add_mock = AsyncMock()
     closed_mock = AsyncMock(return_value=set())
 
     with (
         patch(
-            "agentception.db.queries.get_issues_missing_ticket_blocked",
+            "agentception.db.queries.get_issues_missing_blocked_deps",
             new=AsyncMock(return_value=[]),
         ),
         patch(
@@ -934,7 +934,7 @@ async def test_stamp_missing_ticket_blocked_skips_when_no_candidates() -> None:
             add_mock,
         ),
     ):
-        await _stamp_missing_ticket_blocked("cgcardona/agentception")
+        await _stamp_missing_blocked_deps("cgcardona/agentception")
 
     closed_mock.assert_not_awaited()
     add_mock.assert_not_awaited()

--- a/agentception/tests/test_issue_creator.py
+++ b/agentception/tests/test_issue_creator.py
@@ -219,7 +219,7 @@ async def test_file_issues_emits_done_event_last() -> None:
 
 @pytest.mark.anyio
 async def test_file_issues_edits_body_for_depends_on() -> None:
-    """An issue with depends_on gets a body edit and a ticket-blocked label add."""
+    """An issue with depends_on gets a body edit and a blocked/deps label add."""
     spec = _make_spec(with_depends_on=True)
 
     create_count = 0
@@ -253,11 +253,11 @@ async def test_file_issues_edits_body_for_depends_on() -> None:
     )
     assert body_arg is not None and "Blocked by:" in body_arg
 
-    # Separate add_label_to_issue call stamps ticket-blocked on the dep issue.
+    # Separate add_label_to_issue call stamps blocked/deps on the dep issue.
     add_label_mock.assert_awaited_once()
     call_args = add_label_mock.call_args
     assert call_args is not None
-    assert call_args.args[1] == "ticket-blocked"
+    assert call_args.args[1] == "blocked/deps"
 
     blocked_events = [e for e in events if e["t"] == "blocked"]
     assert len(blocked_events) == 1
@@ -381,7 +381,7 @@ async def test_file_issues_yields_error_on_create_failure() -> None:
 @pytest.mark.anyio
 async def test_bootstrap_labels_creates_scoped_phase_labels() -> None:
     """_bootstrap_labels creates '{initiative}/{N}-{slug}' labels, not bare phase labels.
-    Also ensures the pipeline-gate labels (pipeline-active, blocked) are created.
+    Also ensures the pipeline-gate labels (pipeline/active, pipeline/gated, blocked/deps) are created.
     """
     spec = _make_spec(initiative="ac-build")
     created_labels: list[str] = []
@@ -407,8 +407,9 @@ async def test_bootstrap_labels_creates_scoped_phase_labels() -> None:
     # Initiative label itself must be created.
     assert "ac-build" in created_labels
     # Pipeline-gate labels must always be bootstrapped.
-    assert "pipeline-active" in created_labels
-    assert "blocked" in created_labels
+    assert "pipeline/active" in created_labels
+    assert "pipeline/gated" in created_labels
+    assert "blocked/deps" in created_labels
 
 
 @pytest.mark.anyio
@@ -444,13 +445,13 @@ async def test_file_issues_uses_scoped_labels_on_gh_create() -> None:
         bare_phase = [lbl for lbl in label_args if lbl.startswith("phase-") and "/" not in lbl]
         assert bare_phase == [], f"Unexpected global phase label(s): {bare_phase}"
         # Every issue gets exactly one pipeline-gate label.
-        gate = [lbl for lbl in label_args if lbl in ("pipeline-active", "blocked")]
+        gate = [lbl for lbl in label_args if lbl in ("pipeline/active", "pipeline/gated")]
         assert len(gate) == 1, f"Expected exactly one gate label, got {gate}"
 
 
 @pytest.mark.anyio
 async def test_file_issues_phase_gate_labels_by_phase_position() -> None:
-    """Phase 0 issues get 'pipeline-active'; phase 1+ issues get 'blocked'."""
+    """Phase 0 issues get 'pipeline/active'; phase 1+ issues get 'pipeline/gated'."""
     spec = _make_spec(initiative="ac-workflow")
     # Capture (phase_scoped_label, gate_label) per create call.
     phase_gate_pairs: list[tuple[str, str]] = []
@@ -460,7 +461,7 @@ async def test_file_issues_phase_gate_labels_by_phase_position() -> None:
         if "create" in cmd:
             label_args = [cmd[i + 1] for i, a in enumerate(cmd) if a == "--label"]
             scoped = next((lbl for lbl in label_args if lbl.startswith("ac-workflow/")), "")
-            gate = next((lbl for lbl in label_args if lbl in ("pipeline-active", "blocked")), "")
+            gate = next((lbl for lbl in label_args if lbl in ("pipeline/active", "pipeline/gated")), "")
             phase_gate_pairs.append((scoped, gate))
             return _mock_proc(stdout=_issue_url(len(phase_gate_pairs)))
         return _mock_proc()
@@ -474,9 +475,9 @@ async def test_file_issues_phase_gate_labels_by_phase_position() -> None:
     assert phase_gate_pairs, "No create calls recorded"
     for scoped, gate in phase_gate_pairs:
         if scoped.endswith("/0-foundation"):
-            assert gate == "pipeline-active", f"Phase-0 issue got {gate!r} instead of pipeline-active"
+            assert gate == "pipeline/active", f"Phase-0 issue got {gate!r} instead of pipeline/active"
         else:
-            assert gate == "blocked", f"Non-phase-0 issue got {gate!r} instead of blocked"
+            assert gate == "pipeline/gated", f"Non-phase-0 issue got {gate!r} instead of pipeline/gated"
 
 
 def test_embed_phase_gate_appends_blocking_notice() -> None:

--- a/agentception/tests/test_reseed_initiative_phases.py
+++ b/agentception/tests/test_reseed_initiative_phases.py
@@ -74,7 +74,7 @@ def _make_session_ctx(issues: list[MagicMock], has_existing_phase: bool) -> Magi
 async def test_reseed_derives_sequential_deps_from_scoped_labels() -> None:
     """When initiative_phases is empty, phases are seeded with sequential deps."""
     issues = [
-        _mock_issue(["ac-build", "ac-build/0-foundation", "pipeline-active"]),
+        _mock_issue(["ac-build", "ac-build/0-foundation", "pipeline/active"]),
         _mock_issue(["ac-build", "ac-build/1-features", "blocked"]),
         _mock_issue(["ac-build", "ac-build/2-polish", "blocked"]),
     ]
@@ -115,7 +115,7 @@ async def test_reseed_derives_sequential_deps_from_scoped_labels() -> None:
 async def test_reseed_skips_initiative_with_existing_phase_metadata() -> None:
     """If initiative_phases already has rows, the initiative is not reseeded."""
     issues = [
-        _mock_issue(["ac-build", "ac-build/0-foundation", "pipeline-active"]),
+        _mock_issue(["ac-build", "ac-build/0-foundation", "pipeline/active"]),
     ]
     captured: list[str] = []
 
@@ -141,7 +141,7 @@ async def test_reseed_skips_initiative_with_existing_phase_metadata() -> None:
 async def test_reseed_skips_initiative_with_no_scoped_labels() -> None:
     """Issues with no scoped labels produce no phase metadata."""
     issues = [
-        _mock_issue(["ac-build", "pipeline-active"]),  # no ac-build/* label
+        _mock_issue(["ac-build", "pipeline/active"]),  # no ac-build/* label
     ]
     captured: list[str] = []
 

--- a/docs/agent-tree-protocol.md
+++ b/docs/agent-tree-protocol.md
@@ -74,8 +74,8 @@ that repeats after each wave of children completes, until both queues drain.
 ```
 loop:
   issues ← list_issues(label=scope_value, state="open")
-            filtered: exclude "agent:wip" (claimed), "blocked" (phase-gated),
-                      "ticket-blocked" (unresolved dependencies)
+            filtered: exclude "agent/wip" (claimed), "pipeline/gated" (phase-gated),
+                      "blocked/deps" (has open ticket dependencies)
   prs    ← list_pull_requests(state="open", unreviewed=true)
 
   issues > 0:
@@ -108,7 +108,7 @@ optional chain-spawn.
 
 ```
 enter:
-  claim scope_value                            # mark issue/PR as "agent:wip"
+  claim scope_value                            # mark issue/PR as "agent/wip"
 
   scope_type == "issue":
     read issue, check out branch, implement
@@ -242,7 +242,7 @@ Loops until both queues are empty.
 ```
 # Open issues for the scope label
 github_list_issues(label="$SCOPE_VALUE", state="open")
-# → filter: exclude issues labelled "agent:wip" (claimed) or "blocked" (phase-gated)
+# → filter: exclude issues labelled "agent/wip" (claimed) or "pipeline/gated" (phase-gated)
 # Only work on issues that have neither label.
 ```
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -383,7 +383,7 @@ Send a user message into a running agent's context. The agent's SSE stream picks
 
 #### `POST /api/runs/{run_id}/stop`
 
-Stop a running agent. Sets `status = DONE`, removes the `agent:wip` label.
+Stop a running agent. Sets `status = DONE`, removes the `agent/wip` label.
 
 ---
 
@@ -441,7 +441,7 @@ Legacy orchestration control endpoints. Prefer MCP tools for new integrations.
 | `POST` | `/api/control/spawn` | Spawn a single agent |
 | `POST` | `/api/control/spawn-wave` | Spawn a wave of agents |
 | `POST` | `/api/control/sweep` | Sweep stale runs |
-| `POST` | `/api/control/reset-build` | Full reset: remove all worktrees, clear all agent:wip, set active runs to unknown |
+| `POST` | `/api/control/reset-build` | Full reset: remove all worktrees, clear all agent/wip, set active runs to unknown |
 | `POST` | `/api/control/trigger-poll` | Trigger an immediate GitHub poll |
 
 ---

--- a/docs/reference/yaml-config.md
+++ b/docs/reference/yaml-config.md
@@ -41,7 +41,7 @@ repo:
 
 ```yaml
 pipeline:
-  claim_label: "agent:wip"
+  claim_label: "agent/wip"
   max_pool_size: 0
   phases:
     - "ac-workflow/0-foundation"
@@ -50,7 +50,7 @@ pipeline:
 
 | Key | Description |
 |-----|-------------|
-| `claim_label` | GitHub label applied to issues when an agent claims them. Remove to release. Default: `"agent:wip"`. |
+| `claim_label` | GitHub label applied to issues when an agent claims them. Remove to release. Default: `"agent/wip"`. |
 | `max_pool_size` | Unused — agents are spawned without a concurrency cap. Set to `0`. |
 | `phases` | **Strict phase order** for the active initiative. The CTO and chain-spawn logic iterate this list top-to-bottom. Add/remove phases here, then update the matching `labels.phases` section and re-run `generate.py`. |
 
@@ -92,7 +92,7 @@ Single source of truth for all GitHub labels. Running `sync_labels.sh` creates/u
 ```yaml
 labels:
   claim:
-    name: "agent:wip"
+    name: "agent/wip"
     color: "0075ca"
     description: "Claimed by a pipeline agent — do not assign manually"
 
@@ -120,7 +120,7 @@ labels:
 
 | Section | Description |
 |---------|-------------|
-| `claim` | The `agent:wip` claim label — applied/removed at runtime by agents. |
+| `claim` | The `agent/wip` claim label — applied/removed at runtime by agents. |
 | `project` | Top-level initiative label (e.g. `ac-workflow`). Update when switching projects. |
 | `phases` | Phase labels — must match `pipeline.phases` in name and order. |
 | `utility` | Standard triage/status labels (bug, enhancement, documentation, etc.). |

--- a/scripts/gen_prompts/config.yaml
+++ b/scripts/gen_prompts/config.yaml
@@ -71,18 +71,28 @@ labels:
     color: "0075ca"
     description: "Claimed by a pipeline agent — do not assign manually"
 
+  # ── Pipeline state labels ──────────────────────────────────────────────────────
+  # Applied/removed automatically by the system — never set manually.
+  # pipeline/active  : issue is ready for agent dispatch (phase 0, or phase gate opened)
+  # pipeline/gated   : issue is waiting for a prior phase to complete
+  # blocked/deps     : issue has open ticket-level dependencies; poller removes once all deps close
+  pipeline:
+    - name: "pipeline/active"
+      color: "2ecc71"
+      description: "Ready for agent dispatch — phase gate is open"
+    - name: "pipeline/gated"
+      color: "d73a4a"
+      description: "Phase gate closed — prior phase must complete before dispatch"
+    - name: "blocked/deps"
+      color: "cfd3d7"
+      description: "Has open ticket dependencies — poller removes once all deps close"
+
   # ── Special labels ────────────────────────────────────────────────────────────
   # Labels used for pipeline control that don't fit other namespaces.
   special:
     - name: "conductor-reminder"
       color: "e4e669"
       description: "Open: pipeline incomplete — re-run agent-conductor.md"
-    - name: "ticket-blocked"
-      color: "cfd3d7"
-      description: "Blocked on a dep issue — poller removes once all deps close"
-    - name: "blocked"
-      color: "d73a4a"
-      description: "Blocked on external dependency — cannot proceed"
 
   # ── Team namespace ─────────────────────────────────────────────────────────────
   # CEO reads team/* labels to discover which C-level coordinators to dispatch.

--- a/scripts/gen_prompts/sync_labels.sh
+++ b/scripts/gen_prompts/sync_labels.sh
@@ -22,10 +22,13 @@ sync_label() {
 echo '── Claim ───────────────────────────────────────────────────'
 sync_label 'agent/wip' '0075ca' 'Claimed by a pipeline agent — do not assign manually'
 
+echo '── Pipeline ────────────────────────────────────────────────'
+sync_label 'pipeline/active' '2ecc71' 'Ready for agent dispatch — phase gate is open'
+sync_label 'pipeline/gated' 'd73a4a' 'Phase gate closed — prior phase must complete before dispatch'
+sync_label 'blocked/deps' 'cfd3d7' 'Has open ticket dependencies — poller removes once all deps close'
+
 echo '── Special ─────────────────────────────────────────────────'
 sync_label 'conductor-reminder' 'e4e669' 'Open: pipeline incomplete — re-run agent-conductor.md'
-sync_label 'ticket-blocked' 'cfd3d7' 'Blocked on a dep issue — poller removes once all deps close'
-sync_label 'blocked' 'd73a4a' 'Blocked on external dependency — cannot proceed'
 
 echo '── Teams ───────────────────────────────────────────────────'
 sync_label 'team/engineering' '7c3aed' 'Engineering team (owned by CTO)'

--- a/scripts/gen_prompts/templates/agent-engineer.md.j2
+++ b/scripts/gen_prompts/templates/agent-engineer.md.j2
@@ -115,9 +115,9 @@ Before finalising your four, confirm each pair is independent:
 
 If issues are **dependent** (B cannot ship without A):
 1. State it in the issue body: `**Depends on #A** — implement after #A is merged.`
-2. Label it `ticket-blocked` (distinct from `blocked`, which is the phase-gate label).
+2. Label it `blocked/deps` (distinct from `pipeline/gated`, which is the phase-gate label).
 3. Do **not** assign it to a parallel agent until #A is merged.
-4. The poller automatically removes `ticket-blocked` once all dependencies close.
+4. The poller automatically removes `blocked/deps` once all dependencies close.
 5. Only then is it safe for the coordinator to pick it up in the next dispatch cycle.
 
 ---
@@ -493,7 +493,7 @@ STEP 3 — IMPLEMENT (only if STEP 2 found nothing):
       echo "   A) If the dependency's code is NOT needed to implement this issue → proceed."
       echo "      Note unmet deps in the PR body. Use TYPE_CHECKING guards for any missing imports."
       echo "   B) If the dependency's code IS required (e.g. imports a module that doesn't exist yet)"
-      echo "      → clean abort: remove agent:wip, remove this worktree, and skip this issue."
+      echo "      → clean abort: remove agent/wip, remove this worktree, and skip this issue."
       echo "      CLEAN ABORT sequence:"
       echo "        MCP: github_remove_label(issue_number=N, label=\"{{ claim_label }}\")"
       echo "        MCP: github_remove_label(issue_number=N, label=\"status/in-progress\")"
@@ -681,7 +681,7 @@ STEP 5 — PUSH & CREATE PR:
   if [ -n "$MY_PR_NUM" ]; then
     sed -i '' "s/^LINKED_PR=.*/LINKED_PR=$MY_PR_NUM/" .agent-task 2>/dev/null || true
     echo "✅ LINKED_PR=$MY_PR_NUM written back to .agent-task"
-    # ⚠️  Do NOT add agent:wip to the PR here. agent:wip on a PR means
+    # ⚠️  Do NOT add agent/wip to the PR here. agent/wip on a PR means
     # "a reviewer is actively working on this." The reviewer claims it in STEP 3
     # of agent-reviewer.md after its idempotency gate passes. The idempotency
     # gate (reviewDecision = APPROVED check) already prevents double-reviews without
@@ -718,7 +718,7 @@ STEP 6 — SPAWN A QA REVIEWER FOR YOUR OWN PR (run this before self-destructing
     # Create a fresh review worktree at the PR branch tip.
     REVIEW_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$MY_PR"
     git -C "$REPO" worktree add "$REVIEW_WORKTREE" "origin/$MY_BRANCH"
-    # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+    # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
     # after passing the idempotency gate. Adding it here causes stale labels when the
     # reviewer is never launched or crashes before claiming.
 
@@ -880,8 +880,8 @@ same parallel batch.
 
 **Dependency detection:** If issue B cannot function without A's code:
 1. Note `**Depends on #A**` in B's issue body.
-2. Label B as `ticket-blocked` (NOT `blocked` — `blocked` is for phase-gating only).
-3. The poller removes `ticket-blocked` automatically once A is closed.
+2. Label B as `blocked/deps` (NOT `pipeline/gated` — `pipeline/gated` is for phase-gating only).
+3. The poller removes `blocked/deps` automatically once A is closed.
 4. Merge A first; the coordinator will pick up B on the next dispatch cycle.
 
 ### Step C — Confirm `dev` is up to date

--- a/scripts/gen_prompts/templates/agent-reviewer.md.j2
+++ b/scripts/gen_prompts/templates/agent-reviewer.md.j2
@@ -753,8 +753,8 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
   │ URL and the exact error, and let the user merge manually.                  │
   └─────────────────────────────────────────────────────────────────────────────
 
-  # 6. Clear agent:wip now that the PR is merged — it must not persist on closed PRs.
-       # MCP: github_remove_label(issue_number=N, label="agent:wip")
+  # 6. Clear agent/wip now that the PR is merged — it must not persist on closed PRs.
+       # MCP: github_remove_label(issue_number=N, label="agent/wip")
 
   # 7. Delete the remote branch — CHECK EXISTENCE FIRST.
   # GitHub auto-delete-head-branches is ENABLED on this repo, so the branch is
@@ -796,7 +796,7 @@ STEP 6 — PRE-MERGE SYNC (only if grade is A or B):
          #       issue_number=<N>, state="closed", state_reason="completed")
          # MCP: add_issue_comment(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}",
          #       issue_number=<N>, body="$CLOSE_COMMENT")
-         # MCP: github_remove_label(issue_number=<N>, label="agent:wip")
+         # MCP: github_remove_label(issue_number=<N>, label="agent/wip")
          echo "Close each issue via MCP issue_write + add_issue_comment + github_remove_label"
        else
          # Fallback: re-parse the PR body if CLOSES_ISSUES was empty in task file
@@ -967,7 +967,7 @@ STEP 8 — SPAWN YOUR SUCCESSOR (run this before self-destructing):
       # Pick the next unclaimed issue from ACTIVE_LABEL only.
       # MCP: list_issues (user-github)(label="$ACTIVE_LABEL", state="open")
       # Filter out any with label "{{ claim_label }}" (already claimed),
-      # "blocked" (phase-gated), or "ticket-blocked" (unresolved ticket-level
+      # "pipeline/gated" (phase-gated), or "blocked/deps" (unresolved ticket-level
       # dependency — the poller removes this label once all deps close).
       # Take the lowest-numbered remaining issue.
       NEXT_ISSUE=<lowest unclaimed issue number from MCP response>
@@ -1079,7 +1079,7 @@ TASK
       NEXT_BRANCH=<headRefName from MCP response>
       NEXT_WORKTREE="$HOME/.agentception/worktrees/agentception/pr-$NEXT_PR"
       git -C "$REPO" worktree add "$NEXT_WORKTREE" "origin/$NEXT_BRANCH"
-      # ⚠️  Do NOT add agent:wip here. The reviewer claims the label itself in STEP 3
+      # ⚠️  Do NOT add agent/wip here. The reviewer claims the label itself in STEP 3
       # after passing the idempotency gate. Adding it here causes stale labels when the
       # reviewer is never launched or crashes before claiming.
 
@@ -1152,7 +1152,7 @@ TASK
   fi
 
 STEP 9 — SELF-DESTRUCT (always run this after STEP 8, merge or not, early stop or not):
-  # Unconditionally clear agent:wip — covers D/F grade, merge failure, and timeout paths
+  # Unconditionally clear agent/wip — covers D/F grade, merge failure, and timeout paths
   # where STEP 6 was never reached. Removing a non-existent label is a no-op.
   # MCP: github_remove_label(issue_number=N, label="{{ claim_label }}")
   WORKTREE=$(pwd)

--- a/scripts/gen_prompts/templates/dispatcher.md.j2
+++ b/scripts/gen_prompts/templates/dispatcher.md.j2
@@ -150,7 +150,7 @@ Step 3: Run your tier's GitHub queries via MCP to discover what needs doing.
   coordinator (engineering-coordinator role) — call:
     list_issues (user-github)(label="{scope_value}", state="open")
   Filter out any issues with label "{{ claim_label }}" (already claimed),
-  "blocked" (phase-gated — prior phase not yet complete), or "ticket-blocked"
+  "pipeline/gated" (phase-gated — prior phase not yet complete), or "blocked/deps"
   (has unresolved ticket-level dependencies — do not dispatch until all are closed).
   Only work on issues with none of these three labels.
   Then: spawn one engineer per eligible issue (all in parallel via Task calls).

--- a/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
@@ -92,8 +92,8 @@ SEED:
          # MCP: list_issues (user-github)(state="open", labels=["$TEAM_LABEL", "$ACTIVE_PHASE"])
          # → filter result to exclude issues that have any of these labels:
          #     "{{ claim_label }}"  (already claimed by another agent)
-         #     "blocked"            (phase-gated — prior phase not yet complete)
-         #     "ticket-blocked"     (has unresolved ticket-level dependency — the
+         #     "pipeline/gated"     (phase-gated — prior phase not yet complete)
+         #     "blocked/deps"       (has unresolved ticket-level dependency — the
          #                           poller removes this label automatically once
          #                           all deps close; never dispatch these manually)
          # → append remaining to CANDIDATES
@@ -116,8 +116,8 @@ SEED:
        done
 
   3.6 Dependency gate — CRITICAL for sequential issues:
-     Primary signal: if an issue has the "ticket-blocked" label (already filtered
-     out in step 3), it must NOT be seeded. The poller removes "ticket-blocked"
+     Primary signal: if an issue has the "blocked/deps" label (already filtered
+     out in step 3), it must NOT be seeded. The poller removes "blocked/deps"
      automatically once all deps close, so by the time this coordinator runs, any
      issue without that label has met its ticket-level deps.
      Secondary signal (belt-and-suspenders): parse "Blocked by #NNN" from the

--- a/tests/test_plan_advance_phase.py
+++ b/tests/test_plan_advance_phase.py
@@ -33,8 +33,8 @@ def _make_pipeline_config(**overrides: object) -> PipelineConfig:
         "max_qa_vps": 1,
         "pool_size_per_vp": 4,
         "active_labels_order": ["phase-1", "phase-2"],
-        "phase_advance_blocked_label": "blocked",
-        "phase_advance_active_label": "pipeline-active",
+        "phase_advance_blocked_label": "pipeline/gated",
+        "phase_advance_active_label": "pipeline/active",
     }
     defaults.update(overrides)
     return PipelineConfig.model_validate(defaults)
@@ -93,9 +93,9 @@ async def test_plan_advance_phase_all_closed_unlocks_to_phase_issues() -> None:
 
     # Correct label names used.
     for call in mock_remove.call_args_list:
-        assert call.args[1] == "blocked"
+        assert call.args[1] == "pipeline/gated"
     for call in mock_add.call_args_list:
-        assert call.args[1] == "pipeline-active"
+        assert call.args[1] == "pipeline/active"
 
 
 # ---------------------------------------------------------------------------
@@ -217,7 +217,7 @@ async def test_plan_advance_phase_no_from_phase_issues_unlocks_to_phase() -> Non
 
     assert result["advanced"] is True
     assert result["unlocked_count"] == 1
-    mock_add.assert_called_once_with(30, "pipeline-active")
+    mock_add.assert_called_once_with(30, "pipeline/active")
 
 
 # ---------------------------------------------------------------------------
@@ -246,9 +246,9 @@ async def test_unlock_issue_calls_remove_then_add() -> None:
             new=fake_add,
         ),
     ):
-        await _unlock_issue(42, "blocked", "pipeline-active")
+        await _unlock_issue(42, "pipeline/gated", "pipeline/active")
 
-    assert call_order == ["remove:blocked", "add:pipeline-active"]
+    assert call_order == ["remove:pipeline/gated", "add:pipeline/active"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `agent:wip` → `agent/wip` (templates and docs; Python already used slash)
- `blocked` → `pipeline/gated` (phase-gate label — the old name was ambiguous and the description in config.yaml was factually wrong)
- `ticket-blocked` → `blocked/deps` (dependency-tracking label — old name conflated two different concepts)
- `pipeline-active` → `pipeline/active` (pairs symmetrically with `pipeline/gated`)
- Added `pipeline` and `blocked` to `_TAXONOMY_NAMESPACES` in `persist.py` so the reseed function never mistakes `pipeline/active` for an initiative slug

## Files changed

- Python: `models`, `issue_creator`, `poller`, `db/queries`, `plan_advance_phase`, `spawn_child`, `persist`, `task_builders`
- Tests: `test_issue_creator`, `test_agentception_poller`, `test_plan_advance_phase`, `test_reseed_initiative_phases`, `test_agentception_spawn`
- Templates + generated: all `.agentception/*.md` files, `sync_labels.sh`
- Docs: `agent-tree-protocol`, `yaml-config`, `api`
- Config: `config.yaml`, `pipeline-config.json`

## Test plan
- [x] `mypy` — 0 errors
- [x] `typing_audit` — 0 Any patterns
- [x] `pytest` — 1499 passed
- [x] `generate.py --check` — 0 drift