### PR TITLE
fix: eliminate two showstoppers blocking autonomous agent pipeline

### DIFF
--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -114,22 +114,37 @@ Your review checklist above is your minimum bar. Every item in the checklist is 
 
 ## Baseline Discipline
 
+All task context comes from your `task/briefing` MCP prompt — **do not read any file**.
+Extract these variables from your briefing before doing anything else:
+
+```bash
+# Set from your task/briefing — never read a file
+# PR_NUMBER="<pr_number from briefing>"
+# GH_REPO="<gh_repo from briefing>"
+# ISSUE_NUMBER="<issue_number from briefing>"
+# BRANCH="<branch from briefing>"
+WTNAME=$(basename "$(pwd)")
+```
+
 Before checking out the PR branch, record the pre-existing mypy state on `dev`:
 ```bash
-N=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['target']['pr_number'])")
-GH_REPO=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['repo']['gh_repo'])")
-GH_REPO=${GH_REPO:-cgcardona/agentception}
-WTNAME=$(basename "$(pwd)")
-# Determine if this PR is an AgentCeption PR:
-# Call pull_request_read(owner="cgcardona", repo="agentception", pullNumber=N)
-# If any label name contains "team/", run:
-#   docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
-# Otherwise (generic PR — no "team/" labels), run:
 REPO=$(git worktree list | head -1 | awk '{print $1}')
-cd "$REPO" && docker compose exec agentception sh -c \
-  "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
+cd "$REPO" && docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/" 2>&1 | tail -5
 ```
+
 Your job is to ensure the PR does not *introduce* new errors. But if you touch a file with pre-existing errors, you own them.
+
+## Approval and Merge Protocol
+
+Once you have assigned a grade:
+
+- **A or B** — approve and merge using MCP tools (never shell out):
+  1. `github_approve_pr(pr_number=PR_NUMBER)` — submit the approving review.
+  2. `github_merge_pr(pr_number=PR_NUMBER, delete_branch=true)` — squash-merge and delete the head branch.
+  3. `github_add_comment(issue_number=ISSUE_NUMBER, body="...")` — post your grade and summary on the issue.
+- **C** — fix in place, re-run mypy + tests, re-grade. Do not stop here.
+- **D** — do not merge. Post a comment explaining the blocking issue and open a follow-up GitHub issue.
+- **F** — do not merge. Escalate immediately via `github_add_comment` and stop.
 
 ## Decision Hierarchy
 

--- a/agentception/mcp/github_tools.py
+++ b/agentception/mcp/github_tools.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 """AgentCeption MCP tools for GitHub operations.
 
 Exposes key ``readers.github`` functions as MCP tools so agents can
-atomically claim/label issues and post comments through the same typed,
-cached, logged interface used by the UI.
+atomically claim/label issues, post comments, approve PRs, and merge PRs
+through the same typed, cached, logged interface used by the UI.
 
 Read operations (list_issues, issue_read, list_pull_requests, pull_request_read)
 are delegated to the ``user-github`` MCP server — use those tools directly.
@@ -15,6 +15,8 @@ Tool catalogue:
   github_claim_issue   — add the agent/wip claim label to an issue
   github_unclaim_issue — remove the agent/wip claim label from an issue
   github_add_comment   — post a Markdown comment on an issue
+  github_approve_pr    — submit an approving review on a pull request
+  github_merge_pr      — squash-merge a pull request (optionally delete branch)
 """
 
 import logging
@@ -23,7 +25,9 @@ from agentception.readers.github import (
     add_comment_to_issue,
     add_label_to_issue,
     add_wip_label,
+    approve_pr,
     clear_wip_label,
+    merge_pr,
     remove_label_from_issue,
 )
 
@@ -133,3 +137,57 @@ async def github_add_comment(issue_number: int, body: str) -> dict[str, object]:
         logger.error("❌ github_add_comment #%d: %s", issue_number, exc)
         return {"ok": False, "error": str(exc)}
     return {"ok": True, "issue_number": issue_number, "comment_url": comment_url}
