### PR TITLE
feat: expose full cognitive architecture corpus via MCP resources

### DIFF
--- a/.agentception/roles/ceo.md
+++ b/.agentception/roles/ceo.md
@@ -105,22 +105,50 @@ file. Load it as the very first thing you do, before any tool call or analysis.
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 
@@ -335,22 +363,50 @@ Load them as the very first thing you do.
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 ```
@@ -564,22 +620,50 @@ the Engineering Coordinator via Task(), use this verbatim as Part 2 of the Task 
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 You are an Engineering Coordinator. You receive a scoped task, decompose it into
@@ -729,22 +813,50 @@ Load it as the very first thing you do — see STEP 0 below.
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 

--- a/.agentception/roles/coordinator.md
+++ b/.agentception/roles/coordinator.md
@@ -11,22 +11,50 @@ Load it as the very first thing you do — see STEP 0 below.
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -50,22 +50,50 @@ Load them as the very first thing you do.
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 ```
@@ -279,22 +307,50 @@ the Engineering Coordinator via Task(), use this verbatim as Part 2 of the Task 
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 You are an Engineering Coordinator. You receive a scoped task, decompose it into
@@ -444,22 +500,50 @@ Load it as the very first thing you do — see STEP 0 below.
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 

--- a/.agentception/roles/database-architect.md
+++ b/.agentception/roles/database-architect.md
@@ -11,22 +11,50 @@ Load it as the very first thing you do — see STEP 0 below.
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 ## Core Contract

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -6,22 +6,50 @@
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 You are an Engineering Coordinator. You receive a scoped task, decompose it into

--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -10,22 +10,50 @@ You do not negotiate on type safety. You do not ship dirty mypy. You fix C-grade
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 ## Core Contract

--- a/.agentception/roles/python-developer.md
+++ b/.agentception/roles/python-developer.md
@@ -10,22 +10,50 @@ Your cognitive architecture and full task context were delivered in your initial
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 ## Core Contract

--- a/.agentception/roles/qa-coordinator.md
+++ b/.agentception/roles/qa-coordinator.md
@@ -15,22 +15,50 @@ Load it as the very first thing you do — see STEP 0 below.
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.
 
 
 

--- a/agentception/mcp/prompts.py
+++ b/agentception/mcp/prompts.py
@@ -238,6 +238,23 @@ async def _get_task_briefing(arguments: dict[str, str]) -> ACPromptResult | None
     )
 
 
+def _parse_arch_components(cognitive_arch: str) -> tuple[list[str], list[str]]:
+    """Parse a ``cognitive_arch`` string into figure IDs and skill IDs.
+
+    Format: ``figure1[,figure2]:skill1:skill2:...``
+    Examples:
+        ``"guido_van_rossum:python"``         → (["guido_van_rossum"], ["python"])
+        ``"linus_torvalds"``                   → (["linus_torvalds"], [])
+        ``"lovelace,shannon:htmx:jinja2"``    → (["lovelace", "shannon"], ["htmx", "jinja2"])
+    """
+    if not cognitive_arch or cognitive_arch == "not set":
+        return [], []
+    tokens = cognitive_arch.strip().split(":")
+    figures = [f.strip() for f in tokens[0].split(",") if f.strip()]
+    skills = [s.strip() for s in tokens[1:] if s.strip()]
+    return figures, skills
+
+
 def _render_task_briefing(ctx: RunContextRow, role_content: str) -> str:
     """Compose the Markdown briefing from task context and role definition."""
     run_id: str = ctx["run_id"]
@@ -249,6 +266,9 @@ def _render_task_briefing(ctx: RunContextRow, role_content: str) -> str:
     task_description: str | None = ctx["task_description"]
     batch_id: str | None = ctx["batch_id"]
     parent_run_id: str | None = ctx["parent_run_id"]
+
+    # Parse cognitive architecture into components for direct MCP resource links.
+    figure_ids, skill_ids = _parse_arch_components(cognitive_arch)
 
     # Build the assignment section — differs between ad-hoc and issue runs.
     if task_description:
@@ -276,7 +296,7 @@ def _render_task_briefing(ctx: RunContextRow, role_content: str) -> str:
         f"## Task Briefing — run `{run_id}`",
         "",
         f"**Role:** {role}  ",
