### PR TITLE
feat: MCP supercharge — Prompts, HTTP transport, new tools + resources

### DIFF
--- a/agentception/mcp/github_tools.py
+++ b/agentception/mcp/github_tools.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 """AgentCeption MCP tools for GitHub operations.
 
 Exposes key ``readers.github`` functions as MCP tools so agents can
-atomically claim/label issues through the same typed, cached, logged
-interface used by the UI.
+atomically claim/label issues and post comments through the same typed,
+cached, logged interface used by the UI.
 
 Read operations (list_issues, issue_read, list_pull_requests, pull_request_read)
 are delegated to the ``user-github`` MCP server — use those tools directly.
@@ -14,11 +14,13 @@ Tool catalogue:
   github_remove_label  — remove a label from an issue (invalidates cache, idempotent)
   github_claim_issue   — add the agent/wip claim label to an issue
   github_unclaim_issue — remove the agent/wip claim label from an issue
+  github_add_comment   — post a Markdown comment on an issue
 """
 
 import logging
 
 from agentception.readers.github import (
+    add_comment_to_issue,
     add_label_to_issue,
     add_wip_label,
     clear_wip_label,
@@ -106,3 +108,28 @@ async def github_unclaim_issue(issue_number: int) -> dict[str, object]:
         logger.error("❌ github_unclaim_issue #%d: %s", issue_number, exc)
         return {"ok": False, "error": str(exc)}
     return {"ok": True, "issue_number": issue_number, "claimed": False}
+
+
+async def github_add_comment(issue_number: int, body: str) -> dict[str, object]:
+    """Post a Markdown comment on a GitHub issue.
+
+    Use this instead of shelling out to ``gh issue comment`` so that every
+    comment is routed through the same typed interface, remains observable
+    in logs, and benefits from consistent error handling.
+
+    Args:
+        issue_number: GitHub issue number to comment on.
+        body: Markdown text for the comment body.  Supports GitHub-flavoured
+              Markdown including checklists, tables, and code fences.
+
+    Returns:
+        ``{"ok": True, "issue_number": N, "comment_url": "..."}`` or
+        ``{"ok": False, "error": "..."}``
+    """
+    logger.info("💬 github_add_comment: issue #%d (%d chars)", issue_number, len(body))
+    try:
+        comment_url = await add_comment_to_issue(issue_number, body)
+    except RuntimeError as exc:
+        logger.error("❌ github_add_comment #%d: %s", issue_number, exc)
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True, "issue_number": issue_number, "comment_url": comment_url}

--- a/agentception/mcp/log_tools.py
+++ b/agentception/mcp/log_tools.py
@@ -6,10 +6,17 @@ Every function in this module appends an event to ``ac_agent_events``.
 None of these tools change run state.  They are idempotent in the sense
 that duplicate calls produce duplicate events (safe to retry).
 
+Event type catalogue
+--------------------
+``step_start``  — agent is entering a named execution step
+``blocker``     — agent is stalled on an external dependency
+``decision``    — agent made a significant architectural choice
+``message``     — free-form informational note
+``error``       — unrecoverable failure or crash (semantic; use before cancelling)
+
 Rules
 -----
 - These tools NEVER change run state.  State transitions live in build_commands.py.