+
+
+async def github_approve_pr(pr_number: int) -> dict[str, object]:
+    """Submit an approving review on a GitHub pull request.
+
+    Use this instead of shelling out to ``gh pr review --approve`` directly.
+    All approvals are routed through the same typed, logged interface and
+    invalidate the PR cache so subsequent reads reflect the updated review state.
+
+    Args:
+        pr_number: GitHub PR number to approve.
+
+    Returns:
+        ``{"ok": True, "pr_number": N}`` or ``{"ok": False, "error": "..."}``
+    """
+    logger.info("✅ github_approve_pr: approving PR #%d", pr_number)
+    try:
+        await approve_pr(pr_number)
+    except RuntimeError as exc:
+        logger.error("❌ github_approve_pr #%d: %s", pr_number, exc)
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True, "pr_number": pr_number}
+
+
+async def github_merge_pr(
+    pr_number: int,
+    delete_branch: bool = True,
+) -> dict[str, object]:
+    """Squash-merge a GitHub pull request and optionally delete the head branch.
+
+    Use this instead of shelling out to ``gh pr merge`` directly. Routing
+    merges through this tool keeps them observable, logged, and auditable.
+    The cache is invalidated on success.
+
+    Only call this after the PR has been approved (grade A or B) and all
+    required checks pass. For grade C, fix in place and re-grade first.
+
+    Args:
+        pr_number:     GitHub PR number to merge.
+        delete_branch: When ``True`` (default), delete the head branch after merge.
+
+    Returns:
+        ``{"ok": True, "pr_number": N, "delete_branch": bool}`` or
+        ``{"ok": False, "error": "..."}``
+    """
+    logger.info(
+        "🚀 github_merge_pr: merging PR #%d (delete_branch=%s)", pr_number, delete_branch
+    )
+    try:
+        await merge_pr(pr_number, delete_branch=delete_branch)
+    except RuntimeError as exc:
+        logger.error("❌ github_merge_pr #%d: %s", pr_number, exc)
+        return {"ok": False, "error": str(exc)}
+    return {"ok": True, "pr_number": pr_number, "delete_branch": delete_branch}

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -57,7 +57,9 @@ from agentception.mcp.log_tools import (
 from agentception.mcp.github_tools import (
     github_add_comment,
     github_add_label,
+    github_approve_pr,
     github_claim_issue,
+    github_merge_pr,
     github_remove_label,
     github_unclaim_issue,
 )
@@ -606,6 +608,51 @@ TOOLS: list[ACToolDef] = [
             "additionalProperties": False,
         },
     ),
+    ACToolDef(
+        name="github_approve_pr",
+        description=(
+            "Submit an approving review on a GitHub pull request. "
+            "Use this after grading the PR A or B — do NOT shell out to 'gh pr review --approve'. "
+            "Routes the approval through the typed, logged interface so it is auditable. "
+            "Returns {ok, pr_number}."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "pr_number": {
+                    "type": "integer",
+                    "description": "GitHub PR number to approve.",
+                },
+            },
+            "required": ["pr_number"],
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="github_merge_pr",
+        description=(
+            "Squash-merge a GitHub pull request. "
+            "Call this only after github_approve_pr succeeds and the grade is A or B. "
+            "Do NOT call this for C/D/F grades — fix in place or escalate first. "
+            "Do NOT shell out to 'gh pr merge' directly. "
+            "Returns {ok, pr_number, delete_branch}."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "pr_number": {
+                    "type": "integer",
+                    "description": "GitHub PR number to merge.",
+                },
+                "delete_branch": {
+                    "type": "boolean",
+                    "description": "Delete the head branch after merge. Defaults to true.",
+                },
+            },
+            "required": ["pr_number"],
+            "additionalProperties": False,
+        },
+    ),
 ]
 
 # ---------------------------------------------------------------------------
@@ -779,6 +826,8 @@ def call_tool(name: str, arguments: dict[str, object]) -> ACToolResult:
         "github_claim_issue",
         "github_unclaim_issue",
         "github_add_comment",
