### PR TITLE
fix: wire ANTHROPIC_API_KEY into container env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       # HOST_ROLE_FILE so Cursor agents (on the host) can resolve role files.
       # Override via HOST_REPO_DIR in .env when the repo is not at the default.
       HOST_REPO_DIR: ${HOST_REPO_DIR:-}
-      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       # gh CLI reads GITHUB_TOKEN when the keychain (macOS) is unavailable inside Docker.
       # Set GITHUB_TOKEN in .env to a PAT with repo+issues scope.
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}


### PR DESCRIPTION
## Summary

- `docker-compose.yml` was still passing `OPENROUTER_API_KEY` into the container environment
- The `ANTHROPIC_API_KEY` env var was never reaching the container, so every LLM call raised `RuntimeError: ANTHROPIC_API_KEY is not configured`
- Replace with `ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}`

## Test plan

- [x] `docker compose up -d` picks up the new env var after this change
