### PR TITLE
fix: update agent-task-spec and MCP docs to reflect DB-backed task context

### DIFF
--- a/.agentception/agent-task-spec.md
+++ b/.agentception/agent-task-spec.md
@@ -1,574 +1,132 @@
-# `.agent-task` — Formal TOML Specification
+# Agent Task Context — DB-Backed Specification
 
-> **Version:** 2.0  
-> **Format:** [TOML 1.0](https://toml.io/en/v1.0.0)  
-> **Parsed by:** `agentception/readers/worktrees.py` (Python `tomllib`, stdlib since 3.11)  
-> **Read by:** Cursor's LLM (full raw text as context) + AgentCeption dashboard
+> **Version:** 3.0  
+> **Source:** `ACAgentRun` DB row  
+> **Access:** `ac://runs/{run_id}/context` MCP resource · `task/briefing` MCP prompt  
+> **Parsed by:** `agentception/db/queries.py` → `RunContextRow` TypedDict
 
 ---
 
 ## Overview
 
-Every agent worktree contains exactly one `.agent-task` file. It is the **single source of
-truth** for that agent's assignment, identity, pipeline position, and execution constraints.
+Every agent run is fully described by a row in the `agent_runs` table.  Agents read
+their task context exclusively from the database — no file is written to the worktree.
 
-Two consumers read this file with different goals:
+Two read paths are available:
 
-| Consumer | What it reads | How |
-|----------|--------------|-----|
-| AgentCeption dashboard | Typed scalar fields for monitoring/telemetry | `tomllib.loads()` → `TaskFile` Pydantic model |
-| Cursor's LLM | Full raw text as natural language context | File read → LLM context window |
-
-Because the LLM reads the entire file, **any valid TOML you add is immediately available
-to the agent** — even fields AgentCeption doesn't formally parse. This makes the file
-extensible at zero cost.
+| Path | Returns | When to use |
+|------|---------|-------------|
+| `ac://runs/{run_id}/context` | Full `RunContextRow` as JSON | Machine consumption — tool calls, automated processing |
+| `task/briefing` (MCP prompt) | Natural-language briefing assembled from the DB row | Human-readable startup message for the agent loop |
 
 ---
 
-## File Layout
+## `RunContextRow` Field Reference
 
-```toml
-# ── Section order is conventional, not required by TOML ──────────────────────
+All fields are present in the JSON returned by `ac://runs/{run_id}/context`.
 
-[task]          # Core identity and lifecycle control
-[agent]         # Who is running this task
-[repo]          # GitHub and git coordinates
-[pipeline]      # Batch/wave/coordinator lineage for traceability
-[spawn]         # Orchestration control: chaining, sub-agents
-[target]        # What this task acts on (issue, PR, or custom)
-[worktree]      # Local filesystem coordinates
-[output]        # Async result rendezvous (for Cursor-driven workflows)
-[domain]        # Domain context (non-tech orgs: marketing, legal, ops, etc.)
+### Identity
 
-# ── Optional payload sections (workflow-specific) ─────────────────────────────
-[plan_draft]    # workflow = "plan-spec": brain dump dispatch to Cursor
-[enriched]      # Coordinator manifest (structured issue set)
+| Field | Type | Description |
+|-------|------|-------------|
+| `run_id` | string | Unique run identifier. Format: `"issue-42-a1b2c3"` \| `"label-ac-workflow-x9y8"` \| `"adhoc-1a2b3c"` |
+| `status` | string | Execution state — see **Status values** below |
+| `spawned_at` | string | ISO 8601 UTC timestamp when the run was created |
+| `last_activity_at` | string \| null | ISO 8601 UTC timestamp of most-recent status update |
+| `completed_at` | string \| null | ISO 8601 UTC timestamp of terminal-state transition |
 
-# ── Sub-task queues (coordinator and conductor workflows only) ────────────────
-[[issue_queue]]         # repeated for each sub-task
-[[pr_queue]]            # repeated for each PR review sub-task
-[[deliverable_queue]]   # repeated for each non-code deliverable
-```
-
----
-
-## Field Reference
-
-### `[task]`
-
-Core identity. Required in every task file.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `version` | string | yes | Spec version — always `"2.0"` for TOML files |
-| `workflow` | string | yes | Workflow type — see **Workflow Types** below |
-| `id` | string | yes | UUID v4 uniquely identifying this task instance |
-| `created_at` | datetime | yes | ISO 8601 datetime when this file was written |
-| `attempt_n` | int | yes | Retry counter. Agent hard-stops when `attempt_n > 2` |
-| `required_output` | string | yes | Artifact the agent must produce before self-destructing |
-| `on_block` | string | yes | `"stop"` \| `"escalate"` — what to do when blocked |
-
-**Workflow types** (extensible — add new rows as workflows are built):
-
-| Value | Consumer | Produces |
-|-------|----------|---------|
-| `issue-to-pr` | Implementation engineer | GitHub PR |
-| `pr-review` | QA reviewer | Merge + grade |
-| `coordinator` | Batch coordinator | N worktrees + N child agents |
-| `conductor` | Meta-orchestrator | Pipeline state report |
-| `bugs-to-issues` | Issue creator | GitHub issues |
-| `plan-spec` | Cursor LLM | YAML PlanSpec written to `output.path` |
-| `task-to-deliverable` | Any domain agent | Domain-specific artifact |
-
-**`required_output` values:**
+**Status values:**
 
 | Value | Meaning |
 |-------|---------|
-| `pr_url` | Open pull request URL |
-| `grade,merge_status,pr_url` | Full review result |
-| `pipeline_status_report` | Conductor summary |
-| `yaml_file` | Cursor writes YAML to `output.path` |
-| `deliverable_path` | Non-code output written to `output.path` |
+| `pending_launch` | Created, waiting for the agent loop to start |
+| `implementing` | Agent loop is active |
+| `reviewing` | PR reviewer is active |
+| `blocked` | Agent self-reported a blocker |
+| `completed` | Successful finish |
+| `failed` | Unrecoverable error |
+| `cancelled` | Manually stopped or iteration limit hit |
+| `stopped` | Graceful stop (e.g. worktree reaped) |
 
 ---
 
-### `[agent]`
-
-Who is executing this task.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `role` | string | yes | Role slug: `"python-developer"`, `"pr-reviewer"`, `"qa-coordinator"`, etc. |
-| `tier` | string | yes | Behavioral execution tier: `"coordinator"` \| `"worker"`. Written as `TIER=` in the `.agent-task` file. Any coordinator can be the tree root. For workers, `scope_type` (`issue` or `pr`) and `role` identify the kind of work — the tier does not. |
-| `org_domain` | string | no | Organisational slot for UI hierarchy: `"c-suite"` \| `"engineering"` \| `"qa"`. Written as `ORG_DOMAIN=` when provided. A chain-spawned PR reviewer with `tier=reviewer` should have `org_domain=qa` so the dashboard places it under the QA column regardless of its physical parent. |
-| `cognitive_arch` | string | yes | `"figure:skill1:skill2"` — resolved by `resolve_arch.py` |
-| `session_id` | string | no | Set by the agent at runtime: `"eng-20260303T134821Z-a7f2"` |
-
-**`cognitive_arch` format:**
-
-```
-figures,figure2:skill1:skill2:skill3
-│                │
-│                └─ colon-separated skill domain IDs (from cognitive_archetypes/skill_domains/)
-└─ comma-separated figure/archetype IDs (from cognitive_archetypes/figures/)
-
-Examples:
-  "turing:python"                     — single figure + one skill
-  "dijkstra:jinja2:htmx:alpine"       — single figure + three skills  
-  "lovelace,shannon:htmx:d3:python"   — two-figure blend + three skills
-  "the_architect:python:fastapi"       — archetype + two skills
-```
-
----
-
-### `[repo]`
-
-Git and GitHub coordinates.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `gh_repo` | string | yes | GitHub slug: `"owner/repo"`. **Never derive from local path.** |
-| `base` | string | yes | Base branch to merge into: `"dev"` |
-| `gh_token_env` | string | no | Env var name containing GitHub token (default: `"GH_TOKEN"`) |
-
----
-
-### `[pipeline]`
-
-Lineage for traceability. Every artifact produced (commit, PR, issue comment) embeds these.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `batch_id` | string | yes | Coordinator-level batch fingerprint: `"eng-20260303T134821Z-a7f2"` |
-| `parent_run_id` | string | no | `run_id` of the agent that physically spawned this one. Empty for root (CTO). For chain-spawned reviewers this is the engineer's `run_id`, not the coordinator's — the dashboard uses `agent.org_domain` to position the node in the UI hierarchy regardless. |
-| `wave` | string | no | Named wave: `"5-plan-step-v2"` |
-| `coord_fingerprint` | string | no | The spawning coordinator's fingerprint string (role + batch ID). Written by the spawner via `build_spawn_child(coord_fingerprint=...)` and read by leaf agents to include in GitHub issue/PR fingerprint comments without re-deriving it. Format: `"Engineering Coordinator · <batch_id>"`. |
-| `vp_fingerprint` | string | no | Coordinator agent's session ID — propagated to leaf agents (legacy field name) |
-| `cto_wave` | string | no | CTO-level orchestration round for full-pipeline traces |
-
-Commit message trailers written by every agent:
-```
-AgentCeption-Batch: <pipeline.batch_id>
-AgentCeption-Session: <agent.session_id>
-```
-
----
-
-### `[spawn]`
-
-Controls how this agent spawns and hands off to successors.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `mode` | string | yes | `"chain"` \| `"single"` \| `"coordinator"` |
-| `sub_agents` | bool | yes | `true` → act as sub-coordinator, launch agents from `[[issue_queue]]` |
-| `max_concurrent` | int | no | Safety valve for sub-coordinators (default: 4) |
-
-**`spawn.mode` values:**
-
-| Value | Behaviour |
-|-------|-----------|
-| `"chain"` | After PR is opened, immediately spawn a QA reviewer for that PR |
-| `"single"` | Do the work and stop — no chaining |
-| `"coordinator"` | Create worktrees from `[[issue_queue]]`, launch one leaf per worktree, report back |
-
----
-
-### `[target]`
-
-What this task acts on. Fields present depend on workflow type.
-
-| Field | Type | Workflows | Description |
-|-------|------|-----------|-------------|
-| `issue_number` | int | `issue-to-pr` | GitHub issue number |
-| `issue_title` | string | `issue-to-pr` | Display title |
-| `issue_url` | string | `issue-to-pr` | Full GitHub URL |
-| `phase_label` | string | `issue-to-pr` | Phase label applied on GitHub |
-| `batch_label` | string | `issue-to-pr` | Batch label applied on GitHub |
-| `all_labels` | [string] | `issue-to-pr` | All labels on this issue |
-| `depends_on` | [int] | `issue-to-pr` | Issue numbers that must be merged first |
-| `closes` | [int] | `issue-to-pr` | Issue numbers to close when PR merges |
-| `file_ownership` | [string] | `issue-to-pr` | Files this agent owns (prevents conflicts) |
-| `pr_number` | int | `pr-review` | Pull request number |
-| `pr_title` | string | `pr-review` | PR display title |
-| `pr_url` | string | `pr-review` | Full GitHub URL |
-| `pr_branch` | string | `pr-review` | PR head branch |
-| `files_changed` | [string] | `pr-review` | Files modified in the PR |
-| `has_migration` | bool | `pr-review` | `true` if PR contains an Alembic migration |
-| `closes_issues` | [int] | `pr-review` | Issues this PR closes |
-| `grade_threshold` | string | `pr-review` | Minimum grade to merge: `"A"` \| `"B"` \| `"C"` |
-| `merge_after` | int | `pr-review` | PR number that must merge before this one |
-| `deliverable_type` | string | `task-to-deliverable` | What gets produced (domain-specific) |
-| `deliverable_description` | string | `task-to-deliverable` | Full description of the deliverable |
-
----
-
-### `[worktree]`
-
-Local filesystem coordinates.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `path` | string | yes | Absolute path to this worktree |
-| `branch` | string | no | Git branch name (created by the agent for `issue-to-pr`) |
-| `linked_pr` | int | no | Written back by agent after PR opens: `0` until then |
-
----
-
-### `[output]`
-
-Async result rendezvous. Used when Cursor does LLM work and writes a result back to disk.
-
-| Field | Type | Workflows | Description |
-|-------|------|-----------|-------------|
-| `path` | string | `plan-spec`, `task-to-deliverable` | Absolute path Cursor writes its output to |
-| `draft_id` | string | `plan-spec` | UUID correlating to the AgentCeption dashboard request |
-| `format` | string | any | Output format: `"yaml"` \| `"json"` \| `"markdown"` \| `"toml"` |
-| `schema_tool` | string | `plan-spec` | MCP resource URI to read the output schema: `"ac://plan/schema"` |
-
-When `output.path` is present, the AgentCeption poller watches for this file.
-When it appears, the poller emits an SSE event:
-```json
-{"event": "task_output_ready", "data": {"draft_id": "...", "path": "...", "format": "..."}}
-```
-
----
-
-### `[domain]`
-
-Domain context for non-engineering workflows. Lets AgentCeption support any org type.
+### Agent identity
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `name` | string | Domain name: `"engineering"` \| `"marketing"` \| `"legal"` \| `"ops"` \| `"finance"` |
-| `org_preset` | string | Org preset ID from `org-presets.yaml` |
-| `language` | string | Human language for deliverables (default: `"en"`) |
-| `context` | string | Free-form domain context injected into agent prompt |
-| `tools` | [string] | Domain-specific MCP tools available to this agent |
+| `role` | string | Role slug: `"python-developer"`, `"pr-reviewer"`, `"engineering-coordinator"`, etc. |
+| `tier` | string \| null | Execution tier: `"coordinator"` \| `"worker"` |
+| `org_domain` | string \| null | UI hierarchy slot: `"c-suite"` \| `"engineering"` \| `"qa"` |
+| `cognitive_arch` | string \| null | `"figure:skill1:skill2"` resolved by `resolve_arch.py` |
 
 ---
 
-### `[plan_draft]`
-
-Present only when `task.workflow = "plan-spec"`. Carries the brain dump AgentCeption
-collected from the web UI, dispatched to Cursor for YAML generation.
+### Target
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `dump` | string | Raw brain dump text (multi-line, no escaping needed in TOML `"""`) |
-| `mcp_tools_hint` | string | Which AgentCeption MCP tools to call first |
-| `output_schema` | string | MCP tool name that returns the expected output schema |
-
-```toml
-[plan_draft]
-mcp_tools_hint = "read ac://plan/schema to get the PlanSpec YAML schema first"
-output_schema = "ac://plan/schema"
-dump = """
-We need to build a billing system.
-- Users should be able to subscribe to monthly or annual plans
-- Payment via Stripe
-- Invoices emailed on charge
-- Admin dashboard to manage subscriptions
-"""
-```
+| `issue_number` | int \| null | GitHub issue number this run works on |
+| `pr_number` | int \| null | GitHub PR number (set when the run opens a PR) |
+| `task_description` | string \| null | Inline task description for ad-hoc runs |
 
 ---
 
-### `[enriched]`
-
-Present when a coordinator receives a pre-enriched manifest (output of Plan step 1.A).
-When present, the coordinator skips interpretation and executes directly.
+### Repository
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `manifest_json` | string | JSON-encoded `EnrichedManifest` (full manifest as a multi-line string) |
-| `total_issues` | int | Quick summary: total issue count |
-| `estimated_waves` | int | Quick summary: estimated parallel waves |
-| `phases` | [string] | Phase IDs in dependency order |
+| `gh_repo` | string \| null | GitHub slug: `"owner/repo"` |
+| `branch` | string \| null | Git branch name for this run's worktree |
+| `worktree_path` | string \| null | Absolute container path to the worktree |
 
 ---
 
-### `[[issue_queue]]`
+### Pipeline lineage
 
-Repeated table. Each entry is one sub-task for a `spawn.mode = "coordinator"` agent.
-The coordinator creates one worktree per entry and launches one leaf agent.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `number` | int | yes | GitHub issue number |
-| `title` | string | yes | Display title |
-| `role` | string | yes | Role slug for the leaf agent |
-| `cognitive_arch` | string | yes | `"figure:skill"` for the leaf agent |
-| `depends_on` | [int] | yes | Issue numbers that must complete first (can be `[]`) |
-| `file_ownership` | [string] | no | Files this leaf agent owns |
-| `branch` | string | no | Override branch name (default: `"feat/issue-<number>"`) |
-
-```toml
-[[issue_queue]]
-number = 870
-title = "MCP layer + schema tools"
-role = "python-developer"
-cognitive_arch = "turing:python"
-depends_on = []
-file_ownership = ["agentception/mcp/"]
-
-[[issue_queue]]
-number = 871
-title = "Plan tools: label context + coordinator spawn"
-role = "python-developer"
-cognitive_arch = "turing:python"
-depends_on = [870]
-file_ownership = ["agentception/mcp/plan_tools.py"]
-```
+| Field | Type | Description |
+|-------|------|-------------|
+| `batch_id` | string \| null | Coordinator-level batch fingerprint. Format: `"eng-20260303T134821Z-a7f2"` |
+| `parent_run_id` | string \| null | `run_id` of the agent that physically spawned this run. Null for root dispatches |
+| `coord_fingerprint` | string \| null | Spawning coordinator's human-readable fingerprint for GitHub comments. Format: `"Engineering Coordinator · <batch_id>"` |
+| `is_resumed` | bool | `true` when this is a retry of a previously cancelled/stale run |
 
 ---
 
-### `[[pr_queue]]`
+## Reading task context at startup
 
-Repeated table. Each entry is one PR to review, for `workflow = "coordinator"` QA runs.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `number` | int | yes | PR number |
-| `title` | string | yes | PR display title |
-| `branch` | string | yes | PR head branch |
-| `role` | string | yes | Reviewer role slug |
-| `cognitive_arch` | string | yes | Reviewer cognitive architecture |
-| `grade_threshold` | string | yes | Minimum grade to merge |
-| `merge_order` | int | yes | `1` = first, `2` = second, etc. (must be serial for safety) |
-| `closes_issues` | [int] | no | Issues closed by this PR |
-
----
-
-### `[[deliverable_queue]]`
-
-Repeated table. For non-code workflows — any domain agent producing structured output.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `id` | string | yes | Unique deliverable ID within this batch |
-| `title` | string | yes | Human-readable title |
-| `type` | string | yes | Deliverable type: `"blog-post"` \| `"legal-brief"` \| `"market-analysis"` \| etc. |
-| `role` | string | yes | Role slug |
-| `cognitive_arch` | string | yes | Cognitive architecture |
-| `output_format` | string | yes | `"markdown"` \| `"json"` \| `"pdf"` |
-| `depends_on` | [string] | yes | Deliverable IDs that must complete first |
-| `context` | string | no | Domain-specific context injected into agent prompt |
-
----
-
-## Complete Examples
-
-### Issue-to-PR (engineering)
-
-```toml
-[task]
-version = "0.1.1"
-workflow = "issue-to-pr"
-id = "3f4a9c2e-1b8d-4e7f-a6c5-9d2e8f0b1a3c"
-created_at = 2026-03-03T13:48:21Z
-attempt_n = 0
-required_output = "pr_url"
-on_block = "stop"
-
-[agent]
-role = "python-developer"
-tier = "engineer"
-org_domain = "engineering"
-cognitive_arch = "turing:python"
-
-[repo]
-gh_repo = "cgcardona/agentception"
-base = "dev"
-
-[pipeline]
-batch_id = "eng-20260303T134821Z-a7f2"
-parent_run_id = "label-AC-UI-5-plan-step-v2-20260303T134000Z-x9y1"   # engineering-coordinator's run_id
-wave = "5-plan-step-v2"
-
-[spawn]
-mode = "chain"   # engineer spawns its own pr-reviewer immediately after opening the PR
-sub_agents = false
-
-[target]
-issue_number = 872
-issue_title = "POST /api/plan/draft — accept brain dump, dispatch to Cursor via .agent-task"
-issue_url = "https://github.com/cgcardona/agentception/issues/872"
-phase_label = "plan-step-v2/2-api-endpoints"
-all_labels = ["enhancement", "ac-workflow/5-plan-step-v2", "plan-step-v2/2-api-endpoints"]
-depends_on = [870, 871]
-closes = [872]
-file_ownership = ["agentception/routes/api/plan.py", "agentception/tests/test_agentception_plan_api.py"]
-
-[worktree]
-path = "/tmp/worktrees/issue-872"
-branch = "feat/issue-872"
-linked_pr = 0
-```
-
----
-
-### Plan-spec (Cursor-driven brain dump)
-
-```toml
-[task]
-version = "0.1.1"
-workflow = "plan-spec"
-id = "8b2c4d1e-9f3a-4b7e-c5d8-2e1f6a9b0c3d"
-created_at = 2026-03-03T14:22:00Z
-attempt_n = 0
-required_output = "yaml_file"
-on_block = "stop"
-
-[agent]
-role = "python-developer"
-cognitive_arch = "turing:python"
-
-[repo]
-gh_repo = "cgcardona/agentception"
-base = "dev"
-
-[pipeline]
-batch_id = "plan-20260303T142200Z-f7e1"
-
-[spawn]
-mode = "single"
-sub_agents = false
-
-[worktree]
-path = "/tmp/worktrees/plan-draft-8b2c4d1e"
-
-[output]
-path = "/tmp/worktrees/plan-draft-8b2c4d1e/.plan-output.yaml"
-draft_id = "8b2c4d1e-9f3a-4b7e-c5d8-2e1f6a9b0c3d"
-format = "yaml"
-schema_tool = "ac://plan/schema"
-
-[plan_draft]
-mcp_tools_hint = "read ac://plan/schema first to get the PlanSpec YAML format, then produce valid YAML matching that schema"
-dump = """
-We need to build a billing system for our SaaS product.
-
-Users should be able to:
-- Subscribe to monthly or annual plans
-- Pay via Stripe (card + ACH)
-- Receive invoices by email on each charge
-- View billing history in their account dashboard
-
-Admins should be able to:
-- View all active subscriptions
-- Manually cancel or refund subscriptions
-- See monthly revenue charts
-"""
-```
-
----
-
-### Non-tech workflow (marketing team)
-
-```toml
-[task]
-version = "0.1.1"
-workflow = "task-to-deliverable"
-id = "c1d2e3f4-a5b6-4c7d-8e9f-0a1b2c3d4e5f"
-created_at = 2026-03-03T15:00:00Z
-attempt_n = 0
-required_output = "deliverable_path"
-on_block = "escalate"
-
-[agent]
-role = "content-writer"
-cognitive_arch = "sagan:writing"
-
-[repo]
-gh_repo = "acme-corp/content"
-base = "main"
-
-[pipeline]
-batch_id = "mktg-20260303T150000Z-b9c2"
-wave = "q1-campaign"
-
-[spawn]
-mode = "single"
-sub_agents = false
-
-[domain]
-name = "marketing"
-org_preset = "content-team"
-language = "en"
-context = "B2B SaaS, technical audience, tone: authoritative but approachable"
-tools = ["brand_guidelines", "seo_keyword_lookup", "competitor_analysis"]
-
-[target]
-deliverable_type = "blog-post"
-deliverable_description = "Write a 1200-word blog post about using AI agents to automate team workflows. Target: CTOs at Series A startups. Include 3 real-world examples."
-
-[worktree]
-path = "/tmp/worktrees/content-c1d2e3f4"
-
-[output]
-path = "/tmp/worktrees/content-c1d2e3f4/blog-post-ai-agents.md"
-format = "markdown"
-```
-
----
-
-## Parser Contract (AgentCeption)
-
-AgentCeption's `parse_agent_task()` in `agentception/readers/worktrees.py` reads the file
-using `tomllib.loads()`. The following fields are formally tracked in the `TaskFile` model
-(everything else is available to the LLM but silently ignored by the dashboard):
+The agent loop calls `task/briefing` with the `run_id` to get the complete initial
+message.  Agents may also call `ac://runs/{run_id}/context` directly for structured
+access to any field:
 
 ```
-task.workflow → TaskFile.task
-task.id → TaskFile.id
-task.attempt_n → TaskFile.attempt_n
-task.required_output → TaskFile.required_output
-task.on_block → TaskFile.on_block
-agent.role → TaskFile.role
-agent.tier → TaskFile.tier
-agent.org_domain → TaskFile.org_domain
-agent.cognitive_arch → TaskFile.cognitive_arch
-agent.session_id → TaskFile.session_id
-repo.gh_repo → TaskFile.gh_repo
-repo.base → TaskFile.base
-pipeline.batch_id → TaskFile.batch_id
-pipeline.parent_run_id → TaskFile.parent_run_id
-pipeline.coord_fingerprint → TaskFile.coord_fingerprint   (written by spawner; read by leaf for GitHub comments)
-pipeline.wave → TaskFile.wave
-spawn.mode → TaskFile.spawn_mode
-spawn.sub_agents → TaskFile.spawn_sub_agents
-target.issue_number → TaskFile.issue_number
-target.pr_number → TaskFile.pr_number
-target.depends_on → TaskFile.depends_on
-target.closes → TaskFile.closes_issues
-target.file_ownership → TaskFile.file_ownership
-worktree.path → TaskFile.worktree
-worktree.branch → TaskFile.branch
-worktree.linked_pr → TaskFile.linked_pr
-output.draft_id → TaskFile.draft_id
-output.path → TaskFile.output_path
-domain.name → TaskFile.domain
+# Via MCP prompt (natural language)
+get_prompt("task/briefing", arguments={"run_id": "<run_id>"})
+
+# Via MCP resource (structured JSON)
+read_resource("ac://runs/{run_id}/context")
 ```
+
+Both sources are authoritative — they read the same DB row.
 
 ---
 
-## Extension Guide
+## Related resources
 
-### Adding a new workflow type
+| URI | Contents |
+|-----|---------|
+| `ac://runs/{run_id}/context` | This spec — full `RunContextRow` as JSON |
+| `ac://runs/{run_id}/events` | Structured event log for this run |
+| `ac://runs/{run_id}/children` | Child runs spawned by this run |
+| `ac://runs/active` | All currently active runs |
+| `ac://runs/pending` | Runs in `pending_launch` state |
+| `ac://batches/{batch_id}/tree` | Full batch run tree |
 
-1. Add a row to the **Workflow types** table above.
-2. Add a `[[workflow_name_queue]]` section if it needs sub-task coordination.
-3. Add any workflow-specific payload section (`[workflow_name_payload]`).
-4. Add the new workflow's `required_output` value to the table.
-5. Update `agentception/models.py` `TaskFile` with any new fields the dashboard needs.
-6. Update the coordinator prompt that writes this workflow's task files.
+---
 
-### Adding a new domain (non-tech org)
+## Planning pipeline (coordinator/conductor)
 
-1. Add an entry to `org-presets.yaml` with the domain's role topology.
-2. Add role files to `.agentception/roles/` for any new roles.
-3. Add cognitive architecture figures/skills to `scripts/gen_prompts/cognitive_archetypes/`
-   if the domain has domain-specific figures (e.g., `ogilvy.yaml` for marketing).
-4. Set `domain.name` and `domain.org_preset` in the task file.
-5. No code changes needed — the domain context flows through the LLM's prompt.
+Coordinator and conductor agents write `.agent-task` TOML files for **plan-draft**
+workflows only (brain-dump → YAML generation via the plan UI).  These files are read
+by `agentception/readers/worktrees.py` and are not part of the standard dispatch
+pipeline.  Plan-draft files are accessible via `ac://runs/{run_id}/task` but are
+unrelated to `RunContextRow`.

--- a/agentception/mcp/prompts.py
+++ b/agentception/mcp/prompts.py
@@ -16,10 +16,9 @@ Parameterized prompts (require arguments, DB-backed)
         (role, cognitive_arch, task_description or issue reference, worktree
         path, branch) with the agent's full role definition.
 
-        This is what replaces the ``.agent-task`` file read in the agent loop.
         The loop calls ``get_prompt("task/briefing", {"run_id": run_id})`` to
-        get the initial user message — no file indirection, no inline text
-        pasted into the conversation, just MCP protocol from start to finish.
+        get the initial user message — task context is sourced entirely from
+        the ``ACAgentRun`` DB row, no file reads or inline text pasting.
 
 Prompt naming convention
     ``role/<slug>``     role definition files
@@ -62,7 +61,7 @@ _AGENT_PROMPTS: list[tuple[str, str]] = [
     ("agent/conductor", "Agent conductor — coordinate multi-step agent workflows"),
     ("agent/command-policy", "Agent command policy — rules for safe shell and git usage"),
     ("agent/pipeline-howto", "Pipeline how-to — phase-gate, dependency, and label conventions"),
-    ("agent/task-spec", "Agent task file specification — formal TOML schema for .agent-task files"),
+    ("agent/task-spec", "Agent task context specification — DB-backed RunContextRow field reference"),
     ("agent/cognitive-arch-enrichment-spec", "Cognitive architecture enrichment specification"),
     ("agent/conflict-rules", "Conflict resolution rules for concurrent agent operations"),
 ]
@@ -90,9 +89,8 @@ _PARAMETERIZED_PROMPTS: list[ACPromptDef] = [
         name="task/briefing",
         description=(
             "Full task briefing for a run — role definition, cognitive architecture, "
-            "and task assignment resolved live from the DB. "
-            "Pass run_id to receive the complete initial message for the agent loop. "
-            "Replaces reading a .agent-task file."
+            "and task assignment resolved live from the ACAgentRun DB row. "
+            "Pass run_id to receive the complete initial message for the agent loop."
         ),
         arguments=[
             ACPromptArgument(

--- a/agentception/mcp/query_tools.py
+++ b/agentception/mcp/query_tools.py
@@ -148,12 +148,15 @@ async def query_run_events(run_id: str, after_id: int = 0) -> dict[str, object]:
 
 
 async def query_agent_task(run_id: str) -> dict[str, object]:
-    """Return the parsed contents of the ``.agent-task`` file for *run_id*.
+    """Return the raw ``.agent-task`` TOML text for *run_id* (planning pipeline only).
 
-    The file is read from disk at ``{worktree_path}/.agent-task``.  If the
-    worktree does not exist yet (pending launch) or has already been torn
-    down, returns ``{"ok": False, "error": "..."}`` so agents can handle
-    the failure gracefully.
+    Standard dispatch runs do not write ``.agent-task`` files — use
+    ``ac://runs/{run_id}/context`` for their task context.  This function
+    exists for plan-draft runs created by the planning pipeline, which still
+    write a TOML file at ``{worktree_path}/.agent-task``.
+
+    Returns ``{"ok": False, "error": "..."}`` when the worktree is missing,
+    the run has no worktree path, or the file does not exist.
 
     Args:
         run_id: The run to read the agent task for.

--- a/agentception/mcp/resources.py
+++ b/agentception/mcp/resources.py
@@ -27,7 +27,7 @@ Templated resources (RFC 6570)
     ac://runs/{run_id}/children         — child runs spawned by this run
     ac://runs/{run_id}/events           — full structured event log
     ac://runs/{run_id}/events?after_id={n} — paginated event log (n > 0)
-    ac://runs/{run_id}/task             — raw .agent-task TOML text
+    ac://runs/{run_id}/task             — raw .agent-task TOML (plan-draft runs only)
     ac://batches/{batch_id}/tree        — all runs in a batch, flat list
     ac://plan/figures/{role}            — cognitive-arch figures for a role
     ac://roles/{slug}                   — role definition Markdown for a slug
@@ -229,11 +229,11 @@ RESOURCE_TEMPLATES: list[ACResourceTemplate] = [
         uriTemplate="ac://runs/{run_id}/context",
         name="Run task context",
         description=(
-            "Full task context for a run — the authoritative DB-sourced record. "
-            "Includes role, cognitive_arch, task_description, issue_number, "
-            "worktree_path, branch, status, tier, org_domain, batch_id, and "
-            "parent_run_id. "
-            "Read on startup instead of parsing a .agent-task file. "
+            "Full task context for a run — the authoritative DB-sourced RunContextRow. "
+            "Includes run_id, status, role, cognitive_arch, task_description, "
+            "issue_number, pr_number, worktree_path, branch, tier, org_domain, "
+            "batch_id, parent_run_id, coord_fingerprint, gh_repo, is_resumed, "
+            "spawned_at, last_activity_at, completed_at. "
             "Returns ok=false when the run does not exist."
         ),
         mimeType=_MIME,
@@ -242,10 +242,10 @@ RESOURCE_TEMPLATES: list[ACResourceTemplate] = [
         uriTemplate="ac://runs/{run_id}/task",
         name="Agent task file",
         description=(
-            "Raw text content of the .agent-task TOML file for a run. "
-            "Prefer ac://runs/{run_id}/context for DB-sourced runs — this "
-            "resource is retained for pipeline runs that write a TOML file. "
-            "Returns ok=false if the worktree has been torn down."
+            "Raw text content of the .agent-task TOML file for plan-draft runs "
+            "(planning-pipeline only). Not present for standard dispatch runs — "
+            "use ac://runs/{run_id}/context for DB-sourced task context. "
+            "Returns ok=false if the worktree has been torn down or no file exists."
         ),
         mimeType=_MIME,
     ),

--- a/agentception/mcp/types.py
+++ b/agentception/mcp/types.py
@@ -23,10 +23,10 @@ Resource URIs follow the ``ac://`` scheme with REST-like path segments:
   Templated resources (parameters in braces, RFC 6570):
     ac://runs/{run_id}                — single run metadata
     ac://runs/{run_id}/children       — child runs spawned by this run
-    ac://runs/{run_id}/context        — full task context (DB-sourced, replaces .agent-task)
+    ac://runs/{run_id}/context        — full task context (DB-sourced RunContextRow)
     ac://runs/{run_id}/events         — structured event log
     ac://runs/{run_id}/events?after_id={n} — paginated event log
-    ac://runs/{run_id}/task           — raw .agent-task TOML file (pipeline runs only)
+    ac://runs/{run_id}/task           — raw .agent-task TOML (planning-pipeline plan-draft runs only)
     ac://batches/{batch_id}/tree      — full batch run tree
     ac://plan/figures/{role}          — cognitive-arch figures for a role
 """

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -7,7 +7,7 @@ locally inside this container.
 Pipeline
 --------
 1. Resolve the worktree path from ``settings.worktrees_dir / run_id``.
-2. Load task context from the ``ACAgentRun`` DB row via ``_load_task``.
+2. Load task context from the ``ACAgentRun`` DB row via ``_load_task`` (DB-only).
 3. Load the role file from ``settings.repo_dir / ".agentception/roles/{role}.md"``.
 4. Assemble the system prompt: role content + cognitive architecture context +
    runtime environment note (Python commands run directly, not via docker exec).


### PR DESCRIPTION
## Summary

Closes the `spec_doc` todo from the .agent-task elimination work.

- **`agent-task-spec.md`** rewritten v2→v3: documents the `RunContextRow` TypedDict fields agents actually receive from `ac://runs/{run_id}/context` — not TOML format. Covers all fields (identity, agent, target, repo, pipeline lineage), both read paths, and notes the planning-pipeline plan-draft TOML as the only remaining `.agent-task` writer.
- **`mcp/types.py`**: context resource updated to "DB-sourced RunContextRow"; task resource notes "plan-draft runs only"
- **`mcp/resources.py`**: context description enumerates all `RunContextRow` fields; task description clarifies planning-pipeline-only scope
- **`mcp/query_tools.py`**: `query_agent_task()` docstring updated to clearly state this is planning-pipeline only
- **`mcp/prompts.py`**: `agent/task-spec` description and `task/briefing` description cleaned of `.agent-task` file references

## Test plan

- [x] `mypy agentception/` — zero errors
- [x] `pytest agentception/tests/` — 1686 passed
- [x] `generate.py --check` — no drift