+        "github_approve_pr",
+        "github_merge_pr",
     ):
         err_text = _tool_result_to_text(
             {"error": f"Tool {name!r} is async — use the async call path"}
@@ -1140,6 +1189,35 @@ async def call_tool_async(
                 isError=True,
             )
         result = await github_add_comment(issue_num, body)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
+        )
+
+    if name == "github_approve_pr":
+        pr_num = arguments.get("pr_number")
+        if not isinstance(pr_num, int):
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"pr_number (int) is required"}')],
+                isError=True,
+            )
+        result = await github_approve_pr(pr_num)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
+        )
+
+    if name == "github_merge_pr":
+        pr_num = arguments.get("pr_number")
+        if not isinstance(pr_num, int):
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"pr_number (int) is required"}')],
+                isError=True,
+            )
+        delete_branch = arguments.get("delete_branch", True)
+        if not isinstance(delete_branch, bool):
+            delete_branch = True
+        result = await github_merge_pr(pr_num, delete_branch=delete_branch)
         return ACToolResult(
             content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
             isError=not bool(result.get("ok", False)),

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -812,3 +812,90 @@ async def add_comment_to_issue(issue_number: int, body: str) -> str:
     comment_url = stdout.decode().strip()
     logger.info("✅ Added comment to issue #%d: %s", issue_number, comment_url)
     return comment_url
+
+
+async def approve_pr(pr_number: int) -> None:
+    """Submit an approving review on a pull request.
+
+    Calls ``gh pr review --approve`` so the reviewer agent can approve PRs
+    without shelling out manually.  Invalidates the cache on success.
+
+    Parameters
+    ----------
+    pr_number:
+        GitHub PR number to approve.
+
+    Raises
+    ------
+    RuntimeError
+        When ``gh`` exits with a non-zero status (e.g. the PR is already
+        approved, draft, or the caller lacks write access).
+    """
+    repo = settings.gh_repo
+
+    proc = await asyncio.create_subprocess_exec(
+        "gh", "pr", "review", str(pr_number),
+        "--repo", repo,
+        "--approve",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh pr review --approve failed (exit {proc.returncode}): "
+            f"{stderr.decode().strip()!r}"
+        )
+
+    logger.info("✅ Approved PR #%d", pr_number)
+    _cache_invalidate()
+
+
+async def merge_pr(pr_number: int, delete_branch: bool = True) -> None:
+    """Squash-merge a pull request and optionally delete the head branch.
+
+    Calls ``gh pr merge --squash`` so the reviewer agent can land approved
+    PRs atomically through the same typed, logged interface used by the rest
+    of the pipeline.  Invalidates the cache on success.
+
+    Parameters
+    ----------
+    pr_number:
+        GitHub PR number to merge.
+    delete_branch:
+        When ``True`` (default), also passes ``--delete-branch`` to remove
+        the head branch after the merge.
+
+    Raises
+    ------
+    RuntimeError
+        When ``gh`` exits with a non-zero status (e.g. merge conflicts,
+        branch-protection rules, or missing approvals).
+    """
+    repo = settings.gh_repo
+
+    args = [
+        "gh", "pr", "merge", str(pr_number),
+        "--repo", repo,
+        "--squash",
+        "--auto",
+    ]
+    if delete_branch:
+        args.append("--delete-branch")
+
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh pr merge failed (exit {proc.returncode}): "
+            f"{stderr.decode().strip()!r}"
+        )
+
+    logger.info("✅ Merged PR #%d (delete_branch=%s)", pr_number, delete_branch)
+    _cache_invalidate()

--- a/agentception/tests/test_agentception_github.py
+++ b/agentception/tests/test_agentception_github.py
@@ -23,6 +23,7 @@ from agentception.readers.github import (
     _cache,
     _cache_invalidate,
     add_wip_label,
+    approve_pr,
     clear_wip_label,
     close_pr,
     get_active_label,
@@ -32,6 +33,7 @@ from agentception.readers.github import (
     get_open_prs,
     get_wip_issues,
     gh_json,
+    merge_pr,
 )
 
 
@@ -421,3 +423,121 @@ async def test_add_wip_label_raises_on_failure() -> None:
     ):
         with pytest.raises(RuntimeError, match="gh issue edit"):
             await add_wip_label(42)
