### PR TITLE
feat: Cursor-free agent execution loop

### DIFF
--- a/agentception/routes/api/__init__.py
+++ b/agentception/routes/api/__init__.py
@@ -12,6 +12,7 @@ import path continues to work unchanged.
 
 from fastapi import APIRouter
 
+from .agent_run import router as _agent_run
 from .dispatch import router as _dispatch
 from .runs import router as _runs
 from .ship_api import router as _ship_api
@@ -29,6 +30,7 @@ from .wizard import router as _wizard
 from .worktrees import router as _worktrees
 
 router = APIRouter(prefix="/api", tags=["api"])
+router.include_router(_agent_run)
 router.include_router(_dispatch)
 router.include_router(_runs)
 router.include_router(_ship_api)

--- a/agentception/routes/api/agent_run.py
+++ b/agentception/routes/api/agent_run.py
@@ -1,0 +1,84 @@
+"""Agent execution trigger route.
+
+Provides a single endpoint to launch the Cursor-free agent loop for an
+existing run.  The loop runs as a FastAPI ``BackgroundTask`` and reports
+progress through the MCP log tools (visible in the build dashboard).
+
+Endpoint
+--------
+POST /api/runs/{run_id}/execute
+    Transitions the run to ``implementing`` and fires the agent loop in the
+    background.  Returns ``202 Accepted`` immediately.  The caller should poll
+    the build dashboard or the run inspector to observe progress.
+
+Error codes
+-----------
+404  Run not found.
+409  Run is not in a dispatchable state (must be ``pending_launch`` or
+     ``implementing``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi.responses import JSONResponse
+from sqlalchemy import select
+
+from agentception.db.engine import get_session
+from agentception.db.models import ACAgentRun
+from agentception.mcp.build_commands import build_claim_run
+from agentception.services.agent_loop import run_agent_loop
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/runs", tags=["agent-run"])
+
+# Statuses from which the agent loop may be launched.
+_DISPATCHABLE_STATUSES: frozenset[str] = frozenset({"pending_launch", "implementing"})
+
+
+@router.post("/{run_id}/execute", status_code=202)
+async def execute_agent_run(run_id: str, background_tasks: BackgroundTasks) -> JSONResponse:
+    """Launch the Cursor-free agent loop for *run_id*.
+
+    If the run is ``pending_launch`` it is atomically claimed (transitioned to
+    ``implementing``) before the background task is scheduled.  Runs already
+    ``implementing`` are accepted as-is so the caller can retry a stale loop.
+
+    Returns 202 immediately; progress is visible in the build dashboard.
+    """
+    async with get_session() as session:
+        run: ACAgentRun | None = await session.scalar(
+            select(ACAgentRun).where(ACAgentRun.id == run_id)
+        )
+
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found.")
+
+    if run.status not in _DISPATCHABLE_STATUSES:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Run '{run_id}' is in status '{run.status}' — "
+                f"only {sorted(_DISPATCHABLE_STATUSES)} may be executed."
+            ),
+        )
+
+    if run.status == "pending_launch":
+        claim_result = await build_claim_run(run_id)
+        if not claim_result.get("ok"):
+            raise HTTPException(
+                status_code=409,
+                detail=f"Failed to claim run '{run_id}': {claim_result.get('error')}",
+            )
+        logger.info("✅ execute_agent_run — claimed run_id=%s", run_id)
+
+    background_tasks.add_task(run_agent_loop, run_id)
+    logger.info("✅ execute_agent_run — loop scheduled for run_id=%s", run_id)
+
+    return JSONResponse(
+        status_code=202,
+        content={"ok": True, "run_id": run_id, "message": "Agent loop started."},
+    )

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -1,0 +1,455 @@
+"""Cursor-free agent execution loop.
+
+Replaces Cursor as the agent runtime.  An LLM on Anthropic's infrastructure
+(reached via OpenRouter) does the reasoning; file operations, shell commands,
+and MCP tool calls execute locally inside this container.
+
+Pipeline
+--------
+1. Resolve the worktree path from ``settings.worktrees_dir / run_id``.
+2. Parse ``.agent-task`` via :func:`~agentception.readers.worktrees.parse_agent_task`.
+3. Load the role file from ``settings.repo_dir / ".agentception/roles/{role}.md"``.
+4. Assemble the system prompt: role content + cognitive architecture context +
+   runtime environment note (Python commands run directly, not via docker exec).
+5. Build the combined tool catalogue: local file/shell tools + all MCP tools.
+6. Run the multi-turn conversation loop via
+   :func:`~agentception.services.llm.call_openrouter_with_tools`, dispatching
+   tool calls until the model returns ``stop_reason == "stop"`` or the
+   iteration ceiling is hit.
+7. On completion: call :func:`~agentception.mcp.build_commands.build_complete_run`.
+   On iteration limit or unrecoverable error: call
+   :func:`~agentception.mcp.log_tools.log_run_error` then
+   :func:`~agentception.mcp.build_commands.build_cancel_run`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from agentception.config import settings
+from agentception.mcp.build_commands import build_cancel_run, build_complete_run
+from agentception.mcp.log_tools import log_run_error, log_run_step
+from agentception.mcp.server import TOOLS, call_tool_async
+from agentception.mcp.types import ACToolResult
+from agentception.models import TaskFile
+from agentception.readers.worktrees import parse_agent_task
+from agentception.services.llm import (
+    ToolCall,
+    ToolDefinition,
+    ToolFunction,
+    ToolResponse,
+    call_openrouter_with_tools,
+)
+from agentception.tools.definitions import FILE_TOOL_DEFS, SHELL_TOOL_DEF
+from agentception.tools.file_tools import (
+    list_directory,
+    read_file,
+    search_text,
+    write_file,
+)
+from agentception.tools.shell_tools import run_command
+
+logger = logging.getLogger(__name__)
+
+# Hard cap on conversation turns.  Each iteration is one LLM call.
+_DEFAULT_MAX_ITERATIONS = 50
+
+# Local tool names — dispatched to file/shell functions rather than MCP.
+_LOCAL_TOOL_NAMES: frozenset[str] = frozenset(
+    {"read_file", "write_file", "list_directory", "search_text", "run_command"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def run_agent_loop(
+    run_id: str,
+    *,
+    max_iterations: int = _DEFAULT_MAX_ITERATIONS,
+) -> None:
+    """Run the full agent conversation loop for *run_id*.
+
+    This is designed to be called as a FastAPI ``BackgroundTask`` from the
+    ``POST /api/runs/{run_id}/execute`` route, which has already transitioned
+    the run to ``implementing``.
+
+    Args:
+        run_id: The run identifier, used to locate the worktree and task file.
+        max_iterations: Upper bound on LLM turns (prevents runaway loops).
+    """
+    worktree_path = settings.worktrees_dir / run_id
+
+    task = await _load_task(worktree_path)
+    if task is None:
+        logger.error("❌ agent_loop — no .agent-task for run_id=%s", run_id)
+        await build_cancel_run(run_id)
+        return
+
+    issue_number = task.issue_number or 0
+
+    role_prompt = _load_role_prompt(task.role)
+    system_prompt = _build_system_prompt(role_prompt, task.cognitive_arch or "")
+    tool_defs = _build_tool_definitions()
+    initial_message = _build_initial_message(task, worktree_path)
+
+    messages: list[dict[str, object]] = [{"role": "user", "content": initial_message}]
+
+    logger.info(
+        "✅ agent_loop start — run_id=%s issue=%d tools=%d",
+        run_id,
+        issue_number,
+        len(tool_defs),
+    )
+
+    for iteration in range(1, max_iterations + 1):
+        await log_run_step(
+            issue_number,
+            f"Iteration {iteration}/{max_iterations}",
+            run_id,
+        )
+
+        try:
+            response: ToolResponse = await call_openrouter_with_tools(
+                messages,
+                system=system_prompt,
+                tools=tool_defs,
+            )
+        except Exception as exc:
+            logger.exception("❌ agent_loop LLM error on iteration %d", iteration)
+            await log_run_error(issue_number, f"LLM error: {exc}", run_id)
+            await build_cancel_run(run_id)
+            return
+
+        # Append assistant message to history.
+        assistant_msg: dict[str, object] = {"role": "assistant", "content": response["content"]}
+        if response["tool_calls"]:
+            assistant_msg["tool_calls"] = list(response["tool_calls"])
+        messages.append(assistant_msg)
+
+        if response["stop_reason"] == "stop":
+            logger.info("✅ agent_loop complete — run_id=%s iterations=%d", run_id, iteration)
+            await build_complete_run(
+                issue_number=issue_number,
+                pr_url="",
+                summary=response["content"][:500] if response["content"] else "Agent completed.",
+                agent_run_id=run_id,
+            )
+            return
+
+        if response["stop_reason"] == "tool_calls":
+            tool_results = await _dispatch_tool_calls(
+                response["tool_calls"], worktree_path, run_id
+            )
+            messages.extend(tool_results)
+            continue
+
+        # Unexpected stop reason (e.g. "length").
+        logger.warning(
+            "⚠️ agent_loop unexpected stop_reason=%s on iteration %d",
+            response["stop_reason"],
+            iteration,
+        )
+        await log_run_error(
+            issue_number,
+            f"Unexpected stop_reason={response['stop_reason']!r} on iteration {iteration}",
+            run_id,
+        )
+        await build_cancel_run(run_id)
+        return
+
+    # Reached iteration ceiling.
+    logger.error("❌ agent_loop iteration limit reached — run_id=%s", run_id)
+    await log_run_error(
+        issue_number,
+        f"Agent loop exceeded {max_iterations} iterations without completing.",
+        run_id,
+    )
+    await build_cancel_run(run_id)
+
+
+# ---------------------------------------------------------------------------
+# Task loading helpers
+# ---------------------------------------------------------------------------
+
+
+async def _load_task(worktree_path: Path) -> TaskFile | None:
+    """Parse the ``.agent-task`` file in *worktree_path*.
+
+    Returns ``None`` and logs an error when the file is absent or malformed.
+    """
+    try:
+        return await parse_agent_task(worktree_path)
+    except Exception as exc:
+        logger.error("❌ _load_task error: %s", exc)
+        return None
+
+
+def _load_role_prompt(role: str | None) -> str:
+    """Return the Markdown content of the role file for *role*.
+
+    Falls back to an empty string when the role is unknown or the file is
+    missing, so the agent still has the system prompt's runtime note.
+    """
+    if not role:
+        logger.warning("⚠️ _load_role_prompt — no role specified")
+        return ""
+
+    role_path = settings.repo_dir / ".agentception" / "roles" / f"{role}.md"
+    try:
+        return role_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        logger.warning("⚠️ _load_role_prompt — role file not found: %s", role_path)
+        return ""
+    except OSError as exc:
+        logger.warning("⚠️ _load_role_prompt — OS error reading %s: %s", role_path, exc)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# System prompt assembly
+# ---------------------------------------------------------------------------
+
+_RUNTIME_ENV_NOTE = """\
+---
+## Runtime Environment
+
+You are running **inside the AgentCeption Docker container**, not on the host machine.
+
+- Run Python tools **directly** — do NOT prefix with `docker compose exec agentception`.
+  - ✅ `python3 -m pytest tests/`
+  - ✅ `python3 -m mypy agentception/`
+  - ❌ `docker compose exec agentception python3 -m pytest` (wrong — you are already inside)
+- The repository is mounted at `/app`.  The worktree for your task is at the path
+  in your `.agent-task` file (`[worktree] path`).
+- Git operations run in the worktree directory.
+- Use `run_command` for shell execution.  Use `read_file` / `write_file` for files.
+"""
+
+
+def _build_system_prompt(role_prompt: str, cognitive_arch: str) -> str:
+    """Assemble the full system prompt from the role file and cognitive arch context.
+
+    Args:
+        role_prompt: Raw Markdown content of the agent's role file.
+        cognitive_arch: Cognitive architecture context string from ``.agent-task``.
+
+    Returns:
+        A single multi-part system prompt string.
+    """
+    parts: list[str] = []
+
+    if role_prompt:
+        parts.append(role_prompt.strip())
+
+    if cognitive_arch:
+        parts.append(f"---\n## Cognitive Architecture Context\n\n{cognitive_arch.strip()}")
+
+    parts.append(_RUNTIME_ENV_NOTE.strip())
+
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Initial user message
+# ---------------------------------------------------------------------------
+
+
+def _build_initial_message(task: TaskFile, worktree_path: Path) -> str:
+    """Build the first user message that kicks off the agent conversation.
+
+    Args:
+        task: Parsed ``.agent-task`` data.
+        worktree_path: Container-side path to the worktree directory.
+
+    Returns:
+        A brief markdown message directing the agent to read its task file.
+    """
+    run_id = task.id or str(worktree_path.name)
+    issue_ref = f"#{task.issue_number}" if task.issue_number else "(no issue)"
+    role = task.role or "unknown"
+    task_file_path = worktree_path / ".agent-task"
+
+    return (
+        f"You have been dispatched to work on issue {issue_ref} "
+        f"as a **{role}** agent (run `{run_id}`).\n\n"
+        f"Your worktree is at: `{worktree_path}`\n"
+        f"Your configuration is at: `{task_file_path}`\n\n"
+        f"Start by reading your `.agent-task` file to understand your full "
+        f"instructions, then proceed with your work."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool catalogue
+# ---------------------------------------------------------------------------
+
+
+def _mcp_tool_to_openai(tool_name: str, description: str, input_schema: dict[str, object]) -> ToolDefinition:
+    """Convert an MCP ACToolDef to an OpenAI-format ToolDefinition."""
+    return ToolDefinition(
+        type="function",
+        function=ToolFunction(
+            name=tool_name,
+            description=description,
+            parameters=input_schema,
+        ),
+    )
+
+
+def _build_tool_definitions() -> list[ToolDefinition]:
+    """Build the combined tool list: local tools + MCP tools.
+
+    Local tools (file/shell) are listed first so the model encounters them
+    before the more specialised MCP tools.
+
+    MCP tools that share a name with local tools are excluded (local tools
+    take precedence for file operations).
+    """
+    tool_defs: list[ToolDefinition] = list(FILE_TOOL_DEFS)
+    tool_defs.append(SHELL_TOOL_DEF)
+
+    for mcp_tool in TOOLS:
+        name: object = mcp_tool.get("name")
+        if not isinstance(name, str) or name in _LOCAL_TOOL_NAMES:
+            continue
+        description: object = mcp_tool.get("description", "")
+        input_schema: object = mcp_tool.get("inputSchema", {})
+        if not isinstance(description, str) or not isinstance(input_schema, dict):
+            continue
+        tool_defs.append(_mcp_tool_to_openai(name, description, input_schema))
+
+    return tool_defs
+
+
+# ---------------------------------------------------------------------------
+# Tool dispatch
+# ---------------------------------------------------------------------------
+
+
+async def _dispatch_tool_calls(
+    tool_calls: list[ToolCall],
+    worktree_path: Path,
+    run_id: str,
+) -> list[dict[str, object]]:
+    """Execute each tool call and return a list of tool-result messages.
+
+    Local file/shell tools are dispatched directly.  All other tool names are
+    forwarded to :func:`~agentception.mcp.server.call_tool_async`.
+
+    Args:
+        tool_calls: Tool calls returned by the model.
+        worktree_path: Worktree root used as the default cwd for shell calls
+            and the base for resolving relative file paths.
+        run_id: Used for logging only.
+
+    Returns:
+        A list of ``{"role": "tool", "tool_call_id": str, "content": str}``
+        messages ready to extend the conversation history.
+    """
+    results: list[dict[str, object]] = []
+    for tc in tool_calls:
+        result = await _dispatch_single_tool(tc, worktree_path, run_id)
+        results.append(
+            {
+                "role": "tool",
+                "tool_call_id": tc["id"],
+                "content": json.dumps(result),
+            }
+        )
+    return results
+
+
+def _mcp_result_to_dict(result: ACToolResult) -> dict[str, object]:
+    """Convert an :class:`~agentception.mcp.types.ACToolResult` to a plain dict.
+
+    The model receives the text extracted from the content list so it can
+    understand the tool outcome without needing knowledge of the MCP protocol.
+    """
+    text_parts = [
+        item["text"]
+        for item in result["content"]
+        if item.get("type") == "text" and isinstance(item.get("text"), str)
+    ]
+    return {"ok": not result["isError"], "result": "\n".join(text_parts)}
+
+
+async def _dispatch_single_tool(
+    tool_call: ToolCall,
+    worktree_path: Path,
+    run_id: str,
+) -> dict[str, object]:
+    """Dispatch a single tool call and return its result dict.
+
+    Returns ``{"ok": False, "error": str}`` on argument parse failure so the
+    model always receives structured feedback.
+    """
+    name = tool_call["function"]["name"]
+    args_str = tool_call["function"]["arguments"]
+
+    logger.info("✅ dispatch_tool — run_id=%s tool=%s", run_id, name)
+
+    try:
+        args: dict[str, object] = json.loads(args_str)
+    except json.JSONDecodeError as exc:
+        return {"ok": False, "error": f"Invalid tool arguments (JSON parse error): {exc}"}
+
+    if name not in _LOCAL_TOOL_NAMES:
+        return _mcp_result_to_dict(await call_tool_async(name, args))
+
+    return await _dispatch_local_tool(name, args, worktree_path)
+
+
+async def _dispatch_local_tool(
+    name: str,
+    args: dict[str, object],
+    worktree_path: Path,
+) -> dict[str, object]:
+    """Route a local tool call to the appropriate file or shell function."""
+
+    def _resolve(raw: object, default: Path) -> Path:
+        """Resolve *raw* as a path, falling back to *default*."""
+        if not isinstance(raw, str) or not raw:
+            return default
+        p = Path(raw)
+        return p if p.is_absolute() else worktree_path / p
+
+    if name == "read_file":
+        path = _resolve(args.get("path"), worktree_path)
+        return read_file(path)
+
+    if name == "write_file":
+        path_raw = args.get("path")
+        content_raw = args.get("content")
+        if not isinstance(path_raw, str):
+            return {"ok": False, "error": "write_file: 'path' must be a string"}
+        if not isinstance(content_raw, str):
+            return {"ok": False, "error": "write_file: 'content' must be a string"}
+        return write_file(_resolve(path_raw, worktree_path), content_raw)
+
+    if name == "list_directory":
+        path = _resolve(args.get("path", "."), worktree_path)
+        return list_directory(path)
+
+    if name == "search_text":
+        pattern_raw = args.get("pattern")
+        if not isinstance(pattern_raw, str):
+            return {"ok": False, "error": "search_text: 'pattern' must be a string"}
+        directory = _resolve(args.get("directory", "."), worktree_path)
+        n_results_raw = args.get("n_results", 30)
+        n_results = int(n_results_raw) if isinstance(n_results_raw, int) else 30
+        return await search_text(pattern_raw, directory, n_results=n_results)
+
+    if name == "run_command":
+        command_raw = args.get("command")
+        if not isinstance(command_raw, str):
+            return {"ok": False, "error": "run_command: 'command' must be a string"}
+        cwd_raw = args.get("cwd")
+        cwd = _resolve(cwd_raw, worktree_path) if cwd_raw is not None else worktree_path
+        return await run_command(command_raw, cwd)
+
+    return {"ok": False, "error": f"Unknown local tool: {name!r}"}

--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -9,7 +9,7 @@ Patterns and implementation standards for the LLM client:
   - Exponential backoff retry on 429/5xx/timeout
   - Persistent httpx.AsyncClient (re-used across requests, not recreated per call)
 
-Two public entry points:
+Three public entry points:
 
 ``call_openrouter(user_prompt, ...)``
     Waits for the full completion and returns the text.  No retry for now on
@@ -20,6 +20,13 @@ Two public entry points:
       {"type": "thinking", "text": "..."}  -- reasoning token (chain of thought)
       {"type": "content",  "text": "..."}  -- output token (the actual YAML)
     Callers map these to their own SSE event format.
+
+``call_openrouter_with_tools(messages, ...)``
+    Multi-turn tool-use call.  Accepts a message history and a list of OpenAI-
+    format tool definitions.  Returns a :class:`ToolResponse` containing the
+    model's text output, any tool calls it made, and the stop reason.  The
+    caller is responsible for dispatching tool calls and appending results to
+    the message list before calling again.  Used by the Cursor-free agent loop.
 
 The key is read from ``settings.openrouter_api_key`` (env var
 ``OPENROUTER_API_KEY``).  A missing key raises ``RuntimeError``.
@@ -51,6 +58,49 @@ class LLMChunk(TypedDict):
 
     type: Literal["thinking", "content"]
     text: str
+
+
+# ---------------------------------------------------------------------------
+# Tool-use types (used by call_openrouter_with_tools and agent_loop)
+# ---------------------------------------------------------------------------
+
+
+class ToolFunction(TypedDict):
+    """Function spec inside an OpenAI-format tool definition."""
+
+    name: str
+    description: str
+    parameters: dict[str, object]
+
+
+class ToolDefinition(TypedDict):
+    """OpenAI-format tool definition passed to the model."""
+
+    type: Literal["function"]
+    function: ToolFunction
+
+
+class ToolCallFunction(TypedDict):
+    """Function call detail inside a tool_call response block."""
+
+    name: str
+    arguments: str  # JSON-encoded argument dict
+
+
+class ToolCall(TypedDict):
+    """A single tool invocation returned by the model."""
+
+    id: str
+    type: Literal["function"]
+    function: ToolCallFunction
+
+
+class ToolResponse(TypedDict):
+    """Return value from ``call_openrouter_with_tools``."""
+
+    stop_reason: str  # "stop" | "tool_calls" | "length"
+    content: str  # text output (empty when stop_reason is "tool_calls")
+    tool_calls: list[ToolCall]  # empty when stop_reason is "stop"
 
 
 def _base_headers() -> dict[str, str]:
@@ -292,4 +342,144 @@ async def call_openrouter_stream(
     logger.info(
         "✅ LLM stream done — thinking=%d chars content=%d chars",
         total_thinking, total_content,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multi-turn tool-use call (used by the Cursor-free agent loop)
+# ---------------------------------------------------------------------------
+
+
+async def call_openrouter_with_tools(
+    messages: list[dict[str, object]],
+    *,
+    system: str,
+    tools: list[ToolDefinition],
+    model: str = _MODEL,
+    temperature: float = 0.0,
+    max_tokens: int = 8192,
+) -> ToolResponse:
+    """Call Claude via OpenRouter with tool-use support.
+
+    The caller maintains the full message history and passes it on every turn.
+    This function is stateless — it sends one request and returns the result.
+
+    Args:
+        messages: Conversation history (user / assistant / tool messages).
+            The system prompt is NOT included here; pass it via ``system``.
+        system: System prompt prepended to every request.
+        tools: OpenAI-format tool definitions the model may call.
+        model: OpenRouter model identifier.
+        temperature: Sampling temperature.  Defaults to 0 for determinism.
+        max_tokens: Maximum tokens the model may emit per turn.
+
+    Returns:
+        :class:`ToolResponse` with ``stop_reason``, ``content``, and a
+        (possibly empty) list of ``tool_calls`` to dispatch.
+
+    Raises:
+        RuntimeError: Missing API key or unrecoverable HTTP failure.
+        httpx.HTTPStatusError: Non-2xx after retries.
+    """
+    full_messages: list[dict[str, object]] = []
+    if system:
+        full_messages.append({"role": "system", "content": system})
+    full_messages.extend(messages)
+
+    payload: dict[str, object] = {
+        "model": model,
+        "messages": full_messages,
+        "tools": tools,
+        "tool_choice": "auto",
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "stream": False,
+        "provider": {"order": ["anthropic"], "allow_fallbacks": False},
+    }
+
+    logger.info(
+        "✅ LLM tool-use call — model=%s turns=%d tools=%d",
+        model,
+        len(messages),
+        len(tools),
+    )
+
+    client = _get_client()
+    last_error: Exception | None = None
+
+    for attempt in range(_MAX_RETRIES + 1):
+        if attempt > 0:
+            backoff = 2**attempt
+            logger.warning("⚠️ LLM retry %d/%d after %ds", attempt, _MAX_RETRIES, backoff)
+            await asyncio.sleep(backoff)
+        try:
+            resp = await client.post(_OPENROUTER_URL, json=payload)
+            resp.raise_for_status()
+            break
+        except httpx.HTTPStatusError as exc:
+            last_error = exc
+            if exc.response.status_code in (429, 500, 502, 503, 504):
+                continue
+            raise
+        except (httpx.TimeoutException, httpx.NetworkError) as exc:
+            last_error = exc
+            continue
+    else:
+        raise last_error or RuntimeError("LLM tool-use request failed after retries")
+
+    data: object = resp.json()
+    if not isinstance(data, dict):
+        raise ValueError(f"Unexpected OpenRouter response type: {type(data)}")
+    choices: object = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError(f"OpenRouter returned no choices: {data}")
+    first: object = choices[0]
+    if not isinstance(first, dict):
+        raise ValueError(f"Unexpected choice format: {first}")
+
+    finish_reason: object = first.get("finish_reason", "stop")
+    if not isinstance(finish_reason, str):
+        finish_reason = "stop"
+
+    message: object = first.get("message")
+    if not isinstance(message, dict):
+        raise ValueError(f"Unexpected message format: {first}")
+
+    raw_content: object = message.get("content") or ""
+    content = raw_content if isinstance(raw_content, str) else ""
+
+    raw_tool_calls: object = message.get("tool_calls") or []
+    if not isinstance(raw_tool_calls, list):
+        raw_tool_calls = []
+
+    tool_calls: list[ToolCall] = []
+    for tc in raw_tool_calls:
+        if not isinstance(tc, dict):
+            continue
+        tc_id: object = tc.get("id", "")
+        tc_fn: object = tc.get("function")
+        if not isinstance(tc_id, str) or not isinstance(tc_fn, dict):
+            continue
+        fn_name: object = tc_fn.get("name", "")
+        fn_args: object = tc_fn.get("arguments", "{}")
+        if not isinstance(fn_name, str) or not isinstance(fn_args, str):
+            continue
+        tool_calls.append(
+            ToolCall(
+                id=tc_id,
+                type="function",
+                function=ToolCallFunction(name=fn_name, arguments=fn_args),
+            )
+        )
+
+    logger.info(
+        "✅ LLM tool-use done — stop_reason=%s content_chars=%d tool_calls=%d",
+        finish_reason,
+        len(content),
+        len(tool_calls),
+    )
+    return ToolResponse(
+        stop_reason=finish_reason,
+        content=content,
+        tool_calls=tool_calls,
     )

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -1,0 +1,469 @@
+"""Unit tests for agentception.services.agent_loop.
+
+All external I/O is mocked:
+  - call_openrouter_with_tools  → controlled ToolResponse stubs
+  - build_complete_run / build_cancel_run / log_run_step / log_run_error → AsyncMock
+  - call_tool_async             → AsyncMock returning valid ACToolResult
+  - parse_agent_task            → bypassed via real .agent-task in tmp_path
+  - settings.worktrees_dir      → redirected to tmp_path
+  - settings.repo_dir           → redirected to tmp_path
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentception.mcp.types import ACToolContent, ACToolResult
+from agentception.services.llm import ToolCall, ToolCallFunction, ToolResponse
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MINIMAL_TASK_TOML = """\
+[task]
+id = "test-run-1"
+workflow = "issue-to-pr"
+attempt_n = 0
+
+[agent]
+role = "python-developer"
+tier = "worker"
+cognitive_arch = "Think step by step."
+
+[target]
+scope_type = "issue"
+scope_value = "42"
+
+[worktree]
+path = "{worktree}"
+"""
+
+
+def _write_task(worktree: Path, issue_number: int = 42) -> None:
+    """Write a minimal .agent-task TOML to the worktree root."""
+    toml = (
+        "[task]\n"
+        'id = "test-run-1"\n'
+        'workflow = "issue-to-pr"\n'
+        "attempt_n = 0\n"
+        "\n"
+        "[agent]\n"
+        'role = "python-developer"\n'
+        'tier = "worker"\n'
+        'cognitive_arch = "Think step by step."\n'
+        "\n"
+        "[target]\n"
+        'scope_type = "issue"\n'
+        f'scope_value = "{issue_number}"\n'
+        f"issue_number = {issue_number}\n"
+        "\n"
+        "[worktree]\n"
+        f'path = "{worktree}"\n'
+    )
+    (worktree / ".agent-task").write_text(toml, encoding="utf-8")
+
+
+def _mcp_ok_result(text: str = "ok") -> ACToolResult:
+    """Build a valid ACToolResult for use in mocks."""
+    return ACToolResult(
+        content=[ACToolContent(type="text", text=text)],
+        isError=False,
+    )
+
+
+def _stop_response(content: str = "Task complete.") -> ToolResponse:
+    return ToolResponse(stop_reason="stop", content=content, tool_calls=[])
+
+
+def _tool_response(name: str, args: dict[str, object]) -> ToolResponse:
+    tc = ToolCall(
+        id="call_123",
+        type="function",
+        function=ToolCallFunction(name=name, arguments=json.dumps(args)),
+    )
+    return ToolResponse(stop_reason="tool_calls", content="", tool_calls=[tc])
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunAgentLoop:
+    @pytest.mark.anyio
+    async def test_single_turn_stop(self, tmp_path: Path) -> None:
+        """Agent loop completes in one turn when the model returns stop."""
+        worktree = tmp_path / "test-run-1"
+        worktree.mkdir()
+        _write_task(worktree)
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop.call_openrouter_with_tools",
+                new_callable=AsyncMock,
+                return_value=_stop_response("All done."),
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ) as mock_complete,
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+
+            from agentception.services.agent_loop import run_agent_loop
+
+            await run_agent_loop("test-run-1")
+
+        mock_complete.assert_called_once()
+        call_kwargs = mock_complete.call_args.kwargs
+        assert call_kwargs["issue_number"] == 42
+        assert "All done." in call_kwargs["summary"]
+
+    @pytest.mark.anyio
+    async def test_tool_call_then_stop(self, tmp_path: Path) -> None:
+        """Agent loop dispatches a tool call and continues to stop."""
+        worktree = tmp_path / "test-run-1"
+        worktree.mkdir()
+        _write_task(worktree)
+
+        tool_result = {"ok": True, "content": "file content here", "truncated": False}
+        responses = [
+            _tool_response("read_file", {"path": ".agent-task"}),
+            _stop_response("Done after reading file."),
+        ]
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop.call_openrouter_with_tools",
+                new_callable=AsyncMock,
+                side_effect=responses,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ) as mock_complete,
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.tools.file_tools.read_file",
+                return_value=tool_result,
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+
+            from agentception.services import agent_loop as al
+
+            # Patch the imported names in agent_loop
+            with patch.object(al, "read_file", return_value=tool_result):
+                await al.run_agent_loop("test-run-1")
+
+        mock_complete.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_mcp_tool_dispatched_to_call_tool_async(self, tmp_path: Path) -> None:
+        """Non-local tool names are forwarded to call_tool_async."""
+        worktree = tmp_path / "test-run-1"
+        worktree.mkdir()
+        _write_task(worktree)
+
+        responses = [
+            _tool_response("log_run_step", {"issue_number": 42, "step_name": "Starting"}),
+            _stop_response("Done."),
+        ]
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop.call_openrouter_with_tools",
+                new_callable=AsyncMock,
+                side_effect=responses,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.call_tool_async",
+                new_callable=AsyncMock,
+                return_value=_mcp_ok_result("step recorded"),
+            ) as mock_mcp,
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+
+            from agentception.services.agent_loop import run_agent_loop
+
+            await run_agent_loop("test-run-1")
+
+        mock_mcp.assert_called_once_with("log_run_step", {"issue_number": 42, "step_name": "Starting"})
+
+    @pytest.mark.anyio
+    async def test_iteration_limit_cancels_run(self, tmp_path: Path) -> None:
+        """Exceeding max_iterations triggers log_run_error + build_cancel_run."""
+        worktree = tmp_path / "test-run-1"
+        worktree.mkdir()
+        _write_task(worktree)
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop.call_openrouter_with_tools",
+                new_callable=AsyncMock,
+                return_value=_tool_response("log_run_step", {"issue_number": 42, "step_name": "x"}),
+            ),
+            patch(
+                "agentception.services.agent_loop.build_cancel_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ) as mock_cancel,
+            patch(
+                "agentception.services.agent_loop.log_run_error",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ) as mock_error,
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.call_tool_async",
+                new_callable=AsyncMock,
+                return_value=_mcp_ok_result("step"),
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+
+            from agentception.services.agent_loop import run_agent_loop
+
+            await run_agent_loop("test-run-1", max_iterations=2)
+
+        mock_cancel.assert_called_once_with("test-run-1")
+        mock_error.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_missing_agent_task_cancels_run(self, tmp_path: Path) -> None:
+        """run_agent_loop cancels cleanly when .agent-task is missing."""
+        worktree = tmp_path / "no-task-run"
+        worktree.mkdir()
+        # No .agent-task written
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop.build_cancel_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ) as mock_cancel,
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+
+            from agentception.services.agent_loop import run_agent_loop
+
+            await run_agent_loop("no-task-run")
+
+        mock_cancel.assert_called_once_with("no-task-run")
+
+    @pytest.mark.anyio
+    async def test_llm_error_cancels_run(self, tmp_path: Path) -> None:
+        """LLM exception triggers log_run_error + build_cancel_run."""
+        worktree = tmp_path / "test-run-1"
+        worktree.mkdir()
+        _write_task(worktree)
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop.call_openrouter_with_tools",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("OpenRouter is down"),
+            ),
+            patch(
+                "agentception.services.agent_loop.build_cancel_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ) as mock_cancel,
+            patch(
+                "agentception.services.agent_loop.log_run_error",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ) as mock_error,
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+
+            from agentception.services.agent_loop import run_agent_loop
+
+            await run_agent_loop("test-run-1")
+
+        mock_cancel.assert_called_once_with("test-run-1")
+        mock_error.assert_called_once()
+        error_msg = str(mock_error.call_args)
+        assert "OpenRouter" in error_msg
+
+
+class TestBuildSystemPrompt:
+    def test_assembles_all_parts(self) -> None:
+        from agentception.services.agent_loop import _build_system_prompt
+
+        result = _build_system_prompt("Role content here.", "Think carefully.")
+        assert "Role content here." in result
+        assert "Think carefully." in result
+        assert "Docker container" in result
+
+    def test_empty_role_prompt(self) -> None:
+        from agentception.services.agent_loop import _build_system_prompt
+
+        result = _build_system_prompt("", "arch context")
+        assert "arch context" in result
+        assert "Docker container" in result
+
+    def test_empty_cognitive_arch(self) -> None:
+        from agentception.services.agent_loop import _build_system_prompt
+
+        result = _build_system_prompt("Role file.", "")
+        assert "Role file." in result
+        assert "Docker container" in result
+
+
+class TestBuildToolDefinitions:
+    def test_contains_local_tools(self) -> None:
+        from agentception.services.agent_loop import _build_tool_definitions
+
+        defs = _build_tool_definitions()
+        names = {d["function"]["name"] for d in defs}
+        assert "read_file" in names
+        assert "write_file" in names
+        assert "list_directory" in names
+        assert "search_text" in names
+        assert "run_command" in names
+
+    def test_contains_mcp_tools(self) -> None:
+        from agentception.services.agent_loop import _build_tool_definitions
+
+        defs = _build_tool_definitions()
+        names = {d["function"]["name"] for d in defs}
+        # MCP tools should be present
+        assert "build_complete_run" in names or "log_run_step" in names
+
+    def test_all_defs_have_required_fields(self) -> None:
+        from agentception.services.agent_loop import _build_tool_definitions
+
+        for td in _build_tool_definitions():
+            assert td["type"] == "function"
+            assert "name" in td["function"]
+            assert "description" in td["function"]
+            assert "parameters" in td["function"]
+
+
+class TestDispatchLocalTool:
+    @pytest.mark.anyio
+    async def test_read_file_dispatch(self, tmp_path: Path) -> None:
+        from agentception.services.agent_loop import _dispatch_local_tool
+
+        p = tmp_path / "hello.txt"
+        p.write_text("hi there")
+        result = await _dispatch_local_tool("read_file", {"path": "hello.txt"}, tmp_path)
+        assert result["ok"] is True
+        assert "hi there" in str(result["content"])
+
+    @pytest.mark.anyio
+    async def test_write_file_dispatch(self, tmp_path: Path) -> None:
+        from agentception.services.agent_loop import _dispatch_local_tool
+
+        result = await _dispatch_local_tool(
+            "write_file", {"path": "out.txt", "content": "written!"}, tmp_path
+        )
+        assert result["ok"] is True
+        assert (tmp_path / "out.txt").read_text() == "written!"
+
+    @pytest.mark.anyio
+    async def test_list_directory_dispatch(self, tmp_path: Path) -> None:
+        from agentception.services.agent_loop import _dispatch_local_tool
+
+        (tmp_path / "file.py").write_text("x")
+        result = await _dispatch_local_tool("list_directory", {"path": "."}, tmp_path)
+        assert result["ok"] is True
+        raw_entries = result["entries"]
+        assert isinstance(raw_entries, list)
+        assert "file.py" in raw_entries
+
+    @pytest.mark.anyio
+    async def test_run_command_dispatch(self, tmp_path: Path) -> None:
+        from agentception.services.agent_loop import _dispatch_local_tool
+
+        result = await _dispatch_local_tool(
+            "run_command", {"command": "echo dispatch_ok"}, tmp_path
+        )
+        assert result["ok"] is True
+        assert "dispatch_ok" in str(result["stdout"])
+
+    @pytest.mark.anyio
+    async def test_unknown_tool_returns_error(self, tmp_path: Path) -> None:
+        from agentception.services.agent_loop import _dispatch_local_tool
+
+        result = await _dispatch_local_tool("ghost_tool", {}, tmp_path)
+        assert result["ok"] is False
+        assert "unknown" in str(result["error"]).lower()
+
+    @pytest.mark.anyio
+    async def test_write_file_missing_path_returns_error(self, tmp_path: Path) -> None:
+        from agentception.services.agent_loop import _dispatch_local_tool
+
+        result = await _dispatch_local_tool("write_file", {"content": "x"}, tmp_path)
+        assert result["ok"] is False
+
+    @pytest.mark.anyio
+    async def test_run_command_missing_command_returns_error(self, tmp_path: Path) -> None:
+        from agentception.services.agent_loop import _dispatch_local_tool
+
+        result = await _dispatch_local_tool("run_command", {}, tmp_path)
+        assert result["ok"] is False
+
+
+class TestDispatchToolCalls:
+    @pytest.mark.anyio
+    async def test_invalid_json_returns_error_message(self, tmp_path: Path) -> None:
+        from agentception.services.agent_loop import _dispatch_single_tool
+
+        bad_tc = ToolCall(
+            id="call_bad",
+            type="function",
+            function=ToolCallFunction(name="read_file", arguments="not-valid-json"),
+        )
+        result = await _dispatch_single_tool(bad_tc, tmp_path, "run-1")
+        assert result["ok"] is False
+        assert "json" in str(result["error"]).lower()

--- a/agentception/tests/test_agent_run_api.py
+++ b/agentception/tests/test_agent_run_api.py
@@ -1,0 +1,190 @@
+"""Tests for POST /api/runs/{run_id}/execute.
+
+Covers:
+  - 202 Accepted when run is pending_launch (claims + schedules loop)
+  - 202 Accepted when run is implementing (skips claim, schedules loop)
+  - 404 when run_id is not found
+  - 409 when run is in a terminal/non-dispatchable status
+
+No real database or agent loop is invoked — all DB and service calls are mocked.
+
+Run targeted:
+    pytest agentception/tests/test_agent_run_api.py -v
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+from agentception.db.models import ACAgentRun
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def client() -> Generator[TestClient, None, None]:
+    with TestClient(app) as c:
+        yield c
+
+
+def _mock_session(run: ACAgentRun | None) -> MagicMock:
+    """Build a fake async session that returns *run* from scalar()."""
+    session = AsyncMock()
+    session.scalar = AsyncMock(return_value=run)
+
+    ctx: MagicMock = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+def _make_run(status: str, run_id: str = "run-42") -> ACAgentRun:
+    run = MagicMock(spec=ACAgentRun)
+    run.id = run_id
+    run.status = status
+    return run
+
+
+# ---------------------------------------------------------------------------
+# 202 — pending_launch
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteAgentRunPendingLaunch:
+    def test_returns_202_and_claims_run(self, client: TestClient) -> None:
+        run = _make_run("pending_launch")
+        session_ctx = _mock_session(run)
+
+        with (
+            patch("agentception.routes.api.agent_run.get_session", return_value=session_ctx),
+            patch(
+                "agentception.routes.api.agent_run.build_claim_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ) as mock_claim,
+            patch("agentception.routes.api.agent_run.run_agent_loop", new_callable=AsyncMock),
+        ):
+            resp = client.post("/api/runs/run-42/execute")
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["run_id"] == "run-42"
+        mock_claim.assert_called_once_with("run-42")
+
+    def test_body_contains_run_id(self, client: TestClient) -> None:
+        run = _make_run("pending_launch", "my-special-run")
+        session_ctx = _mock_session(run)
+
+        with (
+            patch("agentception.routes.api.agent_run.get_session", return_value=session_ctx),
+            patch(
+                "agentception.routes.api.agent_run.build_claim_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch("agentception.routes.api.agent_run.run_agent_loop", new_callable=AsyncMock),
+        ):
+            resp = client.post("/api/runs/my-special-run/execute")
+
+        assert resp.json()["run_id"] == "my-special-run"
+
+
+# ---------------------------------------------------------------------------
+# 202 — already implementing
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteAgentRunImplementing:
+    def test_returns_202_without_claiming(self, client: TestClient) -> None:
+        run = _make_run("implementing")
+        session_ctx = _mock_session(run)
+
+        with (
+            patch("agentception.routes.api.agent_run.get_session", return_value=session_ctx),
+            patch(
+                "agentception.routes.api.agent_run.build_claim_run",
+                new_callable=AsyncMock,
+            ) as mock_claim,
+            patch("agentception.routes.api.agent_run.run_agent_loop", new_callable=AsyncMock),
+        ):
+            resp = client.post("/api/runs/run-42/execute")
+
+        assert resp.status_code == 202
+        mock_claim.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 404 — run not found
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteAgentRunNotFound:
+    def test_returns_404(self, client: TestClient) -> None:
+        session_ctx = _mock_session(None)
+
+        with patch("agentception.routes.api.agent_run.get_session", return_value=session_ctx):
+            resp = client.post("/api/runs/ghost-run/execute")
+
+        assert resp.status_code == 404
+        assert "ghost-run" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# 409 — non-dispatchable status
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteAgentRunBadStatus:
+    @pytest.mark.parametrize("status", ["cancelled", "done", "reviewing", "blocked"])
+    def test_returns_409_for_terminal_status(self, client: TestClient, status: str) -> None:
+        run = _make_run(status)
+        session_ctx = _mock_session(run)
+
+        with patch("agentception.routes.api.agent_run.get_session", return_value=session_ctx):
+            resp = client.post("/api/runs/run-42/execute")
+
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert status in detail
+
+    def test_409_body_includes_current_status(self, client: TestClient) -> None:
+        run = _make_run("done")
+        session_ctx = _mock_session(run)
+
+        with patch("agentception.routes.api.agent_run.get_session", return_value=session_ctx):
+            resp = client.post("/api/runs/run-42/execute")
+
+        assert "done" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Claim failure — 409
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteAgentRunClaimFailure:
+    def test_returns_409_when_claim_fails(self, client: TestClient) -> None:
+        run = _make_run("pending_launch")
+        session_ctx = _mock_session(run)
+
+        with (
+            patch("agentception.routes.api.agent_run.get_session", return_value=session_ctx),
+            patch(
+                "agentception.routes.api.agent_run.build_claim_run",
+                new_callable=AsyncMock,
+                return_value={"ok": False, "error": "already claimed"},
+            ),
+        ):
+            resp = client.post("/api/runs/run-42/execute")
+
+        assert resp.status_code == 409
+        assert "already claimed" in resp.json()["detail"]

--- a/agentception/tests/test_file_tools.py
+++ b/agentception/tests/test_file_tools.py
@@ -1,0 +1,222 @@
+"""Unit tests for agentception.tools.file_tools.
+
+Tests run against a real temporary filesystem (``tmp_path`` from pytest).
+The ``search_text`` tests mock the ``rg`` subprocess since ripgrep is an
+optional system dependency that may not be installed in every environment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentception.tools.file_tools import list_directory, read_file, search_text, write_file
+
+
+# ---------------------------------------------------------------------------
+# read_file
+# ---------------------------------------------------------------------------
+
+
+class TestReadFile:
+    def test_reads_text_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "hello.txt"
+        p.write_text("hello world", encoding="utf-8")
+        result = read_file(p)
+        assert result["ok"] is True
+        assert result["content"] == "hello world"
+        assert result["truncated"] is False
+
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        p = tmp_path / "string_path.txt"
+        p.write_text("content", encoding="utf-8")
+        result = read_file(str(p))
+        assert result["ok"] is True
+        assert result["content"] == "content"
+
+    def test_missing_file_returns_error(self, tmp_path: Path) -> None:
+        result = read_file(tmp_path / "nonexistent.txt")
+        assert result["ok"] is False
+        assert "not found" in str(result["error"]).lower()
+
+    def test_truncates_large_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("agentception.tools.file_tools._MAX_READ_BYTES", 10)
+        p = tmp_path / "big.txt"
+        p.write_text("A" * 50, encoding="utf-8")
+        result = read_file(p)
+        assert result["ok"] is True
+        assert result["truncated"] is True
+        assert len(str(result["content"])) == 10
+
+    def test_reads_nested_path(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "c.txt"
+        nested.parent.mkdir(parents=True)
+        nested.write_text("nested", encoding="utf-8")
+        result = read_file(nested)
+        assert result["ok"] is True
+        assert result["content"] == "nested"
+
+
+# ---------------------------------------------------------------------------
+# write_file
+# ---------------------------------------------------------------------------
+
+
+class TestWriteFile:
+    def test_writes_new_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "out.txt"
+        result = write_file(p, "written content")
+        assert result["ok"] is True
+        assert result["bytes_written"] == len("written content".encode())
+        assert p.read_text() == "written content"
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        p = tmp_path / "deep" / "nested" / "file.txt"
+        result = write_file(p, "deep")
+        assert result["ok"] is True
+        assert p.read_text() == "deep"
+
+    def test_overwrites_existing_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "overwrite.txt"
+        p.write_text("original")
+        result = write_file(p, "replaced")
+        assert result["ok"] is True
+        assert p.read_text() == "replaced"
+
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        p = tmp_path / "str.txt"
+        result = write_file(str(p), "via string")
+        assert result["ok"] is True
+        assert p.read_text() == "via string"
+
+    def test_writes_empty_string(self, tmp_path: Path) -> None:
+        p = tmp_path / "empty.txt"
+        result = write_file(p, "")
+        assert result["ok"] is True
+        assert result["bytes_written"] == 0
+        assert p.read_text() == ""
+
+
+# ---------------------------------------------------------------------------
+# list_directory
+# ---------------------------------------------------------------------------
+
+
+class TestListDirectory:
+    def test_lists_files_and_dirs(self, tmp_path: Path) -> None:
+        (tmp_path / "file.txt").write_text("x")
+        (tmp_path / "subdir").mkdir()
+        result = list_directory(tmp_path)
+        assert result["ok"] is True
+        entries = result["entries"]
+        assert isinstance(entries, list)
+        assert "file.txt" in entries
+        assert "subdir/" in entries
+
+    def test_entries_are_sorted(self, tmp_path: Path) -> None:
+        (tmp_path / "z.txt").write_text("z")
+        (tmp_path / "a.txt").write_text("a")
+        (tmp_path / "m.txt").write_text("m")
+        result = list_directory(tmp_path)
+        assert result["ok"] is True
+        raw_entries = result["entries"]
+        assert isinstance(raw_entries, list)
+        entries: list[str] = [str(e) for e in raw_entries]
+        assert entries == sorted(entries)
+
+    def test_directories_suffixed_with_slash(self, tmp_path: Path) -> None:
+        (tmp_path / "mydir").mkdir()
+        result = list_directory(tmp_path)
+        assert result["ok"] is True
+        raw_entries = result["entries"]
+        assert isinstance(raw_entries, list)
+        assert "mydir/" in raw_entries
+
+    def test_not_a_directory_returns_error(self, tmp_path: Path) -> None:
+        p = tmp_path / "file.txt"
+        p.write_text("x")
+        result = list_directory(p)
+        assert result["ok"] is False
+        assert "not a directory" in str(result["error"]).lower()
+
+    def test_missing_directory_returns_error(self, tmp_path: Path) -> None:
+        result = list_directory(tmp_path / "absent")
+        assert result["ok"] is False
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        d = tmp_path / "empty"
+        d.mkdir()
+        result = list_directory(d)
+        assert result["ok"] is True
+        assert result["entries"] == []
+
+
+# ---------------------------------------------------------------------------
+# search_text (async — mocked rg subprocess since rg may not be installed)
+# ---------------------------------------------------------------------------
+
+
+def _make_proc(stdout: bytes, stderr: bytes, returncode: int) -> MagicMock:
+    """Build a fake asyncio subprocess process."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    return proc
+
+
+class TestSearchText:
+    @pytest.mark.anyio
+    async def test_finds_matching_line(self, tmp_path: Path) -> None:
+        (tmp_path / "code.py").write_text("def foo():\n    return 42\n")
+        rg_output = b"code.py\n1:def foo():\n"
+        proc = _make_proc(rg_output, b"", 0)
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc):
+            result = await search_text("def foo", tmp_path)
+        assert result["ok"] is True
+        assert "foo" in str(result["matches"])
+
+    @pytest.mark.anyio
+    async def test_no_matches_returns_placeholder(self, tmp_path: Path) -> None:
+        (tmp_path / "file.txt").write_text("hello world\n")
+        proc = _make_proc(b"", b"", 1)  # rg exits 1 when no matches
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc):
+            result = await search_text("xyzzy_not_here", tmp_path)
+        assert result["ok"] is True
+        assert "(no matches)" in str(result["matches"])
+
+    @pytest.mark.anyio
+    async def test_nonexistent_directory_returns_error(self, tmp_path: Path) -> None:
+        result = await search_text("pattern", tmp_path / "ghost")
+        assert result["ok"] is False
+        assert "does not exist" in str(result["error"]).lower()
+
+    @pytest.mark.anyio
+    async def test_finds_across_multiple_files(self, tmp_path: Path) -> None:
+        (tmp_path / "a.txt").write_text("needle here\n")
+        (tmp_path / "b.txt").write_text("nothing\n")
+        (tmp_path / "c.txt").write_text("another needle\n")
+        rg_output = b"a.txt\n1:needle here\n\nc.txt\n1:another needle\n"
+        proc = _make_proc(rg_output, b"", 0)
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc):
+            result = await search_text("needle", tmp_path)
+        assert result["ok"] is True
+        assert "needle" in str(result["matches"])
+
+    @pytest.mark.anyio
+    async def test_rg_not_found_returns_error(self, tmp_path: Path) -> None:
+        (tmp_path / "file.txt").write_text("content")
+        with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError("rg")):
+            result = await search_text("pattern", tmp_path)
+        assert result["ok"] is False
+        assert "not found" in str(result["error"]).lower()
+
+    @pytest.mark.anyio
+    async def test_rg_error_exit_returns_error(self, tmp_path: Path) -> None:
+        (tmp_path / "file.txt").write_text("content")
+        proc = _make_proc(b"", b"some error", 2)
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc):
+            result = await search_text("pattern", tmp_path)
+        assert result["ok"] is False

--- a/agentception/tests/test_shell_tools.py
+++ b/agentception/tests/test_shell_tools.py
@@ -1,0 +1,171 @@
+"""Unit tests for agentception.tools.shell_tools.
+
+Covers the denylist, timeout handling, stdout/stderr capture, and exit code
+reporting.  Most tests run real subprocesses; the timeout test mocks the
+subprocess to avoid asyncio pipe-transport cleanup issues in the test runner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentception.tools.shell_tools import _is_safe, run_command
+
+
+# ---------------------------------------------------------------------------
+# _is_safe (synchronous helper — no subprocess needed)
+# ---------------------------------------------------------------------------
+
+
+class TestIsSafe:
+    def test_normal_git_command_is_safe(self) -> None:
+        safe, _ = _is_safe("git status")
+        assert safe is True
+
+    def test_python_command_is_safe(self) -> None:
+        safe, _ = _is_safe("python3 -m pytest agentception/tests/")
+        assert safe is True
+
+    def test_rm_rf_root_is_blocked(self) -> None:
+        safe, reason = _is_safe("rm -rf /")
+        assert safe is False
+        assert reason
+
+    def test_rm_rf_home_is_blocked(self) -> None:
+        safe, reason = _is_safe("rm -rf ~")
+        assert safe is False
+        assert reason
+
+    def test_sudo_is_blocked(self) -> None:
+        safe, reason = _is_safe("sudo rm something")
+        assert safe is False
+        assert reason
+
+    def test_shutdown_is_blocked(self) -> None:
+        safe, reason = _is_safe("shutdown now")
+        assert safe is False
+        assert reason
+
+    def test_reboot_is_blocked(self) -> None:
+        safe, reason = _is_safe("reboot")
+        assert safe is False
+        assert reason
+
+    def test_fork_bomb_is_blocked(self) -> None:
+        safe, reason = _is_safe(":(){ :|:& };: ")
+        assert safe is False
+        assert reason
+
+    def test_case_insensitive_matching(self) -> None:
+        safe, reason = _is_safe("SUDO something")
+        assert safe is False
+        assert reason
+
+    def test_mkfs_is_blocked(self) -> None:
+        safe, reason = _is_safe("mkfs.ext4 /dev/sda1")
+        assert safe is False
+        assert reason
+
+    def test_rg_command_is_safe(self) -> None:
+        safe, _ = _is_safe("rg --heading pattern agentception/")
+        assert safe is True
+
+    def test_npm_command_is_safe(self) -> None:
+        safe, _ = _is_safe("npm run build")
+        assert safe is True
+
+
+# ---------------------------------------------------------------------------
+# run_command (async — real subprocesses)
+# ---------------------------------------------------------------------------
+
+
+class TestRunCommand:
+    @pytest.mark.anyio
+    async def test_echo_returns_stdout(self, tmp_path: Path) -> None:
+        result = await run_command("echo hello_world", tmp_path)
+        assert result["ok"] is True
+        assert "hello_world" in str(result["stdout"])
+        assert result["exit_code"] == 0
+
+    @pytest.mark.anyio
+    async def test_exit_code_captured(self, tmp_path: Path) -> None:
+        result = await run_command("false", tmp_path)
+        assert result["ok"] is True
+        assert result["exit_code"] != 0
+
+    @pytest.mark.anyio
+    async def test_stderr_captured(self, tmp_path: Path) -> None:
+        result = await run_command("echo err >&2", tmp_path)
+        assert result["ok"] is True
+        assert "err" in str(result["stderr"])
+
+    @pytest.mark.anyio
+    async def test_blocked_command_returns_error(self, tmp_path: Path) -> None:
+        result = await run_command("rm -rf /", tmp_path)
+        assert result["ok"] is False
+        assert "blocked" in str(result["error"]).lower()
+
+    @pytest.mark.anyio
+    async def test_cwd_defaults_to_none(self) -> None:
+        result = await run_command("echo cwd_test")
+        assert result["ok"] is True
+        assert "cwd_test" in str(result["stdout"])
+
+    @pytest.mark.anyio
+    async def test_cwd_sets_working_directory(self, tmp_path: Path) -> None:
+        result = await run_command("pwd", tmp_path)
+        assert result["ok"] is True
+        assert str(tmp_path) in str(result["stdout"])
+
+    @pytest.mark.anyio
+    async def test_timeout_kills_command_returns_error(self, tmp_path: Path) -> None:
+        """run_command returns an error dict when the subprocess times out.
+
+        The subprocess is mocked to avoid asyncio pipe-transport cleanup
+        issues: real subprocesses leave asyncio pipe readers registered in
+        the event loop after wait_for cancels communicate(), which causes the
+        event loop selector to block.  Mocking isolates the timeout-path logic
+        without touching asyncio internals.
+        """
+        async def _slow_communicate() -> tuple[bytes, bytes]:
+            await asyncio.sleep(9999)
+            return b"", b""
+
+        proc_mock = MagicMock()
+        proc_mock.returncode = -9
+        proc_mock.kill = MagicMock()
+        proc_mock.wait = AsyncMock(return_value=None)
+        proc_mock.communicate = _slow_communicate
+
+        with patch("asyncio.create_subprocess_shell", new_callable=AsyncMock, return_value=proc_mock):
+            result = await run_command("sleep 9999", tmp_path, timeout=1)
+
+        assert result["ok"] is False
+        assert "timed out" in str(result["error"]).lower()
+        proc_mock.kill.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_truncates_large_stdout(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("agentception.tools.shell_tools._MAX_OUTPUT_BYTES", 10)
+        # Use python3 to generate deterministic large output (avoids bash-specific syntax)
+        result = await run_command("python3 -c \"print('A' * 200)\"", tmp_path)
+        assert result["ok"] is True
+        assert result["stdout_truncated"] is True
+        assert len(str(result["stdout"])) <= 10
+
+    @pytest.mark.anyio
+    async def test_compound_command_via_shell(self, tmp_path: Path) -> None:
+        result = await run_command("echo first && echo second", tmp_path)
+        assert result["ok"] is True
+        assert "first" in str(result["stdout"])
+        assert "second" in str(result["stdout"])
+
+    @pytest.mark.anyio
+    async def test_string_cwd(self, tmp_path: Path) -> None:
+        result = await run_command("echo ok", str(tmp_path))
+        assert result["ok"] is True

--- a/agentception/tools/__init__.py
+++ b/agentception/tools/__init__.py
@@ -1,0 +1,11 @@
+"""Local tool implementations for the Cursor-free agent loop.
+
+Provides file-system and shell-execution primitives that the agent loop
+dispatches when the model requests a ``read_file``, ``write_file``,
+``list_directory``, ``search_text``, or ``run_command`` tool call.
+
+All functions return a plain ``dict[str, object]`` so they can be
+JSON-serialised directly into the tool-result message fed back to the model.
+"""
+
+from __future__ import annotations

--- a/agentception/tools/definitions.py
+++ b/agentception/tools/definitions.py
@@ -1,0 +1,153 @@
+"""OpenAI-format tool definitions for the local file and shell tools.
+
+These are imported by ``agent_loop.py`` and merged with the MCP tool
+catalogue before being sent to the model on every iteration.
+
+Schemas follow JSON Schema draft-07 (the subset OpenAI / Anthropic accept).
+"""
+
+from __future__ import annotations
+
+from agentception.services.llm import ToolDefinition, ToolFunction
+
+FILE_TOOL_DEFS: list[ToolDefinition] = [
+    ToolDefinition(
+        type="function",
+        function=ToolFunction(
+            name="read_file",
+            description=(
+                "Read the text content of a file. "
+                "Relative paths are resolved from the worktree root. "
+                "Returns the file content (truncated at 128 KiB if very large)."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the file to read (relative or absolute).",
+                    }
+                },
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+        ),
+    ),
+    ToolDefinition(
+        type="function",
+        function=ToolFunction(
+            name="write_file",
+            description=(
+                "Write text content to a file, creating parent directories as needed. "
+                "Overwrites existing content. "
+                "Relative paths are resolved from the worktree root."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Destination path (relative or absolute).",
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Text content to write (UTF-8).",
+                    },
+                },
+                "required": ["path", "content"],
+                "additionalProperties": False,
+            },
+        ),
+    ),
+    ToolDefinition(
+        type="function",
+        function=ToolFunction(
+            name="list_directory",
+            description=(
+                "List entries in a directory. "
+                "Directories are suffixed with '/'. "
+                "Relative paths are resolved from the worktree root."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Directory to list (default '.' = worktree root).",
+                        "default": ".",
+                    }
+                },
+                "required": [],
+                "additionalProperties": False,
+            },
+        ),
+    ),
+    ToolDefinition(
+        type="function",
+        function=ToolFunction(
+            name="search_text",
+            description=(
+                "Search for a regex or literal pattern in files using ripgrep. "
+                "Returns matching lines with file names and line numbers. "
+                "Respects .gitignore. "
+                "Relative paths are resolved from the worktree root."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "pattern": {
+                        "type": "string",
+                        "description": "Regex or literal pattern to search for.",
+                    },
+                    "directory": {
+                        "type": "string",
+                        "description": "Directory to search (default '.' = worktree root).",
+                        "default": ".",
+                    },
+                    "n_results": {
+                        "type": "integer",
+                        "description": "Max matching lines to return (default 30).",
+                        "default": 30,
+                        "minimum": 1,
+                        "maximum": 200,
+                    },
+                },
+                "required": ["pattern"],
+                "additionalProperties": False,
+            },
+        ),
+    ),
+]
+
+SHELL_TOOL_DEF: ToolDefinition = ToolDefinition(
+    type="function",
+    function=ToolFunction(
+        name="run_command",
+        description=(
+            "Run a shell command and return stdout, stderr, and exit code. "
+            "ENVIRONMENT: you are inside the AgentCeption Docker container, "
+            "so run Python tools directly (python3, pytest, mypy) without "
+            "'docker compose exec agentception'. "
+            "The default working directory is the worktree root. "
+            "Dangerous operations (rm -rf /, sudo, shutdown, …) are blocked."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "Shell command to execute (passed to /bin/sh -c).",
+                },
+                "cwd": {
+                    "type": "string",
+                    "description": (
+                        "Working directory override. "
+                        "Defaults to the worktree root when omitted."
+                    ),
+                },
+            },
+            "required": ["command"],
+            "additionalProperties": False,
+        },
+    ),
+)

--- a/agentception/tools/file_tools.py
+++ b/agentception/tools/file_tools.py
@@ -1,0 +1,161 @@
+"""File-system tools exposed to the agent loop.
+
+Each public function returns ``{"ok": True, ...}`` on success and
+``{"ok": False, "error": "<message>"}`` on failure so the model always
+receives structured feedback rather than a Python exception traceback.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Maximum bytes read from a single file before truncation.
+_MAX_READ_BYTES = 131_072  # 128 KiB
+
+
+def read_file(path: str | Path) -> dict[str, object]:
+    """Return the text content of *path*.
+
+    Args:
+        path: File to read.  Relative paths are resolved from the caller's cwd.
+
+    Returns:
+        ``{"ok": True, "content": str, "truncated": bool}`` on success, or
+        ``{"ok": False, "error": str}`` when the file cannot be read.
+    """
+    p = Path(path)
+    try:
+        raw = p.read_bytes()
+    except FileNotFoundError:
+        logger.warning("⚠️ read_file — not found: %s", p)
+        return {"ok": False, "error": f"File not found: {p}"}
+    except PermissionError:
+        logger.warning("⚠️ read_file — permission denied: %s", p)
+        return {"ok": False, "error": f"Permission denied: {p}"}
+    except OSError as exc:
+        logger.warning("⚠️ read_file — OS error: %s", exc)
+        return {"ok": False, "error": str(exc)}
+
+    truncated = len(raw) > _MAX_READ_BYTES
+    if truncated:
+        raw = raw[:_MAX_READ_BYTES]
+    try:
+        text = raw.decode("utf-8", errors="replace")
+    except Exception as exc:
+        return {"ok": False, "error": f"Decode error: {exc}"}
+
+    return {"ok": True, "content": text, "truncated": truncated}
+
+
+def write_file(path: str | Path, content: str) -> dict[str, object]:
+    """Write *content* to *path*, creating parent directories as needed.
+
+    Args:
+        path: Destination path.
+        content: Text to write (UTF-8).
+
+    Returns:
+        ``{"ok": True, "bytes_written": int}`` on success, or
+        ``{"ok": False, "error": str}`` on failure.
+    """
+    p = Path(path)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    except PermissionError:
+        logger.warning("⚠️ write_file — permission denied: %s", p)
+        return {"ok": False, "error": f"Permission denied: {p}"}
+    except OSError as exc:
+        logger.warning("⚠️ write_file — OS error: %s", exc)
+        return {"ok": False, "error": str(exc)}
+
+    bytes_written = len(content.encode("utf-8"))
+    logger.info("✅ write_file — %s (%d bytes)", p, bytes_written)
+    return {"ok": True, "bytes_written": bytes_written}
+
+
+def list_directory(path: str | Path) -> dict[str, object]:
+    """Return a sorted list of entries in *path*.
+
+    Args:
+        path: Directory to list.
+
+    Returns:
+        ``{"ok": True, "entries": list[str]}`` — each entry is a relative
+        name, with a trailing ``/`` for directories.  Returns an error dict
+        when the path is not a directory or cannot be accessed.
+    """
+    p = Path(path)
+    try:
+        if not p.is_dir():
+            return {"ok": False, "error": f"Not a directory: {p}"}
+        entries = sorted(
+            (f"{child.name}/" if child.is_dir() else child.name)
+            for child in p.iterdir()
+        )
+    except PermissionError:
+        logger.warning("⚠️ list_directory — permission denied: %s", p)
+        return {"ok": False, "error": f"Permission denied: {p}"}
+    except OSError as exc:
+        logger.warning("⚠️ list_directory — OS error: %s", exc)
+        return {"ok": False, "error": str(exc)}
+
+    return {"ok": True, "entries": entries}
+
+
+async def search_text(
+    pattern: str,
+    directory: str | Path,
+    *,
+    n_results: int = 30,
+) -> dict[str, object]:
+    """Search *directory* for lines matching *pattern* using ripgrep.
+
+    Uses ``rg`` (ripgrep) for fast, .gitignore-aware searching.  Falls back
+    to an error result when ``rg`` is not on ``PATH``.
+
+    Args:
+        pattern: Regex or literal pattern forwarded verbatim to ``rg``.
+        directory: Root directory to search.
+        n_results: Maximum number of matching lines to return.
+
+    Returns:
+        ``{"ok": True, "matches": str}`` — rg output (at most *n_results*
+        lines) — or ``{"ok": False, "error": str}`` on failure.
+    """
+    import asyncio
+
+    d = Path(directory)
+    if not d.exists():
+        return {"ok": False, "error": f"Directory does not exist: {d}"}
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "rg",
+            "--heading",
+            "--line-number",
+            "--max-count",
+            str(n_results),
+            pattern,
+            str(d),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30.0)
+    except FileNotFoundError:
+        return {"ok": False, "error": "rg (ripgrep) not found on PATH"}
+    except asyncio.TimeoutError:
+        return {"ok": False, "error": "search_text timed out after 30s"}
+    except OSError as exc:
+        return {"ok": False, "error": str(exc)}
+
+    output = stdout.decode("utf-8", errors="replace")
+    # rg exits 1 when no matches found — that is not an error for us.
+    if proc.returncode not in (0, 1):
+        err_text = stderr.decode("utf-8", errors="replace").strip()
+        return {"ok": False, "error": f"rg failed (exit {proc.returncode}): {err_text}"}
+
+    return {"ok": True, "matches": output or "(no matches)"}

--- a/agentception/tools/shell_tools.py
+++ b/agentception/tools/shell_tools.py
@@ -1,0 +1,142 @@
+"""Shell-execution tool exposed to the agent loop.
+
+``run_command`` runs a shell command inside the AgentCeption container and
+returns its stdout, stderr, and exit code as a structured dict.
+
+Safety is enforced via a denylist of obviously destructive patterns rather
+than an allowlist — the model needs broad access (git, pytest, mypy, rg, gh,
+docker, npm, python3, …) so an allowlist would be too brittle.  Catastrophic
+accidents (``rm -rf /``, fork bombs, privilege escalation) are blocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Maximum captured output per stream to prevent memory exhaustion.
+_MAX_OUTPUT_BYTES = 32_768  # 32 KiB
+
+# Command timeout — generous for slow operations (full pytest suite, npm builds).
+_DEFAULT_TIMEOUT = 300  # 5 minutes
+
+# Substrings that make a command unconditionally dangerous, checked on the
+# lowercase stripped command string.  Exact-match substring search is
+# intentionally conservative to avoid false positives.
+_BLOCKED_PATTERNS: frozenset[str] = frozenset(
+    {
+        "rm -rf /",
+        "rm -rf ~",
+        "rm -rf $home",
+        ":(){ :|:& };:",  # fork bomb
+        "sudo ",
+        "sudo\t",
+        "shutdown",
+        "reboot",
+        "halt",
+        "poweroff",
+        "mkfs",
+        "wipefs",
+        "> /dev/sd",
+        "dd if=",
+        "chmod -r /",
+        "chown -r /",
+    }
+)
+
+
+def _is_safe(command: str) -> tuple[bool, str]:
+    """Return *(safe, reason)*.  ``safe`` is ``False`` when the command matches
+    a blocked pattern.
+    """
+    lower = command.lower().strip()
+    for pattern in _BLOCKED_PATTERNS:
+        if pattern in lower:
+            return False, f"Blocked pattern detected: {pattern!r}"
+    return True, ""
+
+
+async def run_command(
+    command: str,
+    cwd: str | Path | None = None,
+    *,
+    timeout: int = _DEFAULT_TIMEOUT,
+) -> dict[str, object]:
+    """Execute *command* in a subprocess and return structured output.
+
+    The command is run via the system shell (``/bin/sh -c``), which allows
+    pipes, redirections, and compound expressions.  stdout and stderr are
+    captured and truncated to 32 KiB each to avoid blowing the model's
+    context window.
+
+    Args:
+        command: Shell command string to execute.
+        cwd: Working directory.  Defaults to the current process directory.
+        timeout: Maximum seconds to wait before killing the process.
+
+    Returns:
+        ``{"ok": True, "stdout": str, "stderr": str, "exit_code": int,
+        "stdout_truncated": bool, "stderr_truncated": bool}`` on success, or
+        ``{"ok": False, "error": str}`` when the command is blocked, timed
+        out, or fails to launch.
+    """
+    safe, reason = _is_safe(command)
+    if not safe:
+        logger.warning("⚠️ run_command blocked — %s", reason)
+        return {"ok": False, "error": reason}
+
+    cwd_path = Path(cwd) if cwd else None
+    logger.info("✅ run_command — %s (cwd=%s)", shlex.quote(command), cwd_path)
+
+    try:
+        proc = await asyncio.create_subprocess_shell(
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=cwd_path,
+        )
+        try:
+            raw_out, raw_err = await asyncio.wait_for(
+                proc.communicate(), timeout=float(timeout)
+            )
+        except asyncio.TimeoutError:
+            # Kill the process then wait for it to exit.
+            # Avoid calling communicate() again — the cancelled coroutine may
+            # leave asyncio pipe transports in an inconsistent state.  proc.wait()
+            # waits only for the exit code (via SIGCHLD), not via pipe reads.
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            await proc.wait()
+            logger.warning("⚠️ run_command timed out after %ds: %s", timeout, command)
+            return {"ok": False, "error": f"Command timed out after {timeout}s: {command!r}"}
+    except FileNotFoundError as exc:
+        return {"ok": False, "error": f"Command not found: {exc}"}
+    except OSError as exc:
+        return {"ok": False, "error": str(exc)}
+
+    out_truncated = len(raw_out) > _MAX_OUTPUT_BYTES
+    err_truncated = len(raw_err) > _MAX_OUTPUT_BYTES
+    stdout = raw_out[:_MAX_OUTPUT_BYTES].decode("utf-8", errors="replace")
+    stderr = raw_err[:_MAX_OUTPUT_BYTES].decode("utf-8", errors="replace")
+    exit_code: int = proc.returncode if proc.returncode is not None else -1
+
+    logger.info(
+        "✅ run_command done — exit=%d stdout=%d stderr=%d",
+        exit_code,
+        len(stdout),
+        len(stderr),
+    )
+    return {
+        "ok": True,
+        "stdout": stdout,
+        "stderr": stderr,
+        "exit_code": exit_code,
+        "stdout_truncated": out_truncated,
+        "stderr_truncated": err_truncated,
+    }


### PR DESCRIPTION
## Summary

- Adds `call_openrouter_with_tools()` to `llm.py` for multi-turn tool-use conversations with full `ToolDefinition` / `ToolCall` / `ToolResponse` TypedDict types
- Introduces `agentception/tools/` package with `file_tools` (read/write/list/search), `shell_tools` (run_command with denylist safety), and their OpenAI-format schema definitions
- Implements `agentception/services/agent_loop.py` — the core Cursor-free runtime: loads `.agent-task`, assembles system prompt from role file + cognitive arch, merges local + MCP tool catalogues, runs multi-turn conversation loop, dispatches tool calls, handles completion/cancellation
- Adds `POST /api/runs/{run_id}/execute` route that claims a run and fires the loop as a `BackgroundTask` (202 Accepted)

## Test plan

- [ ] `docker compose exec agentception mypy agentception/ tests/` → 0 errors
- [ ] `docker compose exec agentception python3 tools/typing_audit.py --dirs agentception/ tests/ --max-any 0` → passes
- [ ] `docker compose exec agentception pytest agentception/tests/ -v` → 1596 passed, 0 failed
- [ ] `docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py --check` → no drift
