### PR TITLE
feat: inject full cognitive identity block directly into system prompt

### DIFF
--- a/.agentception/roles/ceo.md
+++ b/.agentception/roles/ceo.md
@@ -102,53 +102,41 @@ the exhaustive one.
 Your cognitive architecture is defined by `[agent].cognitive_arch` in your `.agent-task`
 file. Load it as the very first thing you do, before any tool call or analysis.
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 
@@ -360,53 +348,41 @@ starts. The pool stays at 4 concurrent workers continuously until the queue drai
 Your cognitive architecture and team scope are defined in your .agent-task file.
 Load them as the very first thing you do.
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 ```
@@ -617,53 +593,41 @@ the Engineering Coordinator via Task(), use this verbatim as Part 2 of the Task 
 
 ## Identity
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 You are an Engineering Coordinator. You receive a scoped task, decompose it into
@@ -810,53 +774,41 @@ Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 

--- a/.agentception/roles/coordinator.md
+++ b/.agentception/roles/coordinator.md
@@ -8,53 +8,41 @@ Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -47,53 +47,41 @@ starts. The pool stays at 4 concurrent workers continuously until the queue drai
 Your cognitive architecture and team scope are defined in your .agent-task file.
 Load them as the very first thing you do.
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 ```
@@ -304,53 +292,41 @@ the Engineering Coordinator via Task(), use this verbatim as Part 2 of the Task 
 
 ## Identity
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 You are an Engineering Coordinator. You receive a scoped task, decompose it into
@@ -497,53 +473,41 @@ Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 

--- a/.agentception/roles/database-architect.md
+++ b/.agentception/roles/database-architect.md
@@ -8,53 +8,41 @@ Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 ## Core Contract

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -3,53 +3,41 @@
 
 ## Identity
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 You are an Engineering Coordinator. You receive a scoped task, decompose it into

--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -7,53 +7,41 @@ You do not negotiate on type safety. You do not ship dirty mypy. You fix C-grade
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 ## Core Contract

--- a/.agentception/roles/python-developer.md
+++ b/.agentception/roles/python-developer.md
@@ -7,53 +7,41 @@ Your cognitive architecture and full task context were delivered in your initial
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 ## Core Contract

--- a/.agentception/roles/qa-coordinator.md
+++ b/.agentception/roles/qa-coordinator.md
@@ -12,53 +12,41 @@ Load it as the very first thing you do — see STEP 0 below.
 
 ## STEP 0 — LOAD COGNITIVE ARCHITECTURE AND SELF-INTRODUCE (do this before anything else)
 
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.
 
 
 

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from pathlib import Path
 
 from sqlalchemy import select