+
+
+# ---------------------------------------------------------------------------
+# approve_pr
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_approve_pr_passes_review_approve() -> None:
+    """approve_pr() must call gh pr review --approve."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b""),
+    ) as mock_exec:
+        await approve_pr(99)
+
+    call_args = mock_exec.call_args[0]
+    assert "pr" in call_args
+    assert "review" in call_args
+    assert "--approve" in call_args
+    assert "99" in call_args
+
+
+@pytest.mark.anyio
+async def test_approve_pr_invalidates_cache() -> None:
+    """approve_pr() must empty the cache on success."""
+    _cache["some_key"] = ("value", time.monotonic() + 60)
+
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b""),
+    ):
+        await approve_pr(99)
+
+    assert len(_cache) == 0
+
+
+@pytest.mark.anyio
+async def test_approve_pr_raises_on_failure() -> None:
+    """approve_pr() must raise RuntimeError when gh exits non-zero."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b"", returncode=1, stderr=b"already approved"),
+    ):
+        with pytest.raises(RuntimeError, match="gh pr review --approve failed"):
+            await approve_pr(99)
+
+
+# ---------------------------------------------------------------------------
+# merge_pr
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_merge_pr_passes_squash_flag() -> None:
+    """merge_pr() must call gh pr merge --squash."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b""),
+    ) as mock_exec:
+        await merge_pr(99)
+
+    call_args = mock_exec.call_args[0]
+    assert "pr" in call_args
+    assert "merge" in call_args
+    assert "--squash" in call_args
+    assert "99" in call_args
+
+
+@pytest.mark.anyio
+async def test_merge_pr_delete_branch_flag() -> None:
+    """merge_pr() passes --delete-branch when delete_branch=True (default)."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b""),
+    ) as mock_exec:
+        await merge_pr(99, delete_branch=True)
+
+    call_args = mock_exec.call_args[0]
+    assert "--delete-branch" in call_args
+
+
+@pytest.mark.anyio
+async def test_merge_pr_no_delete_branch_flag() -> None:
+    """merge_pr() omits --delete-branch when delete_branch=False."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b""),
+    ) as mock_exec:
+        await merge_pr(99, delete_branch=False)
+
+    call_args = mock_exec.call_args[0]
+    assert "--delete-branch" not in call_args
+
+
+@pytest.mark.anyio
+async def test_merge_pr_invalidates_cache() -> None:
+    """merge_pr() must empty the cache on success."""
+    _cache["some_key"] = ("value", time.monotonic() + 60)
+
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b""),
+    ):
+        await merge_pr(99)
+
+    assert len(_cache) == 0
+
+
+@pytest.mark.anyio
+async def test_merge_pr_raises_on_failure() -> None:
+    """merge_pr() must raise RuntimeError when gh exits non-zero."""
+    with patch(
+        "agentception.readers.github.asyncio.create_subprocess_exec",
+        return_value=_make_process(b"", returncode=1, stderr=b"merge conflict"),
+    ):
+        with pytest.raises(RuntimeError, match="gh pr merge failed"):
+            await merge_pr(99)

--- a/agentception/tests/test_mcp_github_tools.py
+++ b/agentception/tests/test_mcp_github_tools.py
@@ -1,7 +1,8 @@
 """Tests for the MCP github-tools layer.
 
-Covers all five GitHub tools (github_add_label, github_remove_label,
-github_claim_issue, github_unclaim_issue, github_add_comment) exercised through
+Covers all seven GitHub tools (github_add_label, github_remove_label,
+github_claim_issue, github_unclaim_issue, github_add_comment,
+github_approve_pr, github_merge_pr) exercised through
 the full call_tool_async / handle_request_async dispatch path.
 
 Test categories:
@@ -64,6 +65,8 @@ class TestGithubToolsAreAsyncOnly:
         "github_claim_issue",
         "github_unclaim_issue",
         "github_add_comment",
