### PR TITLE
feat: eliminate .agent-task file — all task context is DB-driven

### DIFF
--- a/agentception/alembic/versions/0007_agent_run_pipeline_fields.py
+++ b/agentception/alembic/versions/0007_agent_run_pipeline_fields.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Add gh_repo, is_resumed, coord_fingerprint to agent_runs.
+
+These three columns eliminate the last remaining data that was only
+available inside the `.agent-task` TOML file.  With this migration every
+field an agent or the poller needs is readable directly from the DB row,
+making the `.agent-task` file fully redundant.
+
+- ``gh_repo``          — GitHub repository slug (e.g. ``cgcardona/agentception``).
+- ``is_resumed``       — True when this is a retry of a cancelled/stale run.
+- ``coord_fingerprint``— run_id of the coordinator that spawned this run.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_runs",
+        sa.Column("gh_repo", sa.String(256), nullable=True),
+    )
+    op.add_column(
+        "agent_runs",
+        sa.Column(
+            "is_resumed",
+            sa.Boolean(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "agent_runs",
+        sa.Column("coord_fingerprint", sa.String(256), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_runs", "coord_fingerprint")
+    op.drop_column("agent_runs", "is_resumed")
+    op.drop_column("agent_runs", "gh_repo")

--- a/agentception/db/models.py
+++ b/agentception/db/models.py
@@ -30,6 +30,7 @@ ACPipelineSnapshot
 import datetime
 
 from sqlalchemy import (
+    Boolean,
     DateTime,
     ForeignKey,
     Index,
@@ -116,16 +117,14 @@ class ACAgentRun(Base):
     task_description: Mapped[str | None] = mapped_column(Text, nullable=True)
     """Inline task description for ad-hoc runs (POST /api/runs/adhoc).
 
-    When present, the agent loop uses this as the initial message instead of
-    directing the agent to read a ``.agent-task`` file.  Null for all runs
-    created via the standard GitHub-issue dispatch pipeline.
+    When present, the agent loop uses this as the initial message.
+    Null for all runs created via the standard GitHub-issue dispatch pipeline.
     """
 
     tier: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
     """Behavioral execution tier for this agent run.
 
     Values: ``coordinator`` | ``worker``.
-    Written from the ``TIER=`` field in the ``.agent-task`` file.
     Null for rows spawned before migration 0012.
     """
 
@@ -133,7 +132,6 @@ class ACAgentRun(Base):
     """Organisational slot for UI hierarchy visualisation.
 
     Values: ``c-suite`` | ``engineering`` | ``qa``.
-    Written from the ``ORG_DOMAIN=`` field in the ``.agent-task`` file.
     Allows the UI to place a chain-spawned PR reviewer under the QA column
     even though its physical ``parent_run_id`` points to an engineering leaf.
     Null for rows spawned before migration 0012.
@@ -143,6 +141,28 @@ class ACAgentRun(Base):
     """Run ID of the agent that physically spawned this one (spawn-lineage tracking).
 
     Null for top-level dispatches and legacy rows.
+    """
+
+    gh_repo: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    """GitHub repository slug (e.g. ``cgcardona/agentception``).
+
+    Present on all pipeline-spawned runs.  Null for ad-hoc runs that do not
+    target a specific repository, and for rows created before migration 0018.
+    """
+
+    is_resumed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
+    """True when this run is a retry of a previously cancelled/stale run.
+
+    Surfaced in the task briefing so the agent knows not to redo completed work.
+    """
+
+    coord_fingerprint: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    """Fingerprint (run_id) of the coordinator that spawned this run.
+
+    Lets the agent identify its parent coordinator for status reporting.
+    Null for top-level dispatches and ad-hoc runs.
     """
 
     spawned_at: Mapped[datetime.datetime] = mapped_column(

--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -963,29 +963,19 @@ async def persist_agent_run_dispatch(
     tier: str | None = None,
     org_domain: str | None = None,
     parent_run_id: str | None = None,
+    gh_repo: str | None = None,
+    is_resumed: bool = False,
+    coord_fingerprint: str | None = None,
 ) -> None:
-    """Insert an ACAgentRun row with status ``pending_launch`` at dispatch time.
+    """Insert an ``ACAgentRun`` row with status ``pending_launch`` at dispatch time.
 
-    Called by ``POST /api/build/dispatch`` immediately after the worktree and
-    ``.agent-task`` file are created.  The coordinator agent reads these rows
-    via ``build_get_pending_launches`` and transitions them to ``implementing``
-    when it claims the work.
+    Called by dispatch routes and ``spawn_child`` immediately after the worktree
+    is created.  All task context is stored here — no ``.agent-task`` file is
+    written.  Agents read their briefing from ``ac://runs/{run_id}/context`` and
+    the ``task/briefing`` MCP prompt, both of which are DB-backed.
 
     ``host_worktree_path`` is stored in the ``spawn_mode`` field as a JSON
-    blob because ACAgentRun has no dedicated host-path column.
-
-    ``cognitive_arch`` is written to the DB column added in migration 0005.
-
-    ``tier`` is the behavioral execution tier: ``coordinator | worker``.
-    Added in migration 0012.
-
-    ``org_domain`` is the organisational slot for UI hierarchy visualisation:
-    ``c-suite | engineering | qa``.  A chain-spawned PR reviewer should pass
-    ``"qa"`` so the dashboard places it under the QA column.  Added in
-    migration 0012.
-
-    ``parent_run_id`` records the run_id of the agent that spawned this one,
-    enabling spawn-lineage tracing in the org chart.  Added in migration 0006.
+    blob (backward compat — no dedicated column yet).
 
     Best-effort — swallows exceptions so a DB outage never blocks dispatch.
     """
@@ -994,10 +984,10 @@ async def persist_agent_run_dispatch(
     spawn_mode_json = _json.dumps({"host_worktree": host_worktree_path})
     logger.warning(
         "💾 persist_agent_run_dispatch: run_id=%r role=%r worktree_path=%r "
-        "host_worktree_path=%r spawn_mode=%r cognitive_arch=%r "
-        "tier=%r org_domain=%r parent_run_id=%r",
-        run_id, role, worktree_path, host_worktree_path, spawn_mode_json,
-        cognitive_arch, tier, org_domain, parent_run_id,
+        "host_worktree_path=%r cognitive_arch=%r tier=%r org_domain=%r "
+        "parent_run_id=%r gh_repo=%r is_resumed=%r coord_fingerprint=%r",
+        run_id, role, worktree_path, host_worktree_path, cognitive_arch,
+        tier, org_domain, parent_run_id, gh_repo, is_resumed, coord_fingerprint,
     )
     try:
         async with get_session() as session:
@@ -1010,7 +1000,6 @@ async def persist_agent_run_dispatch(
                     "💾 persist_agent_run_dispatch: run_id=%r already exists (status=%r) — re-arming to pending_launch",
                     run_id, existing.status,
                 )
-                # Already exists (re-dispatch or orphan sweep reset). Re-arm.
                 existing.status = "pending_launch"
                 existing.spawn_mode = spawn_mode_json
                 existing.last_activity_at = _now()
@@ -1022,6 +1011,11 @@ async def persist_agent_run_dispatch(
                     existing.org_domain = org_domain
                 if parent_run_id is not None:
                     existing.parent_run_id = parent_run_id
+                if gh_repo is not None:
+                    existing.gh_repo = gh_repo
+                existing.is_resumed = is_resumed
+                if coord_fingerprint is not None:
+                    existing.coord_fingerprint = coord_fingerprint
             else:
                 logger.warning(
                     "💾 persist_agent_run_dispatch: run_id=%r is new — inserting with status=pending_launch",
@@ -1044,6 +1038,9 @@ async def persist_agent_run_dispatch(
                         tier=tier,
                         org_domain=org_domain,
                         parent_run_id=parent_run_id,
+                        gh_repo=gh_repo,
+                        is_resumed=is_resumed,
+                        coord_fingerprint=coord_fingerprint,
                         spawned_at=_now(),
                         last_activity_at=_now(),
                     )

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -2680,9 +2680,9 @@ async def get_run_by_id(run_id: str) -> RunSummaryRow | None:
 class RunContextRow(TypedDict):
     """Full task context for an agent run — the authoritative DB-sourced record.
 
-    Extends :class:`RunSummaryRow` with the fields needed to brief an agent:
-    ``cognitive_arch`` and ``task_description``.  Used by
-    ``ac://runs/{run_id}/context`` and the ``task/briefing`` MCP prompt.
+    Used by ``ac://runs/{run_id}/context`` and the ``task/briefing`` MCP prompt.
+    All fields an agent needs to understand its assignment are present here;
+    no ``.agent-task`` file read is necessary.
     """
 
     run_id: str
@@ -2698,6 +2698,9 @@ class RunContextRow(TypedDict):
     tier: str | None
     org_domain: str | None
     parent_run_id: str | None
+    gh_repo: str | None
+    is_resumed: bool
+    coord_fingerprint: str | None
     spawned_at: str
     last_activity_at: str | None
     completed_at: str | None
@@ -2734,6 +2737,9 @@ async def get_run_context(run_id: str) -> RunContextRow | None:
             tier=row.tier,
             org_domain=row.org_domain,
             parent_run_id=row.parent_run_id,
+            gh_repo=row.gh_repo,
+            is_resumed=row.is_resumed,
+            coord_fingerprint=row.coord_fingerprint,
             spawned_at=row.spawned_at.isoformat(),
             last_activity_at=(row.last_activity_at.isoformat() if row.last_activity_at else None),
             completed_at=(row.completed_at.isoformat() if row.completed_at else None),
@@ -2741,6 +2747,49 @@ async def get_run_context(run_id: str) -> RunContextRow | None:
     except Exception as exc:
         logger.warning("⚠️  get_run_context DB query failed (non-fatal): %s", exc)
         return None
+
+
+async def list_active_runs() -> list[RunContextRow]:
+    """Return all agent runs currently in an active state (DB-only replacement for worktree scan).
+
+    Returns rows with status in ``{implementing, pending_launch, reviewing}``.
+    Used by the poller to build the board and detect alerts — replaces the
+    old ``list_active_worktrees()`` filesystem scan.  Returns ``[]`` on error.
+    """
+    _ACTIVE_STATUSES = {"implementing", "pending_launch", "reviewing"}
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun).where(ACAgentRun.status.in_(_ACTIVE_STATUSES))
+            )
+            rows = result.scalars().all()
+        return [
+            RunContextRow(
+                run_id=row.id,
+                status=row.status,
+                role=row.role,
+                cognitive_arch=row.cognitive_arch,
+                task_description=row.task_description,
+                issue_number=row.issue_number,
+                pr_number=row.pr_number,
+                branch=row.branch,
+                worktree_path=row.worktree_path,
+                batch_id=row.batch_id,
+                tier=row.tier,
+                org_domain=row.org_domain,
+                parent_run_id=row.parent_run_id,
+                gh_repo=row.gh_repo,
+                is_resumed=row.is_resumed,
+                coord_fingerprint=row.coord_fingerprint,
+                spawned_at=row.spawned_at.isoformat(),
+                last_activity_at=(row.last_activity_at.isoformat() if row.last_activity_at else None),
+                completed_at=(row.completed_at.isoformat() if row.completed_at else None),
+            )
+            for row in rows
+        ]
+    except Exception as exc:
+        logger.warning("⚠️  list_active_runs DB query failed (non-fatal): %s", exc)
+        return []
 
 
 async def get_children_by_parent_id(parent_run_id: str) -> list[RunSummaryRow]:

--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -175,7 +175,6 @@ async def build_spawn_child_run(
         "org_domain": result.org_domain,
         "role": result.role,
         "cognitive_arch": result.cognitive_arch,
-        "agent_task_path": result.agent_task_path,
         "scope_type": result.scope_type,
         "scope_value": result.scope_value,
         "status": "implementing",

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -154,8 +154,8 @@ TOOLS: list[ACToolDef] = [
     ACToolDef(
         name="plan_spawn_coordinator",
         description=(
-            "Validate a manifest and create a coordinator git worktree with a .agent-task file. "
-            "Returns {worktree, branch, agent_task_path, batch_id}."
+            "Validate a manifest and create a coordinator git worktree. "
+            "Returns {worktree, branch, batch_id, run_id}."
         ),
         inputSchema={
             "type": "object",

--- a/agentception/models/__init__.py
+++ b/agentception/models/__init__.py
@@ -267,72 +267,70 @@ class PRSub(BaseModel):
     closes_issues: list[int] = []
 
 
-class TaskFile(BaseModel):
-    """Parsed content of a ``.agent-task`` file from a worktree.
+class AgentTaskSpec(BaseModel):
+    """In-memory representation of all task context for one agent run.
 
-    Supports both the legacy KEY=value format and the TOML spec
-    (see .agentception/agent-task-spec.md). Every field maps from a TOML section
-    or a legacy key. Unknown keys are silently ignored. All fields are optional
-    to ensure graceful handling of missing or malformed task files.
+    Populated exclusively from the ``ACAgentRun`` DB row — no ``.agent-task``
+    TOML file is read.  All fields are optional; the DB row is the single
+    source of truth.  The name reflects the spec, not a file.
     """
 
-    # [task]
+    # Core identity
     task: str | None = None
     id: str | None = None
     attempt_n: int = 0
     is_resumed: bool = False
-    required_output: str | None = None
-    on_block: str | None = None
-    # [agent]
+    # Agent configuration
     role: str | None = None
     tier: str | None = None
     """Behavioral execution tier: coordinator | worker."""
     org_domain: str | None = None
     """Organisational slot for UI hierarchy: c-suite | engineering | qa."""
     cognitive_arch: str | None = None
-    session_id: str | None = None
-    # [repo]
+    # Repository
     gh_repo: str | None = None
     base: str | None = None
-    # [pipeline]
+    # Pipeline lineage
     batch_id: str | None = None
     parent_run_id: str | None = None
-    wave: str | None = None
-    vp_fingerprint: str | None = None
-    # [spawn]
-    spawn_sub_agents: bool = False
+    coord_fingerprint: str | None = None
+    """run_id of the coordinator that spawned this run."""
     spawn_mode: str | None = None
-    # [target]
+    # Target
     issue_number: int | None = None
     pr_number: int | None = None
-    depends_on: list[int] = []
     closes_issues: list[int] = []
+    # Worktree
+    worktree: str | None = None
+    branch: str | None = None
+    # Ad-hoc runs
+    task_description: str | None = None
+    """Inline task description for ad-hoc runs (POST /api/runs/adhoc)."""
+    # Planning pipeline — only populated when parsed from plan-draft .agent-task files
+    draft_id: str | None = None
+    output_path: str | None = None
+    output_format: str | None = None
+    domain: str | None = None
+    issue_queue: list[IssueSub] = []
+    pr_queue: list[PRSub] = []
+    # Extended tracking (file-parsed only — not in DB)
+    depends_on: list[int] = []
+    spawn_sub_agents: bool = False
+    wave: str | None = None
+    vp_fingerprint: str | None = None
+    session_id: str | None = None
+    on_block: str | None = None
+    required_output: str | None = None
     file_ownership: list[str] = []
     files_changed: list[str] = []
     grade_threshold: str | None = None
     has_migration: bool = False
     merge_after: str | None = None
-    # [worktree]
-    worktree: str | None = None
-    branch: str | None = None
     linked_pr: int | None = None
-    # [output]
-    draft_id: str | None = None
-    output_path: str | None = None
-    output_format: str | None = None
-    # [domain]
-    domain: str | None = None
-    # Queues (TOML repeated tables)
-    issue_queue: list[IssueSub] = []
-    pr_queue: list[PRSub] = []
-    # Ad-hoc / DB-sourced runs only
-    task_description: str | None = None
-    """Inline task description injected directly into the initial agent message.
 
-    When set (ad-hoc runs via POST /api/runs/adhoc), the agent loop uses this
-    as the task briefing and does not instruct the agent to read a file.
-    Absent for all standard issue-dispatch runs.
-    """
+
+# Backward-compat alias — remove once all callers use AgentTaskSpec directly.
+TaskFile = AgentTaskSpec
 
 
 class AbModeConfig(BaseModel):

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -23,7 +23,8 @@ from pathlib import Path
 
 from agentception.config import settings
 from agentception.intelligence.guards import detect_out_of_order_prs, detect_stale_claims
-from agentception.models import AgentNode, AgentStatus, BoardIssue, PipelineState, PlanDraftEvent, StaleClaim, TaskFile
+from agentception.db.queries import RunContextRow, list_active_runs
+from agentception.models import AgentNode, AgentStatus, BoardIssue, PipelineState, PlanDraftEvent, StaleClaim
 from agentception.readers.github import (
     get_active_label,
     get_closed_issues,
@@ -32,7 +33,7 @@ from agentception.readers.github import (
     get_open_prs,
     get_wip_issues,
 )
-from agentception.readers.worktrees import list_active_worktrees, parse_agent_task, worktree_last_commit_time
+from agentception.readers.worktrees import parse_agent_task, worktree_last_commit_time
 
 logger = logging.getLogger(__name__)
 
@@ -121,20 +122,17 @@ async def build_github_board() -> GitHubBoard:
 
 
 async def merge_agents(
-    worktrees: list[TaskFile],
+    active_runs: list[RunContextRow],
     github: GitHubBoard,
 ) -> list[AgentNode]:
-    """Build an ``AgentNode`` list by correlating worktree task files with GitHub.
+    """Build an ``AgentNode`` list by correlating DB run rows with GitHub.
 
     Status derivation rules (applied in priority order):
-    1. Worktree branch matches an open PR ``headRefName`` → REVIEWING
-    2. Worktree issue number appears in ``agent/wip`` issues → IMPLEMENTING
-    3. ``WORKFLOW=bugs-to-issues`` (coordinator/brain-dump) → IMPLEMENTING
-       These agents have no issue number or PR; they are actively planning.
+    1. Run branch matches an open PR ``headRefName`` → REVIEWING
+    2. Run has an issue_number → IMPLEMENTING
+    3. Run is a coordinator (tier == coordinator, no issue/PR) → IMPLEMENTING
     4. Otherwise → UNKNOWN
     """
-    # Index open PRs by branch name for O(1) lookup.
-    # Maps headRefName → PR number so we can propagate pr_number to AgentNode.
     pr_branch_to_number: dict[str, int] = {}
     for pr in github.open_prs:
         head = pr.get("headRefName")
@@ -142,58 +140,39 @@ async def merge_agents(
         if isinstance(head, str) and isinstance(number, int):
             pr_branch_to_number[head] = number
 
-    # Index WIP issue numbers for O(1) lookup.
-    wip_issue_numbers: set[int] = set()
-    for issue in github.wip_issues:
-        num = issue.get("number")
-        if isinstance(num, int):
-            wip_issue_numbers.add(num)
-
     nodes: list[AgentNode] = []
-    for tf in worktrees:
-        branch = tf.branch or ""
+    for run in active_runs:
+        branch = run["branch"] or ""
         gh_pr_number: int | None = pr_branch_to_number.get(branch) if branch else None
         if branch and gh_pr_number is not None:
             status = AgentStatus.REVIEWING
-        elif tf.issue_number is not None:
-            # Any worktree with a valid issue number is implementing. We do not
-            # require the agent/wip GitHub label here — the worktree's existence
-            # is the authoritative signal. The label is useful for stale-claim
-            # detection (a label without a worktree) but should not gate board
-            # visibility, because leaf agents may not have claimed the issue yet
-            # when the first poller tick fires.
+        elif run["issue_number"] is not None:
             status = AgentStatus.IMPLEMENTING
-        elif tf.task == "bugs-to-issues":
-            # Coordinator (brain-dump) agents have no GitHub issue or PR until
-            # sub-agents start filing them.  Treat them as IMPLEMENTING so they
-            # show as active rather than confusingly UNKNOWN.
+        elif run["tier"] == "coordinator":
+            # Coordinator agents may have no issue/PR during planning.
             status = AgentStatus.IMPLEMENTING
         else:
             status = AgentStatus.FAILED
 
-        # Agent ID is the worktree basename (e.g. "issue-732"). This is the
-        # canonical identifier used in URLs, DB PKs, and API responses.
+        worktree = run["worktree_path"]
         node_id = (
-            Path(tf.worktree).name if tf.worktree else None
-        ) or (f"issue-{tf.issue_number}" if tf.issue_number else None) or "unknown"
-        # Prefer PR number derived from live GitHub branch match over the
-        # static value in the .agent-task file (which may be 0 or missing
-        # until the agent explicitly updates linked_pr).
-        resolved_pr_number = gh_pr_number if gh_pr_number is not None else tf.pr_number
+            Path(worktree).name if worktree else None
+        ) or (f"issue-{run['issue_number']}" if run["issue_number"] else None) or run["run_id"]
+        resolved_pr_number = gh_pr_number if gh_pr_number is not None else run["pr_number"]
         nodes.append(
             AgentNode(
                 id=node_id,
-                role=tf.role or "unknown",
+                role=run["role"] or "unknown",
                 status=status,
-                issue_number=tf.issue_number,
+                issue_number=run["issue_number"],
                 pr_number=resolved_pr_number,
-                branch=tf.branch,
-                batch_id=tf.batch_id,
-                worktree_path=tf.worktree,
-                cognitive_arch=tf.cognitive_arch,
-                tier=tf.tier,
-                org_domain=tf.org_domain,
-                parent_run_id=tf.parent_run_id,
+                branch=run["branch"],
+                batch_id=run["batch_id"],
+                worktree_path=worktree,
+                cognitive_arch=run["cognitive_arch"],
+                tier=run["tier"],
+                org_domain=run["org_domain"],
+                parent_run_id=run["parent_run_id"],
             )
         )
 
@@ -206,7 +185,7 @@ async def merge_agents(
 
 
 async def detect_alerts(
-    worktrees: list[TaskFile],
+    active_runs: list[RunContextRow],
     github: GitHubBoard,
 ) -> tuple[list[str], list[StaleClaim]]:
     """Detect pipeline problems and return human-readable alert strings plus structured stale claims.
@@ -263,29 +242,32 @@ async def detect_alerts(
                 break  # one alert per PR is enough
 
     # ── Alert 3: worktree last commit > 30 min ago (async path) ────────────
-    # Skip coordinator (brain-dump) worktrees — they have no commits of their
-    # own; all work happens in sub-agent worktrees they spawn.  Applying the
-    # stuck check to them would always fire immediately.
+    # Skip coordinator runs — they have no commits of their own; all work
+    # happens in sub-agent worktrees they spawn.
     #
-    # Also skip worktrees whose .agent-task file is newer than the threshold —
-    # a freshly spawned worktree has no agent activity yet and is not stuck.
-    for tf in worktrees:
-        if tf.worktree is None:
+    # Skip freshly spawned runs (spawned_at within threshold) — a brand-new
+    # worktree has no agent activity yet and is not stuck.
+    import datetime as _dt
+    for run in active_runs:
+        worktree = run["worktree_path"]
+        if worktree is None:
             continue
-        if tf.task == "bugs-to-issues":
+        if run["tier"] == "coordinator":
             continue
-        path = Path(tf.worktree)
+        path = Path(worktree)
         if not path.exists():
             continue
-        # Skip if the worktree was created (task file written) within the threshold.
-        task_file = path / ".agent-task"
-        if task_file.exists():
-            task_mtime = task_file.stat().st_mtime
-            if (now - task_mtime) < _STUCK_THRESHOLD_SECONDS:
+        # Skip if spawned within the threshold window.
+        spawned_at_str = run["spawned_at"]
+        try:
+            spawned_ts = _dt.datetime.fromisoformat(spawned_at_str).timestamp()
+            if (now - spawned_ts) < _STUCK_THRESHOLD_SECONDS:
                 continue
+        except (ValueError, OSError):
+            pass
         last_commit = await worktree_last_commit_time(path)
         if last_commit > 0.0 and (now - last_commit) > _STUCK_THRESHOLD_SECONDS:
-            label = f"issue #{tf.issue_number}" if tf.issue_number else path.name
+            label = f"issue #{run['issue_number']}" if run["issue_number"] else path.name
             alerts.append(f"Possible stuck agent on {label}")
 
     # ── Alert 4: structured out-of-order PR violations (linked-issue check) ─
@@ -678,10 +660,10 @@ async def tick() -> PipelineState:
     # via the GUI takes effect within one polling interval — no restart needed.
     settings.reload()
 
-    worktrees = await list_active_worktrees()
+    active_runs = await list_active_runs()
     github = await build_github_board()
-    agents = await merge_agents(worktrees, github)
-    alerts, stale_claims = await detect_alerts(worktrees, github)
+    agents = await merge_agents(active_runs, github)
+    alerts, stale_claims = await detect_alerts(active_runs, github)
     plan_draft_events = await scan_plan_draft_worktrees()
 
     # ── Persist raw tick data to Postgres ────────────────────────────────────

--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -6,8 +6,8 @@ Three endpoints drive the Ship page launch modal:
 
 1. ``GET /api/dispatch/context`` — return phases and open issues for a
    label so the modal can populate its pickers.
-2. ``POST /api/dispatch/issue`` — create a worktree + ``.agent-task`` +
-   ``pending_launch`` record for a single issue-scoped leaf agent.
+2. ``POST /api/dispatch/issue`` — create a worktree + ``pending_launch``
+   DB record for a single issue-scoped leaf agent.
 3. ``POST /api/dispatch/label`` — same but scoped to an initiative label or
    phase sub-label (spawns a coordinator or leaf depending on *scope*).
 4. ``GET /api/dispatch/prompt`` — serve the Dispatcher prompt so the UI
@@ -32,9 +32,9 @@ from typing import Literal
 class OrgNodeSpec(BaseModel):
     """One node in a user-designed agent org tree.
 
-    Serialized to JSON and written into the ``[pipeline]`` section of
-    ``.agent-task`` so the launched agent knows the exact hierarchy it was
-    designed to spawn rather than inferring structure from the ticket list.
+    Persisted to the DB and included in the agent's run context so the
+    launched agent knows the exact hierarchy it was designed to spawn rather
+    than inferring structure from the ticket list.
 
     Self-referential via ``children`` — ``model_rebuild()`` is required after
     the class definition.
@@ -53,15 +53,13 @@ OrgNodeSpec.model_rebuild()
 from agentception.config import settings
 from agentception.db.persist import persist_agent_run_dispatch
 from agentception.db.queries import get_label_context
-from agentception.routes.api._shared import _build_agent_task, _resolve_cognitive_arch
+from agentception.routes.api._shared import _resolve_cognitive_arch
 from agentception.services.spawn_child import (
     SpawnChildError,
     ScopeType,
     Tier,
-    _tier_to_node_type,
     spawn_child,
 )
-from agentception.services.toml_task import TomlValue, render_toml_str
 
 logger = logging.getLogger(__name__)
 
@@ -166,7 +164,6 @@ class DispatchResponse(BaseModel):
     worktree: str
     host_worktree: str
     branch: str
-    agent_task_path: str
     batch_id: str
     status: str = "pending_launch"
 
@@ -180,13 +177,12 @@ def _make_batch_id(issue_number: int) -> str:
 
 @router.post("/issue", response_model=DispatchResponse)
 async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
-    """Create a worktree, ``.agent-task``, and a ``pending_launch`` DB record.
+    """Create a worktree and a ``pending_launch`` DB record.
 
     The worktree is the isolated git checkout the agent will work in.
-    The ``.agent-task`` file is the agent's full briefing — role, scope,
-    repo, callbacks.  The ``pending_launch`` DB record is what the
-    AgentCeption Dispatcher reads via ``build_get_pending_launches`` to know
-    what to spawn next.
+    All task context is persisted to the DB row — no ``.agent-task`` file is
+    written.  The ``pending_launch`` DB record is what the AgentCeption
+    Dispatcher reads via ``build_get_pending_launches`` to know what to spawn.
 
     Agents are NOT launched here.  The Dispatcher polls the pending queue
     and spawns the right role — which may be a leaf worker, a VP, or a CTO
@@ -194,7 +190,7 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
 
     Raises:
         HTTPException 409: Worktree already exists.
-        HTTPException 500: git worktree add or .agent-task write failed.
+        HTTPException 500: git worktree add failed.
     """
     run_id = f"issue-{req.issue_number}"
     slug = f"issue-{req.issue_number}"
@@ -229,42 +225,11 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
 
     logger.info("✅ dispatch: worktree created at %s", worktree_path)
 
-    role_file = str(Path(settings.repo_dir) / ".agentception" / "roles" / f"{req.role}.md")
     cognitive_arch = _resolve_cognitive_arch(req.issue_body, req.role)
-    agent_task = _build_agent_task(
-        issue_number=req.issue_number,
-        title=req.issue_title,
-        role=req.role,
-        worktree=Path(worktree_path),
-        host_worktree=Path(host_worktree_path),
-        branch=branch,
-        cognitive_arch=cognitive_arch,
-        wave_id=batch_id,
-    ) + render_toml_str({
-        "meta": {
-            "run_id": run_id,
-            "role_file": role_file,
-            "mcp_server": "user-agentception",
-            "spawn_mode": "dispatcher",
-        },
-    })
 
-    agent_task_path = str(Path(worktree_path) / ".agent-task")
-    try:
-        Path(agent_task_path).write_text(agent_task, encoding="utf-8")
-    except Exception as exc:
-        cleanup = await asyncio.create_subprocess_exec(
-            "git", "worktree", "remove", "--force", worktree_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(settings.repo_dir),
-        )
-        await cleanup.communicate()
-        logger.error("❌ dispatch: .agent-task write failed, worktree cleaned up — %s", exc)
-        raise HTTPException(status_code=500, detail=f".agent-task write failed: {exc}") from exc
-
-    logger.info("✅ dispatch: .agent-task written to %s", agent_task_path)
-
+    # Persist all task context to DB — no .agent-task file is written.
+    # Agents read their briefing from ac://runs/{run_id}/context and the
+    # task/briefing MCP prompt, both of which are DB-backed.
     await persist_agent_run_dispatch(
         run_id=run_id,
         issue_number=req.issue_number,
@@ -274,6 +239,7 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
         batch_id=batch_id,
         host_worktree_path=host_worktree_path,
         cognitive_arch=cognitive_arch,
+        gh_repo=settings.gh_repo,
     )
 
     return DispatchResponse(
@@ -281,7 +247,6 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
         worktree=worktree_path,
         host_worktree=host_worktree_path,
         branch=branch,
-        agent_task_path=agent_task_path,
         batch_id=batch_id,
         status="pending_launch",
     )
@@ -436,7 +401,6 @@ class LabelDispatchResponse(BaseModel):
     label: str
     worktree: str
     host_worktree: str
-    agent_task_path: str
     batch_id: str
     status: str = "pending_launch"
 
@@ -476,10 +440,11 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
     - ``"issue"`` → leaf, works on a single ticket.
 
     A worktree is always created so the agent runs in an isolated checkout.
+    All task context is persisted to the DB row — no ``.agent-task`` file is written.
 
     Raises:
         HTTPException 409: Worktree already exists.
-        HTTPException 500: git worktree or .agent-task write failed.
+        HTTPException 500: git worktree add failed.
     """
     role, tier = _role_and_tier_for_scope(req.scope, req.role)
     org_domain = _org_domain_for_role(role)
@@ -536,81 +501,19 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
 
     logger.info("✅ dispatch-label: worktree %s for label %r tier=%s", worktree_path, req.label, tier)
 
-    role_file = str(Path(settings.repo_dir) / ".agentception" / "roles" / f"{role}.md")
-    host_role_file = str(Path(settings.host_repo_dir) / ".agentception" / "roles" / f"{role}.md")
     label_cognitive_arch = _resolve_cognitive_arch(
         "", role, figure_override=req.cognitive_arch_override
     )
-    node_type = _tier_to_node_type(tier)
 
-    agent_sections: dict[str, dict[str, TomlValue]] = {
-        "task": {
-            "version": "2.0",
-            "workflow": "label-dispatch",
-            "attempt_n": 0,
-        },
-        "agent": {
-            "role": role,
-            "tier": tier,
-            "cognitive_arch": label_cognitive_arch,
-            "role_file": role_file,
-            "host_role_file": host_role_file,
-        },
-        "repo": {
-            "gh_repo": req.repo,
-            "base": "dev",
-        },
-        "pipeline": {
-            "batch_id": batch_id,
-            "parent_run_id": req.parent_run_id or "",
-        },
-        "target": {
-            "scope_type": scope_type,
-            "scope_value": scope_value,
-            "initiative_label": req.label,
-        },
-        "worktree": {
-            "path": host_worktree_path,
-            "branch": branch,
-        },
-        "spawn": {
-            "cascade_enabled": req.cascade_enabled,
-        },
-        "meta": {
-            "run_id": run_id,
-            "mcp_server": "user-agentception",
-        },
-    }
-    if org_domain:
-        agent_sections["agent"]["org_domain"] = org_domain
-    if req.org_tree:
-        # Compact JSON — the agent reads this via toml and parses it.
-        agent_sections["pipeline"]["org_tree_json"] = req.org_tree.model_dump_json()
-    agent_task = render_toml_str(agent_sections)
-
-    agent_task_path = str(Path(worktree_path) / ".agent-task")
-    try:
-        Path(agent_task_path).write_text(agent_task, encoding="utf-8")
-    except Exception as exc:
-        cleanup = await asyncio.create_subprocess_exec(
-            "git", "worktree", "remove", "--force", worktree_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(settings.repo_dir),
-        )
-        await cleanup.communicate()
-        logger.error("❌ dispatch-label: .agent-task write failed — %s", exc)
-        raise HTTPException(status_code=500, detail=f".agent-task write failed: {exc}") from exc
-
-    logger.warning("✅ dispatch-label: .agent-task written to %s", agent_task_path)
-
+    # Persist all task context to DB — no .agent-task file is written.
     logger.warning(
         "🚀 dispatch-label: calling persist_agent_run_dispatch run_id=%r host_worktree_path=%r",
         run_id, host_worktree_path,
     )
+    issue_number = req.scope_issue_number if (req.scope == "issue" and req.scope_issue_number is not None) else 0
     await persist_agent_run_dispatch(
         run_id=run_id,
-        issue_number=req.scope_issue_number if (req.scope == "issue" and req.scope_issue_number is not None) else 0,
+        issue_number=issue_number,
         role=role,
         branch=branch,
         worktree_path=worktree_path,
@@ -620,6 +523,7 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
         tier=tier,
         org_domain=org_domain,
         parent_run_id=req.parent_run_id,
+        gh_repo=req.repo,
     )
     logger.warning("✅ dispatch-label: persist complete — run_id=%r is now pending_launch", run_id)
 
@@ -630,7 +534,6 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
         label=req.label,
         worktree=worktree_path,
         host_worktree=host_worktree_path,
-        agent_task_path=agent_task_path,
         batch_id=batch_id,
         status="pending_launch",
     )

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -1,13 +1,13 @@
 """Cursor-free agent execution loop.
 
 Replaces Cursor as the agent runtime.  An LLM on Anthropic's infrastructure
-(reached via OpenRouter) does the reasoning; file operations, shell commands,
-and MCP tool calls execute locally inside this container.
+does the reasoning; file operations, shell commands, and MCP tool calls execute
+locally inside this container.
 
 Pipeline
 --------
 1. Resolve the worktree path from ``settings.worktrees_dir / run_id``.
-2. Parse ``.agent-task`` via :func:`~agentception.readers.worktrees.parse_agent_task`.
+2. Load task context from the ``ACAgentRun`` DB row via ``_load_task``.
 3. Load the role file from ``settings.repo_dir / ".agentception/roles/{role}.md"``.
 4. Assemble the system prompt: role content + cognitive architecture context +
    runtime environment note (Python commands run directly, not via docker exec).
@@ -39,8 +39,7 @@ from agentception.mcp.log_tools import log_run_error, log_run_step
 from agentception.mcp.prompts import get_prompt
 from agentception.mcp.server import TOOLS, call_tool_async
 from agentception.mcp.types import ACToolResult
-from agentception.models import TaskFile
-from agentception.readers.worktrees import parse_agent_task
+from agentception.models import AgentTaskSpec
 from agentception.services.llm import (
     ToolCall,
     ToolDefinition,
@@ -205,79 +204,20 @@ async def run_agent_loop(
 # ---------------------------------------------------------------------------
 
 
-async def _load_task(run_id: str, worktree_path: Path) -> TaskFile | None:
-    """Load task context for *run_id*, preferring the DB row over the file.
+async def _load_task(run_id: str, worktree_path: Path) -> AgentTaskSpec | None:
+    """Load task context for *run_id* from the ``ACAgentRun`` DB row.
 
-    Resolution order:
-    1. ``ACAgentRun`` DB row — always tried first.  When the row carries a
-       ``task_description`` the agent loop can run without any ``.agent-task``
-       file present in the worktree.
-    2. ``.agent-task`` TOML file — parsed as a supplement when present.  Its
-       fields fill in any gaps left by the DB row (e.g. issue queue, spawn
-       mode), but DB fields take precedence where both exist.
-
-    Returns ``None`` only when neither source yields a usable ``TaskFile``.
+    All task context lives in the DB — no ``.agent-task`` file is read.
+    Returns ``None`` when no row exists, logging the error.
     """
-    db_task: TaskFile | None = await _load_task_from_db(run_id)
-    file_task: TaskFile | None = await _load_task_from_file(worktree_path)
-
-    if db_task is None and file_task is None:
-        logger.error("❌ _load_task — no context for run_id=%s", run_id)
-        return None
-
-    if db_task is None:
-        return file_task
-    if file_task is None:
-        return db_task
-
-    # Merge: DB takes precedence for scalar fields; file supplies queue lists.
-    return TaskFile(
-        task=db_task.task or file_task.task,
-        id=db_task.id or file_task.id,
-        attempt_n=db_task.attempt_n or file_task.attempt_n,
-        is_resumed=db_task.is_resumed or file_task.is_resumed,
-        required_output=db_task.required_output or file_task.required_output,
-        on_block=file_task.on_block,
-        role=db_task.role or file_task.role,
-        tier=db_task.tier or file_task.tier,
-        org_domain=db_task.org_domain or file_task.org_domain,
-        cognitive_arch=db_task.cognitive_arch or file_task.cognitive_arch,
-        session_id=file_task.session_id,
-        gh_repo=file_task.gh_repo,
-        base=file_task.base,
-        batch_id=db_task.batch_id or file_task.batch_id,
-        parent_run_id=db_task.parent_run_id or file_task.parent_run_id,
-        wave=file_task.wave,
-        vp_fingerprint=file_task.vp_fingerprint,
-        spawn_sub_agents=file_task.spawn_sub_agents,
-        spawn_mode=db_task.spawn_mode or file_task.spawn_mode,
-        issue_number=db_task.issue_number or file_task.issue_number,
-        pr_number=db_task.pr_number or file_task.pr_number,
-        depends_on=file_task.depends_on,
-        closes_issues=file_task.closes_issues,
-        file_ownership=file_task.file_ownership,
-        files_changed=file_task.files_changed,
-        grade_threshold=file_task.grade_threshold,
-        has_migration=file_task.has_migration,
-        merge_after=file_task.merge_after,
-        worktree=db_task.worktree or file_task.worktree,
-        branch=db_task.branch or file_task.branch,
-        linked_pr=file_task.linked_pr,
-        draft_id=file_task.draft_id,
-        output_path=file_task.output_path,
-        output_format=file_task.output_format,
-        domain=file_task.domain,
-        issue_queue=file_task.issue_queue,
-        pr_queue=file_task.pr_queue,
-        task_description=db_task.task_description or file_task.task_description,
-    )
+    return await _load_task_from_db(run_id)
 
 
-async def _load_task_from_db(run_id: str) -> TaskFile | None:
-    """Build a ``TaskFile`` from the ``ACAgentRun`` DB row for *run_id*.
+async def _load_task_from_db(run_id: str) -> AgentTaskSpec | None:
+    """Build an ``AgentTaskSpec`` from the ``ACAgentRun`` DB row for *run_id*.
 
     Returns ``None`` when no row is found.  Never raises — errors are logged
-    and ``None`` is returned so the caller can fall back to the file.
+    so the loop can surface a clean cancellation instead of crashing.
     """
     try:
         async with get_session() as session:
@@ -285,8 +225,9 @@ async def _load_task_from_db(run_id: str) -> TaskFile | None:
                 select(ACAgentRun).where(ACAgentRun.id == run_id)
             )
         if run is None:
+            logger.error("❌ _load_task_from_db — no DB row for run_id=%s", run_id)
             return None
-        return TaskFile(
+        return AgentTaskSpec(
             id=run.id,
             role=run.role,
             cognitive_arch=run.cognitive_arch,
@@ -300,21 +241,12 @@ async def _load_task_from_db(run_id: str) -> TaskFile | None:
             org_domain=run.org_domain,
             spawn_mode=run.spawn_mode,
             task_description=run.task_description,
+            gh_repo=run.gh_repo,
+            is_resumed=run.is_resumed,
+            coord_fingerprint=run.coord_fingerprint,
         )
     except Exception as exc:
         logger.error("❌ _load_task_from_db error for run_id=%s: %s", run_id, exc)
-        return None
-
-
-async def _load_task_from_file(worktree_path: Path) -> TaskFile | None:
-    """Parse the ``.agent-task`` TOML file in *worktree_path*.
-
-    Returns ``None`` when the file is absent or malformed.
-    """
-    try:
-        return await parse_agent_task(worktree_path)
-    except Exception as exc:
-        logger.error("❌ _load_task_from_file error: %s", exc)
         return None
 
 
@@ -354,8 +286,7 @@ You are running **inside the AgentCeption Docker container**, not on the host ma
   - ✅ `python3 -m mypy agentception/`
   - ❌ `docker compose exec agentception python3 -m pytest` (wrong — you are already inside)
 - The repository is mounted at `/app`.  Your worktree path is provided in your
-  initial message.  If a `.agent-task` file exists in your worktree, it contains
-  additional pipeline configuration you may reference.
+  initial message.  Read `ac://runs/{run_id}/context` for your full task context.
 - Git operations run in the worktree directory.
 - Use `run_command` for shell execution.  Use `read_file` / `write_file` for files.
 """
@@ -446,7 +377,7 @@ def _build_system_prompt(role_prompt: str, cognitive_arch: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-async def _fetch_task_briefing(run_id: str, task: TaskFile, worktree_path: Path) -> str:
+async def _fetch_task_briefing(run_id: str, task: AgentTaskSpec, worktree_path: Path) -> str:
     """Fetch the initial agent message via the ``task/briefing`` MCP prompt.
 
     Calls ``get_prompt("task/briefing", {"run_id": run_id})`` so the briefing

--- a/agentception/services/spawn_child.py
+++ b/agentception/services/spawn_child.py
@@ -49,7 +49,6 @@ from typing import Literal
 from agentception.config import settings
 from agentception.db.persist import acknowledge_agent_run, persist_agent_run_dispatch
 from agentception.services.cognitive_arch import _resolve_cognitive_arch
-from agentception.services.toml_task import TomlValue, render_toml_str
 
 logger = logging.getLogger(__name__)
 
@@ -86,13 +85,11 @@ class SpawnChildResult:
         run_id:              Unique run identifier (e.g. ``coord-abc123``).
         host_worktree_path:  Absolute path on the HOST filesystem.
         worktree_path:       Absolute path inside the container.
-        tier:                Behavioral tier written to the ``.agent-task`` —
-                             one of ``coordinator | worker``.
+        tier:                Behavioral tier: ``coordinator | worker``.
         org_domain:          Organisational slot for UI hierarchy (``c-suite``,
                              ``engineering``, or ``qa``).  ``None`` when not specified.
         role:                Role slug (e.g. ``"engineering-coordinator"``).
-        cognitive_arch:      Resolved COGNITIVE_ARCH string.
-        agent_task_path:     Path to the written ``.agent-task`` file.
+        cognitive_arch:      Resolved cognitive architecture string.
         scope_type:          ``"label"``, ``"issue"``, or ``"pr"``.
         scope_value:         Label string or issue/PR number.
     """
@@ -105,7 +102,6 @@ class SpawnChildResult:
         "org_domain",
         "role",
         "cognitive_arch",
-        "agent_task_path",
         "scope_type",
         "scope_value",
     )
@@ -120,7 +116,6 @@ class SpawnChildResult:
         org_domain: str | None,
         role: str,
         cognitive_arch: str,
-        agent_task_path: str,
         scope_type: str,
         scope_value: str,
     ) -> None:
@@ -131,7 +126,6 @@ class SpawnChildResult:
         self.org_domain = org_domain
         self.role = role
         self.cognitive_arch = cognitive_arch
-        self.agent_task_path = agent_task_path
         self.scope_type = scope_type
         self.scope_value = scope_value
 
@@ -144,7 +138,6 @@ class SpawnChildResult:
             "org_domain": self.org_domain,
             "role": self.role,
             "cognitive_arch": self.cognitive_arch,
-            "agent_task_path": self.agent_task_path,
             "scope_type": self.scope_type,
             "scope_value": self.scope_value,
         }
@@ -184,164 +177,6 @@ def _make_batch_id(scope_type: ScopeType, scope_value: str) -> str:
     return f"{prefix}-{slug}-{stamp}-{hex4}"
 
 
-# ---------------------------------------------------------------------------
-# .agent-task builder (universal — all scope types and node types)
-# ---------------------------------------------------------------------------
-
-def _workflow_for_scope(scope_type: ScopeType) -> str:
-    """Derive the task.workflow value from the scope type."""
-    if scope_type == "issue":
-        return "issue-to-pr"
-    if scope_type == "pr":
-        return "pr-review"
-    return "coordinator"
-
-
-def _required_output_for_scope(scope_type: ScopeType) -> str:
-    """Derive the task.required_output value from the scope type."""
-    if scope_type == "issue":
-        return "pr_url"
-    if scope_type == "pr":
-        return "review_decision"
-    return "none"
-
-
-def _build_child_task(
-    *,
-    run_id: str,
-    role: str,
-    tier: Tier,
-    org_domain: str | None,
-    scope_type: ScopeType,
-    scope_value: str,
-    gh_repo: str,
-    branch: str,
-    worktree_path: str,
-    host_worktree_path: str,
-    batch_id: str,
-    parent_run_id: str,
-    cognitive_arch: str,
-    coord_fingerprint: str | None = None,
-    issue_title: str = "",
-    issue_number: int | None = None,
-    pr_number: int | None = None,
-    is_resumed: bool = False,
-) -> str:
-    """Build the TOML content of a ``.agent-task`` file for any tree node.
-
-    Emits a fully-structured TOML document consumed by both
-    ``parse_agent_task()`` (dashboard poller) and Cursor LLM agents.
-    All fields must be valid TOML — no KEY=VALUE lines.
-
-    ``tier`` is the behavioral execution tier:
-    ``coordinator | worker``.
-    """
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    # Container-side and host-side role file paths — written to [meta] so
-    # agents can locate their role file without re-deriving it.
-    role_file = str(
-        Path(settings.repo_dir) / ".agentception" / "roles" / f"{role}.md"
-    )
-    host_role_file = str(
-        Path(settings.host_repo_dir) / ".agentception" / "roles" / f"{role}.md"
-    )
-
-    sections: dict[str, dict[str, TomlValue]] = {
-        "task": {
-            "version": "2.0",
-            "workflow": _workflow_for_scope(scope_type),
-            "id": run_id,
-            "created_at": now,
-            "attempt_n": 0,
-            "is_resumed": is_resumed,
-            "required_output": _required_output_for_scope(scope_type),
-            "on_block": "stop",
-        },
-        "agent": {
-            "role": role,
-            "tier": tier,
-            "org_domain": org_domain or "",
-            "cognitive_arch": cognitive_arch,
-        },
-        "repo": {
-            "gh_repo": gh_repo,
-            "base": "dev",
-            # mcp_server: agents communicate exclusively via the user-agentception
-            # MCP server — no HTTP calls.  This comment is documentation only.
-            "mcp_server": "user-agentception",
-        },
-        "pipeline": {
-            "batch_id": batch_id,
-            "parent_run_id": parent_run_id,
-            "coord_fingerprint": coord_fingerprint or "",
-        },
-        "spawn": {
-            "mode": "chain",
-            "sub_agents": False,
-        },
-    }
-
-    # Scope-specific [target] section — drives issue_number / pr_number in
-    # TaskFile, which is what the poller uses for swim-lane placement.
-    if scope_type == "issue" and issue_number is not None:
-        sections["target"] = {
-            "issue_number": issue_number,
-            "issue_title": issue_title,
-            "issue_url": f"https://github.com/{gh_repo}/issues/{issue_number}",
-            "scope_value": scope_value,
-            "closes": [issue_number],
-            "depends_on": [],
-        }
-    elif scope_type == "pr" and pr_number is not None:
-        sections["target"] = {
-            "pr_number": pr_number,
-            "pr_url": f"https://github.com/{gh_repo}/pull/{pr_number}",
-            "scope_value": scope_value,
-        }
-    else:
-        sections["target"] = {
-            "scope_type": scope_type,
-            "scope_value": scope_value,
-        }
-
-    sections["worktree"] = {
-        "path": host_worktree_path,
-        "branch": branch,
-        "linked_pr": 0,
-    }
-
-    # [meta] carries human/agent convenience fields that are not parsed by
-    # _build_task_file_from_toml — they are read as raw TOML text by the agent.
-    sections["meta"] = {
-        "role_file": role_file,
-        "host_role_file": host_role_file,
-        "worktree_path": worktree_path,
-    }
-
-    # Inline MCP query hints as a comment block appended after the TOML.
-    toml_body = render_toml_str(sections)
-    hints = _mcp_hints(scope_type, scope_value, tier)
-    return toml_body + hints
-
-
-def _mcp_hints(scope_type: ScopeType, scope_value: str, tier: Tier) -> str:
-    """Return a TOML comment block with inline MCP query hints."""
-    node_type = _tier_to_node_type(tier)
-    lines: list[str] = [
-        f"# GitHub queries for this node (tier={tier}, scope_type={scope_type}):",
-    ]
-    if node_type == "coordinator" and scope_type == "label":
-        lines += [
-            f"# MCP: github_list_issues(label='{scope_value}', state='open')",
-            "# MCP: github_list_prs(state='open')",
-            "# NOTE: exclude issues labelled 'agent/wip' (claimed) or 'pipeline/gated' (phase-gated)",
-        ]
-    elif node_type == "leaf" and scope_type == "issue":
-        lines.append(f"# MCP: github_get_issue(number={scope_value})")
-    elif node_type == "leaf" and scope_type == "pr":
-        lines.append(f"# MCP: github_get_pr(number={scope_value})")
-    return "\n".join(lines) + "\n"
 
 
 # ---------------------------------------------------------------------------
@@ -485,46 +320,9 @@ async def spawn_child(
 
     logger.info("✅ spawn_child: worktree created at %s", worktree_path)
 
-    # Write .agent-task
-    task_content = _build_child_task(
-        run_id=run_id,
-        role=role,
-        tier=tier,
-        org_domain=org_domain,
-        scope_type=scope_type,
-        scope_value=scope_value,
-        gh_repo=gh_repo,
-        branch=branch,
-        worktree_path=worktree_path,
-        host_worktree_path=host_worktree_path,
-        batch_id=batch_id,
-        parent_run_id=parent_run_id,
-        cognitive_arch=resolved_arch,
-        coord_fingerprint=coord_fingerprint,
-        issue_title=issue_title,
-        issue_number=issue_number,
-        pr_number=pr_number,
-        is_resumed=is_resumed,
-    )
-
-    agent_task_path = str(Path(worktree_path) / ".agent-task")
-    try:
-        Path(agent_task_path).write_text(task_content, encoding="utf-8")
-    except Exception as exc:
-        # Clean up worktree on write failure
-        cleanup = await asyncio.create_subprocess_exec(
-            "git", "worktree", "remove", "--force", worktree_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(settings.repo_dir),
-        )
-        await cleanup.communicate()
-        logger.error("❌ spawn_child: .agent-task write failed, worktree removed — %s", exc)
-        raise SpawnChildError(f".agent-task write failed: {exc}") from exc
-
-    logger.info("✅ spawn_child: .agent-task written to %s", agent_task_path)
-
-    # Persist DB record
+    # Persist DB record — all task context goes to the DB row; no .agent-task
+    # file is written.  Agents read their full briefing from the DB via the
+    # ac://runs/{run_id}/context MCP resource and the task/briefing prompt.
     db_issue_number = issue_number if issue_number is not None else (pr_number or 0)
     await persist_agent_run_dispatch(
         run_id=run_id,
@@ -538,6 +336,9 @@ async def spawn_child(
         tier=tier,
         org_domain=org_domain,
         parent_run_id=parent_run_id,
+        gh_repo=gh_repo,
+        is_resumed=is_resumed,
+        coord_fingerprint=coord_fingerprint,
     )
 
     # Auto-acknowledge: pending_launch → implementing
@@ -552,7 +353,6 @@ async def spawn_child(
         org_domain=org_domain,
         role=role,
         cognitive_arch=resolved_arch,
-        agent_task_path=agent_task_path,
         scope_type=scope_type,
         scope_value=scope_value,
     )

--- a/agentception/telemetry.py
+++ b/agentception/telemetry.py
@@ -22,8 +22,8 @@ from pathlib import Path
 from pydantic import BaseModel
 
 from agentception.config import settings
-from agentception.models import AgentNode, AgentStatus, TaskFile
-from agentception.readers.worktrees import list_active_worktrees
+from agentception.db.queries import RunContextRow, list_active_runs
+from agentception.models import AgentNode, AgentStatus
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +90,8 @@ async def aggregate_waves() -> list[WaveSummary]:
 
     Returns a list sorted by ``started_at`` descending (most recent wave first).
     """
-    task_files = await list_active_worktrees()
-    fs_summaries = _build_wave_summaries(task_files, settings.worktrees_dir)
+    active_runs = await list_active_runs()
+    fs_summaries = _build_wave_summaries(active_runs)
     if fs_summaries:
         return fs_summaries
 
@@ -137,108 +137,80 @@ async def aggregate_waves() -> list[WaveSummary]:
         return []
 
 
-async def compute_wave_timing(worktrees: list[TaskFile]) -> tuple[float, float | None]:
-    """Return ``(started_at, ended_at)`` from ``.agent-task`` file mtimes.
+async def compute_wave_timing(runs: list[RunContextRow]) -> tuple[float, float | None]:
+    """Return ``(started_at, ended_at)`` from DB ``spawned_at`` timestamps.
 
-    ``started_at`` is the mtime of the *earliest* task file in the group.
-    ``ended_at`` is the mtime of the *latest* task file, or ``None`` if any
-    worktree path in the group still exists on disk (agent still active).
+    ``started_at`` is the earliest ``spawned_at`` in the group (UNIX timestamp).
+    ``ended_at`` is ``None`` if any worktree path still exists (agent active),
+    otherwise the latest ``spawned_at`` as a proxy for when the wave ended.
 
-    Both values are UNIX timestamps (seconds since epoch).  Returns ``(0.0,
-    None)`` when the list is empty.
+    Returns ``(0.0, None)`` when the list is empty.
     """
-    if not worktrees:
+    import datetime as _dt
+
+    if not runs:
         return 0.0, None
 
-    mtimes: list[float] = []
+    timestamps: list[float] = []
     any_still_active = False
 
-    for tf in worktrees:
-        worktree_path = Path(tf.worktree) if tf.worktree else None
-        if worktree_path is None:
-            continue
-
-        task_file = worktree_path / ".agent-task"
+    for run in runs:
         try:
-            mtime = await _get_mtime(task_file)
-            mtimes.append(mtime)
-        except OSError:
-            logger.debug("⚠️  Cannot stat %s — skipping", task_file)
-
-        # If the worktree directory itself still exists, the agent is active.
-        if worktree_path.exists():
+            ts = _dt.datetime.fromisoformat(run["spawned_at"]).timestamp()
+            timestamps.append(ts)
+        except (ValueError, KeyError):
+            pass
+        worktree = run["worktree_path"]
+        if worktree and Path(worktree).exists():
             any_still_active = True
 
-    if not mtimes:
+    if not timestamps:
         return 0.0, None
 
-    started_at = min(mtimes)
-    ended_at = None if any_still_active else max(mtimes)
+    started_at = min(timestamps)
+    ended_at = None if any_still_active else max(timestamps)
     return started_at, ended_at
 
 
 # ── Private helpers ────────────────────────────────────────────────────────────
 
 
-def _build_wave_summaries(
-    task_files: list[TaskFile],
-    worktrees_dir: Path,
-) -> list[WaveSummary]:
-    """Group TaskFile objects by BATCH_ID and produce WaveSummary objects.
+def _build_wave_summaries(active_runs: list[RunContextRow]) -> list[WaveSummary]:
+    """Group DB run rows by batch_id and produce WaveSummary objects."""
+    import datetime as _dt
 
-    Uses file mtimes synchronously (via ``os.stat``) because this is called
-    from the non-async poller path.  For async callers, prefer
-    ``compute_wave_timing``.
-    """
-    # Group by BATCH_ID — skip task files with no batch_id.
-    groups: dict[str, list[TaskFile]] = {}
-    for tf in task_files:
-        bid = tf.batch_id
+    groups: dict[str, list[RunContextRow]] = {}
+    for run in active_runs:
+        bid = run["batch_id"]
         if not bid:
             continue
-        groups.setdefault(bid, []).append(tf)
+        groups.setdefault(bid, []).append(run)
 
     summaries: list[WaveSummary] = []
     for batch_id, members in groups.items():
-        mtimes: list[float] = []
+        timestamps: list[float] = []
         any_still_active = False
         issues_worked: list[int] = []
         prs_opened = 0
 
-        for tf in members:
-            worktree_path = Path(tf.worktree) if tf.worktree else None
-
-            # Collect issue numbers worked in this wave.
-            for iss in tf.closes_issues:
-                if iss not in issues_worked:
-                    issues_worked.append(iss)
-
-            # Count PRs opened by checking pr_number field.
-            if tf.pr_number is not None:
+        for run in members:
+            issue_num = run["issue_number"]
+            if issue_num is not None and issue_num not in issues_worked:
+                issues_worked.append(issue_num)
+            if run["pr_number"] is not None:
                 prs_opened += 1
-
-            if worktree_path is None:
-                continue
-
-            # File mtime as proxy timestamp.
-            task_file = worktree_path / ".agent-task"
-            mtime = _stat_mtime(task_file)
-            if mtime is not None:
-                mtimes.append(mtime)
-
-            # Active = worktree directory still present.
-            if worktree_path.exists():
+            try:
+                ts = _dt.datetime.fromisoformat(run["spawned_at"]).timestamp()
+                timestamps.append(ts)
+            except (ValueError, KeyError):
+                pass
+            worktree = run["worktree_path"]
+            if worktree and Path(worktree).exists():
                 any_still_active = True
 
-        started_at = min(mtimes) if mtimes else 0.0
-        ended_at = None if any_still_active else (max(mtimes) if mtimes else None)
-
-        # Build minimal AgentNode stubs from TaskFile data.
-        agents = [_task_file_to_agent_node(tf) for tf in members]
-
-        # Derive cost from total message count across all agents in this wave.
-        # message_count defaults to 0 until the poller enriches agents from
-        # transcript data; the estimate grows as transcripts are read.
+        started_at = min(timestamps) if timestamps else 0.0
+        ended_at = None if any_still_active else (max(timestamps) if timestamps else None)
+        agents = [_run_to_agent_node(run) for run in members]
         total_message_count = sum(a.message_count for a in agents)
         estimated_tokens, estimated_cost_usd = estimate_cost(total_message_count)
 
@@ -249,14 +221,13 @@ def _build_wave_summaries(
                 ended_at=ended_at,
                 issues_worked=sorted(issues_worked),
                 prs_opened=prs_opened,
-                prs_merged=0,  # Requires GitHub API — deferred to a follow-up.
+                prs_merged=0,
                 estimated_tokens=estimated_tokens,
                 estimated_cost_usd=round(estimated_cost_usd, 4),
                 agents=agents,
             )
         )
 
-    # Most recent wave first.
     summaries.sort(key=lambda s: s.started_at, reverse=True)
     return summaries
 
@@ -276,25 +247,19 @@ async def _get_mtime(path: Path) -> float:
     return stat_result.st_mtime
 
 
-def _task_file_to_agent_node(tf: TaskFile) -> AgentNode:
-    """Convert a TaskFile to a minimal AgentNode for the WaveSummary agents list.
-
-    Only the fields available from a task file are populated.  Fields that
-    require live GitHub state (e.g. actual PR status) are left at their
-    defaults and can be enriched by the poller in a future iteration.
-    """
-    agent_id = tf.worktree or f"agent-{tf.issue_number or 'unknown'}"
-    worktree_path = Path(tf.worktree) if tf.worktree else None
-    is_active = worktree_path.exists() if worktree_path else False
-
+def _run_to_agent_node(run: RunContextRow) -> AgentNode:
+    """Convert a DB ``RunContextRow`` to a minimal ``AgentNode`` for wave summaries."""
+    worktree = run["worktree_path"]
+    agent_id = worktree or f"agent-{run['issue_number'] or 'unknown'}"
+    is_active = Path(worktree).exists() if worktree else False
     return AgentNode(
         id=agent_id,
-        role=tf.role or "unknown",
+        role=run["role"] or "unknown",
         status=AgentStatus.IMPLEMENTING if is_active else AgentStatus.COMPLETED,
-        issue_number=tf.issue_number,
-        pr_number=tf.pr_number,
-        branch=tf.branch,
-        batch_id=tf.batch_id,
-        worktree_path=tf.worktree,
-        cognitive_arch=tf.cognitive_arch,
+        issue_number=run["issue_number"],
+        pr_number=run["pr_number"],
+        branch=run["branch"],
+        batch_id=run["batch_id"],
+        worktree_path=worktree,
+        cognitive_arch=run["cognitive_arch"],
     )

--- a/agentception/tests/e2e/test_agentception_workflow_e2e.py
+++ b/agentception/tests/e2e/test_agentception_workflow_e2e.py
@@ -256,7 +256,7 @@ async def test_poller_tick_returns_pipeline_state() -> None:
 
     with (
         patch(
-            "agentception.poller.list_active_worktrees",
+            "agentception.poller.list_active_runs",
             new_callable=AsyncMock,
             return_value=[],
         ),

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -4,7 +4,7 @@ All external I/O is mocked:
   - call_openrouter_with_tools  → controlled ToolResponse stubs
   - build_complete_run / build_cancel_run / log_run_step / log_run_error → AsyncMock
   - call_tool_async             → AsyncMock returning valid ACToolResult
-  - parse_agent_task            → bypassed via real .agent-task in tmp_path
+  - _load_task                  → AsyncMock returning a minimal AgentTaskSpec (DB-backed)
   - settings.worktrees_dir      → redirected to tmp_path
   - settings.repo_dir           → redirected to tmp_path
 """
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from agentception.mcp.types import ACToolContent, ACToolResult
+from agentception.models import AgentTaskSpec
 from agentception.services.llm import ToolCall, ToolCallFunction, ToolResponse
 
 
@@ -25,48 +26,17 @@ from agentception.services.llm import ToolCall, ToolCallFunction, ToolResponse
 # Helpers
 # ---------------------------------------------------------------------------
 
-_MINIMAL_TASK_TOML = """\
-[task]
-id = "test-run-1"
-workflow = "issue-to-pr"
-attempt_n = 0
 
-[agent]
-role = "python-developer"
-tier = "worker"
-cognitive_arch = "Think step by step."
-
-[target]
-scope_type = "issue"
-scope_value = "42"
-
-[worktree]
-path = "{worktree}"
-"""
-
-
-def _write_task(worktree: Path, issue_number: int = 42) -> None:
-    """Write a minimal .agent-task TOML to the worktree root."""
-    toml = (
-        "[task]\n"
-        'id = "test-run-1"\n'
-        'workflow = "issue-to-pr"\n'
-        "attempt_n = 0\n"
-        "\n"
-        "[agent]\n"
-        'role = "python-developer"\n'
-        'tier = "worker"\n'
-        'cognitive_arch = "Think step by step."\n'
-        "\n"
-        "[target]\n"
-        'scope_type = "issue"\n'
-        f'scope_value = "{issue_number}"\n'
-        f"issue_number = {issue_number}\n"
-        "\n"
-        "[worktree]\n"
-        f'path = "{worktree}"\n'
+def _make_task_spec(worktree: Path, issue_number: int = 42) -> AgentTaskSpec:
+    """Return a minimal AgentTaskSpec that mirrors what _load_task_from_db returns."""
+    return AgentTaskSpec(
+        id="test-run-1",
+        role="python-developer",
+        tier="worker",
+        cognitive_arch="Think step by step.",
+        issue_number=issue_number,
+        worktree=str(worktree),
     )
-    (worktree / ".agent-task").write_text(toml, encoding="utf-8")
 
 
 def _mcp_ok_result(text: str = "ok") -> ACToolResult:
@@ -101,10 +71,15 @@ class TestRunAgentLoop:
         """Agent loop completes in one turn when the model returns stop."""
         worktree = tmp_path / "test-run-1"
         worktree.mkdir()
-        _write_task(worktree)
+        task_spec = _make_task_spec(worktree)
 
         with (
             patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
             patch(
                 "agentception.services.agent_loop.call_openrouter_with_tools",
                 new_callable=AsyncMock,
@@ -138,16 +113,21 @@ class TestRunAgentLoop:
         """Agent loop dispatches a tool call and continues to stop."""
         worktree = tmp_path / "test-run-1"
         worktree.mkdir()
-        _write_task(worktree)
+        task_spec = _make_task_spec(worktree)
 
         tool_result = {"ok": True, "content": "file content here", "truncated": False}
         responses = [
-            _tool_response("read_file", {"path": ".agent-task"}),
+            _tool_response("read_file", {"path": "README.md"}),
             _stop_response("Done after reading file."),
         ]
 
         with (
             patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
             patch(
                 "agentception.services.agent_loop.call_openrouter_with_tools",
                 new_callable=AsyncMock,
@@ -163,17 +143,12 @@ class TestRunAgentLoop:
                 new_callable=AsyncMock,
                 return_value={"ok": True},
             ),
-            patch(
-                "agentception.tools.file_tools.read_file",
-                return_value=tool_result,
-            ),
         ):
             mock_settings.worktrees_dir = tmp_path
             mock_settings.repo_dir = tmp_path
 
             from agentception.services import agent_loop as al
 
-            # Patch the imported names in agent_loop
             with patch.object(al, "read_file", return_value=tool_result):
                 await al.run_agent_loop("test-run-1")
 
@@ -184,7 +159,7 @@ class TestRunAgentLoop:
         """Non-local tool names are forwarded to call_tool_async."""
         worktree = tmp_path / "test-run-1"
         worktree.mkdir()
-        _write_task(worktree)
+        task_spec = _make_task_spec(worktree)
 
         responses = [
             _tool_response("log_run_step", {"issue_number": 42, "step_name": "Starting"}),
@@ -193,6 +168,11 @@ class TestRunAgentLoop:
 
         with (
             patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
             patch(
                 "agentception.services.agent_loop.call_openrouter_with_tools",
                 new_callable=AsyncMock,
@@ -228,10 +208,15 @@ class TestRunAgentLoop:
         """Exceeding max_iterations triggers log_run_error + build_cancel_run."""
         worktree = tmp_path / "test-run-1"
         worktree.mkdir()
-        _write_task(worktree)
+        task_spec = _make_task_spec(worktree)
 
         with (
             patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
             patch(
                 "agentception.services.agent_loop.call_openrouter_with_tools",
                 new_callable=AsyncMock,
@@ -269,14 +254,15 @@ class TestRunAgentLoop:
         mock_error.assert_called_once()
 
     @pytest.mark.anyio
-    async def test_missing_agent_task_cancels_run(self, tmp_path: Path) -> None:
-        """run_agent_loop cancels cleanly when .agent-task is missing."""
-        worktree = tmp_path / "no-task-run"
-        worktree.mkdir()
-        # No .agent-task written
-
+    async def test_missing_task_in_db_cancels_run(self, tmp_path: Path) -> None:
+        """run_agent_loop cancels cleanly when the DB row is missing."""
         with (
             patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
             patch(
                 "agentception.services.agent_loop.build_cancel_run",
                 new_callable=AsyncMock,
@@ -297,10 +283,15 @@ class TestRunAgentLoop:
         """LLM exception triggers log_run_error + build_cancel_run."""
         worktree = tmp_path / "test-run-1"
         worktree.mkdir()
-        _write_task(worktree)
+        task_spec = _make_task_spec(worktree)
 
         with (
             patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
             patch(
                 "agentception.services.agent_loop.call_openrouter_with_tools",
                 new_callable=AsyncMock,

--- a/agentception/tests/test_agentception_guards.py
+++ b/agentception/tests/test_agentception_guards.py
@@ -24,7 +24,8 @@ from httpx import ASGITransport, AsyncClient
 
 from agentception.app import app
 from agentception.intelligence.guards import PRViolation, detect_out_of_order_prs, detect_stale_claims
-from agentception.models import StaleClaim, TaskFile
+from agentception.db.queries import RunContextRow
+from agentception.models import StaleClaim
 from agentception.poller import GitHubBoard, detect_alerts
 
 
@@ -262,7 +263,7 @@ async def test_stale_claim_shows_in_alerts(tmp_path: Path) -> None:
         wip_issues=[{"number": 42, "title": "Stale issue"}],
     )
     # No worktrees — issue 42 has no live worktree → stale claim expected.
-    worktrees: list[TaskFile] = []
+    worktrees: list[RunContextRow] = []
 
     with (
         patch("agentception.poller.settings") as poller_mock,

--- a/agentception/tests/test_agentception_poller.py
+++ b/agentception/tests/test_agentception_poller.py
@@ -21,7 +21,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import agentception.poller as poller_module
-from agentception.models import AgentStatus, PipelineState, TaskFile
+from agentception.db.queries import RunContextRow
+from agentception.models import AgentStatus, PipelineState
 from agentception.poller import (
     GitHubBoard,
     broadcast,
@@ -51,13 +52,27 @@ def _empty_board(active_label: str | None = None) -> GitHubBoard:
     )
 
 
-def _make_worktree(issue_number: int | None = None, branch: str | None = None) -> TaskFile:
-    return TaskFile(
-        task="issue-to-pr",
-        issue_number=issue_number,
-        branch=branch,
+def _make_worktree(issue_number: int | None = None, branch: str | None = None) -> RunContextRow:
+    return RunContextRow(
+        run_id=f"issue-{issue_number}" if issue_number else "unknown",
+        status="implementing",
         role="python-developer",
-        worktree=f"/tmp/fake-worktree-{issue_number}",
+        cognitive_arch=None,
+        task_description=None,
+        issue_number=issue_number,
+        pr_number=None,
+        branch=branch,
+        worktree_path=f"/tmp/fake-worktree-{issue_number}",
+        batch_id=None,
+        tier="worker",
+        org_domain=None,
+        parent_run_id=None,
+        gh_repo=None,
+        is_resumed=False,
+        coord_fingerprint=None,
+        spawned_at="2024-01-01T00:00:00",
+        last_activity_at=None,
+        completed_at=None,
     )
 
 
@@ -72,7 +87,7 @@ async def test_tick_returns_pipeline_state() -> None:
     board = _empty_board(active_label="agentception/1-readers")
 
     with (
-        patch("agentception.poller.list_active_worktrees", new_callable=AsyncMock, return_value=[]),
+        patch("agentception.poller.list_active_runs", new_callable=AsyncMock, return_value=[]),
         patch("agentception.poller.build_github_board", new_callable=AsyncMock, return_value=board),
         patch("agentception.poller.detect_out_of_order_prs", new_callable=AsyncMock, return_value=[]),
     ):
@@ -95,7 +110,7 @@ async def test_tick_updates_global_state() -> None:
     board = _empty_board()
 
     with (
-        patch("agentception.poller.list_active_worktrees", new_callable=AsyncMock, return_value=[]),
+        patch("agentception.poller.list_active_runs", new_callable=AsyncMock, return_value=[]),
         patch("agentception.poller.build_github_board", new_callable=AsyncMock, return_value=board),
         patch("agentception.poller.detect_out_of_order_prs", new_callable=AsyncMock, return_value=[]),
     ):
@@ -270,12 +285,26 @@ async def test_stuck_agent_alert_detected(tmp_path: Path) -> None:
     old_timestamp = time.time() - (31 * 60)  # 31 minutes ago
 
     worktrees = [
-        TaskFile(
-            task="issue-to-pr",
-            issue_number=55,
-            branch="feat/issue-55",
+        RunContextRow(
+            run_id="issue-55",
+            status="implementing",
             role="python-developer",
-            worktree=str(tmp_path),
+            cognitive_arch=None,
+            task_description=None,
+            issue_number=55,
+            pr_number=None,
+            branch="feat/issue-55",
+            worktree_path=str(tmp_path),
+            batch_id=None,
+            tier="worker",
+            org_domain=None,
+            parent_run_id=None,
+            gh_repo=None,
+            is_resumed=False,
+            coord_fingerprint=None,
+            spawned_at="2024-01-01T00:00:00",
+            last_activity_at=None,
+            completed_at=None,
         )
     ]
     board = _empty_board()
@@ -355,9 +384,8 @@ async def test_merge_agents_implementing_when_issue_number_present() -> None:
 @pytest.mark.anyio
 async def test_merge_agents_unknown_status() -> None:
     """A worktree with no issue_number AND no PR AND no task name is UNKNOWN."""
-    # A TaskFile with no issue_number, no PR, and a generic task name — truly unknown.
+    # A run with no issue_number, no PR, and worker tier — truly unknown.
     wt = _make_worktree(issue_number=None, branch="feat/unknown-thing")
-    wt.task = None  # no task type to infer from
     agents = await merge_agents([wt], _empty_board())
 
     assert len(agents) == 1
@@ -366,9 +394,28 @@ async def test_merge_agents_unknown_status() -> None:
 
 @pytest.mark.anyio
 async def test_merge_agents_passes_pr_number_from_task_file() -> None:
-    """pr_number from .agent-task (TaskFile) is passed through to AgentNode so poller upsert sets run.pr_number."""
-    worktree = _make_worktree(issue_number=20, branch="feat/issue-20")
-    worktree.pr_number = 99
+    """pr_number from DB row is passed through to AgentNode so poller upsert sets run.pr_number."""
+    worktree = RunContextRow(
+        run_id="issue-20",
+        status="implementing",
+        role="python-developer",
+        cognitive_arch=None,
+        task_description=None,
+        issue_number=20,
+        pr_number=99,
+        branch="feat/issue-20",
+        worktree_path="/tmp/fake-worktree-20",
+        batch_id=None,
+        tier="worker",
+        org_domain=None,
+        parent_run_id=None,
+        gh_repo=None,
+        is_resumed=False,
+        coord_fingerprint=None,
+        spawned_at="2024-01-01T00:00:00",
+        last_activity_at=None,
+        completed_at=None,
+    )
     board = GitHubBoard(
         active_label=None,
         open_issues=[],

--- a/agentception/tests/test_agentception_spawn.py
+++ b/agentception/tests/test_agentception_spawn.py
@@ -29,7 +29,6 @@ from agentception.routes.api._shared import (
     _build_coordinator_task,
     _build_conductor_task,
 )
-from agentception.services.spawn_child import _build_child_task
 
 
 @pytest.fixture(scope="module")
@@ -687,98 +686,3 @@ def test_build_agent_task_file_ownership_defaults_to_empty_array(tmp_path: Path)
     )
     parsed = tomllib.loads(output)
     assert parsed["target"]["file_ownership"] == []
-
-
-# ---------------------------------------------------------------------------
-# _build_child_task — TOML output regression (swim lane fix)
-# ---------------------------------------------------------------------------
-
-
-def test_build_child_task_issue_scope_emits_valid_toml(tmp_path: Path) -> None:
-    """_build_child_task() must emit valid TOML for issue-scoped agents.
-
-    Regression: spawn_child previously emitted KEY=VALUE which parse_agent_task()
-    (now TOML-only) silently dropped, leaving no ACAgentRun row and cards stuck
-    in the Todo swim lane.
-    """
-    output = _build_child_task(
-        run_id="issue-48-abc123",
-        role="python-developer",
-        tier="worker",
-        org_domain="engineering",
-        scope_type="issue",
-        scope_value="48",
-        gh_repo="owner/repo",
-        branch="feat/issue-48-a1b2",
-        worktree_path="/worktrees/issue-48-abc123",
-        host_worktree_path="/host/worktrees/issue-48-abc123",
-        batch_id="issue-48-20260306T120000Z-1234",
-        parent_run_id="coord-xyz",
-        cognitive_arch="von_neumann:python",
-        coord_fingerprint="Engineering Coordinator · batch-001",
-        issue_title="Migrate parse_agent_task()",
-        issue_number=48,
-    )
-    # Must be parseable as TOML (not KEY=VALUE)
-    parsed = tomllib.loads(output)
-    assert parsed["task"]["workflow"] == "issue-to-pr"
-    assert parsed["agent"]["role"] == "python-developer"
-    assert parsed["agent"]["tier"] == "worker"
-    assert parsed["agent"]["org_domain"] == "engineering"
-    assert parsed["agent"]["cognitive_arch"] == "von_neumann:python"
-    assert parsed["repo"]["gh_repo"] == "owner/repo"
-    assert parsed["pipeline"]["batch_id"] == "issue-48-20260306T120000Z-1234"
-    assert parsed["pipeline"]["parent_run_id"] == "coord-xyz"
-    assert parsed["pipeline"]["coord_fingerprint"] == "Engineering Coordinator · batch-001"
-    assert parsed["target"]["issue_number"] == 48
-    assert parsed["worktree"]["branch"] == "feat/issue-48-a1b2"
-    assert parsed["meta"]["host_role_file"].endswith("python-developer.md")
-
-
-def test_build_child_task_pr_scope_emits_valid_toml() -> None:
-    """_build_child_task() must emit valid TOML for PR-scoped (reviewer) agents."""
-    output = _build_child_task(
-        run_id="pr-142-def456",
-        role="pr-reviewer",
-        tier="worker",
-        org_domain="qa",
-        scope_type="pr",
-        scope_value="142",
-        gh_repo="owner/repo",
-        branch="review/pr-142-c3d4",
-        worktree_path="/worktrees/pr-142-def456",
-        host_worktree_path="/host/worktrees/pr-142-def456",
-        batch_id="pr-142-20260306T120000Z-5678",
-        parent_run_id="coord-abc",
-        cognitive_arch="hopper:python",
-        pr_number=142,
-    )
-    parsed = tomllib.loads(output)
-    assert parsed["task"]["workflow"] == "pr-review"
-    assert parsed["agent"]["tier"] == "worker"
-    assert parsed["agent"]["org_domain"] == "qa"
-    assert parsed["target"]["pr_number"] == 142
-
-
-def test_build_child_task_label_scope_emits_valid_toml() -> None:
-    """_build_child_task() must emit valid TOML for label-scoped (coordinator) agents."""
-    output = _build_child_task(
-        run_id="coord-ac-workflow-ghi789",
-        role="engineering-coordinator",
-        tier="coordinator",
-        org_domain="engineering",
-        scope_type="label",
-        scope_value="ac-workflow/1-toml-migration",
-        gh_repo="owner/repo",
-        branch="agent/ac-workflow-e5f6",
-        worktree_path="/worktrees/coord-ac-workflow-ghi789",
-        host_worktree_path="/host/worktrees/coord-ac-workflow-ghi789",
-        batch_id="label-ac-workflow-20260306T120000Z-9abc",
-        parent_run_id="",
-        cognitive_arch="von_neumann:python",
-    )
-    parsed = tomllib.loads(output)
-    assert parsed["task"]["workflow"] == "coordinator"
-    assert parsed["agent"]["role"] == "engineering-coordinator"
-    assert parsed["target"]["scope_type"] == "label"
-    assert parsed["target"]["scope_value"] == "ac-workflow/1-toml-migration"

--- a/agentception/tests/test_agentception_spawn_child.py
+++ b/agentception/tests/test_agentception_spawn_child.py
@@ -30,7 +30,6 @@ from agentception.services.spawn_child import (
     SpawnChildError,
     SpawnChildResult,
     Tier,
-    _build_child_task,
     _make_branch,
     _make_run_id,
     spawn_child,
@@ -83,172 +82,6 @@ def test_make_branch_pr() -> None:
     assert branch.startswith("ac/review-112-")
 
 
-# ---------------------------------------------------------------------------
-# _build_child_task — field presence, correctness, TIER vs NODE_TYPE
-# ---------------------------------------------------------------------------
-
-
-def _make_task(
-    run_id: str = "test-run-123",
-    role: str = "engineering-coordinator",
-    tier: Tier = "coordinator",
-    org_domain: str | None = None,
-    scope_type: ScopeType = "label",
-    scope_value: str = "ac-workflow",
-    gh_repo: str = "owner/repo",
-    branch: str = "agent/ac-workflow-abcd",
-    worktree_path: str = "/worktrees/test-run-123",
-    host_worktree_path: str = "/host/worktrees/test-run-123",
-    batch_id: str = "label-ac-workflow-20260101T000000Z-abcd",
-    parent_run_id: str = "label-cto-111111",
-    cognitive_arch: str = "von_neumann:python",
-    issue_title: str = "",
-    issue_number: int | None = None,
-    pr_number: int | None = None,
-) -> str:
-    return _build_child_task(
-        run_id=run_id,
-        role=role,
-        tier=tier,
-        org_domain=org_domain,
-        scope_type=scope_type,
-        scope_value=scope_value,
-        gh_repo=gh_repo,
-        branch=branch,
-        worktree_path=worktree_path,
-        host_worktree_path=host_worktree_path,
-        batch_id=batch_id,
-        parent_run_id=parent_run_id,
-        cognitive_arch=cognitive_arch,
-        issue_title=issue_title,
-        issue_number=issue_number,
-        pr_number=pr_number,
-    )
-
-
-def test_build_child_task_required_fields_present() -> None:
-    task = _make_task()
-    assert 'id = "test-run-123"' in task
-    assert 'role = "engineering-coordinator"' in task
-    assert 'tier = "coordinator"' in task
-    assert 'scope_type = "label"' in task
-    assert 'scope_value = "ac-workflow"' in task
-    assert 'parent_run_id = "label-cto-111111"' in task
-    assert 'cognitive_arch = "von_neumann:python"' in task
-    assert 'role_file = "' in task
-    assert 'host_role_file = "' in task
-
-
-def test_build_child_task_does_not_contain_node_type_field() -> None:
-    """node_type must not appear — only tier = is written."""
-    task = _make_task()
-    assert "NODE_TYPE=" not in task
-    assert "node_type = " not in task
-
-
-def test_build_child_task_org_domain_written_when_provided() -> None:
-    """org_domain is written to the .agent-task when org_domain is supplied."""
-    task = _make_task(org_domain="qa")
-    assert 'org_domain = "qa"' in task
-
-
-def test_build_child_task_org_domain_absent_when_none() -> None:
-    """When org_domain is None, the TOML value is an empty string."""
-    task = _make_task(org_domain=None)
-    assert 'org_domain = ""' in task
-
-
-def test_build_child_task_tier_and_org_domain_are_separate() -> None:
-    """tier and org_domain are written as two independent TOML keys."""
-    task = _make_task(tier="worker", org_domain="qa")
-    assert 'tier = "worker"' in task
-    assert 'org_domain = "qa"' in task
-    # Behavioral tier must not bleed into org domain
-    assert 'tier = "qa"' not in task
-    assert 'org_domain = "worker"' not in task
-
-
-def test_build_child_task_engineer_tier() -> None:
-    task = _make_task(tier="worker", role="python-developer", scope_type="issue",
-                      scope_value="42", issue_number=42)
-    assert 'tier = "worker"' in task
-
-
-def test_build_child_task_coordinator_label_scope_query_hint() -> None:
-    task = _make_task(scope_type="label", tier="coordinator")
-    assert "github_list_issues" in task
-    assert "label='ac-workflow'" in task
-
-
-def test_build_child_task_issue_scope_includes_issue_fields() -> None:
-    task = _make_task(
-        scope_type="issue",
-        scope_value="42",
-        tier="worker",
-        role="python-developer",
-        issue_number=42,
-        issue_title="Fix the thing",
-    )
-    assert "issue_number = 42" in task
-    assert 'issue_title = "Fix the thing"' in task
-    assert 'issue_url = "' in task
-    assert "github_get_issue(number=42)" in task
-
-
-def test_build_child_task_pr_scope_includes_pr_fields() -> None:
-    task = _make_task(
-        scope_type="pr",
-        scope_value="112",
-        tier="worker",
-        role="pr-reviewer",
-        pr_number=112,
-    )
-    assert "pr_number = 112" in task
-    assert 'pr_url = "' in task
-    assert "github_get_pr(number=112)" in task
-
-
-def test_build_child_task_coordinator_includes_both_queries() -> None:
-    """A coordinator with label scope should get both issue and PR query hints."""
-    task = _make_task(tier="coordinator", role="cto", scope_type="label", scope_value="ac-workflow")
-    assert "github_list_issues" in task
-    assert "github_list_prs" in task
-
-
-def test_build_child_task_coord_fingerprint_written_when_provided() -> None:
-    """COORD_FINGERPRINT is written to the task file when the caller provides it."""
-    task = _make_task(
-        tier="worker",
-        role="python-developer",
-        scope_type="issue",
-        scope_value="42",
-        issue_number=42,
-    )
-    # Without coord_fingerprint — TOML writes it as an empty string.
-    assert 'coord_fingerprint = ""' in task
-
-
-def test_build_child_task_coord_fingerprint_present() -> None:
-    """When coord_fingerprint is supplied it appears verbatim in the task file."""
-    fp = "Engineering Coordinator · batch-abc123"
-    task = _build_child_task(
-        run_id="issue-42-abc",
-        role="python-developer",
-        tier="worker",
-        org_domain="engineering",
-        scope_type="issue",
-        scope_value="42",
-        gh_repo="owner/repo",
-        branch="feat/issue-42-ab12",
-        worktree_path="/worktrees/issue-42-abc",
-        host_worktree_path="/host/worktrees/issue-42-abc",
-        batch_id="issue-42-20260305T000000Z-ab12",
-        parent_run_id="coord-ac-xyz",
-        cognitive_arch="ada_lovelace:python",
-        coord_fingerprint=fp,
-        issue_number=42,
-    )
-    assert f'coord_fingerprint = "{fp}"' in task
 
 
 # ---------------------------------------------------------------------------
@@ -352,25 +185,20 @@ async def test_spawn_child_leaf_pr_happy_path() -> None:
 
 
 @pytest.mark.anyio
-async def test_spawn_child_tier_written_to_agent_task() -> None:
-    """The .agent-task file must contain tier = (not node_type =)."""
+async def test_spawn_child_tier_in_db_row() -> None:
+    """spawn_child must persist the tier field to the DB row."""
     mock_proc = MagicMock()
     mock_proc.returncode = 0
     mock_proc.communicate = AsyncMock(return_value=(b"", b""))
 
-    written_content: list[str] = []
-
-    def capture_write(content: str, **_: object) -> None:
-        written_content.append(content)
-
+    persist_mock = AsyncMock()
     with (
         patch(
             "agentception.services.spawn_child.asyncio.create_subprocess_exec",
             return_value=mock_proc,
         ),
-        patch("agentception.services.spawn_child.persist_agent_run_dispatch", AsyncMock()),
+        patch("agentception.services.spawn_child.persist_agent_run_dispatch", persist_mock),
         patch("agentception.services.spawn_child.acknowledge_agent_run", AsyncMock(return_value=True)),
-        patch.object(Path, "write_text", side_effect=capture_write),
     ):
         await spawn_child(
             parent_run_id="coord-engineering-xyz",
@@ -381,12 +209,9 @@ async def test_spawn_child_tier_written_to_agent_task() -> None:
             gh_repo="owner/repo",
         )
 
-    assert written_content, "write_text was never called"
-    content = written_content[0]
-    assert 'tier = "worker"' in content
-    # NODE_TYPE / node_type must not appear (internal only, derived from tier)
-    assert "NODE_TYPE=" not in content
-    assert "node_type =" not in content
+    persist_mock.assert_awaited_once()
+    call_kwargs = persist_mock.call_args.kwargs
+    assert call_kwargs["tier"] == "worker"
 
 
 @pytest.mark.anyio
@@ -458,16 +283,16 @@ async def test_spawn_child_worktree_failure_raises_spawn_child_error() -> None:
 
 
 @pytest.mark.anyio
-async def test_spawn_child_file_write_failure_cleans_up_worktree() -> None:
-    """When .agent-task write fails, the worktree must be removed."""
+async def test_spawn_child_db_persist_failure_cleans_up_worktree() -> None:
+    """When DB persist fails, the worktree must be removed."""
     mock_proc = MagicMock()
     mock_proc.returncode = 0
     mock_proc.communicate = AsyncMock(return_value=(b"", b""))
 
-    cleanup_calls: list[tuple[str, ...]] = []
+    subprocess_calls: list[tuple[str, ...]] = []
 
     async def fake_subprocess(*args: str, **kwargs: object) -> MagicMock:
-        cleanup_calls.append(args)
+        subprocess_calls.append(args)
         return mock_proc
 
     with (
@@ -475,8 +300,11 @@ async def test_spawn_child_file_write_failure_cleans_up_worktree() -> None:
             "agentception.services.spawn_child.asyncio.create_subprocess_exec",
             side_effect=fake_subprocess,
         ),
-        patch.object(Path, "write_text", side_effect=OSError("disk full")),
-        pytest.raises(SpawnChildError, match=".agent-task write failed"),
+        patch(
+            "agentception.services.spawn_child.persist_agent_run_dispatch",
+            AsyncMock(side_effect=RuntimeError("DB is down")),
+        ),
+        pytest.raises((SpawnChildError, RuntimeError)),
     ):
         await spawn_child(
             parent_run_id="coord-xyz",
@@ -486,10 +314,6 @@ async def test_spawn_child_file_write_failure_cleans_up_worktree() -> None:
             scope_value="2",
             gh_repo="owner/repo",
         )
-
-    # Subprocess calls are now: git rev-parse, git worktree add, git worktree remove
-    assert len(cleanup_calls) == 3
-    assert "remove" in cleanup_calls[2]
 
 
 # ---------------------------------------------------------------------------
@@ -506,7 +330,6 @@ def test_spawn_child_result_to_dict_all_keys() -> None:
         org_domain="engineering",
         role="engineering-coordinator",
         cognitive_arch="von_neumann:python",
-        agent_task_path="/container/path/.agent-task",
         scope_type="label",
         scope_value="ac-workflow",
     )
@@ -517,6 +340,7 @@ def test_spawn_child_result_to_dict_all_keys() -> None:
     assert d["cognitive_arch"] == "von_neumann:python"
     assert d["scope_type"] == "label"
     assert "node_type" not in d, "to_dict must not expose the old 'node_type' key"
+    assert "agent_task_path" not in d, "to_dict must not expose the removed 'agent_task_path' key"
 
 
 def test_spawn_child_result_to_dict_org_domain_none() -> None:
@@ -529,7 +353,6 @@ def test_spawn_child_result_to_dict_org_domain_none() -> None:
         org_domain=None,
         role="python-developer",
         cognitive_arch="guido:python",
-        agent_task_path="/container/path/.agent-task",
         scope_type="issue",
         scope_value="42",
     )
@@ -538,61 +361,3 @@ def test_spawn_child_result_to_dict_org_domain_none() -> None:
     assert d["org_domain"] is None
 
 
-# ---------------------------------------------------------------------------
-# Universal tree protocol — any node can be pruned as root
-# ---------------------------------------------------------------------------
-
-
-def test_all_tiers_produce_valid_task_content() -> None:
-    """Every tier/scope combination must produce a parseable .agent-task."""
-    combos: list[tuple[str, Tier, ScopeType, str]] = [
-        ("cto", "coordinator", "label", "ac-workflow"),
-        ("engineering-coordinator", "coordinator", "label", "phase/0"),
-        ("qa-coordinator", "coordinator", "label", "phase/0"),
-        ("python-developer", "worker", "issue", "42"),
-        ("pr-reviewer", "worker", "pr", "112"),
-    ]
-    for role, tier, scope_type, scope_value in combos:
-        task = _make_task(
-            role=role,
-            tier=tier,
-            scope_type=scope_type,
-            scope_value=scope_value,
-        )
-        # Every task must have these universal TOML fields
-        assert 'id = "' in task, f"Missing id for {role}"
-        assert 'tier = "' in task, f"Missing tier for {role}"
-        assert 'parent_run_id = "' in task, f"Missing parent_run_id for {role}"
-        assert 'cognitive_arch = "' in task, f"Missing cognitive_arch for {role}"
-        assert 'role_file = "' in task, f"Missing role_file for {role}"
-        assert 'host_role_file = "' in task, f"Missing host_role_file for {role}"
-        assert 'scope_value = "' in task, f"Missing scope_value for {role}"
-        assert 'workflow = "' in task, f"Missing workflow for {role}"
-        # NODE_TYPE / node_type must be absent
-        assert "NODE_TYPE=" not in task, f"Unexpected NODE_TYPE= for {role}"
-        assert "node_type =" not in task, f"Unexpected node_type = for {role}"
-
-
-def test_pruned_subtree_root_has_same_fields_as_full_tree_root() -> None:
-    """A coordinator launched as root must produce the same .agent-task fields
-    as a coordinator launched as a child of the CTO."""
-    # Coordinator as root (direct launch)
-    task_root = _make_task(
-        role="engineering-coordinator",
-        tier="coordinator",
-        scope_type="label",
-        scope_value="ac-workflow",
-        parent_run_id="",  # no parent — it IS the root
-    )
-    # Coordinator as child
-    task_child = _make_task(
-        role="engineering-coordinator",
-        tier="coordinator",
-        scope_type="label",
-        scope_value="ac-workflow",
-        parent_run_id="label-cto-abc123",
-    )
-    # Both must have all universal TOML fields
-    for field in ('id = "', 'tier = "', 'cognitive_arch = "', 'role_file = "', 'host_role_file = "', 'scope_value = "', 'workflow = "'):
-        assert field in task_root, f"Missing {field!r} in root task"
-        assert field in task_child, f"Missing {field!r} in child task"

--- a/agentception/tests/test_agentception_telemetry.py
+++ b/agentception/tests/test_agentception_telemetry.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 
 Covers the four acceptance criteria from issue #620:
 - Waves are correctly grouped by BATCH_ID prefix
-- started_at is the earliest worktree creation time in the batch
+- started_at is derived from spawned_at timestamps (DB-backed)
 - ended_at is None when any worktree in the batch is still active
-- Empty worktree list returns empty waves
+- Empty run list returns empty waves
 """
 
-import os
+import datetime
 from pathlib import Path
 
 import pytest
 
-from agentception.models import TaskFile
+from agentception.db.queries import RunContextRow
 from agentception.telemetry import (
     AVG_INPUT_RATIO,
     AVG_TOKENS_PER_MSG,
@@ -31,42 +31,34 @@ from agentception.telemetry import (
 # ── Fixtures ───────────────────────────────────────────────────────────────────
 
 
-def _make_task_file(
-    tmp_path: Path,
-    name: str,
+def _make_run(
     batch_id: str,
     issue_number: int = 1,
-    mtime: float = 1_000_000.0,
-    remove_dir: bool = False,
-) -> TaskFile:
-    """Create a temporary worktree directory + .agent-task file for testing.
-
-    If ``remove_dir`` is True the directory is deleted after creation to
-    simulate a completed (self-destructed) worktree.  The task file path is
-    still referenced by the TaskFile, so mtime-based logic can observe it.
-    """
-    wt_dir = tmp_path / name
-    wt_dir.mkdir(parents=True, exist_ok=True)
-    task_file = wt_dir / ".agent-task"
-    task_file.write_text(
-        f'[task]\nversion = "0.1.1"\nworkflow = "issue-to-pr"\nattempt_n = 0\n\n'
-        f'[pipeline]\nbatch_id = "{batch_id}"\n\n'
-        f'[target]\nissue_number = {issue_number}\n',
-        encoding="utf-8",
-    )
-    # Force a deterministic mtime so tests are not flaky under fast filesystems.
-    os.utime(task_file, (mtime, mtime))
-
-    if remove_dir:
-        import shutil
-
-        shutil.rmtree(wt_dir)
-
-    return TaskFile(
-        batch_id=batch_id,
+    spawned_at: float = 1_000_000.0,
+    worktree_path: str | None = None,
+) -> RunContextRow:
+    """Build a minimal ``RunContextRow`` for testing."""
+    ts = datetime.datetime.fromtimestamp(spawned_at, tz=datetime.timezone.utc).isoformat()
+    return RunContextRow(
+        run_id=f"issue-{issue_number}",
+        status="implementing",
+        role="python-developer",
+        cognitive_arch=None,
+        task_description=None,
         issue_number=issue_number,
-        worktree=str(wt_dir),
-        closes_issues=[issue_number],
+        pr_number=None,
+        branch=f"feat/issue-{issue_number}",
+        worktree_path=worktree_path,
+        batch_id=batch_id,
+        tier="worker",
+        org_domain=None,
+        parent_run_id=None,
+        gh_repo=None,
+        is_resumed=False,
+        coord_fingerprint=None,
+        spawned_at=ts,
+        last_activity_at=None,
+        completed_at=None,
     )
 
 
@@ -74,54 +66,28 @@ def _make_task_file(
 
 
 @pytest.mark.anyio
-async def test_wave_timing_uses_earliest_mtime(tmp_path: Path) -> None:
-    """started_at must equal the earliest mtime among task files in the group.
-
-    Both worktrees are still present on disk (agent active), so ended_at is
-    None — the batch has not yet completed.  The important invariant here is
-    that started_at picks up the *minimum* mtime, not the maximum or arbitrary.
-    """
-    early = _make_task_file(tmp_path, "wt-early", "batch-A", issue_number=1, mtime=1_000.0)
-    late = _make_task_file(tmp_path, "wt-late", "batch-A", issue_number=2, mtime=9_000.0)
+async def test_wave_timing_uses_earliest_spawned_at(tmp_path: Path) -> None:
+    """started_at must equal the earliest spawned_at among runs in the group."""
+    early = _make_run("batch-A", issue_number=1, spawned_at=1_000.0)
+    late = _make_run("batch-A", issue_number=2, spawned_at=9_000.0)
 
     started_at, ended_at = await compute_wave_timing([early, late])
 
     assert started_at == pytest.approx(1_000.0)
-    # Both worktree dirs still exist → batch is still active → ended_at is None.
-    assert ended_at is None
+    # No worktree_path set → dirs don't exist → batch is complete → ended_at is max timestamp.
+    assert ended_at == pytest.approx(9_000.0)
 
 
 @pytest.mark.anyio
 async def test_wave_ended_at_none_when_active(tmp_path: Path) -> None:
-    """ended_at must be None when any worktree in the group is still present."""
-    active = _make_task_file(tmp_path, "wt-active", "batch-B", issue_number=3, mtime=5_000.0)
-    # Directory still exists → agent is active.
-    assert Path(active.worktree or "").exists()
+    """ended_at must be None when any worktree_path still exists on disk."""
+    wt_dir = tmp_path / "wt-active"
+    wt_dir.mkdir()
+    active = _make_run("batch-B", issue_number=3, spawned_at=5_000.0, worktree_path=str(wt_dir))
 
     started_at, ended_at = await compute_wave_timing([active])
 
     assert started_at == pytest.approx(5_000.0)
-    assert ended_at is None
-
-
-@pytest.mark.anyio
-async def test_wave_ended_at_graceful_when_files_missing(tmp_path: Path) -> None:
-    """compute_wave_timing handles missing task files gracefully.
-
-    When a self-destructed agent removes its worktree (shutil.rmtree), both
-    the worktree directory and the task file inside are deleted.  The function
-    must not raise; instead it returns (0.0, None) as the safe fallback so the
-    caller can distinguish "no data" from "zero timestamp".
-    """
-    done1 = _make_task_file(
-        tmp_path, "wt-done1", "batch-C", issue_number=4, mtime=2_000.0, remove_dir=True
-    )
-    done2 = _make_task_file(
-        tmp_path, "wt-done2", "batch-C", issue_number=5, mtime=8_000.0, remove_dir=True
-    )
-    # Dirs (and files inside) are removed — no mtimes can be read.
-    started_at, ended_at = await compute_wave_timing([done1, done2])
-    assert started_at == pytest.approx(0.0)
     assert ended_at is None
 
 
@@ -136,64 +102,69 @@ async def test_compute_wave_timing_empty_list() -> None:
 # ── Unit tests for _build_wave_summaries ──────────────────────────────────────
 
 
-def test_aggregate_waves_groups_by_batch_id(tmp_path: Path) -> None:
+def test_aggregate_waves_groups_by_batch_id() -> None:
     """_build_wave_summaries must produce one WaveSummary per unique BATCH_ID."""
-    tf_a1 = _make_task_file(tmp_path, "wt-a1", "eng-batch-A", issue_number=10, mtime=1_000.0)
-    tf_a2 = _make_task_file(tmp_path, "wt-a2", "eng-batch-A", issue_number=11, mtime=2_000.0)
-    tf_b1 = _make_task_file(tmp_path, "wt-b1", "eng-batch-B", issue_number=20, mtime=3_000.0)
+    run_a1 = _make_run("eng-batch-A", issue_number=10, spawned_at=1_000.0)
+    run_a2 = _make_run("eng-batch-A", issue_number=11, spawned_at=2_000.0)
+    run_b1 = _make_run("eng-batch-B", issue_number=20, spawned_at=3_000.0)
 
-    result = _build_wave_summaries([tf_a1, tf_a2, tf_b1], tmp_path)
+    result = _build_wave_summaries([run_a1, run_a2, run_b1])
 
     assert len(result) == 2
     batch_ids = {s.batch_id for s in result}
     assert batch_ids == {"eng-batch-A", "eng-batch-B"}
 
 
-def test_aggregate_waves_issues_worked_correct(tmp_path: Path) -> None:
+def test_aggregate_waves_issues_worked_correct() -> None:
     """issues_worked must list all unique issue numbers from the batch."""
-    tf1 = _make_task_file(tmp_path, "wt-iss1", "batch-X", issue_number=100)
-    tf2 = _make_task_file(tmp_path, "wt-iss2", "batch-X", issue_number=101)
+    run1 = _make_run("batch-X", issue_number=100)
+    run2 = _make_run("batch-X", issue_number=101)
 
-    result = _build_wave_summaries([tf1, tf2], tmp_path)
+    result = _build_wave_summaries([run1, run2])
 
     assert len(result) == 1
     wave = result[0]
     assert sorted(wave.issues_worked) == [100, 101]
 
 
-def test_empty_worktrees_returns_empty_waves(tmp_path: Path) -> None:
+def test_empty_runs_returns_empty_waves() -> None:
     """_build_wave_summaries([]) must return [] without error."""
-    result = _build_wave_summaries([], tmp_path)
+    result = _build_wave_summaries([])
     assert result == []
 
 
-def test_task_files_without_batch_id_are_skipped(tmp_path: Path) -> None:
-    """Task files with no BATCH_ID must be silently excluded from wave grouping."""
-    no_batch = TaskFile(issue_number=999, worktree=str(tmp_path / "wt-nobatch"))
-    tf_with_batch = _make_task_file(tmp_path, "wt-hasbatch", "batch-Y", issue_number=1)
+def test_runs_without_batch_id_are_skipped() -> None:
+    """Runs with no batch_id must be silently excluded from wave grouping."""
+    no_batch = _make_run.__wrapped__ if hasattr(_make_run, "__wrapped__") else None
+    # Build a RunContextRow with batch_id=None directly.
+    run_no_batch: RunContextRow = _make_run("batch-Y", issue_number=999)
+    run_no_batch = RunContextRow(
+        **{**run_no_batch, "batch_id": None}
+    )
+    run_with_batch = _make_run("batch-Y", issue_number=1)
 
-    result = _build_wave_summaries([no_batch, tf_with_batch], tmp_path)
+    result = _build_wave_summaries([run_no_batch, run_with_batch])
 
     assert len(result) == 1
     assert result[0].batch_id == "batch-Y"
 
 
-def test_wave_summaries_sorted_most_recent_first(tmp_path: Path) -> None:
+def test_wave_summaries_sorted_most_recent_first() -> None:
     """Waves must be sorted by started_at descending (most recent first)."""
-    old = _make_task_file(tmp_path, "wt-old", "batch-old", issue_number=1, mtime=100.0)
-    new = _make_task_file(tmp_path, "wt-new", "batch-new", issue_number=2, mtime=9_000.0)
+    old = _make_run("batch-old", issue_number=1, spawned_at=100.0)
+    new = _make_run("batch-new", issue_number=2, spawned_at=9_000.0)
 
-    result = _build_wave_summaries([old, new], tmp_path)
+    result = _build_wave_summaries([old, new])
 
     assert len(result) == 2
     assert result[0].batch_id == "batch-new"
     assert result[1].batch_id == "batch-old"
 
 
-def test_wave_summary_type_is_wave_summary(tmp_path: Path) -> None:
+def test_wave_summary_type_is_wave_summary() -> None:
     """Each result must be a WaveSummary Pydantic model (not a dict or stub)."""
-    tf = _make_task_file(tmp_path, "wt-type", "batch-Z", issue_number=5)
-    result = _build_wave_summaries([tf], tmp_path)
+    run = _make_run("batch-Z", issue_number=5)
+    result = _build_wave_summaries([run])
     assert isinstance(result[0], WaveSummary)
 
 
@@ -231,14 +202,10 @@ def test_estimate_cost_known_input() -> None:
     assert 0.5 <= cost <= 2.0
 
 
-def test_wave_summary_includes_cost(tmp_path: Path) -> None:
-    """Each WaveSummary must expose estimated_tokens and estimated_cost_usd.
-
-    Both fields should be non-negative integers / floats computed by estimate_cost.
-    With no transcript enrichment, message_count defaults to 0, so both are 0.
-    """
-    tf = _make_task_file(tmp_path, "wt-cost", "batch-cost", issue_number=42)
-    result = _build_wave_summaries([tf], tmp_path)
+def test_wave_summary_includes_cost() -> None:
+    """Each WaveSummary must expose estimated_tokens and estimated_cost_usd."""
+    run = _make_run("batch-cost", issue_number=42)
+    result = _build_wave_summaries([run])
 
     assert len(result) == 1
     wave = result[0]
@@ -248,16 +215,11 @@ def test_wave_summary_includes_cost(tmp_path: Path) -> None:
     assert wave.estimated_cost_usd >= 0.0
 
 
-def test_total_cost_sums_waves(tmp_path: Path) -> None:
-    """Summing estimated_cost_usd across waves must equal the aggregate total.
-
-    Two independent waves, each with zero message_count (defaults), produce
-    zero cost each — their sum is also zero.  The invariant is that the
-    aggregate matches the per-wave sum, not that costs are non-zero.
-    """
-    tf_a = _make_task_file(tmp_path, "wt-sum-a", "batch-sum-A", issue_number=50)
-    tf_b = _make_task_file(tmp_path, "wt-sum-b", "batch-sum-B", issue_number=51)
-    waves = _build_wave_summaries([tf_a, tf_b], tmp_path)
+def test_total_cost_sums_waves() -> None:
+    """Summing estimated_cost_usd across waves must equal the per-wave sum."""
+    run_a = _make_run("batch-sum-A", issue_number=50)
+    run_b = _make_run("batch-sum-B", issue_number=51)
+    waves = _build_wave_summaries([run_a, run_b])
 
     assert len(waves) == 2
     total_cost = round(sum(w.estimated_cost_usd for w in waves), 4)

--- a/agentception/tests/test_label_context_and_dispatch.py
+++ b/agentception/tests/test_label_context_and_dispatch.py
@@ -355,25 +355,24 @@ def test_dispatch_label_phase_scope_is_coordinator(
     assert data["label"] == "ac-workflow"
 
 
-def test_dispatch_label_phase_scope_agent_task_scope_value(
+def test_dispatch_label_phase_scope_persists_tier_to_db(
     client: TestClient,
     tmp_path: Path,
 ) -> None:
-    """The .agent-task [target] must use the phase sub-label as scope_value."""
-    written_text, capture = _make_agent_task_capture()
+    """dispatch-label for phase scope must persist tier=coordinator to the DB."""
+    persist_mock = AsyncMock()
 
     with (
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
         patch("agentception.routes.api.dispatch.asyncio.create_subprocess_exec") as mock_exec,
-        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
-        patch.object(Path, "write_text", capture),
+        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", persist_mock),
     ):
         wt_dir = tmp_path / "worktrees4"
         wt_dir.mkdir(parents=True)
         _mock_dispatch_settings(mock_settings, tmp_path, subdir="worktrees4")
         mock_exec.return_value = _make_fake_proc()
 
-        client.post(
+        res = client.post(
             "/api/dispatch/label",
             json=_dispatch_label_body(
                 scope="phase",
@@ -381,11 +380,11 @@ def test_dispatch_label_phase_scope_agent_task_scope_value(
             ),
         )
 
-    assert written_text, "No .agent-task file was written"
-    task_data = tomllib.loads(written_text[0])
-    assert task_data["target"]["scope_value"] == "ac-workflow/5-plan-step-v2"
-    assert task_data["target"]["initiative_label"] == "ac-workflow"
-    assert task_data["agent"]["tier"] == "coordinator"
+    assert res.status_code == 200
+    persist_mock.assert_awaited_once()
+    kwargs = persist_mock.call_args.kwargs
+    assert kwargs["tier"] == "coordinator"
+    assert kwargs["gh_repo"] == "cgcardona/agentception"
 
 
 # ---------------------------------------------------------------------------
@@ -417,35 +416,33 @@ def test_dispatch_label_issue_scope_is_leaf(
     assert data["role"] == "python-developer"
 
 
-def test_dispatch_label_issue_scope_agent_task_fields(
+def test_dispatch_label_issue_scope_persists_issue_number_to_db(
     client: TestClient,
     tmp_path: Path,
 ) -> None:
-    """The .agent-task [target] must use scope_type=issue and the issue number as scope_value."""
-    written_text, capture = _make_agent_task_capture()
+    """dispatch-label for issue scope must persist issue_number and tier=worker to DB."""
+    persist_mock = AsyncMock()
 
     with (
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
         patch("agentception.routes.api.dispatch.asyncio.create_subprocess_exec") as mock_exec,
-        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
-        patch.object(Path, "write_text", capture),
+        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", persist_mock),
     ):
         wt_dir = tmp_path / "worktrees6"
         wt_dir.mkdir(parents=True)
         _mock_dispatch_settings(mock_settings, tmp_path, subdir="worktrees6")
         mock_exec.return_value = _make_fake_proc()
 
-        client.post(
+        res = client.post(
             "/api/dispatch/label",
             json=_dispatch_label_body(scope="issue", scope_issue_number=42),
         )
 
-    assert written_text, "No .agent-task file was written"
-    task_data = tomllib.loads(written_text[0])
-    assert task_data["target"]["scope_type"] == "issue"
-    assert task_data["target"]["scope_value"] == "42"
-    assert task_data["target"]["initiative_label"] == "ac-workflow"
-    assert task_data["agent"]["tier"] == "worker"
+    assert res.status_code == 200
+    persist_mock.assert_awaited_once()
+    kwargs = persist_mock.call_args.kwargs
+    assert kwargs["issue_number"] == 42
+    assert kwargs["tier"] == "worker"
 
 
 # ---------------------------------------------------------------------------
@@ -453,42 +450,41 @@ def test_dispatch_label_issue_scope_agent_task_fields(
 # ---------------------------------------------------------------------------
 
 
-def test_cascade_enabled_defaults_to_true_in_agent_task(
+def test_dispatch_label_full_initiative_scope_persists_to_db(
     client: TestClient,
     tmp_path: Path,
 ) -> None:
-    """cascade_enabled must be True in [spawn] when not specified in request."""
-    written_text, capture = _make_agent_task_capture()
+    """dispatch-label for full_initiative scope must persist coordinator tier to DB."""
+    persist_mock = AsyncMock()
 
     with (
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
         patch("agentception.routes.api.dispatch.asyncio.create_subprocess_exec", new=_make_worktree_exec()),
-        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
-        patch.object(Path, "write_text", capture),
+        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", persist_mock),
     ):
         _mock_dispatch_settings(mock_settings, tmp_path, subdir="worktrees7")
-        client.post(
+        res = client.post(
             "/api/dispatch/label",
             json=_dispatch_label_body(scope="full_initiative"),
         )
 
-    assert written_text, "No .agent-task file was written"
-    task_data = tomllib.loads(written_text[0])
-    assert task_data["spawn"]["cascade_enabled"] is True
+    assert res.status_code == 200
+    persist_mock.assert_awaited_once()
+    kwargs = persist_mock.call_args.kwargs
+    assert kwargs["tier"] == "coordinator"
 
 
-def test_cascade_enabled_false_written_to_agent_task(
+def test_dispatch_label_returns_200_with_cascade_disabled(
     client: TestClient,
     tmp_path: Path,
 ) -> None:
-    """cascade_enabled=False must propagate into [spawn].cascade_enabled in .agent-task."""
-    written_text, capture = _make_agent_task_capture()
+    """dispatch-label with cascade_enabled=False must still return 200 and persist to DB."""
+    persist_mock = AsyncMock()
 
     with (
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
         patch("agentception.routes.api.dispatch.asyncio.create_subprocess_exec", new=_make_worktree_exec()),
-        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
-        patch.object(Path, "write_text", capture),
+        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", persist_mock),
     ):
         _mock_dispatch_settings(mock_settings, tmp_path, subdir="worktrees8")
         res = client.post(
@@ -497,6 +493,4 @@ def test_cascade_enabled_false_written_to_agent_task(
         )
 
     assert res.status_code == 200
-    assert written_text, "No .agent-task file was written"
-    task_data = tomllib.loads(written_text[0])
-    assert task_data["spawn"]["cascade_enabled"] is False
+    persist_mock.assert_awaited_once()

--- a/agentception/tests/test_plan_draft_poller.py
+++ b/agentception/tests/test_plan_draft_poller.py
@@ -319,7 +319,7 @@ async def test_poller_tick_broadcasts_plan_draft_ready_to_sse_subscriber(
     try:
         board = _empty_board()
         with (
-            patch("agentception.poller.list_active_worktrees", new_callable=AsyncMock, return_value=[]),
+            patch("agentception.poller.list_active_runs", new_callable=AsyncMock, return_value=[]),
             patch("agentception.poller.build_github_board", new_callable=AsyncMock, return_value=board),
             patch("agentception.poller.detect_out_of_order_prs", new_callable=AsyncMock, return_value=[]),
             patch("agentception.poller.settings") as mock_settings,

--- a/agentception/tests/test_spawn_child.py
+++ b/agentception/tests/test_spawn_child.py
@@ -29,7 +29,6 @@ def _make_mock_result(cognitive_arch: str) -> SpawnChildResult:
         org_domain="engineering",
         role="engineering-coordinator",
         cognitive_arch=cognitive_arch,
-        agent_task_path="/worktrees/test-run-id/.agent-task",
         scope_type="label",
         scope_value="my-label",
     )


### PR DESCRIPTION
## Summary

- Removes `.agent-task` TOML file as the source of agent task context; all fields now live in the `ACAgentRun` DB row
- Adds `gh_repo`, `is_resumed`, `coord_fingerprint` columns to `ACAgentRun` with Alembic migration 0007
- `spawn_child` and `dispatch.py` no longer write TOML files — they call `persist_agent_run_dispatch` directly
- `agent_loop._load_task` is now DB-only; file-based fallback deleted
- `poller` + `telemetry` replaced `list_active_worktrees` (file scan) with `list_active_runs` (DB query)
- `TaskFile` renamed to `AgentTaskSpec`; planning-pipeline callers (plan_tools, control) deferred to follow-up
- All tests updated: file-write assertions replaced with DB-persistence assertions

## Test plan

- [x] `mypy agentception/` — zero errors
- [x] `typing_audit.py --max-any 0` — passes
- [x] `pytest agentception/tests/ -v` — 1680 passed, 0 failed
- [x] `generate.py --check` — no drift