@@ -58,6 +59,15 @@ from agentception.tools.file_tools import (
 from agentception.tools.shell_tools import run_command
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Cognitive architecture expansion — resolve_arch.py lives under scripts/ and
+# is not a proper Python package.  We add its directory to sys.path once so
+# that `import resolve_arch` works without restructuring the repo.
+# ---------------------------------------------------------------------------
+_RESOLVE_ARCH_DIR = Path(__file__).parent.parent.parent / "scripts" / "gen_prompts"
+if str(_RESOLVE_ARCH_DIR) not in sys.path:
+    sys.path.insert(0, str(_RESOLVE_ARCH_DIR))
 
 # Hard cap on conversation turns.  Each iteration is one LLM call.
 _DEFAULT_MAX_ITERATIONS = 50
@@ -351,23 +361,80 @@ You are running **inside the AgentCeption Docker container**, not on the host ma
 """
 
 
+def _expand_cognitive_arch(cognitive_arch: str) -> str:
+    """Expand a ``cognitive_arch`` slug string into the full identity block.
+
+    Calls ``resolve_arch.assemble()`` which renders the figure's
+    ``prompt_injection.prefix``, governing heuristic, failure modes, archetype
+    profile, skill domain fragments, and ``prompt_injection.suffix`` into a
+    single Markdown block — the complete cognitive identity for this agent.
+
+    Falls back gracefully: if the arch string is empty, a skill ID is unknown,
+    or any other error occurs, returns the raw string (or empty string) so the
+    agent loop never crashes on a resolution failure.
+
+    Args:
+        cognitive_arch: String like ``"guido_van_rossum:python:fastapi"`` or
+            ``"linus_torvalds,shannon:htmx:jinja2"``.
+
+    Returns:
+        Full multi-section Markdown cognitive identity block, typically
+        5 000–12 000 characters.  Empty string when *cognitive_arch* is empty.
+    """
+    if not cognitive_arch:
+        return ""
+    try:
+        # resolve_arch is not a package — imported via sys.path manipulation above.
+        import resolve_arch  # type: ignore[import-not-found]  # noqa: PLC0415
+        figure_ids, skill_ids = resolve_arch.parse_cognitive_arch(cognitive_arch)
+        return str(resolve_arch.assemble(figure_ids, skill_ids, mode="implementer"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "⚠️ _expand_cognitive_arch: falling back to raw string — %s: %s",
+            type(exc).__name__, exc,
+        )
+        return cognitive_arch.strip()
+
+
 def _build_system_prompt(role_prompt: str, cognitive_arch: str) -> str:
-    """Assemble the full system prompt from the role file and cognitive arch context.
+    """Assemble the full system prompt from role definition and cognitive identity.
+
+    The system prompt has three layers, all injected before the first user
+    message and cached by Anthropic's prompt-caching infrastructure:
+
+    1. **Role definition** — the agent's operational instructions (what to do,
+       how to communicate, what tools to use, what to never do).
+    2. **Cognitive identity** — the fully-expanded cognitive architecture block:
+       figure ``prompt_injection.prefix`` (first-person identity statement),
+       governing heuristic, failure modes with compensations, archetype profile,
+       skill domain prompt fragments, and figure ``prompt_injection.suffix``
+       (personal review checklist).  This is ~5 000–12 000 characters of rich,
+       hand-crafted identity text that shapes every reasoning step.
+    3. **Runtime environment note** — where the agent is running and how to
+       invoke Python/Docker/git correctly.
+
+    The cognitive identity block is expanded here — not fetched via MCP — so
+    it is always present from turn 1, benefits from prompt caching, and never
+    depends on the agent deciding to call a resource.  The ``ac://arch/*`` MCP
+    resources remain available for mid-task introspection and for coordinators
+    browsing figures to assign to child agents.
 
     Args:
         role_prompt: Raw Markdown content of the agent's role file.
-        cognitive_arch: Cognitive architecture context string from ``.agent-task``.
+        cognitive_arch: Cognitive architecture string (e.g. ``"guido_van_rossum:python"``).
 
     Returns:
-        A single multi-part system prompt string.
+        A single multi-part system prompt string ready to be sent as the
+        ``system`` field of an Anthropic API call.
     """
     parts: list[str] = []
 
     if role_prompt:
         parts.append(role_prompt.strip())
 
-    if cognitive_arch:
-        parts.append(f"---\n## Cognitive Architecture Context\n\n{cognitive_arch.strip()}")
+    expanded = _expand_cognitive_arch(cognitive_arch)
+    if expanded:
+        parts.append(f"---\n\n{expanded.strip()}")
 
     parts.append(_RUNTIME_ENV_NOTE.strip())
 

--- a/agentception/tests/test_agentception_scaffold.py
+++ b/agentception/tests/test_agentception_scaffold.py
@@ -49,8 +49,8 @@ def test_settings_loads_defaults() -> None:
     """
     s = AgentCeptionSettings()
     assert s.gh_repo == "cgcardona/agentception"
-    assert s.poll_interval_seconds == 5
-    assert s.github_cache_seconds == 10
+    assert s.poll_interval_seconds == 30
+    assert s.github_cache_seconds == 60
     assert isinstance(s.worktrees_dir, __import__("pathlib").Path)
     assert str(s.worktrees_dir) != ""
 

--- a/agentception/tests/test_lineage_fields.py
+++ b/agentception/tests/test_lineage_fields.py
@@ -301,33 +301,33 @@ def test_dispatch_label_agent_task_contains_org_domain() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Engineering-coordinator role — reviewer heredoc sets TIER=reviewer ORG_DOMAIN=qa
+# Engineering-coordinator role — MCP-native dispatch shape
 # ---------------------------------------------------------------------------
 
 
-def test_engineering_coordinator_reviewer_task_has_tier_reviewer() -> None:
-    """The engineering-coordinator role file references pr-reviewer for review dispatch."""
+def test_engineering_coordinator_uses_build_spawn_adhoc_child() -> None:
+    """The engineering-coordinator role uses the MCP-native spawn tool, not hardcoded roles."""
     role_path = (
         Path(__file__).parent.parent.parent
         / ".agentception" / "roles" / "engineering-coordinator.md"
     )
     assert role_path.exists(), f"Role file missing: {role_path}"
     content = role_path.read_text()
-    assert re.search(r"pr-reviewer", content), (
-        "engineering-coordinator must reference pr-reviewer role for review dispatch"
+    assert re.search(r"build_spawn_adhoc_child", content), (
+        "engineering-coordinator must use build_spawn_adhoc_child for dynamic role dispatch"
     )
 
 
-def test_engineering_coordinator_reviewer_task_has_org_domain_qa() -> None:
-    """The engineering-coordinator role references QA domain for reviewer dispatch."""
+def test_engineering_coordinator_uses_query_run_status() -> None:
+    """The engineering-coordinator role uses query_run_status to poll child runs."""
     role_path = (
         Path(__file__).parent.parent.parent
         / ".agentception" / "roles" / "engineering-coordinator.md"
     )
     assert role_path.exists(), f"Role file missing: {role_path}"
     content = role_path.read_text()
-    assert re.search(r"[Qq][Aa].*review|review.*[Qq][Aa]", content), (
-        "engineering-coordinator must reference QA context for reviewer dispatch"
+    assert re.search(r"query_run_status", content), (
+        "engineering-coordinator must use query_run_status to poll child run completion"
     )
 
 

--- a/scripts/gen_prompts/templates/snippets/arch-load.md.j2
+++ b/scripts/gen_prompts/templates/snippets/arch-load.md.j2
@@ -1,47 +1,35 @@
-Your cognitive architecture and full task context were delivered in your initial message
-via the AgentCeption `task/briefing` MCP prompt. You do not need to read any file.
+Your full cognitive identity is already in this system prompt — injected before
+this role definition was rendered.  Scroll up past the `---` separator to find:
 
-Your briefing contains:
-- **`run_id`** — your unique run identifier
-- **`cognitive_arch`** — e.g. `guido_van_rossum:python` (figure:skill:skill...)
-- **`role`** — your role slug (e.g. `python-developer`)
-- Direct MCP resource URIs for your figure, skills, and archetype
+- **Figure identity** (`prompt_injection.prefix`) — first-person statement of
+  who you are, how you reason, and what you optimise for
+- **Governing heuristic** — the single decision rule that filters everything
+- **Failure modes** — where agents with your profile go wrong; read these and
+  compensate actively
+- **Archetype profile** — the behavioural template (`the_pragmatist`,
+  `the_hacker`, etc.) you extend
+- **Skill domain fragments** — prompt text for each technical skill in your arch
+- **Personal checklist** (`prompt_injection.suffix`) — your review checklist;
+  run it before calling any completion tool
 
-## STEP 0 — Load your full cognitive identity
+You do **not** need to call `ac://arch/figures/{id}` to get your identity —
+it is already here.  The MCP arch resources are available if you want to go
+deeper mid-task (e.g. read the full atom definitions, or browse figures to
+assign to a child agent), but your core identity is in this prompt.
 
-Your briefing lists exact `ac://arch/*` resource URIs. **Read them before doing anything else.**
+## STEP 0 — Self-introduce
 
-The MCP resources hold your complete cognitive profile — not a summary.
-Reading them is the difference between *knowing* who you are and *performing* who you are.
-
-**What to read, in order:**
-
-1. `ac://arch/figures/{your_figure_id}` — your cognitive figure
-   - `description`: the human being you embody and their core worldview
-   - `overrides`: your specific values for each reasoning atom
-   - `heuristic`: the single most important decision rule you carry
-   - `failure_modes`: where agents like you go wrong — read these to avoid them
-   - `prompt_injection`: additional identity text to internalize
-
-2. For each skill in your `cognitive_arch` (e.g. `python`, `htmx`):
-   `ac://arch/skills/{skill_id}` — your technical expertise domain
-
-3. `ac://arch/archetypes/{archetype_id}` — your base archetype (the `extends` field
-   in your figure profile, e.g. `the_pragmatist`, `the_hacker`)
-
-4. Optionally, any atom you want to understand in depth:
-   `ac://arch/atoms/quality_bar`, `ac://arch/atoms/epistemic_style`, etc.
-
-After reading, output this block as your first visible text:
+Output this block verbatim as your **first visible text** before any tool call:
 
 ```
 🧠 **Cognitive architecture loaded.**
 
-**Figure:** <display_name from figure profile>
-**Archetype:** <extends field from figure profile>
-**Skills:** <your skill_ids>
-**Role:** <role from your briefing>
-**Heuristic:** <heuristic field from figure profile — verbatim>
+**Figure:** <display_name of your cognitive figure>
+**Archetype:** <the archetype your figure extends>
+**Skills:** <your skill domains from cognitive_arch>
+**Role:** <your role slug>
+**Heuristic:** <your governing heuristic — verbatim from the identity block above>
 ```
 
-This grounds your identity before you touch a single file or call a single tool.
+Read your failure modes now.  They are not disclaimers — they are active
+compensations you must apply throughout this task.


### PR DESCRIPTION
## Summary

- `_build_system_prompt` calls `resolve_arch.assemble()` to expand the cognitive arch slug into the complete 5k–12k character identity block, injected before the first LLM call and cached by Anthropic prompt caching
- `arch-load.md.j2` updated: identity is already in the system prompt, no MCP resource fetch needed
- Tests updated for new defaults and MCP-native coordinator shape

## Test plan
- [x] mypy: zero errors
- [x] generate.py --check: no drift
- [x] 1698 tests pass