+        "github_approve_pr",
+        "github_merge_pr",
     ])
     def test_sync_call_tool_returns_error(self, name: str) -> None:
         result = call_tool(name, {"issue_number": 1, "label": "x", "body": "x"})
@@ -306,3 +309,128 @@ class TestGithubAddComment:
         payload = json.loads(text)
         assert isinstance(payload, dict)
         assert payload["comment_url"] == comment_url
+
+
+# ---------------------------------------------------------------------------
+# github_approve_pr
+# ---------------------------------------------------------------------------
+
+
+class TestGithubApprovePr:
+    @pytest.mark.anyio
+    async def test_happy_path(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.approve_pr",
+            new_callable=AsyncMock,
+        ):
+            resp = await _dispatch("github_approve_pr", {"pr_number": 99})
+        payload = _result_payload(resp)
+        assert payload == {"ok": True, "pr_number": 99}
+
+    @pytest.mark.anyio
+    async def test_runtime_error_returns_ok_false(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.approve_pr",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("already approved"),
+        ):
+            resp = await _dispatch("github_approve_pr", {"pr_number": 99})
+        payload = _result_payload(resp)
+        assert payload["ok"] is False
+        assert "already approved" in payload["error"]
+
+    @pytest.mark.anyio
+    async def test_missing_pr_number_returns_error(self) -> None:
+        resp = await _dispatch("github_approve_pr", {})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+    def test_github_approve_pr_is_in_tools_list(self) -> None:
+        from agentception.mcp.server import list_tools
+        names = [t["name"] for t in list_tools()]
+        assert "github_approve_pr" in names
+
+    @pytest.mark.anyio
+    async def test_call_tool_async_dispatches_correctly(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.approve_pr",
+            new_callable=AsyncMock,
+        ):
+            result = await call_tool_async("github_approve_pr", {"pr_number": 42})
+        assert result["isError"] is False
+        payload = json.loads(result["content"][0]["text"])
+        assert isinstance(payload, dict)
+        assert payload["ok"] is True
+        assert payload["pr_number"] == 42
+
+
+# ---------------------------------------------------------------------------
+# github_merge_pr
+# ---------------------------------------------------------------------------
+
+
+class TestGithubMergePr:
+    @pytest.mark.anyio
+    async def test_happy_path_default_delete_branch(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.merge_pr",
+            new_callable=AsyncMock,
+        ):
+            resp = await _dispatch("github_merge_pr", {"pr_number": 88})
+        payload = _result_payload(resp)
+        assert payload["ok"] is True
+        assert payload["pr_number"] == 88
+        assert payload["delete_branch"] is True
+
+    @pytest.mark.anyio
+    async def test_happy_path_no_delete_branch(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.merge_pr",
+            new_callable=AsyncMock,
+        ):
+            resp = await _dispatch(
+                "github_merge_pr", {"pr_number": 88, "delete_branch": False}
+            )
+        payload = _result_payload(resp)
+        assert payload["ok"] is True
+        assert payload["delete_branch"] is False
+
+    @pytest.mark.anyio
+    async def test_runtime_error_returns_ok_false(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.merge_pr",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("merge conflict"),
+        ):
+            resp = await _dispatch("github_merge_pr", {"pr_number": 88})
+        payload = _result_payload(resp)
+        assert payload["ok"] is False
+        assert "merge conflict" in payload["error"]
+
+    @pytest.mark.anyio
+    async def test_missing_pr_number_returns_error(self) -> None:
+        resp = await _dispatch("github_merge_pr", {})
+        result = resp.get("result")
+        assert isinstance(result, dict)
+        assert result["isError"] is True
+
+    def test_github_merge_pr_is_in_tools_list(self) -> None:
+        from agentception.mcp.server import list_tools
+        names = [t["name"] for t in list_tools()]
+        assert "github_merge_pr" in names
+
+    @pytest.mark.anyio
+    async def test_call_tool_async_dispatches_correctly(self) -> None:
+        with patch(
+            "agentception.mcp.github_tools.merge_pr",
+            new_callable=AsyncMock,
+        ):
+            result = await call_tool_async(
+                "github_merge_pr", {"pr_number": 7, "delete_branch": True}
+            )
+        assert result["isError"] is False
+        payload = json.loads(result["content"][0]["text"])
+        assert isinstance(payload, dict)
+        assert payload["ok"] is True
+        assert payload["pr_number"] == 7

