### PR TITLE
fix: move docstring before from __future__ import annotations in new MCP files

### DIFF
--- a/agentception/mcp/prompts.py
+++ b/agentception/mcp/prompts.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """MCP Prompts catalogue for AgentCeption.
 
 Exposes every compiled role file and agent prompt as a first-class MCP Prompt
@@ -21,6 +19,9 @@ All prompts are static (no arguments) and returned as a single ``user`` message
 whose ``text`` is the raw Markdown file content.  Agents may prepend the
 returned message to their conversation context.
 """
+
+from __future__ import annotations
+
 
 import logging
 from pathlib import Path

--- a/agentception/routes/api/mcp.py
+++ b/agentception/routes/api/mcp.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """HTTP Streamable MCP endpoint.
 
 Exposes the AgentCeption MCP server over HTTP in addition to the stdio transport,
@@ -38,6 +36,9 @@ Notes
 - No authentication: the endpoint is protected only by network access controls.
   Add API-key middleware when exposing outside a trusted network.
 """
+
+from __future__ import annotations
+
 
 import logging
 

--- a/agentception/tests/test_mcp_github_tools.py
+++ b/agentception/tests/test_mcp_github_tools.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Tests for the MCP github-tools layer.
 
 Covers all five GitHub tools (github_add_label, github_remove_label,
@@ -13,6 +11,9 @@ Test categories:
   - Async-only guard: github tools must fail from the sync call_tool path
   - Error propagation: RuntimeError from readers.github surfaces as ok=false
 """
+
+from __future__ import annotations
+
 
 import json
 from unittest.mock import AsyncMock, patch

--- a/agentception/tests/test_mcp_http.py
+++ b/agentception/tests/test_mcp_http.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Tests for the HTTP Streamable MCP endpoint.
 
 Covers POST /api/mcp via httpx.AsyncClient against the FastAPI test app.
@@ -11,6 +9,9 @@ Test categories:
   - Error cases: malformed JSON, missing fields, invalid method
   - New tools accessible via HTTP (log_run_error, github_add_comment)
 """
+
+from __future__ import annotations
+
 
 import json
 from unittest.mock import AsyncMock, patch

--- a/agentception/tests/test_mcp_log_tools.py
+++ b/agentception/tests/test_mcp_log_tools.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Tests for the MCP log-tools layer.
 
 Covers all five log tools (log_run_step, log_run_blocker, log_run_decision,
@@ -13,6 +11,9 @@ Test categories:
   - Argument validation errors
   - Async tool guard: log tools are async-only and return an error from call_tool
 """
+
+from __future__ import annotations
+
 
 import json
 from unittest.mock import AsyncMock, patch

--- a/agentception/tests/test_mcp_prompts.py
+++ b/agentception/tests/test_mcp_prompts.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Tests for the MCP Prompts capability.
 
 Covers:
@@ -10,6 +8,9 @@ Covers:
   - ping JSON-RPC handler
   - initialize declares prompts capability
 """
+
+from __future__ import annotations
+
 
 import json
 from pathlib import Path


### PR DESCRIPTION
All six files created in PR #351 had `from __future__ import annotations` on line 1 before the module docstring. Fixed the ordering in:

- `agentception/mcp/prompts.py`
- `agentception/routes/api/mcp.py`
- `agentception/tests/test_mcp_log_tools.py`
- `agentception/tests/test_mcp_github_tools.py`
- `agentception/tests/test_mcp_prompts.py`
- `agentception/tests/test_mcp_http.py`

mypy clean, 85 affected tests pass.