### PR TITLE
fix: replace old colon-format label references with slash format

### DIFF
--- a/.agentception/agent-engineer.md
+++ b/.agentception/agent-engineer.md
@@ -443,8 +443,8 @@ writes — they add caching, structured output, and logging.
 | `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
-| `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
-| `github_unclaim_issue(issue_number)` | `gh issue edit N --remove-label "agent:wip"` |
+| `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent/wip"` |
+| `github_unclaim_issue(issue_number)` | `gh issue edit N --remove-label "agent/wip"` |
 
 **GitHub MCP server** (`user-github-*` — direct GitHub API):
 
@@ -1513,7 +1513,7 @@ Set them as shell variables from the context your briefing provided:
 # ISSUE_NUMBER="<issue_number from briefing>"
 # BRANCH="<branch from briefing>"
 
-# ── 1. CLAIM — post immediately after adding agent:wip label ────────────────
+# ── 1. CLAIM — post immediately after adding agent/wip label ────────────────
 AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
 CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 REPO="<path to repo root>"  # e.g. /Users/gabriel/dev/tellurstori/agentception

--- a/.agentception/agent-reviewer.md
+++ b/.agentception/agent-reviewer.md
@@ -339,8 +339,8 @@ writes — they add caching, structured output, and logging.
 | `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
-| `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
-| `github_unclaim_issue(issue_number)` | `gh issue edit N --remove-label "agent:wip"` |
+| `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent/wip"` |
+| `github_unclaim_issue(issue_number)` | `gh issue edit N --remove-label "agent/wip"` |
 
 **GitHub MCP server** (`user-github-*` — direct GitHub API):
 

--- a/.agentception/roles/python-developer.md
+++ b/.agentception/roles/python-developer.md
@@ -133,7 +133,7 @@ Set them as shell variables from the context your briefing provided:
 # ISSUE_NUMBER="<issue_number from briefing>"
 # BRANCH="<branch from briefing>"
 
-# ── 1. CLAIM — post immediately after adding agent:wip label ────────────────
+# ── 1. CLAIM — post immediately after adding agent/wip label ────────
 AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
 CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 REPO="<path to repo root>"  # e.g. /Users/gabriel/dev/tellurstori/agentception

--- a/scripts/gen_prompts/templates/roles/python-developer.md.j2
+++ b/scripts/gen_prompts/templates/roles/python-developer.md.j2
@@ -84,7 +84,7 @@ Set them as shell variables from the context your briefing provided:
 # ISSUE_NUMBER="<issue_number from briefing>"
 # BRANCH="<branch from briefing>"
 
-# ── 1. CLAIM — post immediately after adding agent:wip label ────────────────
+# ── 1. CLAIM — post immediately after adding {{ claim_label }} label ────────
 AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
 CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 REPO="<path to repo root>"  # e.g. /Users/gabriel/dev/tellurstori/agentception

--- a/scripts/gen_prompts/templates/snippets/github-mcp-reference.md.j2
+++ b/scripts/gen_prompts/templates/snippets/github-mcp-reference.md.j2
@@ -11,8 +11,8 @@ writes — they add caching, structured output, and logging.
 | `pull_request_read (user-github)(pr_number)` | `gh pr view N --json ...` |
 | `github_add_label(issue_number, label)` | `gh issue edit N --add-label X` |
 | `github_remove_label(issue_number, label)` | `gh issue edit N --remove-label X` |
-| `github_claim_issue(issue_number)` | `gh issue edit N --add-label "agent:wip"` |
-| `github_unclaim_issue(issue_number)` | `gh issue edit N --remove-label "agent:wip"` |
+| `github_claim_issue(issue_number)` | `gh issue edit N --add-label "{{ claim_label }}"` |
+| `github_unclaim_issue(issue_number)` | `gh issue edit N --remove-label "{{ claim_label }}"` |
 
 **GitHub MCP server** (`user-github-*` — direct GitHub API):
 


### PR DESCRIPTION
## Summary

- Updated `agent:wip` → `agent/wip` across all template and static prompt files to match the current RESTful slash-namespaced label format.
- In `.j2` templates, replaced the hardcoded string with `{{ claim_label }}` so it stays in sync with `config.yaml` automatically — no more drift.
- Files changed: `python-developer.md.j2`, `github-mcp-reference.md.j2` (templates), `agent-engineer.md`, `agent-reviewer.md` (static prompts), and the regenerated `python-developer.md`.

## Test plan
- [x] `generate.py --check` — 0 files would be updated
- [x] Zero `agent:wip` occurrences remaining in templates or .agentception/