-        f"**Cognitive Architecture:** {cognitive_arch}  ",
+        f"**Cognitive Architecture:** `{cognitive_arch}`  ",
         f"**Worktree:** `{worktree_path}`  ",
         f"**Branch:** `{branch}`",
     ]
@@ -295,11 +315,42 @@ def _render_task_briefing(ctx: RunContextRow, role_content: str) -> str:
         "",
         "---",
         "",
-        "## Available MCP Resources",
+        "## Your Cognitive Identity (MCP Resources)",
+        "",
+        "Read these resources to fully internalize who you are before starting work.",
+        "Your reasoning style, heuristics, failure modes, and skill affinities all",
+        "live here — they are not summaries, they are the source of truth.",
+        "",
+    ]
+
+    # Figure resources — the human whose reasoning style shapes this agent.
+    if figure_ids:
+        for fig in figure_ids:
+            parts.append(f"- `ac://arch/figures/{fig}` — your cognitive figure: full profile, heuristics, failure modes")
+    else:
+        parts.append("- `ac://arch/figures` — browse all available cognitive figures")
+
+    # Skill domain resources — technical expertise areas.
+    if skill_ids:
+        for skill in skill_ids:
+            parts.append(f"- `ac://arch/skills/{skill}` — your skill domain: {skill}")
+    else:
+        parts.append("- `ac://arch/skills/<id>` — fetch any skill domain profile")
+
+    parts += [
+        "- `ac://arch/archetypes` — browse archetypes (your figure's `extends` field names one)",
+        "- `ac://arch/atoms/<atom_id>` — individual reasoning dimension definitions",
+        "  (e.g. `ac://arch/atoms/epistemic_style`, `ac://arch/atoms/quality_bar`)",
+        "",
+        "---",
+        "",
+        "## Available Run Resources",
         "",
         f"- `ac://runs/{run_id}/context` — your full task context from the DB",
         f"- `ac://runs/{run_id}/events` — prior activity log (resume after crash)",
         f"- `ac://runs/{run_id}/children` — child runs you have spawned",
+        "- `ac://roles/list` — all available role slugs",
+        f"- `ac://roles/{role}` — your role definition (also appended below)",
         "- `ac://system/config` — pipeline label names",
         "",
         "---",

--- a/agentception/mcp/resources.py
+++ b/agentception/mcp/resources.py
@@ -38,6 +38,8 @@ import logging
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
+import yaml
+
 from agentception.config import settings
 from agentception.mcp.plan_tools import (
     plan_get_cognitive_figures,
@@ -71,6 +73,15 @@ _MIME = "application/json"
 # (/app is the repo root) and during local development.
 _APP_ROOT = Path(__file__).parent.parent.parent
 _AGENTCEPTION_DIR = _APP_ROOT / ".agentception"
+
+# Cognitive architecture corpus root.
+_ARCH_ROOT = _APP_ROOT / "scripts" / "gen_prompts" / "cognitive_archetypes"
+_ARCH_SUBDIRS: dict[str, str] = {
+    "figures": "figures",
+    "archetypes": "archetypes",
+    "skills": "skill_domains",
+    "atoms": "atoms",
+}
 
 # ---------------------------------------------------------------------------
 # Static resource catalogue
@@ -151,8 +162,28 @@ RESOURCES: list[ACResourceDef] = [
         description=(
             "All role slugs defined in the team taxonomy. "
             "Returns {roles: [str, ...]} sorted alphabetically. "
-            "Use a slug from this list when calling build_spawn_child_run or "
+            "Use a slug from this list when calling build_spawn_adhoc_child or "
             "reading ac://roles/{slug}."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceDef(
+        uri="ac://arch/figures",
+        name="Cognitive figure index",
+        description=(
+            "Index of all cognitive figures in the corpus. "
+            "Returns {figures: [{id, display_name, description}]} sorted by id. "
+            "Use an id to fetch the full profile at ac://arch/figures/{figure_id}."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceDef(
+        uri="ac://arch/archetypes",
+        name="Cognitive archetype index",
+        description=(
+            "Index of all cognitive archetypes in the corpus. "
+            "Returns {archetypes: [{id, display_name, description}]}. "
+            "Use an id to fetch the full profile at ac://arch/archetypes/{archetype_id}."
         ),
         mimeType=_MIME,
     ),
@@ -249,11 +280,123 @@ RESOURCE_TEMPLATES: list[ACResourceTemplate] = [
         ),
         mimeType=_MIME,
     ),
+    ACResourceTemplate(
+        uriTemplate="ac://arch/figures/{figure_id}",
+        name="Cognitive figure profile",
+        description=(
+            "Full cognitive profile of a named figure — the human being whose "
+            "reasoning style, heuristics, failure modes, and skill affinities "
+            "shape this agent's identity. "
+            "Returns the parsed YAML as structured JSON: id, display_name, "
+            "description, overrides (atom values), skill_domains, heuristic, "
+            "failure_modes, and prompt_injection text. "
+            "Read this to internalize who you are before starting any task. "
+            "Your figure_id comes from the cognitive_arch field in your briefing "
+            "(the token before the first colon, e.g. 'guido_van_rossum' from "
+            "'guido_van_rossum:python')."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceTemplate(
+        uriTemplate="ac://arch/archetypes/{archetype_id}",
+        name="Cognitive archetype profile",
+        description=(
+            "Full definition of a cognitive archetype — the behavioural template "
+            "that a figure extends (e.g. 'the_pragmatist', 'the_hacker'). "
+            "Returns id, display_name, description, default atom values, and "
+            "characteristic traits. "
+            "Your archetype is the 'extends' field in your figure profile."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceTemplate(
+        uriTemplate="ac://arch/skills/{skill_id}",
+        name="Skill domain profile",
+        description=(
+            "Full definition of a skill domain — the technical expertise area "
+            "assigned to this agent (e.g. 'python', 'htmx', 'fastapi'). "
+            "Returns id, display_name, description, and characteristic patterns. "
+            "Your skill_ids come from the tokens after the first colon in your "
+            "cognitive_arch string (e.g. ['python', 'fastapi'] from "
+            "'guido_van_rossum:python:fastapi')."
+        ),
+        mimeType=_MIME,
+    ),
+    ACResourceTemplate(
+        uriTemplate="ac://arch/atoms/{atom_id}",
+        name="Cognitive atom profile",
+        description=(
+            "Full definition of a cognitive atom — a single dimension of reasoning "
+            "style such as 'epistemic_style', 'quality_bar', or 'error_posture'. "
+            "Returns id, display_name, description, and all possible values with "
+            "their meanings. "
+            "Atom values are overridden per-figure and visible in the figure profile."
+        ),
+        mimeType=_MIME,
+    ),
 ]
 
 # ---------------------------------------------------------------------------
 # URI dispatcher
 # ---------------------------------------------------------------------------
+
+
+def _arch_dir(category: str) -> Path:
+    """Resolve the filesystem directory for a given arch category key."""
+    subdir = _ARCH_SUBDIRS.get(category, category)
+    return _ARCH_ROOT / subdir
+
+
+def _read_arch_yaml(category: str, item_id: str) -> dict[str, object]:
+    """Read and parse a single cognitive architecture YAML file.
+
+    Args:
+        category: One of ``"figures"``, ``"archetypes"``, ``"skills"``, ``"atoms"``.
+        item_id:  Filename stem (e.g. ``"guido_van_rossum"``).
+
+    Returns:
+        Parsed YAML content as a dict, plus ``ok=True``.
+        ``{"ok": False, "error": str}`` when not found or unreadable.
+    """
+    path = _arch_dir(category) / f"{item_id}.yaml"
+    if not path.exists():
+        return {"ok": False, "error": f"Arch item '{category}/{item_id}' not found"}
+    try:
+        raw = path.read_text(encoding="utf-8")
+        parsed: dict[str, object] = yaml.safe_load(raw) or {}
+        parsed["ok"] = True
+        return parsed
+    except Exception as exc:  # noqa: BLE001
+        logger.error("❌ _read_arch_yaml %s/%s: %s", category, item_id, exc)
+        return {"ok": False, "error": str(exc)}
+
+
+def _list_arch_items(category: str) -> dict[str, object]:
+    """Return a compact index of all items in an arch category directory.
+
+    Each item includes ``id``, ``display_name``, and ``description`` (first line
+    only) so the agent can browse without fetching each individual resource.
+
+    Returns:
+        ``{"ok": True, category: [...], "count": N}``
+    """
+    d = _arch_dir(category)
+    if not d.is_dir():
+        return {"ok": False, "error": f"Arch directory '{category}' not found at {d}"}
+    items: list[dict[str, object]] = []
+    for path in sorted(d.glob("*.yaml")):
+        try:
+            data: dict[str, object] = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            desc_raw = data.get("description", "")
+            first_line = str(desc_raw).split("\n")[0].strip() if desc_raw else ""
+            items.append({
+                "id": path.stem,
+                "display_name": str(data.get("display_name", path.stem)),
+                "description": first_line,
+            })
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("⚠️ _list_arch_items: skipping %s — %s", path.name, exc)
+    return {"ok": True, category: items, "count": len(items)}
 
 
 def _get_system_config() -> dict[str, object]:
@@ -421,6 +564,34 @@ async def _dispatch(
             return _content(uri, _get_roles_list())
         if len(path_parts) == 1:
             return _content(uri, _get_role(uri, path_parts[0]))
+        return _not_found(uri)
+
+    # ── ac://arch/* ──────────────────────────────────────────────────────────
+    if domain == "arch":
+        # ac://arch/figures  (index — no trailing segment)
+        if path_parts == ["figures"]:
+            return _content(uri, _list_arch_items("figures"))
+
+        # ac://arch/archetypes  (index)
+        if path_parts == ["archetypes"]:
+            return _content(uri, _list_arch_items("archetypes"))
+
+        # ac://arch/figures/{figure_id}
+        if len(path_parts) == 2 and path_parts[0] == "figures":
+            return _content(uri, _read_arch_yaml("figures", path_parts[1]))
+
+        # ac://arch/archetypes/{archetype_id}
+        if len(path_parts) == 2 and path_parts[0] == "archetypes":
+            return _content(uri, _read_arch_yaml("archetypes", path_parts[1]))
+
+        # ac://arch/skills/{skill_id}
+        if len(path_parts) == 2 and path_parts[0] == "skills":
+            return _content(uri, _read_arch_yaml("skills", path_parts[1]))
+
+        # ac://arch/atoms/{atom_id}
+        if len(path_parts) == 2 and path_parts[0] == "atoms":
+            return _content(uri, _read_arch_yaml("atoms", path_parts[1]))
+
         return _not_found(uri)
 
     return _not_found(uri)

--- a/scripts/gen_prompts/templates/snippets/arch-load.md.j2
+++ b/scripts/gen_prompts/templates/snippets/arch-load.md.j2
@@ -1,19 +1,47 @@
 Your cognitive architecture and full task context were delivered in your initial message
 via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
 
-Your context includes:
-- **`cognitive_arch`** — your archetype (e.g. `guido_van_rossum:python`)
+Your briefing contains:
+- **`run_id`** — your unique run identifier
+- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
 - **`role`** — your role slug (e.g. `python-developer`)
-- **`is_resumed`** — whether this is a resumed run (check your briefing header)
+- Direct MCP resource URIs for your figure, skills, and archetype
 
-⚠️ MANDATORY SELF-INTRODUCTION — skip only if your briefing indicates `is_resumed = True`:
+## STEP 0 — Load your full cognitive identity
 
-If this is a fresh run (not resumed), output this block verbatim as your first visible
-text before any tool call:
+Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+
+The MCP resources hold your complete cognitive profile — not a summary.
+Reading them is the difference between *knowing* who you are and *performing* who you are.
+
+**What to read, in order:**
+
+1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
+   - `description`: the human being you embody and their core worldview
+   - `overrides`: your specific values for each reasoning atom
+   - `heuristic`: the single most important decision rule you carry
+   - `failure_modes`: where agents like you go wrong — read these to avoid them
+   - `prompt_injection`: additional identity text to internalize
+
+2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
+   `ac://arch/skills/{skill_id}` — your technical expertise domain
+
+3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
+   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
+
+4. Optionally, any atom you want to understand in depth:
+   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
+
+After reading, output this block as your first visible text:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**My archetype:** <cognitive_arch from your briefing>
-**My role:** <role from your briefing>
+**Figure:** <display_name from figure profile>
+**Archetype:** <extends field from figure profile>
+**Skills:** <your skill_ids>
+**Role:** <role from your briefing>
+**Heuristic:** <heuristic field from figure profile — verbatim>
 ```
+
+This grounds your identity before you touch a single file or call a single tool.


### PR DESCRIPTION
77 figures, 8 archetypes, 45+ skills, 10 atoms — all readable at runtime via ac://arch/*. task/briefing now injects direct resource URIs. arch-load.md.j2 instructs agents to read their full figure profile before starting work.