### PR TITLE
fix: self-throttle on 30K input-tokens/min Tier-1 rate limit

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -24,9 +24,12 @@ Pipeline
 
 from __future__ import annotations
 
+import asyncio
+import collections
 import json
 import logging
 import sys
+import time
 from pathlib import Path
 
 from sqlalchemy import select
@@ -74,13 +77,47 @@ _DEFAULT_MAX_ITERATIONS = 50
 # Tool results longer than this are truncated before being stored in history.
 # read_file / run_command can easily dump 50k+ chars; keeping them unbounded
 # inflates every subsequent input token count linearly.
-_MAX_TOOL_RESULT_CHARS: int = 6_000
+_MAX_TOOL_RESULT_CHARS: int = 3_000
 
 # When the message history (excluding system) exceeds this count, old turns
 # are dropped from the middle.  The first user message (task briefing) and the
 # most-recent _HISTORY_TAIL messages are always kept.
-_MAX_HISTORY_MESSAGES: int = 40
-_HISTORY_TAIL: int = 30
+_MAX_HISTORY_MESSAGES: int = 20
+_HISTORY_TAIL: int = 14
+
+# ---------------------------------------------------------------------------
+# Token-rate guard — keeps input token consumption under the Tier 1 limit
+# (30 000 tokens/minute).  We target 27 000 to leave a safety margin.
+# ---------------------------------------------------------------------------
+
+# Target: 90 % of the 30 000 input-token/minute Tier-1 limit.
+_INPUT_TPM_TARGET: int = 27_000
+_TPM_WINDOW_SECS: float = 60.0
+
+# Rolling window of (monotonic_timestamp, input_tokens) pairs.
+# Module-level; acceptable for single-agent-per-process deployments.
+_tpm_window: collections.deque[tuple[float, int]] = collections.deque()
+
+
+def _tpm_record_and_get_sleep(input_tokens: int) -> float:
+    """Record *input_tokens* in the rolling 60-second window.
+
+    Returns the number of seconds the caller should sleep before making
+    the next API call.  Returns ``0.0`` when no throttling is needed.
+
+    Uses ``time.monotonic`` so the window is immune to clock adjustments.
+    """
+    now = time.monotonic()
+    while _tpm_window and now - _tpm_window[0][0] >= _TPM_WINDOW_SECS:
+        _tpm_window.popleft()
+    _tpm_window.append((now, input_tokens))
+    total = sum(t for _, t in _tpm_window)
+    if total >= _INPUT_TPM_TARGET and _tpm_window:
+        oldest_ts = _tpm_window[0][0]
+        sleep_secs = _TPM_WINDOW_SECS - (now - oldest_ts) + 1.0
+        return max(0.0, sleep_secs)
+    return 0.0
+
 
 # Local tool names — dispatched to file/shell functions rather than MCP.
 _LOCAL_TOOL_NAMES: frozenset[str] = frozenset(
@@ -151,6 +188,16 @@ async def run_agent_loop(
             await log_run_error(issue_number, f"LLM error: {exc}", run_id)
             await build_cancel_run(run_id)
             return
+
+        # Token-rate guard — self-throttle before the next iteration if we are
+        # approaching the 30 000 input-tokens/minute Tier-1 limit.
+        sleep_secs = _tpm_record_and_get_sleep(response.get("input_tokens", 0))
+        if sleep_secs > 0.0:
+            logger.warning(
+                "⚠️ agent_loop: TPM guard — sleeping %.1fs to stay under rate limit",
+                sleep_secs,
+            )
+            await asyncio.sleep(sleep_secs)
 
         # Append assistant message to history.
         assistant_msg: dict[str, object] = {"role": "assistant", "content": response["content"]}

--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -34,7 +34,7 @@ import asyncio
 import json
 import logging
 from collections.abc import AsyncGenerator
-from typing import Literal, TypedDict
+from typing import Literal, NotRequired, TypedDict
 
 import httpx
 
@@ -93,11 +93,17 @@ class ToolCall(TypedDict):
 
 
 class ToolResponse(TypedDict):
-    """Return value from ``call_openrouter_with_tools``."""
+    """Return value from ``call_openrouter_with_tools``.
+
+    ``input_tokens`` is populated from the Anthropic ``usage.input_tokens``
+    field (sum of regular + cached tokens) and is used by the agent loop's
+    token-rate guard to stay within the 30K input tokens/minute Tier 1 limit.
+    """
 
     stop_reason: str  # "stop" | "tool_calls" | "length"
     content: str  # text output (empty when stop_reason is "tool_calls")
     tool_calls: list[ToolCall]  # empty when stop_reason is "stop"
+    input_tokens: NotRequired[int]  # total input tokens consumed this turn
 
 
 # ---------------------------------------------------------------------------
@@ -578,17 +584,20 @@ async def call_openrouter_with_tools(
                 )
             )
 
-    # Log cache usage when present — useful for verifying savings.
+    # Extract token counts — used for rate-limit accounting in the agent loop.
     usage: object = data.get("usage", {})
+    input_tokens: int = 0
     if isinstance(usage, dict):
+        raw_input = usage.get("input_tokens", 0)
+        input_tokens = int(raw_input) if isinstance(raw_input, int) else 0
         cache_write = usage.get("cache_creation_input_tokens", 0)
         cache_read = usage.get("cache_read_input_tokens", 0)
-        if cache_write or cache_read:
-            logger.info(
-                "✅ LLM cache — written=%d read=%d",
-                cache_write,
-                cache_read,
-            )
+        logger.info(
+            "✅ LLM usage — input=%d cache_written=%d cache_read=%d",
+            input_tokens,
+            cache_write,
+            cache_read,
+        )
 
     content = "".join(text_parts)
     logger.info(
@@ -597,4 +606,9 @@ async def call_openrouter_with_tools(
         len(content),
         len(tool_calls),
     )
-    return ToolResponse(stop_reason=stop_reason, content=content, tool_calls=tool_calls)
+    return ToolResponse(
+        stop_reason=stop_reason,
+        content=content,
+        tool_calls=tool_calls,
+        input_tokens=input_tokens,
+    )

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -458,3 +458,35 @@ class TestDispatchToolCalls:
         result = await _dispatch_single_tool(bad_tc, tmp_path, "run-1")
         assert result["ok"] is False
         assert "json" in str(result["error"]).lower()
+
+
+class TestTpmRateGuard:
+    """Unit tests for _tpm_record_and_get_sleep."""
+
+    def setup_method(self) -> None:
+        """Clear the module-level window before each test."""
+        import agentception.services.agent_loop as al
+        al._tpm_window.clear()
+
+    def test_under_limit_returns_zero(self) -> None:
+        """Below the token limit → no sleep required."""
+        from agentception.services.agent_loop import _tpm_record_and_get_sleep
+
+        sleep = _tpm_record_and_get_sleep(5_000)
+        assert sleep == 0.0
+
+    def test_over_limit_returns_positive_sleep(self) -> None:
+        """Exceeding the 27K target → a positive sleep duration is returned."""
+        from agentception.services.agent_loop import _tpm_record_and_get_sleep
+
+        sleep = _tpm_record_and_get_sleep(28_000)
+        assert sleep > 0.0
+
+    def test_multiple_calls_accumulate(self) -> None:
+        """Multiple calls within the window accumulate token counts."""
+        from agentception.services.agent_loop import _tpm_record_and_get_sleep
+
+        _tpm_record_and_get_sleep(10_000)
+        _tpm_record_and_get_sleep(10_000)
+        sleep = _tpm_record_and_get_sleep(10_000)
+        assert sleep > 0.0


### PR DESCRIPTION
## Summary

- `_MAX_TOOL_RESULT_CHARS` 6 000 → 3 000: halves the per-turn tool-result footprint
- `_MAX_HISTORY_MESSAGES` 40 → 20, `_HISTORY_TAIL` 30 → 14: tighter history window
- `_tpm_record_and_get_sleep()`: rolling 60-second token accumulator that sleeps the loop when the window total approaches 27 000 tokens (90% of the 30 000/min Tier-1 limit)
- `ToolResponse.input_tokens` (`NotRequired[int]`): `llm.py` reads `usage.input_tokens` from every Anthropic response so the guard has accurate data

## Test plan

- [x] `mypy agentception/` — zero errors
- [x] `typing_audit.py --max-any 0` — passes
- [x] `pytest agentception/tests/` — 1686 passed, 0 failed (includes 3 new `TestTpmRateGuard` unit tests)
- [x] `generate.py --check` — no drift