### PR TITLE
feat: migrate pure-read MCP tools to MCP Resources (ac:// URI scheme)

### DIFF
--- a/.agentception/agent-task-spec.md
+++ b/.agentception/agent-task-spec.md
@@ -224,7 +224,7 @@ Async result rendezvous. Used when Cursor does LLM work and writes a result back
 | `path` | string | `plan-spec`, `task-to-deliverable` | Absolute path Cursor writes its output to |
 | `draft_id` | string | `plan-spec` | UUID correlating to the AgentCeption dashboard request |
 | `format` | string | any | Output format: `"yaml"` \| `"json"` \| `"markdown"` \| `"toml"` |
-| `schema_tool` | string | `plan-spec` | MCP tool to call to get the output schema: `"plan_get_schema"` |
+| `schema_tool` | string | `plan-spec` | MCP resource URI to read the output schema: `"ac://plan/schema"` |
 
 When `output.path` is present, the AgentCeption poller watches for this file.
 When it appears, the poller emits an SSE event:
@@ -261,8 +261,8 @@ collected from the web UI, dispatched to Cursor for YAML generation.
 
 ```toml
 [plan_draft]
-mcp_tools_hint = "call plan_get_schema() to get the PlanSpec TOML schema first"
-output_schema = "plan_get_schema"
+mcp_tools_hint = "read ac://plan/schema to get the PlanSpec YAML schema first"
+output_schema = "ac://plan/schema"
 dump = """
 We need to build a billing system.
 - Users should be able to subscribe to monthly or annual plans
@@ -442,10 +442,10 @@ path = "/tmp/worktrees/plan-draft-8b2c4d1e"
 path = "/tmp/worktrees/plan-draft-8b2c4d1e/.plan-output.yaml"
 draft_id = "8b2c4d1e-9f3a-4b7e-c5d8-2e1f6a9b0c3d"
 format = "yaml"
-schema_tool = "plan_get_schema"
+schema_tool = "ac://plan/schema"
 
 [plan_draft]
-mcp_tools_hint = "call plan_get_schema() first to get the PlanSpec YAML format, then produce valid YAML matching that schema"
+mcp_tools_hint = "read ac://plan/schema first to get the PlanSpec YAML format, then produce valid YAML matching that schema"
 dump = """
 We need to build a billing system for our SaaS product.
 

--- a/.agentception/dispatcher.md
+++ b/.agentception/dispatcher.md
@@ -12,14 +12,20 @@ Canonical reference: `docs/agent-tree-protocol.md`
 
 ## MCP server identifier
 
-All AgentCeption MCP tools are on server **`user-agentception`**.
-When using `CallMcpTool`, always pass `server="user-agentception"`.
+All AgentCeption MCP tools and resources are on server **`user-agentception`**.
+
+- **Tools** (state mutations): use `CallMcpTool` with `server="user-agentception"`.
+- **Resources** (pure reads): use `FetchMcpResource` with `server="user-agentception"`.
 
 ---
 
 ## Step 1 — Read the queue
 
-Call the `query_pending_runs` MCP tool (server: `user-agentception`).
+Read the `ac://runs/pending` resource (server: `user-agentception`):
+
+```
+FetchMcpResource(server="user-agentception", uri="ac://runs/pending")
+```
 
 It returns a list of pending launches shaped like:
 
@@ -242,7 +248,7 @@ After spawning all Tasks simultaneously, wait for all of them to return before p
 
 ## Step 5 — Check for more
 
-After each batch completes, call `query_pending_runs` again.
+After each batch completes, read `ac://runs/pending` again.
 If more items were queued while you were working (user dispatched more from
 the UI), spawn them too.
 

--- a/agentception/mcp/resources.py
+++ b/agentception/mcp/resources.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+"""MCP resource definitions and URI dispatcher for the AgentCeption server.
+
+All read-only state inspection that was previously expressed as ``query_*``
+tools (and the ``plan_get_*`` tools) is now exposed as MCP Resources — the
+correct abstraction in the MCP spec for stateless, side-effect-free reads.
+
+URI scheme
+----------
+All resources live under the ``ac://`` scheme.  The authority (netloc) acts
+as a resource *domain*, and the path identifies the specific resource within
+that domain.  Parameterised resources follow RFC 6570 Level 1 URI templates.
+
+Static resources
+    ac://runs/active          — all live runs (pending, implementing, blocked)
+    ac://runs/pending         — runs queued for Dispatcher launch
+    ac://system/dispatcher    — dispatcher run counters and active batch_id
+    ac://system/health        — DB reachability and per-status run counts
+    ac://plan/schema          — PlanSpec JSON Schema (changes only on deploy)
+    ac://plan/labels          — GitHub label catalogue for the configured repo
+
+Templated resources (RFC 6570)
+    ac://runs/{run_id}                  — lightweight metadata for one run
+    ac://runs/{run_id}/children         — child runs spawned by this run
+    ac://runs/{run_id}/events           — full structured event log
+    ac://runs/{run_id}/events?after_id={n} — paginated event log (n > 0)
+    ac://runs/{run_id}/task             — raw .agent-task TOML text
+    ac://batches/{batch_id}/tree        — all runs in a batch, flat list
+    ac://plan/figures/{role}            — cognitive-arch figures for a role
+"""
+
+import json
+import logging
+from urllib.parse import parse_qs, urlparse
+
+from agentception.mcp.plan_tools import (
+    plan_get_cognitive_figures,
+    plan_get_labels,
+    plan_get_schema,
+)
+from agentception.mcp.query_tools import (
+    query_active_runs,
+    query_agent_task,
+    query_children,
+    query_dispatcher_state,
+    query_pending_runs,
+    query_run,
+    query_run_events,
+    query_run_tree,
+    query_system_health,
+)
+from agentception.mcp.types import (
+    ACResourceContent,
+    ACResourceDef,
+    ACResourceResult,
+    ACResourceTemplate,
+)
+
+logger = logging.getLogger(__name__)
+
+_MIME = "application/json"
+
+# ---------------------------------------------------------------------------
+# Static resource catalogue
+# ---------------------------------------------------------------------------
+
+RESOURCES: list[ACResourceDef] = [
+    ACResourceDef(
+        uri="ac://runs/active",
+        name="Active runs",
+        description=(
+            "All runs currently in a live or blocked state "
+            "(pending_launch, implementing, reviewing, blocked). "
+            "Use for a system-wide snapshot of the agent fleet."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceDef(
+        uri="ac://runs/pending",
+        name="Pending runs",
+        description=(
+            "Runs queued for launch from the AgentCeption UI. "
+            "The Dispatcher reads this once to discover what the UI has queued. "
+            "Each item has run_id, issue_number, role, host_worktree_path, and batch_id."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceDef(
+        uri="ac://system/dispatcher",
+        name="Dispatcher state",
+        description=(
+            "Current dispatcher state: run counts per status, active run total, "
+            "and the latest active batch_id. "
+            "For supervisory agents that need a high-level view of the system."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceDef(
+        uri="ac://system/health",
+        name="System health",
+        description=(
+            "System-health snapshot: DB reachability, total runs per status. "
+            "Always returns a result — db_ok=false signals a degraded database."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceDef(
+        uri="ac://plan/schema",
+        name="PlanSpec schema",
+        description=(
+            "JSON Schema for PlanSpec — the plan-step-v2 YAML contract. "
+            "Read this to understand the required structure before calling "
+            "plan_validate_spec."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceDef(
+        uri="ac://plan/labels",
+        name="GitHub labels",
+        description=(
+            "Full GitHub label list for the configured repository. "
+            "Returns {labels: [{name: str, description: str}, ...]}."
+        ),
+        mimeType=_MIME,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Resource template catalogue
+# ---------------------------------------------------------------------------
+
+RESOURCE_TEMPLATES: list[ACResourceTemplate] = [
+    ACResourceTemplate(
+        uriTemplate="ac://runs/{run_id}",
+        name="Run metadata",
+        description=(
+            "Lightweight metadata for a single run: status, issue_number, "
+            "parent_run_id, worktree_path, tier, role, batch_id. "
+            "Read on startup to determine current state after a crash or restart. "
+            "Returns ok=false when the run does not exist."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceTemplate(
+        uriTemplate="ac://runs/{run_id}/children",
+        name="Child runs",
+        description=(
+            "All runs spawned by a given parent run_id, ordered by spawn time. "
+            "Coordinator agents use this to track the state of workers they dispatched."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceTemplate(
+        uriTemplate="ac://runs/{run_id}/events",
+        name="Run event log",
+        description=(
+            "Structured MCP events for a run (log_run_step, log_run_blocker, etc.). "
+            "Read to reconstruct what happened in a previous session after a crash. "
+            "Append ?after_id=N to page through events incrementally "
+            "(returns only events with DB id > N)."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceTemplate(
+        uriTemplate="ac://runs/{run_id}/task",
+        name="Agent task file",
+        description=(
+            "Raw text content of the .agent-task TOML file for a run. "
+            "Read to verify configuration on startup or after a restart. "
+            "Returns ok=false if the worktree has been torn down."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceTemplate(
+        uriTemplate="ac://batches/{batch_id}/tree",
+        name="Batch run tree",
+        description=(
+            "All runs in a batch as a flat list with parent_run_id references. "
+            "Assemble into a tree by following parent_run_id links. "
+            "Used by the Dispatcher and supervisory agents to visualise the run hierarchy."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceTemplate(
+        uriTemplate="ac://plan/figures/{role}",
+        name="Cognitive-arch figures",
+        description=(
+            "Cognitive architecture figures compatible with a given role slug. "
+            "Returns {role, figures: [{id, display_name, description}]}. "
+            "Read before assigning cognitive_arch fields in a PlanSpec."
+        ),
+        mimeType=_MIME,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# URI dispatcher
+# ---------------------------------------------------------------------------
+
+
+def _content(uri: str, data: dict[str, object]) -> ACResourceResult:
+    """Wrap a result dict into a single-item ACResourceResult."""
+    return ACResourceResult(
+        contents=[
+            ACResourceContent(
+                uri=uri,
+                mimeType=_MIME,
+                text=json.dumps(data, ensure_ascii=False),
+            )
+        ]
+    )
+
+
+def _not_found(uri: str) -> ACResourceResult:
+    return _content(uri, {"error": f"Unknown resource URI: {uri!r}"})
+
+
+async def read_resource(uri: str) -> ACResourceResult:
+    """Dispatch a ``resources/read`` request by URI.
+
+    Parses the ``ac://`` URI, routes to the appropriate query/plan function,
+    and wraps the result as an :class:`ACResourceResult`.
+
+    Returns a result with ``error`` key when the URI is unknown or when a
+    required path segment is missing.  Never raises.
+    """
+    try:
+        parsed = urlparse(uri)
+    except Exception as exc:
+        logger.warning("⚠️ read_resource: could not parse URI %r: %s", uri, exc)
+        return _content(uri, {"error": f"Invalid URI: {exc}"})
+
+    if parsed.scheme != "ac":
+        return _content(uri, {"error": f"Unsupported URI scheme {parsed.scheme!r} — expected 'ac'"})
+
+    domain = parsed.netloc  # e.g. "runs", "system", "plan", "batches"
+    # path starts with '/' — strip it and split on remaining '/'
+    path_parts = [p for p in parsed.path.split("/") if p]
+    query = parse_qs(parsed.query)  # e.g. {"after_id": ["5"]}
+
+    try:
+        return await _dispatch(uri, domain, path_parts, query)
+    except Exception as exc:
+        logger.error("❌ read_resource: unexpected error for %r: %s", uri, exc, exc_info=True)
+        return _content(uri, {"error": f"Internal error: {exc}"})
+
+
+async def _dispatch(
+    uri: str,
+    domain: str,
+    path_parts: list[str],
+    query: dict[str, list[str]],
+) -> ACResourceResult:
+    """Route a parsed ``ac://`` URI to the appropriate handler."""
+
+    # ── ac://system/* ────────────────────────────────────────────────────────
+    if domain == "system":
+        if path_parts == ["health"]:
+            return _content(uri, await query_system_health())
+        if path_parts == ["dispatcher"]:
+            return _content(uri, await query_dispatcher_state())
+        return _not_found(uri)
+
+    # ── ac://plan/* ──────────────────────────────────────────────────────────
+    if domain == "plan":
+        if path_parts == ["schema"]:
+            return _content(uri, plan_get_schema())
+        if path_parts == ["labels"]:
+            return _content(uri, await plan_get_labels())
+        if len(path_parts) == 2 and path_parts[0] == "figures":
+            role = path_parts[1]
+            return _content(uri, plan_get_cognitive_figures(role))
+        return _not_found(uri)
+
+    # ── ac://batches/* ───────────────────────────────────────────────────────
+    if domain == "batches":
+        # ac://batches/{batch_id}/tree
+        if len(path_parts) == 2 and path_parts[1] == "tree":
+            batch_id = path_parts[0]
+            return _content(uri, await query_run_tree(batch_id))
+        return _not_found(uri)
+
+    # ── ac://runs/* ──────────────────────────────────────────────────────────
+    if domain == "runs":
+        # ac://runs/active  (static — must check before treating "active" as run_id)
+        if path_parts == ["active"]:
+            return _content(uri, await query_active_runs())
+
+        # ac://runs/pending
+        if path_parts == ["pending"]:
+            return _content(uri, await query_pending_runs())
+
+        # ac://runs/{run_id}  and  ac://runs/{run_id}/*
+        if len(path_parts) >= 1:
+            run_id = path_parts[0]
+
+            if len(path_parts) == 1:
+                # ac://runs/{run_id}
+                return _content(uri, await query_run(run_id))
+
+            sub = path_parts[1]
+
+            if sub == "children" and len(path_parts) == 2:
+                return _content(uri, await query_children(run_id))
+
+            if sub == "task" and len(path_parts) == 2:
+                return _content(uri, await query_agent_task(run_id))
+
+            if sub == "events" and len(path_parts) == 2:
+                after_id_vals = query.get("after_id", [])
+                after_id = 0
+                if after_id_vals:
+                    try:
+                        after_id = int(after_id_vals[0])
+                    except ValueError:
+                        pass
+                return _content(uri, await query_run_events(run_id, after_id))
+
+        return _not_found(uri)
+
+    return _not_found(uri)

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -2,15 +2,22 @@ from __future__ import annotations
 
 """AgentCeption MCP JSON-RPC 2.0 server.
 
-Implements a minimal but spec-compliant JSON-RPC 2.0 dispatcher for the
-AgentCeption MCP tool layer.  The dispatcher is synchronous and stateless —
-it handles exactly one request per call to :func:`handle_request`.
+Implements a spec-compliant JSON-RPC 2.0 dispatcher for both MCP Tools
+(actions with side effects) and MCP Resources (stateless, cacheable reads).
 
 Supported methods:
-  ``initialize``  — MCP protocol handshake (returns server capabilities)
-  ``initialized`` — MCP notification (no response; acknowledged silently)
-  ``tools/list``  — returns all registered :class:`~agentception.mcp.types.ACToolDef`
-  ``tools/call``  — dispatches to the named tool function
+  ``initialize``              — MCP handshake; declares tools + resources capabilities
+  ``initialized``             — MCP notification (no response; acknowledged silently)
+  ``tools/list``              — lists all registered :class:`~agentception.mcp.types.ACToolDef`
+  ``tools/call``              — dispatches to the named tool function
+  ``resources/list``          — lists all static :class:`~agentception.mcp.types.ACResourceDef`
+  ``resources/templates/list``— lists all :class:`~agentception.mcp.types.ACResourceTemplate`
+  ``resources/read``          — reads a resource by ``ac://`` URI
+
+Tool vs Resource design
+  Pure reads (no side effects) are Resources, accessed via ``resources/read``.
+  Actions that mutate state (build_*, log_*, github_*, plan mutations) remain Tools.
+  See :mod:`agentception.mcp.resources` for the full URI catalogue.
 
 Error handling follows the JSON-RPC 2.0 specification:
   - Parse errors     → code -32700 (never raised here; caller parses JSON)
@@ -42,17 +49,6 @@ from agentception.mcp.log_tools import (
     log_run_message,
     log_run_step,
 )
-from agentception.mcp.query_tools import (
-    query_active_runs,
-    query_agent_task,
-    query_children,
-    query_dispatcher_state,
-    query_pending_runs,
-    query_run,
-    query_run_events,
-    query_run_tree,
-    query_system_health,
-)
 from agentception.mcp.github_tools import (
     github_add_label,
     github_claim_issue,
@@ -67,7 +63,14 @@ from agentception.mcp.plan_tools import (
     plan_validate_manifest,
     plan_validate_spec,
 )
+from agentception.mcp.resources import (
+    RESOURCES,
+    RESOURCE_TEMPLATES,
+    read_resource,
+)
 from agentception.mcp.types import (
+    ACResourceDef,
+    ACResourceTemplate,
     ACToolContent,
     ACToolDef,
     ACToolResult,
@@ -94,19 +97,13 @@ _SERVER_INFO: dict[str, object] = {"name": "agentception", "version": "0.1.1"}
 
 #: All tools exposed by this MCP server.  Each entry is an :class:`ACToolDef`
 #: mapping the tool name to its description and input JSON Schema.
+#:
+#: Read-only state inspection is exposed as MCP Resources (see :data:`RESOURCES`
+#: and :data:`RESOURCE_TEMPLATES`), not as Tools.  Tools are for actions
+#: that mutate state (build_*, log_*, github_*) or that require validation
+#: input (plan_validate_*, plan_spawn_coordinator, plan_advance_phase).
 TOOLS: list[ACToolDef] = [
-    ACToolDef(
-        name="plan_get_schema",
-        description=(
-            "Return the JSON Schema for PlanSpec — the plan-step-v2 YAML contract. "
-            "Use this to understand the required structure before calling plan_validate_spec."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {},
-            "additionalProperties": False,
-        },
-    ),
+    # ── Plan tools — validation and mutations only (reads are Resources) ──────
     ACToolDef(
         name="plan_validate_spec",
         description=(
@@ -123,44 +120,6 @@ TOOLS: list[ACToolDef] = [
                 }
             },
             "required": ["spec_json"],
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="plan_get_labels",
-        description=(
-            "Fetch the full GitHub label list for the configured repository. "
-            "Returns {labels: [{name: str, description: str}, ...]}."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {},
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="plan_get_cognitive_figures",
-        description=(
-            "Return the catalog of cognitive architecture figures compatible with a given role slug. "
-            "Reads role-taxonomy.yaml to filter figures by role, then returns each figure's id, "
-            "display name, and one-line description. "
-            "Use this before assigning cognitive_arch fields in a PlanSpec so assignments are "
-            "grounded in the actual available figures for each role. "
-            "Returns {role: str, figures: [{id: str, display_name: str, description: str}, ...]} "
-            "or {role: str, figures: [], error: str} when the role is unknown."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "role": {
-                    "type": "string",
-                    "description": (
-                        "Role slug from role-taxonomy.yaml — e.g. 'cto', "
-                        "'engineering-coordinator', 'qa-coordinator', 'python-developer'."
-                    ),
-                }
-            },
-            "required": ["role"],
             "additionalProperties": False,
         },
     ),
@@ -305,154 +264,13 @@ TOOLS: list[ACToolDef] = [
             "additionalProperties": False,
         },
     ),
-    # ── Query tools — read-only state inspection ──────────────────────────────
-    ACToolDef(
-        name="query_pending_runs",
-        description=(
-            "Return all issues queued for launch from the AgentCeption UI. "
-            "The Dispatcher calls this once to discover what the UI has queued. "
-            "Each item has run_id, issue_number, role, host_worktree_path, and batch_id. "
-            "The role tells you what kind of agent to spawn — a leaf worker implements "
-            "one issue directly; a coordinator reads its role file and spawns its own "
-            "children via the Task tool."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {},
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="query_run",
-        description=(
-            "Return lightweight metadata for a single run by run_id. "
-            "Agents call this on startup to determine their current state (status, "
-            "issue_number, parent_run_id, worktree_path, tier, role, batch_id). "
-            "Returns ok=false when the run does not exist."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "run_id": {"type": "string", "description": "The run ID to look up."},
-            },
-            "required": ["run_id"],
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="query_children",
-        description=(
-            "Return all runs spawned by a given parent run_id, ordered by spawn time. "
-            "Coordinator and VP-tier agents use this to track the state of engineers they dispatched."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "run_id": {"type": "string", "description": "The parent run ID."},
-            },
-            "required": ["run_id"],
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="query_run_events",
-        description=(
-            "Return structured MCP events for a run (log_run_step, log_run_blocker, etc.). "
-            "Agents use this to reconstruct what happened in a previous session after a crash. "
-            "Pass after_id to page through events incrementally."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "run_id": {"type": "string", "description": "The run to query events for."},
-                "after_id": {
-                    "type": "integer",
-                    "description": "Return only events with DB id > this value. Defaults to 0.",
-                    "default": 0,
-                },
-            },
-            "required": ["run_id"],
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="query_agent_task",
-        description=(
-            "Return the raw text content of the .agent-task TOML file for a run. "
-            "Agents use this to verify their own configuration on startup or after a restart. "
-            "Returns ok=false if the worktree has been torn down or the file does not exist."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "run_id": {"type": "string", "description": "The run to read the agent task for."},
-            },
-            "required": ["run_id"],
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="query_active_runs",
-        description=(
-            "Return all runs currently in a live or blocked state "
-            "(pending_launch, implementing, reviewing, blocked). "
-            "Supervisory agents and the Dispatcher use this for a system-wide snapshot."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {},
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="query_run_tree",
-        description=(
-            "Return all runs in a batch as a flat list with parent_run_id references. "
-            "Assemble into a tree by following parent_run_id. "
-            "Used by the Dispatcher and supervisory agents to visualise the run hierarchy."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "batch_id": {"type": "string", "description": "The batch fingerprint to query."},
-            },
-            "required": ["batch_id"],
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="query_dispatcher_state",
-        description=(
-            "Return current dispatcher state: run counts per status, active run total, "
-            "and the latest active batch_id. "
-            "Designed for supervisory agents that need a high-level view of the system."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {},
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="query_system_health",
-        description=(
-            "Return a system-health snapshot: DB reachability, total runs per status. "
-            "Always returns a result — db_ok=false signals a degraded database. "
-            "Use for diagnostics and health checks."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {},
-            "additionalProperties": False,
-        },
-    ),
     # ── Build commands — explicit state transitions only ──────────────────────
     ACToolDef(
         name="build_claim_run",
         description=(
             "Atomically claim a pending run before spawning its Task agent. "
-            "Call this with the run_id from query_pending_runs immediately before "
-            "firing the Task so the run cannot be double-claimed by a concurrent "
+            "Call this with the run_id from the ac://runs/pending resource immediately "
+            "before firing the Task so the run cannot be double-claimed by a concurrent "
             "Dispatcher. Transitions the run from pending_launch to implementing. "
             "Returns {ok: true, run_id, previous_state} on success, or "
             "{ok: false, reason} if the run was already claimed — skip that item."
@@ -811,12 +629,25 @@ def list_tools() -> list[ACToolDef]:
     return list(TOOLS)
 
 
+def list_resources() -> list[ACResourceDef]:
+    """Return all registered static MCP resource definitions."""
+    return list(RESOURCES)
+
+
+def list_resource_templates() -> list[ACResourceTemplate]:
+    """Return all registered MCP resource template definitions."""
+    return list(RESOURCE_TEMPLATES)
+
+
 def call_tool(name: str, arguments: dict[str, object]) -> ACToolResult:
     """Dispatch a ``tools/call`` request to the named tool function.
 
-    Note: ``plan_get_labels`` and ``plan_spawn_coordinator`` are async and
-    cannot be invoked here directly.  Callers that need those tools must use
-    the async variants directly or wrap this dispatcher in an async context.
+    Note: all tools that require async I/O (build_*, log_*, github_*, plan
+    mutations) cannot be invoked here directly — they return an error directing
+    the caller to use the async path.  Use :func:`call_tool_async` instead.
+
+    Read-only state inspection has moved to MCP Resources; calling a retired
+    ``query_*`` or ``plan_get_*`` tool name returns a descriptive error.
 
     Args:
         name:      The tool name as it appears in the ``tools/list`` response.
@@ -829,11 +660,32 @@ def call_tool(name: str, arguments: dict[str, object]) -> ACToolResult:
 
     Never raises — all errors are returned as ``isError=True`` results.
     """
-    if name == "plan_get_schema":
-        schema = plan_get_schema()
-        text = _tool_result_to_text(schema)
-        content: list[ACToolContent] = [ACToolContent(type="text", text=text)]
-        return ACToolResult(content=content, isError=False)
+    # Helpful error for callers still using retired query_* / plan_get_* tools.
+    _RESOURCE_REDIRECTS: dict[str, str] = {
+        "query_pending_runs": "ac://runs/pending",
+        "query_run": "ac://runs/{run_id}",
+        "query_children": "ac://runs/{run_id}/children",
+        "query_run_events": "ac://runs/{run_id}/events",
+        "query_agent_task": "ac://runs/{run_id}/task",
+        "query_active_runs": "ac://runs/active",
+        "query_run_tree": "ac://batches/{batch_id}/tree",
+        "query_dispatcher_state": "ac://system/dispatcher",
+        "query_system_health": "ac://system/health",
+        "plan_get_schema": "ac://plan/schema",
+        "plan_get_labels": "ac://plan/labels",
+        "plan_get_cognitive_figures": "ac://plan/figures/{role}",
+    }
+    if name in _RESOURCE_REDIRECTS:
+        uri = _RESOURCE_REDIRECTS[name]
+        err_text = _tool_result_to_text(
+            {
+                "error": (
+                    f"'{name}' has been promoted to a MCP Resource. "
+                    f"Use resources/read with URI: {uri!r}"
+                )
+            }
+        )
+        return ACToolResult(content=[ACToolContent(type="text", text=err_text)], isError=True)
 
     if name == "plan_validate_spec":
         spec_json = arguments.get("spec_json")
@@ -871,38 +723,10 @@ def call_tool(name: str, arguments: dict[str, object]) -> ACToolResult:
             isError=is_error,
         )
 
-    if name == "plan_get_cognitive_figures":
-        role = arguments.get("role")
-        if not isinstance(role, str) or not role:
-            err_text = _tool_result_to_text(
-                {"error": "Missing or invalid required argument 'role' (must be a non-empty string)"}
-            )
-            return ACToolResult(
-                content=[ACToolContent(type="text", text=err_text)],
-                isError=True,
-            )
-        result_figures = plan_get_cognitive_figures(role)
-        text = _tool_result_to_text(result_figures)
-        is_error = "error" in result_figures
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=text)],
-            isError=is_error,
-        )
-
     if name in (
         "plan_get_labels",
         "plan_spawn_coordinator",
         "plan_advance_phase",
-        # Query tools
-        "query_pending_runs",
-        "query_run",
-        "query_children",
-        "query_run_events",
-        "query_agent_task",
-        "query_active_runs",
-        "query_run_tree",
-        "query_dispatcher_state",
-        "query_system_health",
         # Build commands
         "build_claim_run",
         "build_spawn_child_run",
@@ -976,103 +800,6 @@ async def call_tool_async(
         return ACToolResult(
             content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
             isError=is_error,
-        )
-
-    # ── Query tools ─────────────────────────────────────────────────────────
-
-    if name == "query_pending_runs":
-        result = await query_pending_runs()
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=False,
-        )
-
-    if name == "query_run":
-        qr_run_id = arguments.get("run_id")
-        if not isinstance(qr_run_id, str) or not qr_run_id:
-            return ACToolResult(
-                content=[ACToolContent(type="text", text='{"error":"query_run requires a non-empty run_id"}')],
-                isError=True,
-            )
-        result = await query_run(qr_run_id)
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=not bool(result.get("ok", False)),
-        )
-
-    if name == "query_children":
-        qc_run_id = arguments.get("run_id")
-        if not isinstance(qc_run_id, str) or not qc_run_id:
-            return ACToolResult(
-                content=[ACToolContent(type="text", text='{"error":"query_children requires a non-empty run_id"}')],
-                isError=True,
-            )
-        result = await query_children(qc_run_id)
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=False,
-        )
-
-    if name == "query_run_events":
-        qre_run_id = arguments.get("run_id")
-        if not isinstance(qre_run_id, str) or not qre_run_id:
-            return ACToolResult(
-                content=[ACToolContent(type="text", text='{"error":"query_run_events requires a non-empty run_id"}')],
-                isError=True,
-            )
-        after_id_raw = arguments.get("after_id", 0)
-        after_id = int(after_id_raw) if isinstance(after_id_raw, int) else 0
-        result = await query_run_events(qre_run_id, after_id)
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=False,
-        )
-
-    if name == "query_agent_task":
-        qat_run_id = arguments.get("run_id")
-        if not isinstance(qat_run_id, str) or not qat_run_id:
-            return ACToolResult(
-                content=[ACToolContent(type="text", text='{"error":"query_agent_task requires a non-empty run_id"}')],
-                isError=True,
-            )
-        result = await query_agent_task(qat_run_id)
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=not bool(result.get("ok", False)),
-        )
-
-    if name == "query_active_runs":
-        result = await query_active_runs()
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=False,
-        )
-
-    if name == "query_run_tree":
-        qrt_batch_id = arguments.get("batch_id")
-        if not isinstance(qrt_batch_id, str) or not qrt_batch_id:
-            return ACToolResult(
-                content=[ACToolContent(type="text", text='{"error":"query_run_tree requires a non-empty batch_id"}')],
-                isError=True,
-            )
-        result = await query_run_tree(qrt_batch_id)
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=False,
-        )
-
-    if name == "query_dispatcher_state":
-        result = await query_dispatcher_state()
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=False,
-        )
-
-    if name == "query_system_health":
-        result = await query_system_health()
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=False,
         )
 
     # ── Build commands ───────────────────────────────────────────────────────
@@ -1421,16 +1148,14 @@ def handle_request(
     # ── MCP lifecycle handshake ──────────────────────────────────────────────
 
     if method == "initialize":
-        # Respond with our protocol version and tool capability declaration.
         result: dict[str, object] = {
             "protocolVersion": _MCP_PROTOCOL_VERSION,
-            "capabilities": {"tools": {}},
+            "capabilities": {"tools": {}, "resources": {}},
             "serverInfo": _SERVER_INFO,
         }
         return cast(dict[str, object], _make_success_response(request_id, result))
 
     if method == "initialized":
-        # JSON-RPC notification — no id, no response required.
         logger.debug("✅ MCP initialized notification received")
         return None
 
@@ -1479,6 +1204,17 @@ def handle_request(
 
         return cast(dict[str, object], _make_success_response(request_id, tool_result))
 
+    # ── Resource methods (sync server returns method-not-found for reads) ─────
+    # The sync handle_request is only used in tests and legacy callers; all
+    # resource reads require async I/O.  Direct async callers to handle_request_async.
+
+    if method in ("resources/list", "resources/templates/list", "resources/read"):
+        return cast(dict[str, object], _make_error_response(
+            request_id,
+            JSONRPC_ERR_METHOD_NOT_FOUND,
+            f"Method '{method}' requires the async path — use handle_request_async",
+        ))
+
     return cast(dict[str, object], _make_error_response(
         request_id,
         JSONRPC_ERR_METHOD_NOT_FOUND,
@@ -1526,7 +1262,7 @@ async def handle_request_async(
     if method == "initialize":
         result: dict[str, object] = {
             "protocolVersion": _MCP_PROTOCOL_VERSION,
-            "capabilities": {"tools": {}},
+            "capabilities": {"tools": {}, "resources": {}},
             "serverInfo": _SERVER_INFO,
         }
         return cast(dict[str, object], _make_success_response(request_id, result))
@@ -1534,6 +1270,8 @@ async def handle_request_async(
     if method == "initialized":
         logger.debug("✅ MCP initialized notification received")
         return None
+
+    # ── Tool methods ─────────────────────────────────────────────────────────
 
     if method == "tools/list":
         tools = list_tools()
@@ -1581,6 +1319,50 @@ async def handle_request_async(
             ))
 
         return cast(dict[str, object], _make_success_response(request_id, tool_result))
+
+    # ── Resource methods ──────────────────────────────────────────────────────
+
+    if method == "resources/list":
+        resources = list_resources()
+        return cast(dict[str, object], _make_success_response(
+            request_id, {"resources": resources}
+        ))
+
+    if method == "resources/templates/list":
+        templates = list_resource_templates()
+        return cast(dict[str, object], _make_success_response(
+            request_id, {"resourceTemplates": templates}
+        ))
+
+    if method == "resources/read":
+        params_r = raw.get("params")
+        if not isinstance(params_r, dict):
+            return cast(dict[str, object], _make_error_response(
+                request_id,
+                JSONRPC_ERR_INVALID_PARAMS,
+                "params must be an object for resources/read",
+            ))
+        uri = params_r.get("uri")
+        if not isinstance(uri, str) or not uri:
+            return cast(dict[str, object], _make_error_response(
+                request_id,
+                JSONRPC_ERR_INVALID_PARAMS,
+                "params.uri must be a non-empty string",
+            ))
+        try:
+            resource_result = await read_resource(uri)
+        except Exception as exc:
+            logger.error(
+                "❌ handle_request_async: internal error in read_resource — %s",
+                exc,
+                exc_info=True,
+            )
+            return cast(dict[str, object], _make_error_response(
+                request_id,
+                JSONRPC_ERR_INTERNAL_ERROR,
+                f"Internal error: {exc}",
+            ))
+        return cast(dict[str, object], _make_success_response(request_id, resource_result))
 
     return cast(dict[str, object], _make_error_response(
         request_id,

--- a/agentception/mcp/types.py
+++ b/agentception/mcp/types.py
@@ -3,12 +3,31 @@ from __future__ import annotations
 """Protocol TypedDicts for the AgentCeption MCP layer.
 
 All types defined here are self-contained — zero imports from external packages.
-external packages.  They map 1-to-1 with the MCP JSON-RPC 2.0
-wire protocol so callers can rely on them for type-safe serialisation.
+They map 1-to-1 with the MCP JSON-RPC 2.0 wire protocol so callers can rely
+on them for type-safe serialisation.
 
 JSON-RPC 2.0 error codes (JSONRPC_ERR_*) are defined as module-level
 constants rather than an Enum so they remain plain ``int`` values that
 serialise to JSON without adaptation.
+
+Resource URIs follow the ``ac://`` scheme with REST-like path segments:
+
+  Static resources (no parameters):
+    ac://runs/active          — all live runs
+    ac://runs/pending         — runs queued for dispatch
+    ac://system/dispatcher    — dispatcher counters and active batch
+    ac://system/health        — DB reachability and status counts
+    ac://plan/schema          — PlanSpec JSON Schema
+    ac://plan/labels          — GitHub label catalogue
+
+  Templated resources (parameters in braces, RFC 6570):
+    ac://runs/{run_id}                — single run metadata
+    ac://runs/{run_id}/children       — child runs spawned by this run
+    ac://runs/{run_id}/events         — structured event log
+    ac://runs/{run_id}/events?after_id={n} — paginated event log
+    ac://runs/{run_id}/task           — raw .agent-task TOML file
+    ac://batches/{batch_id}/tree      — full batch run tree
+    ac://plan/figures/{role}          — cognitive-arch figures for a role
 """
 
 from typing import TypedDict
@@ -65,6 +84,61 @@ class ACToolResult(TypedDict):
 
     content: list[ACToolContent]
     isError: bool
+
+
+# ---------------------------------------------------------------------------
+# MCP resource protocol types
+# ---------------------------------------------------------------------------
+
+
+class ACResourceDef(TypedDict):
+    """Definition of a single static MCP resource.
+
+    Conforms to the ``resources/list`` response item shape.
+    Static resources have a fixed URI — no template expansion required.
+    """
+
+    uri: str
+    name: str
+    description: str
+    mimeType: str
+
+
+class ACResourceTemplate(TypedDict):
+    """Definition of a parameterised MCP resource template.
+
+    Conforms to the ``resources/templates/list`` response item shape.
+    ``uriTemplate`` follows RFC 6570 Level 1 (``{variable}`` expansion) and
+    may include a query component (``{?param}``).
+    """
+
+    uriTemplate: str
+    name: str
+    description: str
+    mimeType: str
+
+
+class ACResourceContent(TypedDict):
+    """A single content item in a ``resources/read`` response.
+
+    ``uri`` echoes the requested URI.  ``mimeType`` is always
+    ``"application/json"`` for AgentCeption resources.  ``text`` carries
+    the UTF-8 JSON payload.
+    """
+
+    uri: str
+    mimeType: str
+    text: str
+
+
+class ACResourceResult(TypedDict):
+    """Result of a ``resources/read`` invocation.
+
+    ``contents`` is a list with exactly one item for every AgentCeption
+    resource (resources are atomic; no multi-part responses).
+    """
+
+    contents: list[ACResourceContent]
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/tests/test_agentception_mcp_plan.py
+++ b/agentception/tests/test_agentception_mcp_plan.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 manifest validation, and coordinator spawn (AC-870 + AC-871).
 
 Covers:
-- agentception.mcp.types: ACToolDef shape, ACToolResult shape
+- agentception.mcp.types: ACToolDef, ACToolResult, ACResourceDef, ACResourceResult shapes
 - agentception.mcp.plan_tools: plan_get_schema(), plan_validate_spec()
 - agentception.mcp.plan_tools: plan_get_labels(), plan_validate_manifest(),
   plan_spawn_coordinator() (AC-871)
-- agentception.mcp.server: list_tools(), call_tool(), handle_request()
+- agentception.mcp.server: list_tools(), list_resources(), call_tool(), handle_request()
+- Resources: plan_get_schema and plan_get_labels are now ac:// Resources, not Tools
 
 Boundary: zero imports from external packages.
 """
@@ -28,8 +29,17 @@ from agentception.mcp.plan_tools import (
     plan_validate_manifest,
     plan_validate_spec,
 )
-from agentception.mcp.server import TOOLS, call_tool, call_tool_async, handle_request, list_tools
+from agentception.mcp.server import (
+    TOOLS,
+    call_tool,
+    call_tool_async,
+    handle_request,
+    list_resources,
+    list_tools,
+)
 from agentception.mcp.types import (
+    ACResourceDef,
+    ACResourceResult,
     ACToolDef,
     ACToolResult,
     JSONRPC_ERR_INVALID_PARAMS,
@@ -330,10 +340,12 @@ def test_list_tools_returns_non_empty_list() -> None:
     assert len(tools) > 0
 
 
-def test_list_tools_contains_plan_get_schema() -> None:
-    """list_tools() includes plan_get_schema."""
-    names = {t["name"] for t in list_tools()}
-    assert "plan_get_schema" in names
+def test_plan_get_schema_is_resource_not_tool() -> None:
+    """plan_get_schema is exposed as ac://plan/schema Resource, not as a Tool."""
+    tool_names = {t["name"] for t in list_tools()}
+    assert "plan_get_schema" not in tool_names
+    resource_uris = {r["uri"] for r in list_resources()}
+    assert "ac://plan/schema" in resource_uris
 
 
 def test_list_tools_contains_plan_validate_spec() -> None:
@@ -342,10 +354,12 @@ def test_list_tools_contains_plan_validate_spec() -> None:
     assert "plan_validate_spec" in names
 
 
-def test_list_tools_contains_plan_get_labels() -> None:
-    """list_tools() includes plan_get_labels (AC-871)."""
-    names = {t["name"] for t in list_tools()}
-    assert "plan_get_labels" in names
+def test_plan_get_labels_is_resource_not_tool() -> None:
+    """plan_get_labels is exposed as ac://plan/labels Resource, not as a Tool (AC-871)."""
+    tool_names = {t["name"] for t in list_tools()}
+    assert "plan_get_labels" not in tool_names
+    resource_uris = {r["uri"] for r in list_resources()}
+    assert "ac://plan/labels" in resource_uris
 
 
 def test_list_tools_contains_plan_validate_manifest() -> None:
@@ -386,19 +400,13 @@ def test_tools_module_constant_matches_list_tools() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_call_tool_plan_get_schema_returns_result() -> None:
-    """call_tool plan_get_schema returns isError=False with JSON content."""
+def test_call_tool_plan_get_schema_returns_redirect_error() -> None:
+    """call_tool plan_get_schema returns isError=True with redirect message (now a Resource)."""
     result = call_tool("plan_get_schema", {})
-    assert result["isError"] is False
-    assert len(result["content"]) == 1
-
-
-def test_call_tool_plan_get_schema_content_is_valid_json() -> None:
-    """call_tool plan_get_schema content text is valid JSON."""
-    result = call_tool("plan_get_schema", {})
-    text = result["content"][0]["text"]
-    parsed = json.loads(text)
-    assert isinstance(parsed, dict)
+    assert result["isError"] is True
+    payload = json.loads(result["content"][0]["text"])
+    assert "ac://plan/schema" in payload["error"]
+    assert "resources/read" in payload["error"]
 
 
 def test_call_tool_plan_validate_spec_valid_returns_no_error() -> None:
@@ -483,11 +491,15 @@ def test_handle_request_tools_list_string_id() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_handle_request_tools_call_plan_get_schema() -> None:
-    """handle_request tools/call plan_get_schema returns success result."""
+def test_handle_request_tools_call_plan_get_schema_returns_redirect() -> None:
+    """handle_request tools/call plan_get_schema returns redirect error (now a Resource)."""
     resp = _unwrap(handle_request(_call_request("plan_get_schema", {})))
     assert "result" in resp
-    assert "error" not in resp
+    result = resp["result"]
+    assert isinstance(result, dict)
+    assert result.get("isError") is True
+    payload = json.loads(result["content"][0]["text"])
+    assert "ac://plan/schema" in payload["error"]
 
 
 def test_handle_request_tools_call_plan_validate_spec_valid() -> None:

--- a/agentception/tests/test_cognitive_arch_in_plan_spec.py
+++ b/agentception/tests/test_cognitive_arch_in_plan_spec.py
@@ -6,9 +6,9 @@ Covers every layer introduced in the feat/cognitive-arch-in-plan-spec branch:
 
 1. Model layer  — PlanIssue.cognitive_arch, PlanSpec.coordinator_arch,
                   PlanSpec.to_yaml() round-trip.
-2. MCP tool     — plan_get_cognitive_figures(role).
-3. MCP server   — registration and call_tool dispatch for
-                  plan_get_cognitive_figures.
+2. plan_tools   — plan_get_cognitive_figures(role) function.
+3. MCP resource — plan_get_cognitive_figures is exposed as ac://plan/figures/{role}
+                  Resource (not a Tool) and routed correctly via read_resource().
 4. Issue creator — _embed_cognitive_arch, _create_one embedding.
 5. Cognitive arch service — _extract_cognitive_arch_from_body,
                             _resolve_cognitive_arch priority order.
@@ -290,13 +290,22 @@ class TestPlanGetCognitiveFigures:
 
 
 class TestMcpServerCognitiveFigures:
-    def test_tool_is_registered(self) -> None:
+    def test_is_resource_not_tool(self) -> None:
+        """plan_get_cognitive_figures is a Resource (ac://plan/figures/{role}), not a Tool."""
+        from agentception.mcp.resources import RESOURCE_TEMPLATES
         from agentception.mcp.server import list_tools
 
-        names = [t["name"] for t in list_tools()]
-        assert "plan_get_cognitive_figures" in names
+        tool_names = [t["name"] for t in list_tools()]
+        assert "plan_get_cognitive_figures" not in tool_names
 
-    def test_call_tool_dispatches_correctly(self, tmp_path: Path) -> None:
+        template_uris = {t["uriTemplate"] for t in RESOURCE_TEMPLATES}
+        assert "ac://plan/figures/{role}" in template_uris
+
+    @pytest.mark.anyio
+    async def test_read_resource_dispatches_correctly(self, tmp_path: Path) -> None:
+        """ac://plan/figures/{role} resource routes to plan_get_cognitive_figures."""
+        from agentception.mcp.resources import read_resource
+
         tax_path = tmp_path / "role-taxonomy.yaml"
         tax_path.write_text(yaml.dump(_fake_taxonomy({"cto": ["jeff_dean"]})))
         figs_dir = tmp_path / "figures"
@@ -309,18 +318,26 @@ class TestMcpServerCognitiveFigures:
             patch("agentception.mcp.plan_tools._TAXONOMY_PATH", tax_path),
             patch("agentception.mcp.plan_tools._ARCHETYPES_DIR", figs_dir),
         ):
-            result = call_tool("plan_get_cognitive_figures", {"role": "cto"})
+            result = await read_resource("ac://plan/figures/cto")
 
-        assert result["isError"] is False
-        payload: object = json.loads(result["content"][0]["text"])
+        payload: object = json.loads(result["contents"][0]["text"])
         assert isinstance(payload, dict)
         assert payload.get("role") == "cto"
 
-    def test_call_tool_missing_role_returns_error(self) -> None:
+    @pytest.mark.anyio
+    async def test_read_resource_call_tool_redirect_returns_error(self) -> None:
+        """Calling the retired plan_get_cognitive_figures tool returns a redirect error."""
         result = call_tool("plan_get_cognitive_figures", {})
         assert result["isError"] is True
+        payload: object = json.loads(result["content"][0]["text"])
+        assert isinstance(payload, dict)
+        assert "ac://plan/figures/{role}" in str(payload.get("error", ""))
 
-    def test_call_tool_unknown_role_is_error(self, tmp_path: Path) -> None:
+    @pytest.mark.anyio
+    async def test_read_resource_unknown_role_returns_error_in_payload(self, tmp_path: Path) -> None:
+        """ac://plan/figures/{role} for an unknown role returns an error-keyed payload."""
+        from agentception.mcp.resources import read_resource
+
         tax_path = tmp_path / "nonexistent.yaml"
         figs_dir = tmp_path / "figures"
         figs_dir.mkdir()
@@ -328,10 +345,11 @@ class TestMcpServerCognitiveFigures:
             patch("agentception.mcp.plan_tools._TAXONOMY_PATH", tax_path),
             patch("agentception.mcp.plan_tools._ARCHETYPES_DIR", figs_dir),
         ):
-            result = call_tool(
-                "plan_get_cognitive_figures", {"role": "unknown-role-xyz"}
-            )
-        assert result["isError"] is True
+            result = await read_resource("ac://plan/figures/unknown-role-xyz")
+
+        payload: object = json.loads(result["contents"][0]["text"])
+        assert isinstance(payload, dict)
+        assert "error" in payload or payload.get("figures") == []
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/tests/test_mcp_query_tools_pr4.py
+++ b/agentception/tests/test_mcp_query_tools_pr4.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
-"""Tests for PR 4 MCP query tools.
+"""Tests for MCP Resources (formerly query tools).
 
-Covers all 8 new tools via the MCP layer (call_tool_async):
-  - query_run
-  - query_children
-  - query_run_events
-  - query_agent_task
-  - query_active_runs
-  - query_run_tree
-  - query_dispatcher_state
-  - query_system_health
+Covers the full resource layer:
+  - read_resource() URI dispatcher for all ac:// URIs
+  - resources/list, resources/templates/list, resources/read JSON-RPC handlers
+  - Redirect behaviour: calling a retired query_* tool name returns a helpful error
+  - RESOURCES and RESOURCE_TEMPLATES catalogue completeness
 
-Each tool is tested for:
-  - Success path (ok=True, correct payload shape)
-  - Missing/invalid argument handling (isError=True)
-  - TOOLS registry presence
+Resources tested:
+  ac://runs/active
+  ac://runs/pending
+  ac://runs/{run_id}
+  ac://runs/{run_id}/children
+  ac://runs/{run_id}/events (and ?after_id= pagination)
+  ac://runs/{run_id}/task
+  ac://batches/{batch_id}/tree
+  ac://system/dispatcher
+  ac://system/health
+  ac://plan/schema
+  ac://plan/labels
+  ac://plan/figures/{role}
 """
 
 import json
@@ -24,273 +29,257 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from agentception.mcp.server import TOOLS, call_tool_async
-from agentception.mcp.types import ACToolResult
+from agentception.mcp.resources import (
+    RESOURCES,
+    RESOURCE_TEMPLATES,
+    read_resource,
+)
+from agentception.mcp.server import (
+    TOOLS,
+    call_tool_async,
+    handle_request_async,
+    list_resources,
+    list_resource_templates,
+)
+from agentception.mcp.types import ACResourceResult
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _payload(result: ACToolResult) -> dict[str, object]:
-    """Decode the first content item of an ACToolResult as JSON."""
-    raw: str = result["content"][0]["text"]
+
+def _content(result: ACResourceResult) -> dict[str, object]:
+    """Decode the first content item of an ACResourceResult as JSON."""
+    raw: str = result["contents"][0]["text"]
     out: dict[str, object] = json.loads(raw)
     return out
 
 
+def _rpc(method: str, params: dict[str, object] | None = None) -> dict[str, object]:
+    req: dict[str, object] = {"jsonrpc": "2.0", "id": 1, "method": method}
+    if params is not None:
+        req["params"] = params
+    return req
+
+
+def _unwrap_rpc(resp: dict[str, object] | None) -> dict[str, object]:
+    """Assert the RPC response is non-None and return it with narrowed type."""
+    assert resp is not None
+    return resp
+
+
+def _rpc_result(resp: dict[str, object] | None) -> dict[str, object]:
+    """Extract and narrow the 'result' value from an RPC response."""
+    unwrapped = _unwrap_rpc(resp)
+    result = unwrapped["result"]
+    assert isinstance(result, dict)
+    return result
+
+
+def _rpc_contents(resp: dict[str, object] | None) -> list[dict[str, object]]:
+    """Extract the 'contents' list from a resources/read RPC response."""
+    result = _rpc_result(resp)
+    raw_contents = result["contents"]
+    assert isinstance(raw_contents, list)
+    contents: list[dict[str, object]] = [c for c in raw_contents if isinstance(c, dict)]
+    return contents
+
+
 # ---------------------------------------------------------------------------
-# query_run
+# Catalogue completeness
+# ---------------------------------------------------------------------------
+
+
+def test_resources_catalogue_has_expected_uris() -> None:
+    """RESOURCES catalogue contains all expected static resource URIs."""
+    uris = {r["uri"] for r in RESOURCES}
+    assert "ac://runs/active" in uris
+    assert "ac://runs/pending" in uris
+    assert "ac://system/dispatcher" in uris
+    assert "ac://system/health" in uris
+    assert "ac://plan/schema" in uris
+    assert "ac://plan/labels" in uris
+
+
+def test_resource_templates_catalogue_has_expected_templates() -> None:
+    """RESOURCE_TEMPLATES catalogue contains all expected URI templates."""
+    templates = {t["uriTemplate"] for t in RESOURCE_TEMPLATES}
+    assert "ac://runs/{run_id}" in templates
+    assert "ac://runs/{run_id}/children" in templates
+    assert "ac://runs/{run_id}/events" in templates
+    assert "ac://runs/{run_id}/task" in templates
+    assert "ac://batches/{batch_id}/tree" in templates
+    assert "ac://plan/figures/{role}" in templates
+
+
+def test_all_resources_have_required_fields() -> None:
+    """Every resource definition has uri, name, description, and mimeType."""
+    for r in RESOURCES:
+        assert r["uri"]
+        assert r["name"]
+        assert r["description"]
+        assert r["mimeType"] == "application/json"
+
+
+def test_all_resource_templates_have_required_fields() -> None:
+    """Every resource template has uriTemplate, name, description, and mimeType."""
+    for t in RESOURCE_TEMPLATES:
+        assert t["uriTemplate"]
+        assert t["name"]
+        assert t["description"]
+        assert t["mimeType"] == "application/json"
+
+
+def test_list_resources_returns_full_catalogue() -> None:
+    assert list_resources() == RESOURCES
+
+
+def test_list_resource_templates_returns_full_catalogue() -> None:
+    assert list_resource_templates() == RESOURCE_TEMPLATES
+
+
+# ---------------------------------------------------------------------------
+# Retired query_* tools redirect to resource URIs
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_query_run_returns_run_on_success() -> None:
-    """query_run MCP tool returns ok=True with run metadata when run exists."""
-    mock_row = {
-        "run_id": "issue-42",
-        "status": "implementing",
-        "role": "python-developer",
-        "issue_number": 42,
-        "pr_number": None,
-        "branch": "ac/issue-42",
-        "worktree_path": "/worktrees/issue-42",
-        "batch_id": "batch-abc",
-        "tier": "engineer",
-        "org_domain": "engineering",
-        "parent_run_id": "issue-10",
-        "spawned_at": "2026-03-01T00:00:00+00:00",
-        "last_activity_at": None,
-        "completed_at": None,
+async def test_call_tool_async_returns_redirect_error_for_retired_tools() -> None:
+    """Retired query_* tool names return a descriptive error pointing to the resource URI."""
+    retired = {
+        "query_pending_runs": "ac://runs/pending",
+        "query_run": "ac://runs/{run_id}",
+        "query_children": "ac://runs/{run_id}/children",
+        "query_run_events": "ac://runs/{run_id}/events",
+        "query_agent_task": "ac://runs/{run_id}/task",
+        "query_active_runs": "ac://runs/active",
+        "query_run_tree": "ac://batches/{batch_id}/tree",
+        "query_dispatcher_state": "ac://system/dispatcher",
+        "query_system_health": "ac://system/health",
+        "plan_get_schema": "ac://plan/schema",
+        "plan_get_labels": "ac://plan/labels",
+        "plan_get_cognitive_figures": "ac://plan/figures/{role}",
     }
-    with patch("agentception.mcp.query_tools.get_run_by_id", new_callable=AsyncMock, return_value=mock_row):
-        result = await call_tool_async("query_run", {"run_id": "issue-42"})
-
-    assert result["isError"] is False
-    payload = _payload(result)
-    assert payload["ok"] is True
-    run = payload["run"]
-    assert isinstance(run, dict)
-    assert run["run_id"] == "issue-42"
-    assert run["status"] == "implementing"
+    for tool_name, expected_uri in retired.items():
+        result = await call_tool_async(tool_name, {})
+        assert result["isError"] is True, f"{tool_name} should return isError=True"
+        payload = json.loads(result["content"][0]["text"])
+        assert "resources/read" in payload["error"], f"{tool_name} error should mention resources/read"
+        assert expected_uri in payload["error"], f"{tool_name} error should include URI {expected_uri}"
 
 
-@pytest.mark.anyio
-async def test_query_run_returns_error_when_not_found() -> None:
-    """query_run returns isError=True when the run does not exist."""
-    with patch("agentception.mcp.query_tools.get_run_by_id", new_callable=AsyncMock, return_value=None):
-        result = await call_tool_async("query_run", {"run_id": "issue-999"})
-
-    assert result["isError"] is True
-    assert _payload(result)["ok"] is False
-
-
-@pytest.mark.anyio
-async def test_query_run_missing_run_id_returns_error() -> None:
-    """query_run returns isError=True when run_id argument is absent."""
-    result = await call_tool_async("query_run", {})
-    assert result["isError"] is True
-
-
-def test_query_run_in_tools_list() -> None:
-    names = [t["name"] for t in TOOLS]
-    assert "query_run" in names
-
-
-# ---------------------------------------------------------------------------
-# query_children
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.anyio
-async def test_query_children_returns_list_on_success() -> None:
-    """query_children MCP tool returns ok=True with children list."""
-    mock_children = [
-        {
-            "run_id": "issue-100",
-            "status": "implementing",
-            "role": "python-developer",
-            "issue_number": 100,
-            "pr_number": None,
-            "branch": None,
-            "worktree_path": None,
-            "batch_id": "batch-abc",
-            "tier": "engineer",
-            "org_domain": "engineering",
-            "parent_run_id": "issue-42",
-            "spawned_at": "2026-03-01T01:00:00+00:00",
-            "last_activity_at": None,
-            "completed_at": None,
-        }
-    ]
-    with patch(
-        "agentception.mcp.query_tools.get_children_by_parent_id",
-        new_callable=AsyncMock,
-        return_value=mock_children,
+def test_retired_query_tools_not_in_tools_list() -> None:
+    """Retired query_* and plan_get_* tools are not in the TOOLS list."""
+    names = {t["name"] for t in TOOLS}
+    for retired in (
+        "query_pending_runs",
+        "query_run",
+        "query_children",
+        "query_run_events",
+        "query_agent_task",
+        "query_active_runs",
+        "query_run_tree",
+        "query_dispatcher_state",
+        "query_system_health",
+        "plan_get_schema",
+        "plan_get_labels",
+        "plan_get_cognitive_figures",
     ):
-        result = await call_tool_async("query_children", {"run_id": "issue-42"})
-
-    assert result["isError"] is False
-    payload = _payload(result)
-    assert payload["ok"] is True
-    assert payload["count"] == 1
-    children = payload["children"]
-    assert isinstance(children, list)
-    assert children[0]["run_id"] == "issue-100"
-
-
-@pytest.mark.anyio
-async def test_query_children_returns_empty_list_when_none() -> None:
-    """query_children returns ok=True with empty list when no children exist."""
-    with patch(
-        "agentception.mcp.query_tools.get_children_by_parent_id",
-        new_callable=AsyncMock,
-        return_value=[],
-    ):
-        result = await call_tool_async("query_children", {"run_id": "issue-42"})
-
-    assert result["isError"] is False
-    payload = _payload(result)
-    assert payload["count"] == 0
-    assert payload["children"] == []
-
-
-@pytest.mark.anyio
-async def test_query_children_missing_run_id_returns_error() -> None:
-    """query_children returns isError=True when run_id is absent."""
-    result = await call_tool_async("query_children", {})
-    assert result["isError"] is True
-
-
-def test_query_children_in_tools_list() -> None:
-    names = [t["name"] for t in TOOLS]
-    assert "query_children" in names
+        assert retired not in names, f"{retired} should not be in TOOLS"
 
 
 # ---------------------------------------------------------------------------
-# query_run_events
+# JSON-RPC: resources/list
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_query_run_events_returns_events() -> None:
-    """query_run_events returns ok=True with events list."""
-    mock_events = [
-        {"id": 1, "event_type": "step_start", "payload": "{}", "recorded_at": "2026-03-01T00:01:00+00:00"},
-        {"id": 2, "event_type": "blocker", "payload": '{"msg":"waiting"}', "recorded_at": "2026-03-01T00:02:00+00:00"},
-    ]
-    with patch(
-        "agentception.mcp.query_tools.get_agent_events_tail",
-        new_callable=AsyncMock,
-        return_value=mock_events,
-    ):
-        result = await call_tool_async("query_run_events", {"run_id": "issue-42", "after_id": 0})
-
-    assert result["isError"] is False
-    payload = _payload(result)
-    assert payload["ok"] is True
-    assert payload["count"] == 2
+async def test_handle_request_async_resources_list() -> None:
+    """resources/list returns the full static resource catalogue."""
+    resp = await handle_request_async(_rpc("resources/list"))
+    result = _rpc_result(resp)
+    raw_resources = result["resources"]
+    assert isinstance(raw_resources, list)
+    resources: list[dict[str, object]] = [r for r in raw_resources if isinstance(r, dict)]
+    uris = {str(r["uri"]) for r in resources}
+    assert "ac://runs/active" in uris
+    assert "ac://system/health" in uris
+    assert "ac://plan/schema" in uris
 
 
 @pytest.mark.anyio
-async def test_query_run_events_passes_after_id() -> None:
-    """query_run_events passes after_id correctly to the DB function."""
-    with patch(
-        "agentception.mcp.query_tools.get_agent_events_tail",
-        new_callable=AsyncMock,
-        return_value=[],
-    ) as mock_fn:
-        await call_tool_async("query_run_events", {"run_id": "issue-42", "after_id": 5})
-
-    mock_fn.assert_awaited_once_with("issue-42", after_id=5)
+async def test_handle_request_async_resources_templates_list() -> None:
+    """resources/templates/list returns the full resource template catalogue."""
+    resp = await handle_request_async(_rpc("resources/templates/list"))
+    result = _rpc_result(resp)
+    raw_templates = result["resourceTemplates"]
+    assert isinstance(raw_templates, list)
+    templates: list[dict[str, object]] = [t for t in raw_templates if isinstance(t, dict)]
+    uris = {str(t["uriTemplate"]) for t in templates}
+    assert "ac://runs/{run_id}" in uris
+    assert "ac://plan/figures/{role}" in uris
 
 
 @pytest.mark.anyio
-async def test_query_run_events_missing_run_id_returns_error() -> None:
-    """query_run_events returns isError=True when run_id is absent."""
-    result = await call_tool_async("query_run_events", {})
-    assert result["isError"] is True
+async def test_handle_request_async_resources_read_missing_uri_returns_error() -> None:
+    """resources/read with missing params.uri returns an invalid-params error."""
+    resp = await handle_request_async(_rpc("resources/read", {}))
+    unwrapped = _unwrap_rpc(resp)
+    assert "error" in unwrapped
+    raw_error = unwrapped["error"]
+    assert isinstance(raw_error, dict)
+    assert raw_error["code"] == -32602
 
 
-def test_query_run_events_in_tools_list() -> None:
-    names = [t["name"] for t in TOOLS]
-    assert "query_run_events" in names
+@pytest.mark.anyio
+async def test_handle_request_async_resources_read_unknown_uri_returns_error_content() -> None:
+    """resources/read with an unknown URI returns content with an error key (not a JSON-RPC error)."""
+    resp = await handle_request_async(_rpc("resources/read", {"uri": "ac://unknown/path"}))
+    contents = _rpc_contents(resp)
+    assert len(contents) == 1
+    payload = json.loads(str(contents[0]["text"]))
+    assert "error" in payload
+
+
+@pytest.mark.anyio
+async def test_handle_request_async_resources_read_wrong_scheme() -> None:
+    """resources/read with a non-ac:// URI returns an error content item."""
+    resp = await handle_request_async(_rpc("resources/read", {"uri": "http://example.com/foo"}))
+    contents = _rpc_contents(resp)
+    payload = json.loads(str(contents[0]["text"]))
+    assert "error" in payload
 
 
 # ---------------------------------------------------------------------------
-# query_agent_task
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.anyio
-async def test_query_agent_task_returns_content(tmp_path: Path) -> None:
-    """query_agent_task returns ok=True with file content when .agent-task exists."""
-    task_file = tmp_path / ".agent-task"
-    task_file.write_text("[agent]\nrun_id = 42\n")
-
-    mock_teardown = {"worktree_path": str(tmp_path), "branch": "ac/issue-42"}
-    with patch(
-        "agentception.mcp.query_tools.get_agent_run_teardown",
-        new_callable=AsyncMock,
-        return_value=mock_teardown,
-    ):
-        result = await call_tool_async("query_agent_task", {"run_id": "issue-42"})
-
-    assert result["isError"] is False
-    payload = _payload(result)
-    assert payload["ok"] is True
-    assert "run_id = 42" in str(payload["content"])
-
-
-@pytest.mark.anyio
-async def test_query_agent_task_returns_error_when_run_not_found() -> None:
-    """query_agent_task returns isError=True when run does not exist."""
-    with patch(
-        "agentception.mcp.query_tools.get_agent_run_teardown",
-        new_callable=AsyncMock,
-        return_value=None,
-    ):
-        result = await call_tool_async("query_agent_task", {"run_id": "issue-999"})
-
-    assert result["isError"] is True
-    assert _payload(result)["ok"] is False
-
-
-@pytest.mark.anyio
-async def test_query_agent_task_returns_error_when_file_missing(tmp_path: Path) -> None:
-    """query_agent_task returns isError=True when .agent-task file does not exist."""
-    mock_teardown = {"worktree_path": str(tmp_path), "branch": "ac/issue-42"}
-    with patch(
-        "agentception.mcp.query_tools.get_agent_run_teardown",
-        new_callable=AsyncMock,
-        return_value=mock_teardown,
-    ):
-        result = await call_tool_async("query_agent_task", {"run_id": "issue-42"})
-
-    assert result["isError"] is True
-    assert _payload(result)["ok"] is False
-
-
-@pytest.mark.anyio
-async def test_query_agent_task_missing_run_id_returns_error() -> None:
-    """query_agent_task returns isError=True when run_id is absent."""
-    result = await call_tool_async("query_agent_task", {})
-    assert result["isError"] is True
-
-
-def test_query_agent_task_in_tools_list() -> None:
-    names = [t["name"] for t in TOOLS]
-    assert "query_agent_task" in names
-
-
-# ---------------------------------------------------------------------------
-# query_active_runs
+# initialize declares resources capability
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_query_active_runs_returns_list() -> None:
-    """query_active_runs MCP tool returns ok=True with active runs."""
+async def test_initialize_declares_resources_capability() -> None:
+    """initialize response includes both tools and resources capabilities."""
+    resp = await handle_request_async({
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "initialize",
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {}},
+    })
+    result = _rpc_result(resp)
+    caps = result["capabilities"]
+    assert isinstance(caps, dict)
+    assert "tools" in caps
+    assert "resources" in caps
+
+
+# ---------------------------------------------------------------------------
+# ac://runs/active
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_read_resource_active_runs() -> None:
+    """ac://runs/active returns active run list."""
     mock_runs = [
         {
             "run_id": "issue-1",
@@ -301,7 +290,7 @@ async def test_query_active_runs_returns_list() -> None:
             "branch": None,
             "worktree_path": None,
             "batch_id": "batch-x",
-            "tier": "engineer",
+            "tier": "worker",
             "org_domain": "engineering",
             "parent_run_id": None,
             "spawned_at": "2026-03-01T00:00:00+00:00",
@@ -314,27 +303,274 @@ async def test_query_active_runs_returns_list() -> None:
         new_callable=AsyncMock,
         return_value=mock_runs,
     ):
-        result = await call_tool_async("query_active_runs", {})
+        result = await read_resource("ac://runs/active")
 
-    assert result["isError"] is False
-    payload = _payload(result)
+    payload = _content(result)
+    assert result["contents"][0]["uri"] == "ac://runs/active"
     assert payload["ok"] is True
     assert payload["count"] == 1
 
 
-def test_query_active_runs_in_tools_list() -> None:
-    names = [t["name"] for t in TOOLS]
-    assert "query_active_runs" in names
+@pytest.mark.anyio
+async def test_read_resource_active_runs_via_rpc() -> None:
+    """resources/read for ac://runs/active returns correct content via JSON-RPC."""
+    with patch(
+        "agentception.mcp.query_tools.get_active_runs",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        resp = await handle_request_async(_rpc("resources/read", {"uri": "ac://runs/active"}))
+
+    contents = _rpc_contents(resp)
+    assert contents[0]["uri"] == "ac://runs/active"
+    assert contents[0]["mimeType"] == "application/json"
 
 
 # ---------------------------------------------------------------------------
-# query_run_tree
+# ac://runs/pending
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_query_run_tree_returns_nodes() -> None:
-    """query_run_tree MCP tool returns ok=True with tree nodes."""
+async def test_read_resource_pending_runs() -> None:
+    """ac://runs/pending returns the pending run queue."""
+    mock_pending = [
+        {
+            "run_id": "label-batch0-a1b2",
+            "issue_number": 0,
+            "role": "cto",
+            "branch": "agent/batch0-a1b2",
+            "host_worktree_path": "/tmp/worktrees/batch0-a1b2",
+            "batch_id": "label-batch0-20260301-a1b2",
+        }
+    ]
+    with patch(
+        "agentception.mcp.query_tools.get_pending_launches",
+        new_callable=AsyncMock,
+        return_value=mock_pending,
+    ):
+        result = await read_resource("ac://runs/pending")
+
+    payload = _content(result)
+    assert payload["count"] == 1
+    pending = payload["pending"]
+    assert isinstance(pending, list)
+    first = pending[0]
+    assert isinstance(first, dict)
+    assert first["role"] == "cto"
+
+
+# ---------------------------------------------------------------------------
+# ac://runs/{run_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_read_resource_run_returns_metadata() -> None:
+    """ac://runs/{run_id} returns run metadata when the run exists."""
+    mock_row = {
+        "run_id": "issue-42",
+        "status": "implementing",
+        "role": "python-developer",
+        "issue_number": 42,
+        "pr_number": None,
+        "branch": "ac/issue-42",
+        "worktree_path": "/worktrees/issue-42",
+        "batch_id": "batch-abc",
+        "tier": "worker",
+        "org_domain": "engineering",
+        "parent_run_id": "issue-10",
+        "spawned_at": "2026-03-01T00:00:00+00:00",
+        "last_activity_at": None,
+        "completed_at": None,
+    }
+    with patch("agentception.mcp.query_tools.get_run_by_id", new_callable=AsyncMock, return_value=mock_row):
+        result = await read_resource("ac://runs/issue-42")
+
+    payload = _content(result)
+    assert payload["ok"] is True
+    run = payload["run"]
+    assert isinstance(run, dict)
+    assert run["run_id"] == "issue-42"
+    assert run["status"] == "implementing"
+
+
+@pytest.mark.anyio
+async def test_read_resource_run_returns_error_when_not_found() -> None:
+    """ac://runs/{run_id} returns error payload when the run does not exist."""
+    with patch("agentception.mcp.query_tools.get_run_by_id", new_callable=AsyncMock, return_value=None):
+        result = await read_resource("ac://runs/issue-999")
+
+    assert _content(result)["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# ac://runs/{run_id}/children
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_read_resource_children_returns_list() -> None:
+    """ac://runs/{run_id}/children returns child run list."""
+    mock_children = [
+        {
+            "run_id": "issue-100",
+            "status": "implementing",
+            "role": "python-developer",
+            "issue_number": 100,
+            "pr_number": None,
+            "branch": None,
+            "worktree_path": None,
+            "batch_id": "batch-abc",
+            "tier": "worker",
+            "org_domain": "engineering",
+            "parent_run_id": "issue-42",
+            "spawned_at": "2026-03-01T01:00:00+00:00",
+            "last_activity_at": None,
+            "completed_at": None,
+        }
+    ]
+    with patch(
+        "agentception.mcp.query_tools.get_children_by_parent_id",
+        new_callable=AsyncMock,
+        return_value=mock_children,
+    ):
+        result = await read_resource("ac://runs/issue-42/children")
+
+    payload = _content(result)
+    assert payload["ok"] is True
+    assert payload["count"] == 1
+    children = payload["children"]
+    assert isinstance(children, list)
+    first = children[0]
+    assert isinstance(first, dict)
+    assert first["run_id"] == "issue-100"
+
+
+@pytest.mark.anyio
+async def test_read_resource_children_empty_list() -> None:
+    """ac://runs/{run_id}/children returns empty list when no children exist."""
+    with patch(
+        "agentception.mcp.query_tools.get_children_by_parent_id",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        result = await read_resource("ac://runs/issue-42/children")
+
+    payload = _content(result)
+    assert payload["count"] == 0
+    assert payload["children"] == []
+
+
+# ---------------------------------------------------------------------------
+# ac://runs/{run_id}/events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_read_resource_events_returns_events() -> None:
+    """ac://runs/{run_id}/events returns the event log."""
+    mock_events = [
+        {"id": 1, "event_type": "step_start", "payload": "{}", "recorded_at": "2026-03-01T00:01:00+00:00"},
+        {"id": 2, "event_type": "blocker", "payload": '{"msg":"waiting"}', "recorded_at": "2026-03-01T00:02:00+00:00"},
+    ]
+    with patch(
+        "agentception.mcp.query_tools.get_agent_events_tail",
+        new_callable=AsyncMock,
+        return_value=mock_events,
+    ):
+        result = await read_resource("ac://runs/issue-42/events")
+
+    payload = _content(result)
+    assert payload["ok"] is True
+    assert payload["count"] == 2
+
+
+@pytest.mark.anyio
+async def test_read_resource_events_pagination_via_query_string() -> None:
+    """ac://runs/{run_id}/events?after_id=N passes after_id to the DB function."""
+    with patch(
+        "agentception.mcp.query_tools.get_agent_events_tail",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as mock_fn:
+        await read_resource("ac://runs/issue-42/events?after_id=5")
+
+    mock_fn.assert_awaited_once_with("issue-42", after_id=5)
+
+
+@pytest.mark.anyio
+async def test_read_resource_events_default_after_id_is_zero() -> None:
+    """ac://runs/{run_id}/events without after_id defaults to 0."""
+    with patch(
+        "agentception.mcp.query_tools.get_agent_events_tail",
+        new_callable=AsyncMock,
+        return_value=[],
+    ) as mock_fn:
+        await read_resource("ac://runs/issue-42/events")
+
+    mock_fn.assert_awaited_once_with("issue-42", after_id=0)
+
+
+# ---------------------------------------------------------------------------
+# ac://runs/{run_id}/task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_read_resource_task_returns_content(tmp_path: Path) -> None:
+    """ac://runs/{run_id}/task returns the .agent-task TOML content."""
+    task_file = tmp_path / ".agent-task"
+    task_file.write_text("[agent]\nrun_id = 42\n")
+
+    mock_teardown = {"worktree_path": str(tmp_path), "branch": "ac/issue-42"}
+    with patch(
+        "agentception.mcp.query_tools.get_agent_run_teardown",
+        new_callable=AsyncMock,
+        return_value=mock_teardown,
+    ):
+        result = await read_resource("ac://runs/issue-42/task")
+
+    payload = _content(result)
+    assert payload["ok"] is True
+    assert "run_id = 42" in str(payload["content"])
+
+
+@pytest.mark.anyio
+async def test_read_resource_task_returns_error_when_run_not_found() -> None:
+    """ac://runs/{run_id}/task returns error payload when run does not exist."""
+    with patch(
+        "agentception.mcp.query_tools.get_agent_run_teardown",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await read_resource("ac://runs/issue-999/task")
+
+    assert _content(result)["ok"] is False
+
+
+@pytest.mark.anyio
+async def test_read_resource_task_returns_error_when_file_missing(tmp_path: Path) -> None:
+    """ac://runs/{run_id}/task returns error payload when .agent-task file is absent."""
+    mock_teardown = {"worktree_path": str(tmp_path), "branch": "ac/issue-42"}
+    with patch(
+        "agentception.mcp.query_tools.get_agent_run_teardown",
+        new_callable=AsyncMock,
+        return_value=mock_teardown,
+    ):
+        result = await read_resource("ac://runs/issue-42/task")
+
+    assert _content(result)["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# ac://batches/{batch_id}/tree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_read_resource_batch_tree_returns_nodes() -> None:
+    """ac://batches/{batch_id}/tree returns all runs in the batch."""
     mock_nodes = [
         {
             "id": "issue-1",
@@ -357,37 +593,34 @@ async def test_query_run_tree_returns_nodes() -> None:
         new_callable=AsyncMock,
         return_value=mock_nodes,
     ):
-        result = await call_tool_async("query_run_tree", {"batch_id": "batch-x"})
+        result = await read_resource("ac://batches/batch-x/tree")
 
-    assert result["isError"] is False
-    payload = _payload(result)
+    payload = _content(result)
     assert payload["ok"] is True
     assert payload["count"] == 1
     nodes = payload["nodes"]
     assert isinstance(nodes, list)
-    assert nodes[0]["id"] == "issue-1"
+    first = nodes[0]
+    assert isinstance(first, dict)
+    assert first["id"] == "issue-1"
 
 
 @pytest.mark.anyio
-async def test_query_run_tree_missing_batch_id_returns_error() -> None:
-    """query_run_tree returns isError=True when batch_id is absent."""
-    result = await call_tool_async("query_run_tree", {})
-    assert result["isError"] is True
-
-
-def test_query_run_tree_in_tools_list() -> None:
-    names = [t["name"] for t in TOOLS]
-    assert "query_run_tree" in names
+async def test_read_resource_batch_tree_unknown_uri_returns_not_found() -> None:
+    """ac://batches/{batch_id} without /tree returns not-found error payload."""
+    result = await read_resource("ac://batches/batch-x")
+    payload = _content(result)
+    assert "error" in payload
 
 
 # ---------------------------------------------------------------------------
-# query_dispatcher_state
+# ac://system/dispatcher
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_query_dispatcher_state_returns_state() -> None:
-    """query_dispatcher_state MCP tool returns ok=True with status counts."""
+async def test_read_resource_dispatcher_state() -> None:
+    """ac://system/dispatcher returns dispatcher state with status counts."""
     mock_counts = [
         {"status": "implementing", "count": 3},
         {"status": "completed", "count": 10},
@@ -404,10 +637,9 @@ async def test_query_dispatcher_state_returns_state() -> None:
             return_value="batch-xyz",
         ),
     ):
-        result = await call_tool_async("query_dispatcher_state", {})
+        result = await read_resource("ac://system/dispatcher")
 
-    assert result["isError"] is False
-    payload = _payload(result)
+    payload = _content(result)
     assert payload["ok"] is True
     assert payload["active_count"] == 3
     assert payload["latest_batch_id"] == "batch-xyz"
@@ -416,19 +648,14 @@ async def test_query_dispatcher_state_returns_state() -> None:
     assert len(sc) == 2
 
 
-def test_query_dispatcher_state_in_tools_list() -> None:
-    names = [t["name"] for t in TOOLS]
-    assert "query_dispatcher_state" in names
-
-
 # ---------------------------------------------------------------------------
-# query_system_health
+# ac://system/health
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_query_system_health_db_up() -> None:
-    """query_system_health returns ok=True with db_ok=True when DB is reachable."""
+async def test_read_resource_system_health_db_up() -> None:
+    """ac://system/health returns ok=True with db_ok=True when DB is reachable."""
     mock_counts = [{"status": "implementing", "count": 2}]
     with (
         patch(
@@ -442,37 +669,139 @@ async def test_query_system_health_db_up() -> None:
             return_value=mock_counts,
         ),
     ):
-        result = await call_tool_async("query_system_health", {})
+        result = await read_resource("ac://system/health")
 
-    assert result["isError"] is False
-    payload = _payload(result)
+    payload = _content(result)
     assert payload["ok"] is True
     assert payload["db_ok"] is True
     assert payload["total_runs"] == 2
 
 
 @pytest.mark.anyio
-async def test_query_system_health_db_down() -> None:
-    """Regression: query_system_health returns ok=True but db_ok=False when DB is unreachable.
+async def test_read_resource_system_health_db_down() -> None:
+    """Regression: ac://system/health returns db_ok=False when DB is unreachable.
 
-    The tool must never raise — it degrades gracefully so supervisory agents
-    can detect the outage without crashing.
+    The resource must never raise — it degrades gracefully so supervisory
+    agents can detect the outage without crashing.
     """
     with patch(
         "agentception.mcp.query_tools.check_db_reachable",
         new_callable=AsyncMock,
         return_value=False,
     ):
-        result = await call_tool_async("query_system_health", {})
+        result = await read_resource("ac://system/health")
 
-    assert result["isError"] is False
-    payload = _payload(result)
+    payload = _content(result)
     assert payload["ok"] is True
     assert payload["db_ok"] is False
     assert payload["total_runs"] == 0
     assert payload["status_counts"] == []
 
 
-def test_query_system_health_in_tools_list() -> None:
-    names = [t["name"] for t in TOOLS]
-    assert "query_system_health" in names
+# ---------------------------------------------------------------------------
+# ac://plan/schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_read_resource_plan_schema() -> None:
+    """ac://plan/schema returns the PlanSpec JSON Schema."""
+    result = await read_resource("ac://plan/schema")
+
+    payload = _content(result)
+    assert isinstance(payload, dict)
+    assert "type" in payload or "$defs" in payload or "properties" in payload
+
+
+# ---------------------------------------------------------------------------
+# ac://plan/labels
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_read_resource_plan_labels() -> None:
+    """ac://plan/labels returns the GitHub label list."""
+    mock_labels = {"labels": [{"name": "phase/1", "description": "Phase 1"}]}
+    with patch(
+        "agentception.mcp.resources.plan_get_labels",
+        new_callable=AsyncMock,
+        return_value=mock_labels,
+    ):
+        result = await read_resource("ac://plan/labels")
+
+    payload = _content(result)
+    assert "labels" in payload
+    labels = payload["labels"]
+    assert isinstance(labels, list)
+    first_label = labels[0]
+    assert isinstance(first_label, dict)
+    assert first_label["name"] == "phase/1"
+
+
+# ---------------------------------------------------------------------------
+# ac://plan/figures/{role}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_read_resource_plan_figures_known_role() -> None:
+    """ac://plan/figures/{role} returns figure catalogue for a known role."""
+    mock_result = {
+        "role": "python-developer",
+        "figures": [{"id": "fig-1", "display_name": "Flow State", "description": "Deep focus"}],
+    }
+    with patch(
+        "agentception.mcp.resources.plan_get_cognitive_figures",
+        return_value=mock_result,
+    ):
+        result = await read_resource("ac://plan/figures/python-developer")
+
+    payload = _content(result)
+    assert payload["role"] == "python-developer"
+    figures = payload["figures"]
+    assert isinstance(figures, list)
+    assert len(figures) == 1
+
+
+@pytest.mark.anyio
+async def test_read_resource_plan_figures_unknown_role() -> None:
+    """ac://plan/figures/{role} returns error payload for an unknown role."""
+    mock_result = {"role": "unknown-role", "figures": [], "error": "Role not found"}
+    with patch(
+        "agentception.mcp.resources.plan_get_cognitive_figures",
+        return_value=mock_result,
+    ):
+        result = await read_resource("ac://plan/figures/unknown-role")
+
+    payload = _content(result)
+    assert payload["role"] == "unknown-role"
+    assert payload["figures"] == []
+
+
+# ---------------------------------------------------------------------------
+# URI edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_read_resource_unknown_domain_returns_not_found() -> None:
+    """ac://unknowndomain/foo returns a not-found error payload."""
+    result = await read_resource("ac://unknowndomain/foo")
+    payload = _content(result)
+    assert "error" in payload
+
+
+@pytest.mark.anyio
+async def test_read_resource_wrong_scheme_returns_error() -> None:
+    """Non-ac:// URI scheme returns an error payload."""
+    result = await read_resource("https://example.com/runs/active")
+    payload = _content(result)
+    assert "error" in payload
+
+
+@pytest.mark.anyio
+async def test_read_resource_empty_uri_returns_error() -> None:
+    """Empty URI string returns an error payload gracefully."""
+    result = await read_resource("")
+    payload = _content(result)
+    assert "error" in payload

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -58,13 +58,40 @@ If you also run other MCP servers (e.g. a music composition backend), add them a
 - AgentCeption containers must be running: `docker compose up -d`
 - Verify the MCP server responds: `docker compose exec agentception python -m agentception.mcp.stdio_server`
 
+## Tools vs Resources
+
+AgentCeption exposes two kinds of MCP endpoints:
+
+| Kind | Purpose | How to call |
+|------|---------|-------------|
+| **Tools** | Actions with side effects (mutate state, file issues, start agents) | `CallMcpTool(server="user-agentception", toolName=..., arguments={...})` |
+| **Resources** | Pure reads — stateless, cacheable, side-effect-free | `FetchMcpResource(server="user-agentception", uri="ac://...")` |
+
+This is the correct MCP protocol distinction: resources map to the `resources/read` JSON-RPC
+method and are served under the `ac://` URI scheme; tools map to `tools/call`.
+
+### Resource URI catalogue
+
+| URI | What it returns |
+|-----|----------------|
+| `ac://runs/active` | All live runs (pending_launch, implementing, reviewing, blocked) |
+| `ac://runs/pending` | Runs queued for Dispatcher launch |
+| `ac://runs/{run_id}` | Metadata for one run |
+| `ac://runs/{run_id}/children` | Child runs spawned by this run |
+| `ac://runs/{run_id}/events` | Structured event log; append `?after_id=N` to paginate |
+| `ac://runs/{run_id}/task` | Raw `.agent-task` TOML text |
+| `ac://batches/{batch_id}/tree` | All runs in a batch |
+| `ac://system/dispatcher` | Dispatcher counters and active batch_id |
+| `ac://system/health` | DB reachability and per-status counts |
+| `ac://plan/schema` | PlanSpec JSON Schema |
+| `ac://plan/labels` | GitHub label catalogue |
+| `ac://plan/figures/{role}` | Cognitive-arch figures for a role slug |
+
 ## MCP Auto-Approval
 
-The repository ships a `.cursor/mcp.json` at the repo root that connects Cursor to the
-AgentCeption HTTP MCP endpoint. Auto-approval is tiered by risk — read-only and
-observability tools are auto-approved; tools that reach outside the service boundary
-(filing GitHub issues, starting agents, advancing phase gates) always require an explicit
-human confirmation click.
+Auto-approval is tiered by risk — resources (all reads) and observability tools are
+auto-approved; tools that reach outside the service boundary (filing GitHub issues,
+starting agents, advancing phase gates) always require an explicit human confirmation.
 
 ```json
 {
@@ -72,41 +99,39 @@ human confirmation click.
     "agentception": {
       "url": "http://localhost:10003/mcp",
       "autoApprove": [
-        "plan_get_schema",
         "plan_validate_spec",
-        "plan_get_labels",
         "plan_validate_manifest",
-        "build_get_pending_launches",
-        "build_report_step",
-        "build_report_blocker",
-        "build_report_decision"
+        "log_run_step",
+        "log_run_blocker",
+        "log_run_decision",
+        "log_run_message"
       ]
     }
   }
 }
 ```
 
-### Tool approval tiers
+### Approval tiers
 
-| Tier | Tools | Rationale |
-|------|-------|-----------|
-| **Green — auto-approved** | `plan_get_schema`, `plan_validate_spec`, `plan_get_labels`, `plan_validate_manifest`, `build_get_pending_launches` | Pure reads or in-memory validation — no external effects. |
-| **Green — auto-approved** | `build_report_step`, `build_report_blocker`, `build_report_decision` | Append-only observability writes to the DB — no external effects, trivially recoverable. |
-| **Yellow — prompt** | `build_report_done` | Changes pipeline run state in the DB; recoverable but worth a confirmation. |
-| **Red — always prompt** | `plan_spawn_coordinator`, `plan_advance_phase` | File real GitHub issues, create git worktrees, and start live agents. These are irreversible side effects that always warrant an explicit human sign-off. |
+| Tier | Endpoints | Rationale |
+|------|-----------|-----------|
+| **Auto — resources** | All `ac://` URIs | Pure reads — no external effects, always safe. |
+| **Auto — tools** | `plan_validate_spec`, `plan_validate_manifest` | In-memory validation only. |
+| **Auto — tools** | `log_run_step`, `log_run_blocker`, `log_run_decision`, `log_run_message` | Append-only DB writes — no external effects. |
+| **Prompt** | `build_claim_run`, `build_complete_run`, `build_cancel_run`, `build_stop_run`, `build_block_run`, `build_resume_run` | Pipeline state transitions in the DB — recoverable but worth confirming. |
+| **Prompt** | `github_add_label`, `github_remove_label`, `github_claim_issue`, `github_unclaim_issue` | External GitHub API mutations. |
+| **Always prompt** | `plan_spawn_coordinator`, `plan_advance_phase`, `build_spawn_child_run`, `build_teardown_worktree` | Create real GitHub issues, git worktrees, and live agents — irreversible side effects. |
 
 **What this means for you:**
 
-- Read-only and reporting tool calls happen without interruption.
+- Resource reads (`FetchMcpResource`) and observability tool calls happen without interruption.
 - `plan_spawn_coordinator` and `plan_advance_phase` will always show a Cursor confirmation
-  dialog before executing — this is intentional. A mis-fire on either of these creates
-  real GitHub issues and running agent processes that are hard to undo.
+  dialog — a mis-fire creates real GitHub issues and running agent processes that are hard to undo.
 - The AgentCeption server must be running at `http://localhost:10003` (start it with
   `docker compose up -d`).
 
-This file is committed to the repository so the configuration is version-controlled,
-reviewable in PRs, and reproducible across machines without any manual setup.
+## Available tools and resources
 
-## Available MCP tools
-
-See `agentception/mcp/server.py` and `agentception/mcp/build_tools.py` for the full list of registered tools. Cursor's MCP panel will enumerate them automatically once the server entry is in `mcp.json`.
+See `agentception/mcp/server.py` for registered tools and `agentception/mcp/resources.py`
+for the resource catalogue. Cursor's MCP panel enumerates both automatically once the
+server entry is in `mcp.json`.

--- a/docs/plan-spec.md
+++ b/docs/plan-spec.md
@@ -28,7 +28,7 @@ User brain dump (free text)
   GitHub Issues tagged by phase label
 ```
 
-MCP is **not** involved in plan generation. Claude is called directly from AgentCeption's backend (OpenRouter). MCP only enters after the user clicks Launch, when a coordinator agent uses MCP tools (`plan_get_labels`, etc.) to file issues.
+MCP is **not** involved in plan generation. Claude is called directly from AgentCeption's backend (OpenRouter). MCP only enters after the user clicks Launch, when a coordinator agent reads the `ac://plan/labels` resource and uses mutation tools to file issues.
 
 ---
 
@@ -226,7 +226,7 @@ When the user clicks **Launch**, AgentCeption:
 
 The **coordinator agent** (running in Cursor via MCP) then:
 
-1. Calls `plan_get_labels()` to fetch the phase label configuration.
+1. Reads the `ac://plan/labels` resource to fetch the phase label configuration.
 2. Iterates phases in order. For each phase:
    - Creates all GitHub issues in that phase from the PlanIssue data.
    - Applies the phase label and sets `depends_on` metadata.

--- a/docs/reference/cognitive-arch.md
+++ b/docs/reference/cognitive-arch.md
@@ -362,12 +362,12 @@ phases:
 - `coordinator_arch` — maps role slugs to arch strings for orchestration agents (CTO, engineering-coordinator, qa-coordinator, and any future C-level or coordinator variant). Keys are open-ended; new coordinator types require no schema changes.
 - `cognitive_arch` (per issue) — the fully-resolved arch string baked into the issue body at filing time. Leaf engineers read this from the issue and load the matching persona.
 
-### MCP tool: `plan_get_cognitive_figures`
+### MCP resource: `ac://plan/figures/{role}`
 
-Agents and the Phase 1A LLM planner can call this tool to get the filtered figure catalog for any role:
+Agents and the Phase 1A LLM planner can read this resource to get the filtered figure catalog for any role:
 
 ```
-plan_get_cognitive_figures(role: str)
+FetchMcpResource(server="user-agentception", uri="ac://plan/figures/python-developer")
 → {role: str, figures: [{id, display_name, description}, ...]}
 ```
 

--- a/scripts/gen_prompts/templates/dispatcher.md.j2
+++ b/scripts/gen_prompts/templates/dispatcher.md.j2
@@ -12,14 +12,20 @@ Canonical reference: `docs/agent-tree-protocol.md`
 
 ## MCP server identifier
 
-All AgentCeption MCP tools are on server **`user-agentception`**.
-When using `CallMcpTool`, always pass `server="user-agentception"`.
+All AgentCeption MCP tools and resources are on server **`user-agentception`**.
+
+- **Tools** (state mutations): use `CallMcpTool` with `server="user-agentception"`.
+- **Resources** (pure reads): use `FetchMcpResource` with `server="user-agentception"`.
 
 ---
 
 ## Step 1 — Read the queue
 
-Call the `query_pending_runs` MCP tool (server: `user-agentception`).
+Read the `ac://runs/pending` resource (server: `user-agentception`):
+
+```
+FetchMcpResource(server="user-agentception", uri="ac://runs/pending")
+```
 
 It returns a list of pending launches shaped like:
 
@@ -242,7 +248,7 @@ After spawning all Tasks simultaneously, wait for all of them to return before p
 
 ## Step 5 — Check for more
 
-After each batch completes, call `query_pending_runs` again.
+After each batch completes, read `ac://runs/pending` again.
 If more items were queued while you were working (user dispatched more from
 the UI), spawn them too.
 


### PR DESCRIPTION
## Summary

- Promotes all side-effect-free reads from MCP Tools to MCP Resources — the correct protocol primitive for stateless, cacheable reads. The `initialize` response now declares `{"tools": {}, "resources": {}}` and the server handles `resources/list`, `resources/templates/list`, and `resources/read`.
- Adds `agentception/mcp/resources.py` with 6 static resources (`ac://runs/active`, `ac://runs/pending`, `ac://system/dispatcher`, `ac://system/health`, `ac://plan/schema`, `ac://plan/labels`) and 6 URI templates (`ac://runs/{run_id}`, `/children`, `/events{?after_id}`, `/task`, `ac://batches/{batch_id}/tree`, `ac://plan/figures/{role}`).
- Removes 12 retired `query_*` and `plan_get_*` tools from `TOOLS`; calling them returns a descriptive redirect error with the correct resource URI.
- Adds `ACResourceDef`, `ACResourceTemplate`, `ACResourceContent`, `ACResourceResult` TypedDicts to `types.py`.
- Updates dispatcher template, agent-task-spec, cognitive-arch docs, and mcp.md guide throughout.

## Test plan

- [x] `mypy agentception/ tests/` — strict, zero errors
- [x] `typing_audit.py --max-any 0` — passes
- [x] `pytest tests/ agentception/tests/ -q` — 1510 passed
- [x] `generate.py --check` — no drift