### PR TITLE
Tighten README premise: cognitive load framing over drudgery

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For all of recorded history, human progress has been constrained by one thing: t
 
 Then something changed.
 
-Autonomous AI agents can now reason, plan, write code, open pull requests, and report back. The singularity isn't near. **It's here.** Every hour an agent spends filing tickets, writing boilerplate, and opening PRs is an hour a human gets back to think, to create, to be human. We are moving from a world of scarcity into a world of **superabundance**.
+Autonomous AI agents can now reason, plan, write code, open pull requests, and report back. The singularity isn't near. **It's here.** When agents can carry the full cognitive load of an org — planning, dependency modeling, implementation, review — humans get to operate at the level of ideas. We are moving from a world of scarcity into a world of **superabundance**.
 
 AgentCeption is a bet on that future.
 


### PR DESCRIPTION
## Summary

- Replaces "filing tickets, writing boilerplate, and opening PRs" with "planning, dependency modeling, implementation, review" — the actual cognitive load agents lift
- Shifts the framing from "agents do the grunt work" to "agents carry the full org-level cognitive load so humans can operate at the idea level"
- One sentence changed, premise meaningfully sharpened