### PR TITLE
fix: correct Anthropic model IDs to claude-sonnet-4-6 / claude-opus-4-6

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -6,7 +6,7 @@ AgentCeption — multi-agent orchestration system for AI-powered development wor
 
 - **Entry points:** `GET /` (Build dashboard), MCP tools (Cursor/Claude). Same engine, same pipeline.
 - **Stack:** Python 3.12, FastAPI, Jinja2, HTMX, Alpine.js, TypeScript (piecemeal — convert every `.ts` file you touch), SCSS, Pydantic v2, SQLAlchemy (async), Alembic. Fully async.
-- **Models:** `claude-sonnet-4-6-20260217` and `claude-opus-4-6-20260217` via Anthropic direct API. No others.
+- **Models:** `claude-sonnet-4-6` and `claude-opus-4-6` via Anthropic direct API. No others.
 - **Version:** Single source of truth in `pyproject.toml`.
 
 ## Agent scope

--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -43,10 +43,8 @@ from agentception.config import settings
 logger = logging.getLogger(__name__)
 
 _ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
-# Anthropic model IDs — strip the "anthropic/" OpenRouter prefix and replace
-# the dot in the minor version with a hyphen to match Anthropic's ID format.
-_MODEL = "claude-sonnet-4-6-20260217"
-_OPUS_MODEL = "claude-opus-4-6-20260217"
+_MODEL = "claude-sonnet-4-6"
+_OPUS_MODEL = "claude-opus-4-6"
 _ANTHROPIC_VERSION = "2023-06-01"
 _DEFAULT_TIMEOUT = 120.0
 _MAX_RETRIES = 2


### PR DESCRIPTION
## Summary

- Anthropic direct API uses `claude-sonnet-4-6` (no date suffix needed)
- The guessed IDs with date suffixes returned 404
- Confirmed by probing Anthropic API directly from the container
- mypy clean