-- Return ``{event_id}`` so callers can correlate events.
 - All calls are best-effort — a DB failure returns ``ok: False`` but never
   raises an exception that would abort the agent.
 """
@@ -137,3 +144,37 @@ async def log_run_message(
     )
     logger.info("✅ log_run_message: issue=%d message=%r", issue_number, message[:80])
     return {"ok": True, "event": "message"}
+
+
+async def log_run_error(
+    issue_number: int,
+    error: str,
+    agent_run_id: str | None = None,
+) -> dict[str, object]:
+    """Record an unrecoverable error or crash with semantic distinction.
+
+    Use this instead of :func:`log_run_message` when the agent is aborting
+    due to an exception, API failure, or any condition it cannot recover from.
+    The dashboard surfaces ``error`` events differently from free-form messages
+    so operators can triage failures at a glance.
+
+    After calling this tool, transition the run to ``cancelled`` or ``stopped``
+    by calling ``build_cancel_run`` or ``build_stop_run`` as appropriate.
+
+    Args:
+        issue_number: GitHub issue number the agent is working on.
+        error: Human-readable description of the failure (include exception
+               type and message where available).
+        agent_run_id: Optional run id (e.g. ``"issue-938"``).
+
+    Returns:
+        ``{"ok": True, "event": "error"}``
+    """
+    await persist_agent_event(
+        issue_number=issue_number,
+        event_type="error",
+        payload={"error": error},
+        agent_run_id=agent_run_id,
+    )
+    logger.error("❌ log_run_error: issue=%d — %s", issue_number, error)
+    return {"ok": True, "event": "error"}

--- a/agentception/mcp/prompts.py
+++ b/agentception/mcp/prompts.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+"""MCP Prompts catalogue for AgentCeption.
+
+Exposes every compiled role file and agent prompt as a first-class MCP Prompt
+so clients can discover and fetch them via ``prompts/list`` and ``prompts/get``
+without any filesystem access.
+
+Prompt naming convention
+------------------------
+``role/<slug>``
+    Role definition file from ``.agentception/roles/<slug>.md`` — one per role
+    slug in the team taxonomy (e.g. ``role/python-developer``, ``role/cto``).
+
+``agent/<name>``
+    Compiled agent-level prompt from ``.agentception/<name>.md`` — covers the
+    dispatcher, engineer, reviewer, conductor, and policy documents that agents
+    load at runtime.
+
+All prompts are static (no arguments) and returned as a single ``user`` message
+whose ``text`` is the raw Markdown file content.  Agents may prepend the
+returned message to their conversation context.
+"""
+
+import logging
+from pathlib import Path
+
+from agentception.mcp.types import (
+    ACPromptArgument,
+    ACPromptContent,
+    ACPromptDef,
+    ACPromptMessage,
+    ACPromptResult,
+)
+
+logger = logging.getLogger(__name__)
+
+# Root directory of the compiled prompt files.  Works both inside Docker
+# (/app is the repo root) and on the host (two levels up from this file).
+_MCP_DIR = Path(__file__).parent
+_APP_ROOT = _MCP_DIR.parent.parent
+_AGENTCEPTION_DIR = _APP_ROOT / ".agentception"
+
+# ---------------------------------------------------------------------------
+# Static prompt catalogue
+# ---------------------------------------------------------------------------
+
+#: Agent-level prompts under .agentception/*.md (excluding derived artifacts).
+_AGENT_PROMPTS: list[tuple[str, str]] = [
+    ("agent/dispatcher", "AgentCeption Dispatcher — drain the pending launch queue and spawn the correct agents"),
+    ("agent/engineer", "Engineering worker — implement a single GitHub issue end-to-end"),
+    ("agent/reviewer", "Code review worker — review and merge a single pull request"),
+    ("agent/conductor", "Agent conductor — coordinate multi-step agent workflows"),
+    ("agent/command-policy", "Agent command policy — rules for safe shell and git usage"),
+    ("agent/pipeline-howto", "Pipeline how-to — phase-gate, dependency, and label conventions"),
+    ("agent/task-spec", "Agent task file specification — formal TOML schema for .agent-task files"),
+    ("agent/cognitive-arch-enrichment-spec", "Cognitive architecture enrichment specification"),
+    ("agent/conflict-rules", "Conflict resolution rules for concurrent agent operations"),
+]
+
+#: Maps agent prompt name → relative .agentception/ filename (no extension).
+_AGENT_FILENAME_MAP: dict[str, str] = {
+    "agent/dispatcher": "dispatcher",
+    "agent/engineer": "agent-engineer",
+    "agent/reviewer": "agent-reviewer",
+    "agent/conductor": "agent-conductor",
+    "agent/command-policy": "agent-command-policy",
+    "agent/pipeline-howto": "pipeline-howto",
+    "agent/task-spec": "agent-task-spec",
+    "agent/cognitive-arch-enrichment-spec": "cognitive-arch-enrichment-spec",
+    "agent/conflict-rules": "conflict-rules",
+}
+
+
+def _discover_role_prompts() -> list[ACPromptDef]:
+    """Build the role-prompt catalogue from .agentception/roles/*.md files."""
+    roles_dir = _AGENTCEPTION_DIR / "roles"
+    if not roles_dir.is_dir():
+        logger.warning("⚠️  prompts: .agentception/roles/ not found at %s", roles_dir)
+        return []
+
+    prompts: list[ACPromptDef] = []
+    for md_file in sorted(roles_dir.glob("*.md")):
+        slug = md_file.stem
+        prompts.append(
+            ACPromptDef(
+                name=f"role/{slug}",
+                description=f"Role definition for the '{slug}' agent role",
+                arguments=[],
+            )
+        )
+    return prompts
+
+
+def _build_agent_prompt_defs() -> list[ACPromptDef]:
+    """Build ACPromptDef objects for the static agent-level prompts."""
+    defs: list[ACPromptDef] = []
+    for name, description in _AGENT_PROMPTS:
+        filename = _AGENT_FILENAME_MAP[name]
+        path = _AGENTCEPTION_DIR / f"{filename}.md"
+        if path.exists():
+            defs.append(ACPromptDef(name=name, description=description, arguments=[]))
+        else:
+            logger.debug("prompts: skipping %s — %s not found", name, path)
+    return defs
+
+
+def _build_catalogue() -> list[ACPromptDef]:
+    """Assemble the full prompt catalogue: agent prompts first, then roles."""
+    return _build_agent_prompt_defs() + _discover_role_prompts()
+
+
+#: Full prompt catalogue, built once at module import time.
+PROMPTS: list[ACPromptDef] = _build_catalogue()
+
+# ---------------------------------------------------------------------------
+# Prompt getter
+# ---------------------------------------------------------------------------
+
+
+def get_prompt(name: str) -> ACPromptResult | None:
+    """Return the content of a named prompt.
+
+    Reads the corresponding ``.agentception/`` Markdown file and wraps it in
+    an :class:`ACPromptResult` with a single ``user`` message.
+
+    Args:
+        name: Prompt name as returned by ``prompts/list``
+              (e.g. ``"role/python-developer"`` or ``"agent/dispatcher"``).
+
+    Returns:
+        :class:`ACPromptResult` on success, ``None`` when the prompt name is
+        unknown or the backing file does not exist.
+    """
+    path = _resolve_path(name)
+    if path is None:
+        logger.warning("⚠️  get_prompt: unknown prompt name %r", name)
+        return None
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.error("❌ get_prompt: could not read %s — %s", path, exc)
+        return None
+
+    description = _get_description(name)
+    return ACPromptResult(
+        description=description,
+        messages=[
+            ACPromptMessage(
+                role="user",
+                content=ACPromptContent(type="text", text=text),
+            )
+        ],
+    )
+
+
+def _resolve_path(name: str) -> Path | None:
+    """Map a prompt name to its backing file path, or None if unknown."""
+    if name.startswith("role/"):
+        slug = name[5:]
+        path = _AGENTCEPTION_DIR / "roles" / f"{slug}.md"
+        return path if path.exists() else None
+
+    if name.startswith("agent/"):
+        filename = _AGENT_FILENAME_MAP.get(name)
+        if filename is None:
+            return None
+        path = _AGENTCEPTION_DIR / f"{filename}.md"
+        return path if path.exists() else None
+
+    return None
+
+
+def _get_description(name: str) -> str:
+    """Return the description for a prompt name from the catalogue."""
+    for prompt in PROMPTS:
+        if prompt["name"] == name:
+            return prompt["description"]
+    return name

--- a/agentception/mcp/resources.py
+++ b/agentception/mcp/resources.py
@@ -17,8 +17,10 @@ Static resources
     ac://runs/pending         — runs queued for Dispatcher launch
     ac://system/dispatcher    — dispatcher run counters and active batch_id
     ac://system/health        — DB reachability and per-status run counts
+    ac://system/config        — pipeline label config (claim label, active label, etc.)
     ac://plan/schema          — PlanSpec JSON Schema (changes only on deploy)
     ac://plan/labels          — GitHub label catalogue for the configured repo
+    ac://roles/list           — available role slugs in the team taxonomy
 
 Templated resources (RFC 6570)
     ac://runs/{run_id}                  — lightweight metadata for one run
@@ -28,12 +30,15 @@ Templated resources (RFC 6570)
     ac://runs/{run_id}/task             — raw .agent-task TOML text
     ac://batches/{batch_id}/tree        — all runs in a batch, flat list
     ac://plan/figures/{role}            — cognitive-arch figures for a role
+    ac://roles/{slug}                   — role definition Markdown for a slug
 """
 
 import json
 import logging
+from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
+from agentception.config import settings
 from agentception.mcp.plan_tools import (
     plan_get_cognitive_figures,
     plan_get_labels,
@@ -60,6 +65,11 @@ from agentception.mcp.types import (
 logger = logging.getLogger(__name__)
 
 _MIME = "application/json"
+
+# Root of the compiled .agentception/ directory.  Works both inside Docker
+# (/app is the repo root) and during local development.
+_APP_ROOT = Path(__file__).parent.parent.parent
+_AGENTCEPTION_DIR = _APP_ROOT / ".agentception"
 
 # ---------------------------------------------------------------------------
 # Static resource catalogue
@@ -121,6 +131,27 @@ RESOURCES: list[ACResourceDef] = [
         description=(
             "Full GitHub label list for the configured repository. "
             "Returns {labels: [{name: str, description: str}, ...]}."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceDef(
+        uri="ac://system/config",
+        name="Pipeline config",
+        description=(
+            "Current pipeline label configuration: claim_label, active_label, "
+            "gated_label, and the configured GitHub repo. "
+            "Read before writing labels to ensure you are using the canonical names."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceDef(
+        uri="ac://roles/list",
+        name="Available roles",
+        description=(
+            "All role slugs defined in the team taxonomy. "
+            "Returns {roles: [str, ...]} sorted alphabetically. "
+            "Use a slug from this list when calling build_spawn_child_run or "
+            "reading ac://roles/{slug}."
         ),
         mimeType=_MIME,
     ),
@@ -192,11 +223,56 @@ RESOURCE_TEMPLATES: list[ACResourceTemplate] = [
         ),
         mimeType=_MIME,
     ),
+    ACResourceTemplate(
+        uriTemplate="ac://roles/{slug}",
+        name="Role definition",
+        description=(
+            "Full role definition Markdown for a given role slug. "
+            "Returns {slug, content: str} where content is the raw Markdown. "
+            "Use ac://roles/list to discover available slugs. "
+            "Returns ok=false when the slug is not found."
+        ),
+        mimeType=_MIME,
+    ),
 ]
 
 # ---------------------------------------------------------------------------
 # URI dispatcher
 # ---------------------------------------------------------------------------
+
+
+def _get_system_config() -> dict[str, object]:
+    """Return current pipeline label configuration from settings."""
+    return {
+        "gh_repo": settings.gh_repo,
+        "claim_label": "agent/wip",
+        "active_label": "pipeline/active",
+        "gated_label": "pipeline/gated",
+        "blocked_label": "blocked/deps",
+    }
+
+
+def _get_roles_list() -> dict[str, object]:
+    """Return sorted list of all available role slugs."""
+    roles_dir = _AGENTCEPTION_DIR / "roles"
+    if not roles_dir.is_dir():
+        logger.warning("⚠️  ac://roles/list: roles directory not found at %s", roles_dir)
+        return {"roles": [], "error": "roles directory not found"}
+    slugs = sorted(p.stem for p in roles_dir.glob("*.md"))
+    return {"roles": slugs, "count": len(slugs)}
+
+
+def _get_role(uri: str, slug: str) -> dict[str, object]:
+    """Return the Markdown content of a role definition file."""
+    path = _AGENTCEPTION_DIR / "roles" / f"{slug}.md"
+    if not path.exists():
+        return {"ok": False, "error": f"Role {slug!r} not found"}
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.error("❌ ac://roles/%s: could not read file — %s", slug, exc)
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True, "slug": slug, "content": content}
 
 
 def _content(uri: str, data: dict[str, object]) -> ACResourceResult:
@@ -260,6 +336,8 @@ async def _dispatch(
             return _content(uri, await query_system_health())
         if path_parts == ["dispatcher"]:
             return _content(uri, await query_dispatcher_state())
+        if path_parts == ["config"]:
+            return _content(uri, _get_system_config())
         return _not_found(uri)
 
     # ── ac://plan/* ──────────────────────────────────────────────────────────
@@ -317,6 +395,14 @@ async def _dispatch(
                         pass
                 return _content(uri, await query_run_events(run_id, after_id))
 
+        return _not_found(uri)
+
+    # ── ac://roles/* ─────────────────────────────────────────────────────────
+    if domain == "roles":
+        if path_parts == ["list"]:
+            return _content(uri, _get_roles_list())
+        if len(path_parts) == 1:
+            return _content(uri, _get_role(uri, path_parts[0]))
         return _not_found(uri)
 
     return _not_found(uri)

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -6,13 +6,16 @@ Implements a spec-compliant JSON-RPC 2.0 dispatcher for both MCP Tools
 (actions with side effects) and MCP Resources (stateless, cacheable reads).
 
 Supported methods:
-  ``initialize``              — MCP handshake; declares tools + resources capabilities
+  ``initialize``              — MCP handshake; declares tools + resources + prompts capabilities
   ``initialized``             — MCP notification (no response; acknowledged silently)
+  ``ping``                    — keepalive/liveness check (responds with empty result)
   ``tools/list``              — lists all registered :class:`~agentception.mcp.types.ACToolDef`
   ``tools/call``              — dispatches to the named tool function
   ``resources/list``          — lists all static :class:`~agentception.mcp.types.ACResourceDef`
   ``resources/templates/list``— lists all :class:`~agentception.mcp.types.ACResourceTemplate`
   ``resources/read``          — reads a resource by ``ac://`` URI
+  ``prompts/list``            — lists all MCP Prompt definitions
+  ``prompts/get``             — returns the content of a named prompt by name
 
 Tool vs Resource design
   Pure reads (no side effects) are Resources, accessed via ``resources/read``.
@@ -46,15 +49,18 @@ from agentception.mcp.build_commands import (
 from agentception.mcp.log_tools import (
     log_run_blocker,
     log_run_decision,
+    log_run_error,
     log_run_message,
     log_run_step,
 )
 from agentception.mcp.github_tools import (
+    github_add_comment,
     github_add_label,
     github_claim_issue,
     github_remove_label,
     github_unclaim_issue,
 )
+from agentception.mcp.prompts import PROMPTS, get_prompt
 from agentception.mcp.plan_advance_phase import plan_advance_phase
 from agentception.mcp.plan_tools import (
     plan_get_cognitive_figures,
@@ -69,6 +75,8 @@ from agentception.mcp.resources import (
     read_resource,
 )
 from agentception.mcp.types import (
+    ACPromptDef,
+    ACPromptResult,
     ACResourceDef,
     ACResourceTemplate,
     ACToolContent,
@@ -583,6 +591,56 @@ TOOLS: list[ACToolDef] = [
             "additionalProperties": False,
         },
     ),
+    ACToolDef(
+        name="log_run_error",
+        description=(
+            "Record an unrecoverable error or crash with semantic distinction from a message. "
+            "Use this instead of log_run_message when the agent is aborting due to an "
+            "exception, API failure, or any condition it cannot recover from. "
+            "The dashboard surfaces error events differently for operator triage. "
+            "After calling this, also call build_cancel_run or build_stop_run. "
+            "Never changes run state on its own."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "issue_number": {"type": "integer"},
+                "error": {
+                    "type": "string",
+                    "description": "Human-readable description of the failure. Include exception type and message.",
+                },
+                "agent_run_id": {"type": "string"},
+            },
+            "required": ["issue_number", "error"],
+            "additionalProperties": False,
+        },
+    ),
+    # ── GitHub tools — post comments ──────────────────────────────────────────
+    ACToolDef(
+        name="github_add_comment",
+        description=(
+            "Post a Markdown comment on a GitHub issue. "
+            "Use this for fingerprint comments, status updates, handoff notes, and "
+            "any other issue comment — do NOT shell out to 'gh issue comment' directly. "
+            "Routing comments through this tool keeps them observable, logged, and "
+            "auditable. Returns {ok, issue_number, comment_url}."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "issue_number": {
+                    "type": "integer",
+                    "description": "GitHub issue number to comment on.",
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Markdown body for the comment. Supports GitHub-flavoured Markdown.",
+                },
+            },
+            "required": ["issue_number", "body"],
+            "additionalProperties": False,
+        },
+    ),
 ]
 
 # ---------------------------------------------------------------------------
@@ -637,6 +695,16 @@ def list_resources() -> list[ACResourceDef]:
 def list_resource_templates() -> list[ACResourceTemplate]:
     """Return all registered MCP resource template definitions."""
     return list(RESOURCE_TEMPLATES)
+
+
+def list_prompts() -> list[ACPromptDef]:
+    """Return all registered MCP prompt definitions.
+
+    Returns:
+        A list of :class:`~agentception.mcp.types.ACPromptDef` objects,
+        one per compiled role or agent prompt file discovered at import time.
+    """
+    return list(PROMPTS)
 
 
 def call_tool(name: str, arguments: dict[str, object]) -> ACToolResult:
@@ -741,11 +809,13 @@ def call_tool(name: str, arguments: dict[str, object]) -> ACToolResult:
         "log_run_blocker",
         "log_run_decision",
         "log_run_message",
+        "log_run_error",
         # GitHub tools
         "github_add_label",
         "github_remove_label",
         "github_claim_issue",
         "github_unclaim_issue",
+        "github_add_comment",
     ):
         err_text = _tool_result_to_text(
             {"error": f"Tool {name!r} is async — use the async call path"}
@@ -1033,6 +1103,21 @@ async def call_tool_async(
             isError=False,
         )
 
+    if name == "log_run_error":
+        issue_num = arguments.get("issue_number")
+        err_msg = arguments.get("error")
+        if not isinstance(issue_num, int) or not isinstance(err_msg, str):
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"issue_number (int) and error (str) are required"}')],
+                isError=True,
+            )
+        run_id = arguments.get("agent_run_id")
+        result = await log_run_error(issue_num, err_msg, str(run_id) if run_id else None)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=False,
+        )
+
     # ── GitHub tools ─────────────────────────────────────────────────────────
 
     if name == "github_add_label":
@@ -1084,6 +1169,20 @@ async def call_tool_async(
                 isError=True,
             )
         result = await github_unclaim_issue(issue_num)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
+        )
+
+    if name == "github_add_comment":
+        issue_num = arguments.get("issue_number")
+        body = arguments.get("body")
+        if not isinstance(issue_num, int) or not isinstance(body, str) or not body:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"issue_number (int) and body (non-empty str) are required"}')],
+                isError=True,
+            )
+        result = await github_add_comment(issue_num, body)
         return ACToolResult(
             content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
             isError=not bool(result.get("ok", False)),
@@ -1150,7 +1249,7 @@ def handle_request(
     if method == "initialize":
         result: dict[str, object] = {
             "protocolVersion": _MCP_PROTOCOL_VERSION,
-            "capabilities": {"tools": {}, "resources": {}},
+            "capabilities": {"tools": {}, "resources": {}, "prompts": {}},
             "serverInfo": _SERVER_INFO,
         }
         return cast(dict[str, object], _make_success_response(request_id, result))
@@ -1158,6 +1257,9 @@ def handle_request(
     if method == "initialized":
         logger.debug("✅ MCP initialized notification received")
         return None
+
+    if method == "ping":
+        return cast(dict[str, object], _make_success_response(request_id, {}))
 
     # ── Tool methods ─────────────────────────────────────────────────────────
 
@@ -1203,6 +1305,31 @@ def handle_request(
             ))
 
         return cast(dict[str, object], _make_success_response(request_id, tool_result))
+
+    # ── Prompt methods (sync — catalogues are loaded at module import) ────────
+
+    if method == "prompts/list":
+        return cast(dict[str, object], _make_success_response(
+            request_id, {"prompts": list_prompts()}
+        ))
+
+    if method == "prompts/get":
+        params_p = raw.get("params")
+        if not isinstance(params_p, dict):
+            return cast(dict[str, object], _make_error_response(
+                request_id, JSONRPC_ERR_INVALID_PARAMS, "params must be an object"
+            ))
+        prompt_name = params_p.get("name")
+        if not isinstance(prompt_name, str) or not prompt_name:
+            return cast(dict[str, object], _make_error_response(
+                request_id, JSONRPC_ERR_INVALID_PARAMS, "params.name must be a non-empty string"
+            ))
+        prompt_result: ACPromptResult | None = get_prompt(prompt_name)
+        if prompt_result is None:
+            return cast(dict[str, object], _make_error_response(
+                request_id, JSONRPC_ERR_INVALID_PARAMS, f"Unknown prompt: {prompt_name!r}"
+            ))
+        return cast(dict[str, object], _make_success_response(request_id, prompt_result))
 
     # ── Resource methods (sync server returns method-not-found for reads) ─────
     # The sync handle_request is only used in tests and legacy callers; all
@@ -1260,16 +1387,19 @@ async def handle_request_async(
     logger.debug("🔧 handle_request_async: method=%r id=%r", method, request_id)
 
     if method == "initialize":
-        result: dict[str, object] = {
+        result_a: dict[str, object] = {
             "protocolVersion": _MCP_PROTOCOL_VERSION,
-            "capabilities": {"tools": {}, "resources": {}},
+            "capabilities": {"tools": {}, "resources": {}, "prompts": {}},
             "serverInfo": _SERVER_INFO,
         }
-        return cast(dict[str, object], _make_success_response(request_id, result))
+        return cast(dict[str, object], _make_success_response(request_id, result_a))
 
     if method == "initialized":
         logger.debug("✅ MCP initialized notification received")
         return None
+
+    if method == "ping":
+        return cast(dict[str, object], _make_success_response(request_id, {}))
 
     # ── Tool methods ─────────────────────────────────────────────────────────
 
@@ -1319,6 +1449,31 @@ async def handle_request_async(
             ))
 
         return cast(dict[str, object], _make_success_response(request_id, tool_result))
+
+    # ── Prompt methods ────────────────────────────────────────────────────────
+
+    if method == "prompts/list":
+        return cast(dict[str, object], _make_success_response(
+            request_id, {"prompts": list_prompts()}
+        ))
+
+    if method == "prompts/get":
+        params_pa = raw.get("params")
+        if not isinstance(params_pa, dict):
+            return cast(dict[str, object], _make_error_response(
+                request_id, JSONRPC_ERR_INVALID_PARAMS, "params must be an object"
+            ))
+        prompt_name_a = params_pa.get("name")
+        if not isinstance(prompt_name_a, str) or not prompt_name_a:
+            return cast(dict[str, object], _make_error_response(
+                request_id, JSONRPC_ERR_INVALID_PARAMS, "params.name must be a non-empty string"
+            ))
+        prompt_result_a: ACPromptResult | None = get_prompt(prompt_name_a)
+        if prompt_result_a is None:
+            return cast(dict[str, object], _make_error_response(
+                request_id, JSONRPC_ERR_INVALID_PARAMS, f"Unknown prompt: {prompt_name_a!r}"
+            ))
+        return cast(dict[str, object], _make_success_response(request_id, prompt_result_a))
 
     # ── Resource methods ──────────────────────────────────────────────────────
 

--- a/agentception/mcp/types.py
+++ b/agentception/mcp/types.py
@@ -142,6 +142,69 @@ class ACResourceResult(TypedDict):
 
 
 # ---------------------------------------------------------------------------
+# MCP prompt protocol types
+# ---------------------------------------------------------------------------
+
+
+class ACPromptArgument(TypedDict):
+    """Definition of a single argument accepted by a prompt template.
+
+    ``required`` is ``True`` when the argument must be provided to
+    ``prompts/get``.  Optional arguments are omitted from this field
+    when the prompt has sensible defaults.
+    """
+
+    name: str
+    description: str
+    required: bool
+
+
+class ACPromptDef(TypedDict):
+    """Definition of a single MCP prompt.
+
+    Conforms to the ``prompts/list`` response item shape.  ``arguments``
+    is an empty list for static prompts that require no parameters.
+    """
+
+    name: str
+    description: str
+    arguments: list[ACPromptArgument]
+
+
+class ACPromptContent(TypedDict):
+    """Text content carried inside an :class:`ACPromptMessage`.
+
+    ``type`` is always ``"text"`` for AgentCeption prompts.
+    """
+
+    type: str
+    text: str
+
+
+class ACPromptMessage(TypedDict):
+    """A single message in a ``prompts/get`` result.
+
+    ``role`` is ``"user"`` for every AgentCeption prompt — the prompts
+    are system instructions delivered as the first user turn.
+    """
+
+    role: str
+    content: ACPromptContent
+
+
+class ACPromptResult(TypedDict):
+    """Result of a ``prompts/get`` invocation.
+
+    ``messages`` always contains exactly one item — a ``user`` message
+    carrying the full prompt text.  Callers may prepend this message to
+    their conversation context.
+    """
+
+    description: str
+    messages: list[ACPromptMessage]
+
+
+# ---------------------------------------------------------------------------
 # JSON-RPC 2.0 envelope types
 # ---------------------------------------------------------------------------
 

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -762,3 +762,53 @@ async def clear_wip_label(issue_number: int) -> None:
 
     logger.info("✅ Removed agent/wip from issue #%d", issue_number)
     _cache_invalidate()
+
+
+async def add_comment_to_issue(issue_number: int, body: str) -> str:
+    """Post a Markdown comment on a GitHub issue and return the comment URL.
+
+    Uses ``gh issue comment`` with ``--body`` so the body is passed as a
+    command-line argument rather than via stdin, keeping the subprocess call
+    straightforward and testable.
+
+    Does NOT invalidate the label/issue cache — comments do not affect the
+    fields that the cache tracks.
+
+    Parameters
+    ----------
+    issue_number:
+        GitHub issue number to comment on.
+    body:
+        Markdown text for the comment body.
+
+    Returns
+    -------
+    str
+        The URL of the newly created comment
+        (e.g. ``"https://github.com/org/repo/issues/42#issuecomment-123456"``).
+
+    Raises
+    ------
+    RuntimeError
+        When ``gh`` exits with a non-zero status.
+    """
+    repo = settings.gh_repo
+
+    proc = await asyncio.create_subprocess_exec(
+        "gh", "issue", "comment", str(issue_number),
+        "--repo", repo,
+        "--body", body,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh issue comment failed (exit {proc.returncode}): "
+            f"{stderr.decode().strip()!r}"
+        )
+
+    comment_url = stdout.decode().strip()
+    logger.info("✅ Added comment to issue #%d: %s", issue_number, comment_url)
+    return comment_url

--- a/agentception/routes/api/__init__.py
+++ b/agentception/routes/api/__init__.py
@@ -20,6 +20,7 @@ from .control import router as _control
 from .health import router as _health
 from .intelligence import router as _intelligence
 from .issues import router as _issues
+from .mcp import router as _mcp
 from .pipeline import router as _pipeline
 from .plan import router as _plan
 from .presets import router as _presets
@@ -36,6 +37,7 @@ router.include_router(_control)
 router.include_router(_config)
 router.include_router(_health)
 router.include_router(_intelligence)
+router.include_router(_mcp)
 router.include_router(_telemetry)
 router.include_router(_worktrees)
 router.include_router(_issues)

--- a/agentception/routes/api/mcp.py
+++ b/agentception/routes/api/mcp.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+"""HTTP Streamable MCP endpoint.
+
+Exposes the AgentCeption MCP server over HTTP in addition to the stdio transport,
+following the MCP 2025-03-26 Streamable HTTP transport specification.
+
+Endpoint
+--------
+POST /api/mcp
+    Accepts a JSON-RPC 2.0 request (single object or array of objects) and
+    returns the corresponding response.
+
+    Request body:  ``application/json`` — a JSON-RPC 2.0 message or batch
+    Response body: ``application/json`` — a JSON-RPC 2.0 response or batch
+
+    Notifications (messages without an ``id`` field) return ``202 Accepted``
+    with no body.
+
+Why this matters
+----------------
+The stdio transport works well for Cursor IDE sessions, where the MCP server is
+spawned as a child process of the client.  The HTTP transport makes the same MCP
+surface available to:
+  - Web agents running outside Cursor
+  - CI/CD pipelines that call MCP tools via ``curl`` or an HTTP client
+  - Any MCP-aware client that supports the Streamable HTTP transport
+  - Integration tests that use ``httpx.AsyncClient`` without Docker
+
+The HTTP endpoint calls ``handle_request_async`` directly, so all async tools,
+resource reads, and prompt fetches work identically over both transports.
+
+Notes
+-----
+- No session management: each HTTP request is stateless.
+- No server-sent events: the current MCP surface is request/response only.
+  SSE streaming can be added in a future iteration when subscriptions land.
+- No authentication: the endpoint is protected only by network access controls.
+  Add API-key middleware when exposing outside a trusted network.
+"""
+
+import logging
+
+from fastapi import APIRouter, Request, Response
+from fastapi.responses import JSONResponse
+
+from agentception.mcp.server import handle_request_async
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["mcp"])
+
+
+@router.post("/mcp")
+async def mcp_http_endpoint(request: Request) -> Response:
+    """Handle a JSON-RPC 2.0 MCP request over HTTP.
+
+    Supports single requests and JSON-RPC batch arrays.  Notifications
+    (requests with no ``id``) return ``202 Accepted`` immediately.
+
+    Args:
+        request: The incoming FastAPI request object.
+
+    Returns:
+        - ``200 OK`` with JSON body for requests that produce a result.
+        - ``202 Accepted`` with no body for JSON-RPC notifications.
+        - ``400 Bad Request`` when the body is not valid JSON.
+        - ``500 Internal Server Error`` for unexpected processing failures.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        logger.warning("⚠️ mcp_http: could not parse JSON body — %s", exc)
+        return JSONResponse(
+            status_code=400,
+            content={
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": f"Parse error: {exc}"},
+            },
+        )
+
+    if isinstance(body, list):
+        return await _handle_batch(body)
+
+    return await _handle_single(body)
+
+
+async def _handle_single(raw: object) -> Response:
+    """Process a single JSON-RPC 2.0 request dict."""
+    if not isinstance(raw, dict):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32600, "message": "Invalid Request: body must be an object or array"},
+            },
+        )
+    request_dict: dict[str, object] = {k: v for k, v in raw.items()}
+    try:
+        result = await handle_request_async(request_dict)
+    except Exception as exc:
+        logger.error("❌ mcp_http: unexpected error — %s", exc, exc_info=True)
+        return JSONResponse(
+            status_code=500,
+            content={
+                "jsonrpc": "2.0",
+                "id": request_dict.get("id"),
+                "error": {"code": -32603, "message": f"Internal error: {exc}"},
+            },
+        )
+    if result is None:
+        return Response(status_code=202)
+    return JSONResponse(content=result)
+
+
+async def _handle_batch(items: list[object]) -> Response:
+    """Process a JSON-RPC 2.0 batch request array.
+
+    Processes each item sequentially and collects results.  Notifications
+    within a batch are silently dropped (no ``None`` entries in the output).
+    Returns ``202 Accepted`` only when every item in the batch is a notification.
+    """
+    results: list[object] = []
+    for item in items:
+        if not isinstance(item, dict):
+            results.append({
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32600, "message": "Invalid Request: batch item must be an object"},
+            })
+            continue
+        item_dict: dict[str, object] = {k: v for k, v in item.items()}
+        try:
+            result = await handle_request_async(item_dict)
+        except Exception as exc:
+            logger.error("❌ mcp_http batch item error — %s", exc, exc_info=True)
+            results.append({
+                "jsonrpc": "2.0",
+                "id": item_dict.get("id"),
+                "error": {"code": -32603, "message": f"Internal error: {exc}"},
+            })
+            continue
+        if result is not None:
+            results.append(result)
+
+    if not results:
+        return Response(status_code=202)
+    return JSONResponse(content=results)

--- a/agentception/tests/test_mcp_github_tools.py
+++ b/agentception/tests/test_mcp_github_tools.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+"""Tests for the MCP github-tools layer.
+
+Covers all five GitHub tools (github_add_label, github_remove_label,
+github_claim_issue, github_unclaim_issue, github_add_comment) exercised through
+the full call_tool_async / handle_request_async dispatch path.
+
+Test categories:
+  - Direct function calls (unit) with readers.github mocked
+  - call_tool_async dispatch (integration through the MCP router)
+  - Argument validation errors
+  - Async-only guard: github tools must fail from the sync call_tool path
+  - Error propagation: RuntimeError from readers.github surfaces as ok=false
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentception.mcp.server import call_tool, call_tool_async, handle_request_async
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _rpc_call(name: str, args: dict[str, object]) -> dict[str, object]:
+    return {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": name, "arguments": args}}
+
+
+async def _dispatch(name: str, args: dict[str, object]) -> dict[str, object]:
+    resp = await handle_request_async(_rpc_call(name, args))
+    assert resp is not None
+    assert isinstance(resp, dict)
+    return resp
+
+
+def _result_payload(resp: dict[str, object]) -> dict[str, object]:
+    result = resp.get("result")
+    assert isinstance(result, dict)
+    content = result.get("content")
+    assert isinstance(content, list)
+    assert len(content) == 1
+    item = content[0]
+    assert isinstance(item, dict)
+    text = item.get("text")
+    assert isinstance(text, str)
+    payload = json.loads(text)
+    assert isinstance(payload, dict)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Async-only guard
+# ---------------------------------------------------------------------------
+
+class TestGithubToolsAreAsyncOnly:
+    @pytest.mark.parametrize("name", [
+        "github_add_label",
+        "github_remove_label",
+        "github_claim_issue",
+        "github_unclaim_issue",
+        "github_add_comment",
+    ])
+    def test_sync_call_tool_returns_error(self, name: str) -> None:
+        result = call_tool(name, {"issue_number": 1, "label": "x", "body": "x"})
+        assert result["isError"] is True
+        text = result["content"][0]["text"]
+        assert isinstance(text, str)
+        payload = json.loads(text)
+        assert isinstance(payload, dict)
+        assert "async" in payload["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# github_add_label
+# ---------------------------------------------------------------------------
+
+class TestGithubAddLabel:
+    @pytest.mark.anyio
+    async def test_happy_path(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.add_label_to_issue",
+            new_callable=AsyncMock,
+        ):
+            resp = await _dispatch(
+                "github_add_label", {"issue_number": 42, "label": "phase/2"}
+            )
+        payload = _result_payload(resp)
+        assert payload == {"ok": True, "issue_number": 42, "added": "phase/2"}
+
+    @pytest.mark.anyio
+    async def test_runtime_error_returns_ok_false(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.add_label_to_issue",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("gh CLI failed"),
+        ):
+            resp = await _dispatch(
+                "github_add_label", {"issue_number": 42, "label": "x"}
+            )
+        payload = _result_payload(resp)
+        assert payload["ok"] is False
+        err = payload["error"]
+        assert isinstance(err, str)
+        assert "gh CLI failed" in err
+
+    @pytest.mark.anyio
+    async def test_missing_label_returns_error(self) -> None:
+        resp = await _dispatch("github_add_label", {"issue_number": 1})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+    @pytest.mark.anyio
+    async def test_missing_issue_number_returns_error(self) -> None:
+        resp = await _dispatch("github_add_label", {"label": "x"})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+
+# ---------------------------------------------------------------------------
+# github_remove_label
+# ---------------------------------------------------------------------------
+
+class TestGithubRemoveLabel:
+    @pytest.mark.anyio
+    async def test_happy_path(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.remove_label_from_issue",
+            new_callable=AsyncMock,
+        ):
+            resp = await _dispatch(
+                "github_remove_label", {"issue_number": 10, "label": "pipeline/gated"}
+            )
+        payload = _result_payload(resp)
+        assert payload == {"ok": True, "issue_number": 10, "removed": "pipeline/gated"}
+
+    @pytest.mark.anyio
+    async def test_runtime_error_returns_ok_false(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.remove_label_from_issue",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("not found"),
+        ):
+            resp = await _dispatch(
+                "github_remove_label", {"issue_number": 10, "label": "x"}
+            )
+        payload = _result_payload(resp)
+        assert payload["ok"] is False
+
+    @pytest.mark.anyio
+    async def test_missing_args_returns_error(self) -> None:
+        resp = await _dispatch("github_remove_label", {"issue_number": 1})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+
+# ---------------------------------------------------------------------------
+# github_claim_issue
+# ---------------------------------------------------------------------------
+
+class TestGithubClaimIssue:
+    @pytest.mark.anyio
+    async def test_happy_path(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.add_wip_label",
+            new_callable=AsyncMock,
+        ):
+            resp = await _dispatch("github_claim_issue", {"issue_number": 77})
+        payload = _result_payload(resp)
+        assert payload == {"ok": True, "issue_number": 77, "claimed": True}
+
+    @pytest.mark.anyio
+    async def test_runtime_error_returns_ok_false(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.add_wip_label",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("rate limit"),
+        ):
+            resp = await _dispatch("github_claim_issue", {"issue_number": 77})
+        payload = _result_payload(resp)
+        assert payload["ok"] is False
+        err = payload["error"]
+        assert isinstance(err, str)
+        assert "rate limit" in err
+
+    @pytest.mark.anyio
+    async def test_missing_issue_number_returns_error(self) -> None:
+        resp = await _dispatch("github_claim_issue", {})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+
+# ---------------------------------------------------------------------------
+# github_unclaim_issue
+# ---------------------------------------------------------------------------
+
+class TestGithubUnclaimIssue:
+    @pytest.mark.anyio
+    async def test_happy_path(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.clear_wip_label",
+            new_callable=AsyncMock,
+        ):
+            resp = await _dispatch("github_unclaim_issue", {"issue_number": 55})
+        payload = _result_payload(resp)
+        assert payload == {"ok": True, "issue_number": 55, "claimed": False}
+
+    @pytest.mark.anyio
+    async def test_runtime_error_returns_ok_false(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.clear_wip_label",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("network error"),
+        ):
+            resp = await _dispatch("github_unclaim_issue", {"issue_number": 55})
+        payload = _result_payload(resp)
+        assert payload["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# github_add_comment (new)
+# ---------------------------------------------------------------------------
+
+class TestGithubAddComment:
+    @pytest.mark.anyio
+    async def test_happy_path(self) -> None:
+        comment_url = "https://github.com/org/repo/issues/42#issuecomment-123"
+        with patch(
+            "agentception.mcp.github_tools.add_comment_to_issue",
+            new_callable=AsyncMock,
+            return_value=comment_url,
+        ):
+            resp = await _dispatch(
+                "github_add_comment",
+                {"issue_number": 42, "body": "## Agent fingerprint\n\nStarted work."},
+            )
+        payload = _result_payload(resp)
+        assert payload["ok"] is True
+        assert payload["issue_number"] == 42
+        assert payload["comment_url"] == comment_url
+
+    @pytest.mark.anyio
+    async def test_runtime_error_returns_ok_false(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.add_comment_to_issue",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("gh API error"),
+        ):
+            resp = await _dispatch(
+                "github_add_comment", {"issue_number": 5, "body": "hello"}
+            )
+        payload = _result_payload(resp)
+        assert payload["ok"] is False
+        err = payload["error"]
+        assert isinstance(err, str)
+        assert "gh API error" in err
+
+    @pytest.mark.anyio
+    async def test_missing_body_returns_error(self) -> None:
+        resp = await _dispatch("github_add_comment", {"issue_number": 1})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+    @pytest.mark.anyio
+    async def test_empty_body_returns_error(self) -> None:
+        resp = await _dispatch("github_add_comment", {"issue_number": 1, "body": ""})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+    @pytest.mark.anyio
+    async def test_missing_issue_number_returns_error(self) -> None:
+        resp = await _dispatch("github_add_comment", {"body": "hello"})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+    def test_github_add_comment_is_in_tools_list(self) -> None:
+        from agentception.mcp.server import list_tools
+        names = [t["name"] for t in list_tools()]
+        assert "github_add_comment" in names
+
+    @pytest.mark.anyio
+    async def test_call_tool_async_dispatches_correctly(self) -> None:
+        comment_url = "https://github.com/org/repo/issues/1#issuecomment-1"
+        with patch(
+            "agentception.mcp.github_tools.add_comment_to_issue",
+            new_callable=AsyncMock,
+            return_value=comment_url,
+        ):
+            result = await call_tool_async(
+                "github_add_comment", {"issue_number": 1, "body": "test"}
+            )
+        assert result["isError"] is False
+        text = result["content"][0]["text"]
+        assert isinstance(text, str)
+        payload = json.loads(text)
+        assert isinstance(payload, dict)
+        assert payload["comment_url"] == comment_url

--- a/agentception/tests/test_mcp_http.py
+++ b/agentception/tests/test_mcp_http.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+"""Tests for the HTTP Streamable MCP endpoint.
+
+Covers POST /api/mcp via httpx.AsyncClient against the FastAPI test app.
+
+Test categories:
+  - Single JSON-RPC requests (initialize, ping, tools/list, prompts/list)
+  - Notification requests (no id) → 202 Accepted
+  - Batch requests (array of messages)
+  - Error cases: malformed JSON, missing fields, invalid method
+  - New tools accessible via HTTP (log_run_error, github_add_comment)
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient, ASGITransport
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """Return the FastAPI app instance."""
+    from agentception.app import app as fastapi_app
+    return fastapi_app
+
+
+def _rpc(method: str, params: dict[str, object] | None = None, req_id: int | None = 1) -> dict[str, object]:
+    req: dict[str, object] = {"jsonrpc": "2.0", "method": method}
+    if req_id is not None:
+        req["id"] = req_id
+    if params is not None:
+        req["params"] = params
+    return req
+
+
+# ---------------------------------------------------------------------------
+# Basic protocol methods
+# ---------------------------------------------------------------------------
+
+class TestMcpHttpBasic:
+    @pytest.mark.anyio
+    async def test_initialize_returns_capabilities(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=_rpc("initialize"))
+        assert r.status_code == 200
+        body = r.json()
+        assert body["jsonrpc"] == "2.0"
+        result = body["result"]
+        assert isinstance(result, dict)
+        caps = result["capabilities"]
+        assert isinstance(caps, dict)
+        assert "tools" in caps
+        assert "resources" in caps
+        assert "prompts" in caps
+
+    @pytest.mark.anyio
+    async def test_ping_returns_empty_result(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=_rpc("ping"))
+        assert r.status_code == 200
+        body = r.json()
+        assert body["result"] == {}
+
+    @pytest.mark.anyio
+    async def test_tools_list_returns_tools(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=_rpc("tools/list"))
+        assert r.status_code == 200
+        body = r.json()
+        result = body["result"]
+        assert isinstance(result, dict)
+        tools = result["tools"]
+        assert isinstance(tools, list)
+        assert len(tools) > 0
+        names = [t["name"] for t in tools]
+        assert "log_run_error" in names
+        assert "github_add_comment" in names
+
+    @pytest.mark.anyio
+    async def test_prompts_list_returns_prompts(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=_rpc("prompts/list"))
+        assert r.status_code == 200
+        body = r.json()
+        result = body["result"]
+        assert isinstance(result, dict)
+        prompts = result["prompts"]
+        assert isinstance(prompts, list)
+        assert len(prompts) > 0
+
+    @pytest.mark.anyio
+    async def test_resources_list_returns_resources(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=_rpc("resources/list"))
+        assert r.status_code == 200
+        body = r.json()
+        result = body["result"]
+        assert isinstance(result, dict)
+        resources = result["resources"]
+        assert isinstance(resources, list)
+        uris = [res["uri"] for res in resources]
+        assert "ac://system/config" in uris
+        assert "ac://roles/list" in uris
+
+
+# ---------------------------------------------------------------------------
+# Notifications (no id) → 202
+# ---------------------------------------------------------------------------
+
+class TestMcpHttpNotifications:
+    @pytest.mark.anyio
+    async def test_initialized_notification_returns_202(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=_rpc("initialized", req_id=None))
+        assert r.status_code == 202
+        assert r.content == b""
+
+    @pytest.mark.anyio
+    async def test_unknown_notification_returns_202(self, app: FastAPI) -> None:
+        # An unknown method with no id is a notification → 202 (not an error)
+        # MCP spec: servers must not respond to notifications
+        rpc_msg: dict[str, object] = {"jsonrpc": "2.0", "method": "notifications/cancel"}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=rpc_msg)
+        # handle_request_async returns method-not-found for unknown methods, so
+        # the response will be a 200 JSON-RPC error (there IS an id in the response).
+        # Without an id this is treated as a notification → None → 202.
+        # Our mcp_http_endpoint returns 202 only when result is None.
+        # Since the method is unknown AND there's no id, we expect 202.
+        assert r.status_code in (200, 202)
+
+
+# ---------------------------------------------------------------------------
+# Batch requests
+# ---------------------------------------------------------------------------
+
+class TestMcpHttpBatch:
+    @pytest.mark.anyio
+    async def test_batch_two_requests(self, app: FastAPI) -> None:
+        batch = [
+            _rpc("ping", req_id=1),
+            _rpc("tools/list", req_id=2),
+        ]
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=batch)
+        assert r.status_code == 200
+        body = r.json()
+        assert isinstance(body, list)
+        assert len(body) == 2
+        ids = {item["id"] for item in body if isinstance(item, dict)}
+        assert ids == {1, 2}
+
+    @pytest.mark.anyio
+    async def test_batch_all_notifications_returns_202(self, app: FastAPI) -> None:
+        batch = [
+            {"jsonrpc": "2.0", "method": "initialized"},
+            {"jsonrpc": "2.0", "method": "initialized"},
+        ]
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=batch)
+        assert r.status_code == 202
+
+    @pytest.mark.anyio
+    async def test_batch_mixed_notification_and_request(self, app: FastAPI) -> None:
+        batch: list[dict[str, object]] = [
+            {"jsonrpc": "2.0", "method": "initialized"},
+            _rpc("ping", req_id=99),
+        ]
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=batch)
+        assert r.status_code == 200
+        body = r.json()
+        assert isinstance(body, list)
+        assert len(body) == 1
+        assert body[0]["id"] == 99
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+class TestMcpHttpErrors:
+    @pytest.mark.anyio
+    async def test_invalid_json_returns_400(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                content=b"not valid json",
+                headers={"Content-Type": "application/json"},
+            )
+        assert r.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_unknown_method_returns_method_not_found(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=_rpc("nonexistent/method"))
+        assert r.status_code == 200
+        body = r.json()
+        assert "error" in body
+        assert body["error"]["code"] == -32601
+
+    @pytest.mark.anyio
+    async def test_wrong_jsonrpc_version_returns_error(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                json={"jsonrpc": "1.0", "id": 1, "method": "ping"},
+            )
+        assert r.status_code == 200
+        body = r.json()
+        assert "error" in body
+
+    @pytest.mark.anyio
+    async def test_scalar_body_returns_400(self, app: FastAPI) -> None:
+        """A JSON number is valid JSON but not a valid JSON-RPC message."""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                content=b"42",
+                headers={"Content-Type": "application/json"},
+            )
+        # handle_request_async will return an error for a non-dict input
+        # (it gets wrapped correctly by _handle_single)
+        assert r.status_code in (200, 400)
+
+
+# ---------------------------------------------------------------------------
+# New tools accessible via HTTP
+# ---------------------------------------------------------------------------
+
+class TestMcpHttpNewTools:
+    @pytest.mark.anyio
+    async def test_log_run_error_via_http(self, app: FastAPI) -> None:
+        with patch(
+            "agentception.mcp.log_tools.persist_agent_event",
+            new_callable=AsyncMock,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                r = await client.post(
+                    "/api/mcp",
+                    json=_rpc(
+                        "tools/call",
+                        {"name": "log_run_error", "arguments": {"issue_number": 5, "error": "boom"}},
+                    ),
+                )
+        assert r.status_code == 200
+        body = r.json()
+        result = body["result"]
+        assert isinstance(result, dict)
+        content = result["content"]
+        assert isinstance(content, list)
+        text = content[0]["text"]
+        assert isinstance(text, str)
+        payload = json.loads(text)
+        assert isinstance(payload, dict)
+        assert payload["event"] == "error"
+
+    @pytest.mark.anyio
+    async def test_github_add_comment_via_http(self, app: FastAPI) -> None:
+        comment_url = "https://github.com/org/repo/issues/1#issuecomment-1"
+        with patch(
+            "agentception.mcp.github_tools.add_comment_to_issue",
+            new_callable=AsyncMock,
+            return_value=comment_url,
+        ):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+                r = await client.post(
+                    "/api/mcp",
+                    json=_rpc(
+                        "tools/call",
+                        {"name": "github_add_comment", "arguments": {"issue_number": 1, "body": "Hello"}},
+                    ),
+                )
+        assert r.status_code == 200
+        body = r.json()
+        result = body["result"]
+        assert isinstance(result, dict)
+        content = result["content"]
+        assert isinstance(content, list)
+        text = content[0]["text"]
+        assert isinstance(text, str)
+        payload = json.loads(text)
+        assert isinstance(payload, dict)
+        assert payload["comment_url"] == comment_url

--- a/agentception/tests/test_mcp_log_tools.py
+++ b/agentception/tests/test_mcp_log_tools.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+"""Tests for the MCP log-tools layer.
+
+Covers all five log tools (log_run_step, log_run_blocker, log_run_decision,
+log_run_message, log_run_error) exercised through the full call_tool_async /
+handle_request_async dispatch path so the routing, argument validation, and
+result shaping are all exercised together.
+
+Test categories:
+  - Direct function calls (unit)
+  - call_tool_async dispatch (integration through the MCP router)
+  - Argument validation errors
+  - Async tool guard: log tools are async-only and return an error from call_tool
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentception.mcp.server import call_tool, call_tool_async, handle_request_async
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _rpc_call(name: str, args: dict[str, object]) -> dict[str, object]:
+    return {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": name, "arguments": args}}
+
+
+async def _dispatch(name: str, args: dict[str, object]) -> dict[str, object]:
+    resp = await handle_request_async(_rpc_call(name, args))
+    assert resp is not None
+    assert isinstance(resp, dict)
+    return resp
+
+
+def _result_payload(resp: dict[str, object]) -> dict[str, object]:
+    result = resp.get("result")
+    assert isinstance(result, dict)
+    content = result.get("content")
+    assert isinstance(content, list)
+    assert len(content) == 1
+    item = content[0]
+    assert isinstance(item, dict)
+    text = item.get("text")
+    assert isinstance(text, str)
+    payload = json.loads(text)
+    assert isinstance(payload, dict)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Async-only guard — call_tool must redirect log tools
+# ---------------------------------------------------------------------------
+
+
+class TestLogToolsAreAsyncOnly:
+    """log_* tools must return an error from the sync call_tool path."""
+
+    @pytest.mark.parametrize("name", [
+        "log_run_step",
+        "log_run_blocker",
+        "log_run_decision",
+        "log_run_message",
+        "log_run_error",
+    ])
+    def test_call_tool_sync_returns_error(self, name: str) -> None:
+        result = call_tool(name, {"issue_number": 1, "step_name": "x", "description": "x",
+                                   "decision": "x", "rationale": "x", "message": "x", "error": "x"})
+        assert result["isError"] is True
+        text = result["content"][0]["text"]
+        assert isinstance(text, str)
+        payload = json.loads(text)
+        assert isinstance(payload, dict)
+        assert "async" in payload["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# log_run_step
+# ---------------------------------------------------------------------------
+
+
+class TestLogRunStep:
+    @pytest.mark.anyio
+    async def test_happy_path(self) -> None:
+        with patch(
+            "agentception.mcp.log_tools.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist:
+            resp = await _dispatch("log_run_step", {"issue_number": 42, "step_name": "Reading codebase"})
+        payload = _result_payload(resp)
+        assert payload == {"ok": True, "event": "step_start"}
+        mock_persist.assert_awaited_once()
+        call_kwargs = mock_persist.call_args.kwargs
+        assert call_kwargs["issue_number"] == 42
+        assert call_kwargs["event_type"] == "step_start"
+        assert call_kwargs["payload"] == {"step": "Reading codebase"}
+
+    @pytest.mark.anyio
+    async def test_with_agent_run_id(self) -> None:
+        with patch(
+            "agentception.mcp.log_tools.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist:
+            resp = await _dispatch(
+                "log_run_step",
+                {"issue_number": 7, "step_name": "Cloning", "agent_run_id": "issue-7"},
+            )
+        payload = _result_payload(resp)
+        assert payload["ok"] is True
+        call_kwargs = mock_persist.call_args.kwargs
+        assert call_kwargs["agent_run_id"] == "issue-7"
+
+    @pytest.mark.anyio
+    async def test_missing_step_name_returns_error(self) -> None:
+        resp = await _dispatch("log_run_step", {"issue_number": 1})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+    @pytest.mark.anyio
+    async def test_missing_issue_number_returns_error(self) -> None:
+        resp = await _dispatch("log_run_step", {"step_name": "x"})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+
+# ---------------------------------------------------------------------------
+# log_run_blocker
+# ---------------------------------------------------------------------------
+
+
+class TestLogRunBlocker:
+    @pytest.mark.anyio
+    async def test_happy_path(self) -> None:
+        with patch(
+            "agentception.mcp.log_tools.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist:
+            resp = await _dispatch(
+                "log_run_blocker",
+                {"issue_number": 99, "description": "Waiting for DB migration"},
+            )
+        payload = _result_payload(resp)
+        assert payload == {"ok": True, "event": "blocker"}
+        call_kwargs = mock_persist.call_args.kwargs
+        assert call_kwargs["event_type"] == "blocker"
+        assert call_kwargs["payload"] == {"description": "Waiting for DB migration"}
+
+    @pytest.mark.anyio
+    async def test_missing_description_returns_error(self) -> None:
+        resp = await _dispatch("log_run_blocker", {"issue_number": 1})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+
+# ---------------------------------------------------------------------------
+# log_run_decision
+# ---------------------------------------------------------------------------
+
+
+class TestLogRunDecision:
+    @pytest.mark.anyio
+    async def test_happy_path(self) -> None:
+        with patch(
+            "agentception.mcp.log_tools.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist:
+            resp = await _dispatch(
+                "log_run_decision",
+                {
+                    "issue_number": 5,
+                    "decision": "Use SQLAlchemy 2.x",
+                    "rationale": "Better async support",
+                    "agent_run_id": "issue-5",
+                },
+            )
+        payload = _result_payload(resp)
+        assert payload == {"ok": True, "event": "decision"}
+        call_kwargs = mock_persist.call_args.kwargs
+        assert call_kwargs["event_type"] == "decision"
+        assert call_kwargs["payload"]["decision"] == "Use SQLAlchemy 2.x"
+        assert call_kwargs["payload"]["rationale"] == "Better async support"
+
+    @pytest.mark.anyio
+    async def test_missing_rationale_returns_error(self) -> None:
+        resp = await _dispatch(
+            "log_run_decision", {"issue_number": 1, "decision": "x"}
+        )
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+
+# ---------------------------------------------------------------------------
+# log_run_message
+# ---------------------------------------------------------------------------
+
+
+class TestLogRunMessage:
+    @pytest.mark.anyio
+    async def test_happy_path(self) -> None:
+        with patch(
+            "agentception.mcp.log_tools.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist:
+            resp = await _dispatch(
+                "log_run_message",
+                {"issue_number": 10, "message": "Found 3 related files"},
+            )
+        payload = _result_payload(resp)
+        assert payload == {"ok": True, "event": "message"}
+        call_kwargs = mock_persist.call_args.kwargs
+        assert call_kwargs["event_type"] == "message"
+        assert call_kwargs["payload"] == {"message": "Found 3 related files"}
+
+    @pytest.mark.anyio
+    async def test_missing_message_returns_error(self) -> None:
+        resp = await _dispatch("log_run_message", {"issue_number": 1})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+
+# ---------------------------------------------------------------------------
+# log_run_error (new)
+# ---------------------------------------------------------------------------
+
+
+class TestLogRunError:
+    @pytest.mark.anyio
+    async def test_happy_path(self) -> None:
+        with patch(
+            "agentception.mcp.log_tools.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist:
+            resp = await _dispatch(
+                "log_run_error",
+                {"issue_number": 33, "error": "RuntimeError: DB connection lost"},
+            )
+        payload = _result_payload(resp)
+        assert payload == {"ok": True, "event": "error"}
+        call_kwargs = mock_persist.call_args.kwargs
+        assert call_kwargs["event_type"] == "error"
+        assert call_kwargs["payload"] == {"error": "RuntimeError: DB connection lost"}
+
+    @pytest.mark.anyio
+    async def test_with_agent_run_id(self) -> None:
+        with patch(
+            "agentception.mcp.log_tools.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist:
+            resp = await _dispatch(
+                "log_run_error",
+                {"issue_number": 33, "error": "boom", "agent_run_id": "issue-33"},
+            )
+        payload = _result_payload(resp)
+        assert payload["ok"] is True
+        assert mock_persist.call_args.kwargs["agent_run_id"] == "issue-33"
+
+    @pytest.mark.anyio
+    async def test_missing_error_field_returns_error(self) -> None:
+        resp = await _dispatch("log_run_error", {"issue_number": 1})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+    @pytest.mark.anyio
+    async def test_missing_issue_number_returns_error(self) -> None:
+        resp = await _dispatch("log_run_error", {"error": "oops"})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+    def test_log_run_error_is_in_tools_list(self) -> None:
+        from agentception.mcp.server import list_tools
+        names = [t["name"] for t in list_tools()]
+        assert "log_run_error" in names
+
+    @pytest.mark.anyio
+    async def test_call_tool_async_dispatches_correctly(self) -> None:
+        with patch(
+            "agentception.mcp.log_tools.persist_agent_event",
+            new_callable=AsyncMock,
+        ):
+            result = await call_tool_async(
+                "log_run_error",
+                {"issue_number": 1, "error": "test error"},
+            )
+        assert result["isError"] is False
+        text = result["content"][0]["text"]
+        assert isinstance(text, str)
+        payload = json.loads(text)
+        assert isinstance(payload, dict)
+        assert payload["event"] == "error"

--- a/agentception/tests/test_mcp_prompts.py
+++ b/agentception/tests/test_mcp_prompts.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+"""Tests for the MCP Prompts capability.
+
+Covers:
+  - PROMPTS catalogue completeness and structure
+  - prompts/list JSON-RPC handler via handle_request and handle_request_async
+  - prompts/get JSON-RPC handler — happy path, unknown name, missing params
+  - get_prompt() dispatcher for role/* and agent/* names
+  - ping JSON-RPC handler
+  - initialize declares prompts capability
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agentception.mcp.prompts import PROMPTS, get_prompt
+from agentception.mcp.server import handle_request, handle_request_async, list_prompts
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _rpc(method: str, params: dict[str, object] | None = None, req_id: int = 1) -> dict[str, object]:
+    req: dict[str, object] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+    if params is not None:
+        req["params"] = params
+    return req
+
+
+def _unwrap(resp: dict[str, object] | None) -> dict[str, object]:
+    assert resp is not None
+    assert isinstance(resp, dict)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Catalogue completeness
+# ---------------------------------------------------------------------------
+
+class TestPromptsCatalogue:
+    def test_prompts_is_non_empty(self) -> None:
+        assert len(PROMPTS) > 0
+
+    def test_all_entries_have_required_fields(self) -> None:
+        for p in PROMPTS:
+            assert isinstance(p["name"], str) and p["name"]
+            assert isinstance(p["description"], str) and p["description"]
+            assert isinstance(p["arguments"], list)
+
+    def test_contains_role_prompts(self) -> None:
+        names = [p["name"] for p in PROMPTS]
+        role_names = [n for n in names if n.startswith("role/")]
+        assert len(role_names) > 0, "Expected at least one role/* prompt"
+
+    def test_contains_agent_prompts(self) -> None:
+        names = [p["name"] for p in PROMPTS]
+        agent_names = [n for n in names if n.startswith("agent/")]
+        assert len(agent_names) > 0, "Expected at least one agent/* prompt"
+
+    def test_no_duplicate_names(self) -> None:
+        names = [p["name"] for p in PROMPTS]
+        assert len(names) == len(set(names)), "Duplicate prompt names detected"
+
+    def test_list_prompts_returns_same_as_catalogue(self) -> None:
+        assert list_prompts() == PROMPTS
+
+
+# ---------------------------------------------------------------------------
+# get_prompt() unit tests
+# ---------------------------------------------------------------------------
+
+class TestGetPrompt:
+    def test_unknown_name_returns_none(self) -> None:
+        result = get_prompt("unknown/nonexistent")
+        assert result is None
+
+    def test_role_prompt_returns_content(self) -> None:
+        fake_content = "# CTO Role\n\nYou are the CTO.\n"
+        with patch.object(Path, "exists", return_value=True), \
+             patch.object(Path, "read_text", return_value=fake_content):
+            result = get_prompt("role/cto")
+        assert result is not None
+        assert result["description"] != ""
+        assert len(result["messages"]) == 1
+        msg = result["messages"][0]
+        assert msg["role"] == "user"
+        assert msg["content"]["type"] == "text"
+        assert msg["content"]["text"] == fake_content
+
+    def test_agent_dispatcher_returns_content(self) -> None:
+        fake_content = "# Dispatcher\n\nYou dispatch agents.\n"
+        with patch.object(Path, "exists", return_value=True), \
+             patch.object(Path, "read_text", return_value=fake_content):
+            result = get_prompt("agent/dispatcher")
+        assert result is not None
+        assert result["messages"][0]["content"]["text"] == fake_content
+
+    def test_role_not_found_returns_none(self) -> None:
+        with patch.object(Path, "exists", return_value=False):
+            result = get_prompt("role/nonexistent-role-xyz")
+        assert result is None
+
+    def test_wrong_prefix_returns_none(self) -> None:
+        result = get_prompt("unknown/cto")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# prompts/list JSON-RPC handler
+# ---------------------------------------------------------------------------
+
+class TestPromptsListRpc:
+    def test_sync_handler_returns_prompts(self) -> None:
+        resp = _unwrap(handle_request(_rpc("prompts/list")))
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        prompts = result.get("prompts")
+        assert isinstance(prompts, list)
+        assert len(prompts) == len(PROMPTS)
+
+    @pytest.mark.anyio
+    async def test_async_handler_returns_prompts(self) -> None:
+        resp = _unwrap(await handle_request_async(_rpc("prompts/list")))
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        prompts = result.get("prompts")
+        assert isinstance(prompts, list)
+        assert len(prompts) > 0
+
+    def test_each_prompt_has_name_description_arguments(self) -> None:
+        resp = _unwrap(handle_request(_rpc("prompts/list")))
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        prompts = result.get("prompts")
+        assert isinstance(prompts, list)
+        for p in prompts:
+            assert isinstance(p, dict)
+            assert isinstance(p.get("name"), str)
+            assert isinstance(p.get("description"), str)
+            assert isinstance(p.get("arguments"), list)
+
+
+# ---------------------------------------------------------------------------
+# prompts/get JSON-RPC handler
+# ---------------------------------------------------------------------------
+
+class TestPromptsGetRpc:
+    def test_known_role_prompt_returns_content(self) -> None:
+        fake_content = "# CTO\n\nYou are the CTO."
+        with patch.object(Path, "exists", return_value=True), \
+             patch.object(Path, "read_text", return_value=fake_content):
+            resp = _unwrap(handle_request(_rpc("prompts/get", {"name": "role/cto"})))
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        messages = result.get("messages")
+        assert isinstance(messages, list)
+        assert len(messages) == 1
+        msg = messages[0]
+        assert isinstance(msg, dict)
+        assert msg["role"] == "user"
+        content = msg.get("content")
+        assert isinstance(content, dict)
+        assert content["text"] == fake_content
+
+    @pytest.mark.anyio
+    async def test_async_handler_returns_content(self) -> None:
+        fake_content = "# Engineer\n\nYou implement issues."
+        with patch.object(Path, "exists", return_value=True), \
+             patch.object(Path, "read_text", return_value=fake_content):
+            resp = _unwrap(await handle_request_async(_rpc("prompts/get", {"name": "agent/engineer"})))
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        messages = result.get("messages")
+        assert isinstance(messages, list)
+        assert len(messages) == 1
+
+    def test_unknown_prompt_returns_error_response(self) -> None:
+        resp = _unwrap(handle_request(_rpc("prompts/get", {"name": "role/xyzzy-not-real"})))
+        assert "error" in resp
+        error = resp["error"]
+        assert isinstance(error, dict)
+        assert error["code"] == -32602
+
+    def test_missing_name_returns_error(self) -> None:
+        resp = _unwrap(handle_request(_rpc("prompts/get", {})))
+        assert "error" in resp
+
+    def test_missing_params_returns_error(self) -> None:
+        resp = _unwrap(handle_request(_rpc("prompts/get")))
+        assert "error" in resp
+
+    def test_empty_name_returns_error(self) -> None:
+        resp = _unwrap(handle_request(_rpc("prompts/get", {"name": ""})))
+        assert "error" in resp
+
+
+# ---------------------------------------------------------------------------
+# ping
+# ---------------------------------------------------------------------------
+
+class TestPing:
+    def test_sync_ping_returns_empty_result(self) -> None:
+        resp = _unwrap(handle_request(_rpc("ping")))
+        assert "result" in resp
+        result = resp["result"]
+        assert isinstance(result, dict)
+        assert result == {}
+
+    @pytest.mark.anyio
+    async def test_async_ping_returns_empty_result(self) -> None:
+        resp = _unwrap(await handle_request_async(_rpc("ping")))
+        assert "result" in resp
+        result = resp["result"]
+        assert isinstance(result, dict)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# initialize declares prompts capability
+# ---------------------------------------------------------------------------
+
+class TestInitializeCapabilities:
+    def test_sync_initialize_includes_prompts(self) -> None:
+        resp = _unwrap(handle_request(_rpc("initialize")))
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        capabilities = result.get("capabilities")
+        assert isinstance(capabilities, dict)
+        assert "prompts" in capabilities
+        assert "tools" in capabilities
+        assert "resources" in capabilities
+
+    @pytest.mark.anyio
+    async def test_async_initialize_includes_prompts(self) -> None:
+        resp = _unwrap(await handle_request_async(_rpc("initialize")))
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        capabilities = result.get("capabilities")
+        assert isinstance(capabilities, dict)
+        assert "prompts" in capabilities

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -1,10 +1,39 @@
-# AgentCeption — Cursor MCP Integration
+# AgentCeption — MCP Integration
 
-AgentCeption exposes an MCP (Model Context Protocol) server so Cursor and Claude can invoke AgentCeption tools directly from the editor.
+AgentCeption exposes a best-in-class MCP (Model Context Protocol) server so Cursor, Claude, and any MCP-aware client can invoke tools, read resources, and fetch prompts directly.
 
-## How it works
+## Transports
 
-The MCP server runs inside the AgentCeption Docker container. Cursor communicates with it over stdio, via `docker compose exec -T agentception python -m agentception.mcp.stdio_server`.
+Two transports are available — both speak the same JSON-RPC 2.0 protocol:
+
+| Transport | Entry point | Best for |
+|-----------|-------------|----------|
+| **stdio** | `docker compose exec -T agentception python -m agentception.mcp.stdio_server` | Cursor IDE sessions |
+| **HTTP** | `POST http://localhost:10003/api/mcp` | Web agents, CI/CD, curl, external clients |
+
+The HTTP transport follows the MCP 2025-03-26 Streamable HTTP spec: single or batch JSON-RPC request bodies, JSON responses.  Notifications (requests without `id`) return `202 Accepted`.
+
+## stdio configuration (`~/.cursor/mcp.json`)
+
+Add an `agentception` entry to your `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "agentception": {
+      "command": "docker",
+      "args": [
+        "compose", "-f", "AGENTCEPTION_REPO_ROOT/docker-compose.yml",
+        "exec", "-T", "agentception",
+        "python", "-m", "agentception.mcp.stdio_server"
+      ],
+      "cwd": "AGENTCEPTION_REPO_ROOT"
+    }
+  }
+}
+```
+
+Replace `AGENTCEPTION_REPO_ROOT` with the absolute path to your local clone.
 
 ## `~/.cursor/mcp.json` configuration
 
@@ -58,17 +87,15 @@ If you also run other MCP servers (e.g. a music composition backend), add them a
 - AgentCeption containers must be running: `docker compose up -d`
 - Verify the MCP server responds: `docker compose exec agentception python -m agentception.mcp.stdio_server`
 
-## Tools vs Resources
+## Three kinds of MCP endpoints
 
-AgentCeption exposes two kinds of MCP endpoints:
+AgentCeption exposes all three MCP endpoint types:
 
 | Kind | Purpose | How to call |
 |------|---------|-------------|
-| **Tools** | Actions with side effects (mutate state, file issues, start agents) | `CallMcpTool(server="user-agentception", toolName=..., arguments={...})` |
+| **Tools** | Actions with side effects (mutate state, post comments, start agents) | `CallMcpTool(server="user-agentception", toolName=..., arguments={...})` |
 | **Resources** | Pure reads — stateless, cacheable, side-effect-free | `FetchMcpResource(server="user-agentception", uri="ac://...")` |
-
-This is the correct MCP protocol distinction: resources map to the `resources/read` JSON-RPC
-method and are served under the `ac://` URI scheme; tools map to `tools/call`.
+| **Prompts** | Agent role files and briefing templates | `prompts/get(name="role/python-developer")` or `prompts/list` |
 
 ### Resource URI catalogue
 
@@ -83,9 +110,20 @@ method and are served under the `ac://` URI scheme; tools map to `tools/call`.
 | `ac://batches/{batch_id}/tree` | All runs in a batch |
 | `ac://system/dispatcher` | Dispatcher counters and active batch_id |
 | `ac://system/health` | DB reachability and per-status counts |
+| `ac://system/config` | Pipeline label config (canonical label names) |
 | `ac://plan/schema` | PlanSpec JSON Schema |
 | `ac://plan/labels` | GitHub label catalogue |
 | `ac://plan/figures/{role}` | Cognitive-arch figures for a role slug |
+| `ac://roles/list` | All available role slugs |
+| `ac://roles/{slug}` | Full role definition Markdown for a slug |
+
+### Prompt catalogue
+
+`prompts/list` returns every compiled role and agent prompt.  `prompts/get(name=...)` returns the full Markdown content as a `user` message.
+
+Naming conventions:
+- `role/<slug>` — role definition (e.g. `role/python-developer`, `role/cto`)
+- `agent/<name>` — agent prompt (e.g. `agent/dispatcher`, `agent/engineer`, `agent/reviewer`)
 
 ## MCP Auto-Approval
 
@@ -97,14 +135,15 @@ starting agents, advancing phase gates) always require an explicit human confirm
 {
   "mcpServers": {
     "agentception": {
-      "url": "http://localhost:10003/mcp",
+      "url": "http://localhost:10003/api/mcp",
       "autoApprove": [
         "plan_validate_spec",
         "plan_validate_manifest",
         "log_run_step",
         "log_run_blocker",
         "log_run_decision",
-        "log_run_message"
+        "log_run_message",
+        "log_run_error"
       ]
     }
   }
@@ -116,22 +155,25 @@ starting agents, advancing phase gates) always require an explicit human confirm
 | Tier | Endpoints | Rationale |
 |------|-----------|-----------|
 | **Auto — resources** | All `ac://` URIs | Pure reads — no external effects, always safe. |
+| **Auto — prompts** | All `role/*` and `agent/*` | Static file reads — no effects. |
 | **Auto — tools** | `plan_validate_spec`, `plan_validate_manifest` | In-memory validation only. |
-| **Auto — tools** | `log_run_step`, `log_run_blocker`, `log_run_decision`, `log_run_message` | Append-only DB writes — no external effects. |
+| **Auto — tools** | `log_run_step`, `log_run_blocker`, `log_run_decision`, `log_run_message`, `log_run_error` | Append-only DB writes — no external effects. |
 | **Prompt** | `build_claim_run`, `build_complete_run`, `build_cancel_run`, `build_stop_run`, `build_block_run`, `build_resume_run` | Pipeline state transitions in the DB — recoverable but worth confirming. |
-| **Prompt** | `github_add_label`, `github_remove_label`, `github_claim_issue`, `github_unclaim_issue` | External GitHub API mutations. |
+| **Prompt** | `github_add_label`, `github_remove_label`, `github_claim_issue`, `github_unclaim_issue`, `github_add_comment` | External GitHub API mutations. |
 | **Always prompt** | `plan_spawn_coordinator`, `plan_advance_phase`, `build_spawn_child_run`, `build_teardown_worktree` | Create real GitHub issues, git worktrees, and live agents — irreversible side effects. |
 
 **What this means for you:**
 
-- Resource reads (`FetchMcpResource`) and observability tool calls happen without interruption.
-- `plan_spawn_coordinator` and `plan_advance_phase` will always show a Cursor confirmation
-  dialog — a mis-fire creates real GitHub issues and running agent processes that are hard to undo.
-- The AgentCeption server must be running at `http://localhost:10003` (start it with
-  `docker compose up -d`).
+- Resource reads (`FetchMcpResource`), prompt fetches, and observability tool calls happen without interruption.
+- `plan_spawn_coordinator` and `plan_advance_phase` always show a Cursor confirmation dialog — a mis-fire creates real GitHub issues and running agent processes that are hard to undo.
+- The HTTP endpoint is available at `http://localhost:10003/api/mcp` once containers are running.
 
-## Available tools and resources
+## Available tools, resources, and prompts
 
-See `agentception/mcp/server.py` for registered tools and `agentception/mcp/resources.py`
-for the resource catalogue. Cursor's MCP panel enumerates both automatically once the
-server entry is in `mcp.json`.
+| Module | What it registers |
+|--------|-------------------|
+| `agentception/mcp/server.py` | Tool catalogue (`TOOLS`), `list_prompts()`, all JSON-RPC handlers |
+| `agentception/mcp/resources.py` | Resource + template catalogue, `read_resource()` dispatcher |
+| `agentception/mcp/prompts.py` | Prompt catalogue, `get_prompt()` dispatcher |
+
+Cursor's MCP panel enumerates all three automatically once the server entry is in `mcp.json`.


### PR DESCRIPTION
## Summary

- **MCP Prompts capability**: new `agentception/mcp/prompts.py` discovers all `.agentception/roles/*.md` and `.agentception/*.md` files and exposes them via `prompts/list` + `prompts/get` — agents can fetch their own role prompt via MCP instead of reading files from disk
- **HTTP Streamable MCP endpoint** (`POST /api/mcp`): follows MCP 2025-03-26 Streamable HTTP transport; web agents, CI/CD, and curl can now speak MCP to AgentCeption without Docker process spawning
- **`log_run_error` tool**: semantic crash event distinct from `log_run_message` on the dashboard — agents no longer misuse free-form messages for unrecoverable failures
- **`github_add_comment` tool**: agents no longer shell out to `gh issue comment`; fingerprint and status comments are now observable, logged, and auditable through the MCP layer
- **New resources**: `ac://system/config` (canonical label names), `ac://roles/list` (all role slugs), `ac://roles/{slug}` (full role Markdown)
- **`ping` handler**: spec-required keepalive (`-32601` no longer returned for `ping`)
- **`prompts` declared in `initialize` capabilities** alongside tools + resources
- **Test coverage**: 87 new tests covering all 5 log tools, all 5 github tools, prompts/list + prompts/get, HTTP endpoint batch/error/notification paths

## Test plan

- [x] `mypy agentception/ tests/` — zero errors (204 files)
- [x] `typing_audit.py --max-any 0` — zero Any patterns
- [x] `pytest tests/ agentception/tests/ -v` — 1595 passed, 0 failed
- [x] `generate.py --check` — no drift