### PR TITLE
fix: use MCP for audit trail comments; remove stale .agent-task docstrings

### DIFF
--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -86,9 +86,8 @@ Never skip type checking. A passing test with an underlying type error is a defe
 
 ## Audit Trail — Required at Every Touch Point
 
-You must post fingerprint comments to GitHub at each lifecycle event.
-These are the only audibility signal visible to the human operator.
-All values come from your task briefing — do NOT read any file to obtain them.
+Post a fingerprint comment at each lifecycle event. All values come from your
+task briefing — do NOT read any file to obtain them.
 
 ```bash
 # Populate from your task briefing before running anything below:
@@ -100,8 +99,13 @@ All values come from your task briefing — do NOT read any file to obtain them.
 # ISSUE_NUMBER="<issue_number from briefing>"
 # BRANCH="<branch from briefing>"
 WTNAME=$(basename "$(pwd)")
+```
 
-# ── 1. CLAIM — post immediately after adding agent/wip label ─────────
+### Event 1 — Claim (immediately after adding `agent/wip` label)
+
+Generate the fingerprint:
+
+```bash
 AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
 CLAIMED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 REPO=$(git worktree list | head -1 | awk '{print $1}')
@@ -132,20 +136,35 @@ if [ -z "$CLAIM_FINGERPRINT" ]; then
 </details>"
 fi
 
-gh issue comment "$ISSUE_NUMBER" --repo "$GH_REPO" \
-  --body "🔖 **Claimed by agent**
+```
 
-$CLAIM_FINGERPRINT" 2>/dev/null || true
+Post the claim comment — **always prefer MCP**:
 
-# ── 2. PR CREATED — embed fingerprint in PR body ─────────────────────────────
-# When calling create_pull_request (via MCP user-github), include
-# $CLAIM_FINGERPRINT at the end of the PR body:
-#
-#   body = "## Summary\n...\n\nCloses #$ISSUE_NUMBER\n\n$CLAIM_FINGERPRINT"
+```
+# Preferred (MCP — logged and auditable):
+github_add_comment(issue_number=<ISSUE_NUMBER>, body="🔖 **Claimed by agent**\n\n<CLAIM_FINGERPRINT>")
 
-# ── 3. DONE — post implementation complete comment on the issue ───────────────
-gh issue comment "$ISSUE_NUMBER" --repo "$GH_REPO" \
-  --body "🤖 **Implemented by agent** — PR #$PR_NUMBER
+# Fallback (only if MCP unavailable):
+# gh issue comment "$ISSUE_NUMBER" --repo "$GH_REPO" \
+#   --body "🔖 **Claimed by agent**\n\n$CLAIM_FINGERPRINT" 2>/dev/null || true
+```
 
-$CLAIM_FINGERPRINT" 2>/dev/null || true
+### Event 2 — PR Created
+
+Include `$CLAIM_FINGERPRINT` verbatim at the end of the PR body when calling
+`create_pull_request` (via `user-github` MCP):
+
+```
+body = "## Summary\n...\n\nCloses #<ISSUE_NUMBER>\n\n<CLAIM_FINGERPRINT>"
+```
+
+### Event 3 — Done (after PR is merged or work is complete)
+
+```
+# Preferred (MCP):
+github_add_comment(issue_number=<ISSUE_NUMBER>, body="🤖 **Implemented by agent** — PR #<PR_NUMBER>\n\n<CLAIM_FINGERPRINT>")
+
+# Fallback:
+# gh issue comment "$ISSUE_NUMBER" --repo "$GH_REPO" \
+#   --body "🤖 **Implemented by agent** — PR #$PR_NUMBER\n\n$CLAIM_FINGERPRINT" 2>/dev/null || true
 ```