--- a/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
@@ -30,22 +30,37 @@ Your review checklist above is your minimum bar. Every item in the checklist is 
 
 ## Baseline Discipline
 
+All task context comes from your `task/briefing` MCP prompt — **do not read any file**.
+Extract these variables from your briefing before doing anything else:
+
+```bash
+# Set from your task/briefing — never read a file
+# PR_NUMBER="<pr_number from briefing>"
+# GH_REPO="<gh_repo from briefing>"
+# ISSUE_NUMBER="<issue_number from briefing>"
+# BRANCH="<branch from briefing>"
+WTNAME=$(basename "$(pwd)")
+```
+
 Before checking out the PR branch, record the pre-existing mypy state on `dev`:
 ```bash
-N=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['target']['pr_number'])")
-GH_REPO=$(python3 -c "import tomllib; d=tomllib.loads(open('.agent-task').read()); print(d['repo']['gh_repo'])")
-GH_REPO=${GH_REPO:-{{ gh_repo }}}
-WTNAME=$(basename "$(pwd)")
-# Determine if this PR is an AgentCeption PR:
-# Call pull_request_read(owner="{{ gh_repo.split('/')[0] }}", repo="{{ gh_repo.split('/')[1] }}", pullNumber=N)
-# If any label name contains "{{ active_label_prefix }}", run:
-#   {{ active_mypy }} 2>&1 | tail -5
-# Otherwise (generic PR — no "{{ active_label_prefix }}" labels), run:
 REPO=$(git worktree list | head -1 | awk '{print $1}')
-cd "$REPO" && docker compose exec agentception sh -c \
-  "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/ /worktrees/$WTNAME/tests/" 2>&1 | tail -5
+cd "$REPO" && {{ active_mypy }} 2>&1 | tail -5
 ```
+
 Your job is to ensure the PR does not *introduce* new errors. But if you touch a file with pre-existing errors, you own them.
+
+## Approval and Merge Protocol
+
+Once you have assigned a grade:
+
+- **A or B** — approve and merge using MCP tools (never shell out):
+  1. `github_approve_pr(pr_number=PR_NUMBER)` — submit the approving review.
+  2. `github_merge_pr(pr_number=PR_NUMBER, delete_branch=true)` — squash-merge and delete the head branch.
+  3. `github_add_comment(issue_number=ISSUE_NUMBER, body="...")` — post your grade and summary on the issue.
+- **C** — fix in place, re-run mypy + tests, re-grade. Do not stop here.
+- **D** — do not merge. Post a comment explaining the blocking issue and open a follow-up GitHub issue.
+- **F** — do not merge. Escalate immediately via `github_add_comment` and stop.
 
 ## Decision Hierarchy
 


### PR DESCRIPTION
## Summary

- **Showstopper 1 — `pr-reviewer.md.j2` read `.agent-task`**: The Baseline Discipline block used Python to extract `pr_number` and `gh_repo` from the deleted TOML file, causing a guaranteed `FileNotFoundError` at runtime. Replaced with the DB-backed `task/briefing` pattern (same as `python-developer`). Added an explicit **Approval and Merge Protocol** section directing the reviewer to use the new MCP tools.
- **Showstopper 2 — no MCP tools to approve or merge PRs**: Added `approve_pr()` / `merge_pr()` to `readers/github.py` and wired them as `github_approve_pr` / `github_merge_pr` through `mcp/github_tools.py` and `server.py` (TOOLS list, async dispatch, sync-only guard).

## Test plan

- [x] `mypy agentception/` — zero errors
- [x] `typing_audit.py --max-any 0` — passes
- [x] `pytest test_agentception_github.py test_mcp_github_tools.py` — 65 passed, 0 warnings
- [x] `generate.py --check` — no drift