--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -90,11 +90,11 @@ async def build_spawn_child_run(
     """Create a child agent node in the tree and return its worktree path.
 
     Any coordinator agent calls this tool to atomically spawn a child.
-    The tool creates the worktree, writes the ``.agent-task`` file (with
-    TIER, ORG_DOMAIN if provided, COGNITIVE_ARCH, SCOPE_TYPE,
-    SCOPE_VALUE, PARENT_RUN_ID, and all required fields), registers the DB
-    record, and auto-acknowledges the run so the caller can immediately fire
-    a Task call.
+    The tool creates the worktree, persists all task context to the DB row
+    (role, cognitive_arch, tier, scope, parent lineage, and all required fields),
+    and auto-acknowledges the run so the caller can immediately fire a Task call.
+    No ``.agent-task`` file is written — the child reads its full context via
+    ``ac://runs/{run_id}/context`` and the ``task/briefing`` MCP prompt.
 
     Was: ``build_spawn_child``.
 

--- a/agentception/services/spawn_child.py
+++ b/agentception/services/spawn_child.py
@@ -210,21 +210,21 @@ async def spawn_child(
 ) -> SpawnChildResult:
     """Atomically create a child agent node in the agent tree.
 
-    Creates the worktree, writes ``.agent-task``, registers the DB record,
-    and auto-acknowledges (``pending_launch`` → ``implementing``) so the
-    caller can immediately fire a Task tool call.
+    Creates the worktree, persists all task context to the DB row, and
+    auto-acknowledges (``pending_launch`` → ``implementing``) so the caller
+    can immediately fire a Task tool call.  No ``.agent-task`` file is written.
+    The child receives its full task context via the DB-backed MCP surface:
+    ``ac://runs/{run_id}/context`` and the ``task/briefing`` MCP prompt.
 
     Args:
         parent_run_id:      ``run_id`` of the calling agent (lineage tracking).
         role:               Child's role slug (e.g. ``"engineering-coordinator"``).
         tier:               Behavioral execution tier for this child —
-                            ``"coordinator"`` or ``"worker"``.
-                            Written as ``TIER=`` in the
-                            ``.agent-task`` file.  The caller always knows which
-                            tier it is spawning — this is never inferred.
+                            ``"coordinator"`` or ``"worker"``.  The caller always
+                            knows which tier it is spawning — this is never inferred.
         org_domain:         Organisational slot for UI hierarchy visualisation —
                             ``"c-suite"``, ``"engineering"``, or ``"qa"``.  Optional;
-                            written as ``ORG_DOMAIN=`` when provided.  A
+                            written to the DB row when provided.  A
                             chain-spawned PR reviewer should pass ``"qa"`` so the
                             dashboard places it in the QA column even though its
                             physical ``parent_run_id`` points to an engineering leaf.
@@ -233,13 +233,12 @@ async def spawn_child(
         gh_repo:            ``"owner/repo"`` string.
         issue_body:         Issue body text (used for COGNITIVE_ARCH skill extraction
                             when ``cognitive_arch`` is not provided).
-        issue_title:        Issue title (written to ISSUE_TITLE field).
+        issue_title:        Issue title (written to the DB row).
         skills_hint:        Explicit skill list override for COGNITIVE_ARCH
                             (used when ``cognitive_arch`` is not provided).
-        coord_fingerprint:  The spawning coordinator's fingerprint string.  Written
-                            as ``COORD_FINGERPRINT=`` in the child's ``.agent-task``
-                            so leaf agents can include it in their GitHub fingerprint
-                            comments without having to re-derive it.
+        coord_fingerprint:  The spawning coordinator's fingerprint string.
+                            Persisted to the DB row so leaf agents can include it
+                            in their GitHub fingerprint comments without re-deriving.
         cognitive_arch:     When provided, forward this exact arch string to the child
                             without re-resolving.  Coordinators must pass their own
                             ``cognitive_arch`` here so the field propagates unchanged

--- a/agentception/static/js/org_designer.ts
+++ b/agentception/static/js/org_designer.ts
@@ -152,7 +152,6 @@ interface DispatchResponse {
   label: string;
   worktree: string;
   host_worktree: string;
-  agent_task_path: string;
   status: string;
 }
 

--- a/scripts/gen_prompts/templates/roles/developer.md.j2
+++ b/scripts/gen_prompts/templates/roles/developer.md.j2
@@ -37,9 +37,8 @@ Never skip type checking. A passing test with an underlying type error is a defe
 
 ## Audit Trail — Required at Every Touch Point
 
-You must post fingerprint comments to GitHub at each lifecycle event.
-These are the only audibility signal visible to the human operator.
-All values come from your task briefing — do NOT read any file to obtain them.
+Post a fingerprint comment at each lifecycle event. All values come from your
+task briefing — do NOT read any file to obtain them.
 
 ```bash
 # Populate from your task briefing before running anything below:
@@ -51,18 +50,43 @@ All values come from your task briefing — do NOT read any file to obtain them.
 # ISSUE_NUMBER="<issue_number from briefing>"
 # BRANCH="<branch from briefing>"
 WTNAME=$(basename "$(pwd)")
+```
 
-# ── 1. CLAIM — post immediately after adding {{ claim_label }} label ─────────
+### Event 1 — Claim (immediately after adding `{{ claim_label }}` label)
+
+Generate the fingerprint:
+
+```bash
 {% include 'snippets/fingerprint-claim.md.j2' %}
-# ── 2. PR CREATED — embed fingerprint in PR body ─────────────────────────────
-# When calling create_pull_request (via MCP user-github), include
-# $CLAIM_FINGERPRINT at the end of the PR body:
-#
-#   body = "## Summary\n...\n\nCloses #$ISSUE_NUMBER\n\n$CLAIM_FINGERPRINT"
+```
 
-# ── 3. DONE — post implementation complete comment on the issue ───────────────
-gh issue comment "$ISSUE_NUMBER" --repo "$GH_REPO" \
-  --body "🤖 **Implemented by agent** — PR #$PR_NUMBER
+Post the claim comment — **always prefer MCP**:
 
-$CLAIM_FINGERPRINT" 2>/dev/null || true
+```
+# Preferred (MCP — logged and auditable):
+github_add_comment(issue_number=<ISSUE_NUMBER>, body="🔖 **Claimed by agent**\n\n<CLAIM_FINGERPRINT>")
+
+# Fallback (only if MCP unavailable):
+# gh issue comment "$ISSUE_NUMBER" --repo "$GH_REPO" \
+#   --body "🔖 **Claimed by agent**\n\n$CLAIM_FINGERPRINT" 2>/dev/null || true
+```
+
+### Event 2 — PR Created
+
+Include `$CLAIM_FINGERPRINT` verbatim at the end of the PR body when calling
+`create_pull_request` (via `user-github` MCP):
+
+```
+body = "## Summary\n...\n\nCloses #<ISSUE_NUMBER>\n\n<CLAIM_FINGERPRINT>"
+```
+
+### Event 3 — Done (after PR is merged or work is complete)
+
+```
+# Preferred (MCP):
+github_add_comment(issue_number=<ISSUE_NUMBER>, body="🤖 **Implemented by agent** — PR #<PR_NUMBER>\n\n<CLAIM_FINGERPRINT>")
+
+# Fallback:
+# gh issue comment "$ISSUE_NUMBER" --repo "$GH_REPO" \
+#   --body "🤖 **Implemented by agent** — PR #$PR_NUMBER\n\n$CLAIM_FINGERPRINT" 2>/dev/null || true
 ```

--- a/scripts/gen_prompts/templates/snippets/fingerprint-claim.md.j2
+++ b/scripts/gen_prompts/templates/snippets/fingerprint-claim.md.j2
@@ -27,8 +27,3 @@ if [ -z "$CLAIM_FINGERPRINT" ]; then
 
 </details>"
 fi
-
-gh issue comment "$ISSUE_NUMBER" --repo "$GH_REPO" \
-  --body "🔖 **Claimed by agent**
-
-$CLAIM_FINGERPRINT" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- `fingerprint-claim.md.j2` is now generation-only — produces `$CLAIM_FINGERPRINT` string without the side-effect `gh issue comment` call. The developer role template now explicitly instructs agents to use `github_add_comment` MCP (primary) with `gh` as fallback only — matching the MCP tool's own description which says not to shell out to `gh issue comment` directly.
- `developer.md.j2` restructured: three explicit Audit Trail events (Claim, PR Created, Done), each with MCP-first comment instruction.
- `spawn_child.py` and `build_commands.py` docstrings corrected: remove false claim that `.agent-task` is written; correctly describe the DB-backed MCP context path.
- `org_designer.ts`: remove `agent_task_path` from `DispatchResponse` TypeScript interface — the last stale reference to the removed field.
- Rebuild `app.js` to include TypeScript change.

## Test plan

- [x] `mypy agentception/` — zero errors
- [x] `pytest agentception/tests/ -q` — 1583 passed
- [x] `generate.py --check` — no drift
- [x] `npm run build:js` — clean bundle