### PR TITLE
feat: wire GitHub MCP server into agent loop, rename Anthropic functions, add memory discipline

### DIFF
--- a/.agentception/roles/ceo.md
+++ b/.agentception/roles/ceo.md
@@ -582,7 +582,8 @@ COORD_SELF_FINGERPRINT="$CLAIM_FINGERPRINT"
 Post your start fingerprint on the parent scope issue (if scope_type == "issue"):
 
 ```
-github_add_comment(issue_number=<scope_value>, body="🌳 **Coordinator started**\n\n<COORD_SELF_FINGERPRINT>")
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<scope_value>,
+                  body="🌳 **Coordinator started**\n\n<COORD_SELF_FINGERPRINT>")
 ```
 
 ---
@@ -609,7 +610,7 @@ log_run_step(
 ```
 
 When you create new GitHub issues to track subtasks, **always include your fingerprint
-in the issue body**. Use `issue_write` (user-github MCP) and append:
+in the issue body**. Use `create_issue` (GitHub MCP) and append:
 
 ```
 \n\n---\n_Created by coordinator:_\n\n<COORD_SELF_FINGERPRINT>
@@ -675,7 +676,8 @@ When all children have terminated:
    child_run_ids in a `log_run_error` call.
 4. Post a completion fingerprint on the parent scope issue (if scope_type == "issue"):
    ```
-   github_add_comment(issue_number=<scope_value>, body="✅ **Coordinator done** — N/N children completed\n\n<COORD_SELF_FINGERPRINT>")
+   add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<scope_value>,
+                     body="✅ **Coordinator done** — N/N children completed\n\n<COORD_SELF_FINGERPRINT>")
    ```
 5. Call `log_run_step` with `step_name = "coordinator_done"`.
 

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -324,7 +324,8 @@ COORD_SELF_FINGERPRINT="$CLAIM_FINGERPRINT"
 Post your start fingerprint on the parent scope issue (if scope_type == "issue"):
 
 ```
-github_add_comment(issue_number=<scope_value>, body="🌳 **Coordinator started**\n\n<COORD_SELF_FINGERPRINT>")
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<scope_value>,
+                  body="🌳 **Coordinator started**\n\n<COORD_SELF_FINGERPRINT>")
 ```
 
 ---
@@ -351,7 +352,7 @@ log_run_step(
 ```
 
 When you create new GitHub issues to track subtasks, **always include your fingerprint
-in the issue body**. Use `issue_write` (user-github MCP) and append:
+in the issue body**. Use `create_issue` (GitHub MCP) and append:
 
 ```
 \n\n---\n_Created by coordinator:_\n\n<COORD_SELF_FINGERPRINT>
@@ -417,7 +418,8 @@ When all children have terminated:
    child_run_ids in a `log_run_error` call.
 4. Post a completion fingerprint on the parent scope issue (if scope_type == "issue"):
    ```
-   github_add_comment(issue_number=<scope_value>, body="✅ **Coordinator done** — N/N children completed\n\n<COORD_SELF_FINGERPRINT>")
+   add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<scope_value>,
+                     body="✅ **Coordinator done** — N/N children completed\n\n<COORD_SELF_FINGERPRINT>")
    ```
 5. Call `log_run_step` with `step_name = "coordinator_done"`.
 

--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -146,21 +146,17 @@ fi
 
 ```
 
-Post the claim comment — **always prefer MCP**:
+Post the claim comment via GitHub MCP:
 
 ```
-# Preferred (MCP — logged and auditable):
-github_add_comment(issue_number=<ISSUE_NUMBER>, body="🔖 **Claimed by agent**\n\n<CLAIM_FINGERPRINT>")
-
-# Fallback (only if MCP unavailable):
-# gh issue comment "$ISSUE_NUMBER" --repo "$GH_REPO" \
-#   --body "🔖 **Claimed by agent**\n\n$CLAIM_FINGERPRINT" 2>/dev/null || true
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+                  body="🔖 **Claimed by agent**\n\n<CLAIM_FINGERPRINT>")
 ```
 
 ### Event 2 — PR Created
 
 Include `$CLAIM_FINGERPRINT` verbatim at the end of the PR body when calling
-`create_pull_request` (via `user-github` MCP):
+`create_pull_request` via GitHub MCP:
 
 ```
 body = "## Summary\n...\n\nCloses #<ISSUE_NUMBER>\n\n<CLAIM_FINGERPRINT>"
@@ -169,10 +165,6 @@ body = "## Summary\n...\n\nCloses #<ISSUE_NUMBER>\n\n<CLAIM_FINGERPRINT>"
 ### Event 3 — Done (after PR is merged or work is complete)
 
 ```
-# Preferred (MCP):
-github_add_comment(issue_number=<ISSUE_NUMBER>, body="🤖 **Implemented by agent** — PR #<PR_NUMBER>\n\n<CLAIM_FINGERPRINT>")
-
-# Fallback:
-# gh issue comment "$ISSUE_NUMBER" --repo "$GH_REPO" \
-#   --body "🤖 **Implemented by agent** — PR #$PR_NUMBER\n\n$CLAIM_FINGERPRINT" 2>/dev/null || true
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+                  body="🤖 **Implemented by agent** — PR #<PR_NUMBER>\n\n<CLAIM_FINGERPRINT>")
 ```

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -78,7 +78,8 @@ COORD_SELF_FINGERPRINT="$CLAIM_FINGERPRINT"
 Post your start fingerprint on the parent scope issue (if scope_type == "issue"):
 
 ```
-github_add_comment(issue_number=<scope_value>, body="🌳 **Coordinator started**\n\n<COORD_SELF_FINGERPRINT>")
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<scope_value>,
+                  body="🌳 **Coordinator started**\n\n<COORD_SELF_FINGERPRINT>")
 ```
 
 ---
@@ -105,7 +106,7 @@ log_run_step(
 ```
 
 When you create new GitHub issues to track subtasks, **always include your fingerprint
-in the issue body**. Use `issue_write` (user-github MCP) and append:
+in the issue body**. Use `create_issue` (GitHub MCP) and append:
 
 ```
 \n\n---\n_Created by coordinator:_\n\n<COORD_SELF_FINGERPRINT>
@@ -171,7 +172,8 @@ When all children have terminated:
    child_run_ids in a `log_run_error` call.
 4. Post a completion fingerprint on the parent scope issue (if scope_type == "issue"):
    ```
-   github_add_comment(issue_number=<scope_value>, body="✅ **Coordinator done** — N/N children completed\n\n<COORD_SELF_FINGERPRINT>")
+   add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<scope_value>,
+                     body="✅ **Coordinator done** — N/N children completed\n\n<COORD_SELF_FINGERPRINT>")
    ```
 5. Call `log_run_step` with `step_name = "coordinator_done"`.
 

--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -150,30 +150,33 @@ REVIEW_FINGERPRINT="$CLAIM_FINGERPRINT"
 ### Event 1 — Review Started (immediately when you begin)
 
 ```
-github_add_comment(issue_number=<ISSUE_NUMBER>, body="🔍 **Review started**\n\n<REVIEW_FINGERPRINT>")
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+                  body="🔍 **Review started**\n\n<REVIEW_FINGERPRINT>")
 ```
 
 ### Event 2 — Grade Assigned (A or B → merge)
 
-Include `$REVIEW_FINGERPRINT` in the merge comment posted after `github_merge_pr`:
+Include `$REVIEW_FINGERPRINT` in the merge comment posted after `merge_pull_request`:
 
 ```
-github_add_comment(issue_number=<ISSUE_NUMBER>, body="✅ **Grade: A/B — Merged**\n\n<grade summary>\n\n<REVIEW_FINGERPRINT>")
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+                  body="✅ **Grade: A/B — Merged**\n\n<grade summary>\n\n<REVIEW_FINGERPRINT>")
 ```
 
 ### Event 3 — Blocked (D or F → do not merge)
 
 ```
-github_add_comment(issue_number=<ISSUE_NUMBER>, body="🚫 **Grade: D/F — Blocked**\n\n<blocking reason>\n\n<REVIEW_FINGERPRINT>")
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+                  body="🚫 **Grade: D/F — Blocked**\n\n<blocking reason>\n\n<REVIEW_FINGERPRINT>")
 ```
 
 ## Approval and Merge Protocol
 
 Once you have assigned a grade:
 
-- **A or B** — approve and merge using MCP tools (never shell out):
-  1. `github_approve_pr(pr_number=PR_NUMBER)` — submit the approving review.
-  2. `github_merge_pr(pr_number=PR_NUMBER, delete_branch=true)` — squash-merge and delete the head branch.
+- **A or B** — approve and merge using GitHub MCP tools (never shell out):
+  1. `pull_request_review_write(...)` — submit the approving review.
+  2. `merge_pull_request(owner=<OWNER>, repo=<REPO>, pull_number=PR_NUMBER, merge_method="squash")` — squash-merge.
   3. Post Event 2 comment with `$REVIEW_FINGERPRINT` (see Audit Trail above).
 - **C** — fix in place, re-run mypy + tests, re-grade. Do not stop here.
 - **D** — do not merge. Post Event 3 comment with `$REVIEW_FINGERPRINT` and open a follow-up issue.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get update && apt-get install -y gh \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install the GitHub MCP server binary — provides the agent loop with typed
+# GitHub tools (get_issue, list_issues, add_issue_comment, create_pull_request,
+# merge_pull_request, etc.) via the MCP stdio protocol.
+ARG GH_MCP_VERSION=0.32.0
+RUN ARCH=$(dpkg --print-architecture) \
+    && case "$ARCH" in \
+         amd64) GH_MCP_ARCH="x86_64" ;; \
+         arm64) GH_MCP_ARCH="arm64" ;; \
+         *) echo "Unsupported arch: $ARCH" && exit 1 ;; \
+       esac \
+    && curl -fsSL \
+       "https://github.com/github/github-mcp-server/releases/download/v${GH_MCP_VERSION}/github-mcp-server_Linux_${GH_MCP_ARCH}.tar.gz" \
+       | tar xz -C /usr/local/bin github-mcp-server \
+    && chmod +x /usr/local/bin/github-mcp-server \
+    && github-mcp-server --version
+
 # Install Dart Sass — compiles SCSS at build time (no Node.js required).
 ARG DART_SASS_VERSION=1.85.0
 RUN ARCH=$(dpkg --print-architecture) \

--- a/agentception/config.py
+++ b/agentception/config.py
@@ -134,6 +134,14 @@ class AgentCeptionSettings(BaseSettings):
     falls back to the keyword-based heuristic classifier — no LLM is required
     for the service to start.
     """
+    github_token: str = ""
+    """GitHub Personal Access Token for GitHub API calls and the GitHub MCP server.
+
+    Set via ``GITHUB_TOKEN`` env var.  Used by the ``gh`` CLI, the
+    ``readers.github`` HTTP client, and the GitHub MCP server subprocess
+    (mapped to ``GITHUB_PERSONAL_ACCESS_TOKEN``).  When absent, GitHub MCP
+    tools are unavailable in the agent loop.
+    """
     ac_task_runner: TaskRunnerChoice = TaskRunnerChoice.anthropic
     """Task runner backend for agent execution.
     

--- a/agentception/readers/llm_phase_planner.py
+++ b/agentception/readers/llm_phase_planner.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import yaml as _yaml
 
 from agentception.models import PlanSpec
-from agentception.services.llm import call_openrouter
+from agentception.services.llm import call_anthropic
 
 # Paths to the cognitive architecture assets (resolved relative to this file).
 _FIGURES_DIR: Path = (
@@ -521,7 +521,7 @@ async def generate_plan_yaml(dump: str, label_prefix: str = "") -> str:
     if not dump:
         raise ValueError("Plan text must not be empty.")
 
-    raw = await call_openrouter(
+    raw = await call_anthropic(
         dump,
         system_prompt=_build_yaml_system_prompt(),
         temperature=0.2,

--- a/agentception/routes/ui/plan_ui.py
+++ b/agentception/routes/ui/plan_ui.py
@@ -41,7 +41,7 @@ from pydantic import BaseModel
 from starlette.requests import Request
 
 from agentception.readers.llm_phase_planner import _strip_fences
-from agentception.services.llm import LLMChunk, call_openrouter_stream
+from agentception.services.llm import LLMChunk, call_anthropic_stream
 from ._shared import _TEMPLATES
 
 if TYPE_CHECKING:
@@ -320,7 +320,7 @@ async def plan_preview(body: PlanDraftRequest) -> StreamingResponse:
         accumulated = ""
         try:
             chunk: LLMChunk
-            async for chunk in call_openrouter_stream(
+            async for chunk in call_anthropic_stream(
                 augmented_dump,
                 system_prompt=_build_yaml_system_prompt(),
                 temperature=0.2,

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -48,9 +48,10 @@ from agentception.services.llm import (
     ToolDefinition,
     ToolFunction,
     ToolResponse,
-    call_openrouter_with_tools,
+    call_anthropic_with_tools,
 )
 from agentception.services.code_indexer import search_codebase
+from agentception.services.github_mcp_client import GitHubMCPClient
 from agentception.tools.definitions import FILE_TOOL_DEFS, SEARCH_CODEBASE_TOOL_DEF, SHELL_TOOL_DEF
 from agentception.tools.file_tools import (
     list_directory,
@@ -157,16 +158,30 @@ async def run_agent_loop(
 
     role_prompt = _load_role_prompt(task.role)
     system_prompt = _build_system_prompt(role_prompt, task.cognitive_arch or "")
-    tool_defs = _build_tool_definitions()
+
+    # Initialise the GitHub MCP client and fetch its tool definitions.
+    # Failures here are non-fatal — the agent runs without GitHub MCP tools
+    # and falls back to the AgentCeption MCP tools for GitHub mutations.
+    github_client = GitHubMCPClient()
+    github_tool_names: frozenset[str] = frozenset()
+    try:
+        github_tools = await github_client.list_tools()
+        github_tool_names = frozenset(t["function"]["name"] for t in github_tools)
+    except RuntimeError as exc:
+        logger.warning("⚠️ GitHub MCP server unavailable — %s. GitHub reads will use gh CLI.", exc)
+        github_tools = []
+
+    tool_defs = _build_tool_definitions(extra_tools=github_tools)
     initial_message = await _fetch_task_briefing(run_id, task, worktree_path)
 
     messages: list[dict[str, object]] = [{"role": "user", "content": initial_message}]
 
     logger.info(
-        "✅ agent_loop start — run_id=%s issue=%d tools=%d",
+        "✅ agent_loop start — run_id=%s issue=%d tools=%d (github_mcp=%d)",
         run_id,
         issue_number,
         len(tool_defs),
+        len(github_tool_names),
     )
 
     for iteration in range(1, max_iterations + 1):
@@ -178,13 +193,14 @@ async def run_agent_loop(
 
         try:
             bounded = _prune_history(_truncate_tool_results(messages))
-            response: ToolResponse = await call_openrouter_with_tools(
+            response: ToolResponse = await call_anthropic_with_tools(
                 bounded,
                 system=system_prompt,
                 tools=tool_defs,
             )
         except Exception as exc:
             logger.exception("❌ agent_loop LLM error on iteration %d", iteration)
+            await github_client.close()
             await log_run_error(issue_number, f"LLM error: {exc}", run_id)
             await build_cancel_run(run_id)
             return
@@ -207,6 +223,7 @@ async def run_agent_loop(
 
         if response["stop_reason"] == "stop":
             logger.info("✅ agent_loop complete — run_id=%s iterations=%d", run_id, iteration)
+            await github_client.close()
             await build_complete_run(
                 issue_number=issue_number,
                 pr_url="",
@@ -217,7 +234,11 @@ async def run_agent_loop(
 
         if response["stop_reason"] == "tool_calls":
             tool_results = await _dispatch_tool_calls(
-                response["tool_calls"], worktree_path, run_id
+                response["tool_calls"],
+                worktree_path,
+                run_id,
+                github_client=github_client,
+                github_tool_names=github_tool_names,
             )
             messages.extend(tool_results)
             continue
@@ -228,6 +249,7 @@ async def run_agent_loop(
             response["stop_reason"],
             iteration,
         )
+        await github_client.close()
         await log_run_error(
             issue_number,
             f"Unexpected stop_reason={response['stop_reason']!r} on iteration {iteration}",
@@ -238,6 +260,7 @@ async def run_agent_loop(
 
     # Reached iteration ceiling.
     logger.error("❌ agent_loop iteration limit reached — run_id=%s", run_id)
+    await github_client.close()
     await log_run_error(
         issue_number,
         f"Agent loop exceeded {max_iterations} iterations without completing.",
@@ -336,6 +359,17 @@ You are running **inside the AgentCeption Docker container**, not on the host ma
   initial message.  Read `ac://runs/{run_id}/context` for your full task context.
 - Git operations run in the worktree directory.
 - Use `run_command` for shell execution.  Use `read_file` / `write_file` for files.
+- Use GitHub MCP tools (`get_issue`, `list_issues`, `add_issue_comment`,
+  `create_pull_request`, `merge_pull_request`, etc.) for all GitHub operations.
+  Do NOT shell out to `gh` CLI for anything the MCP tools can do.
+
+## Memory Discipline
+
+Your conversation history is your memory.  Before calling `read_file`,
+`list_directory`, or `run_command`, check whether you already have that
+information in the conversation.  **Do not re-read a file or re-run a command
+you have already executed** — the output is already in your context.
+Re-reading wastes tokens and burns iteration budget.  Use what you know.
 """
 
 
@@ -485,28 +519,36 @@ def _mcp_tool_to_openai(tool_name: str, description: str, input_schema: dict[str
     )
 
 
-def _build_tool_definitions() -> list[ToolDefinition]:
-    """Build the combined tool list: local tools + MCP tools.
+def _build_tool_definitions(
+    extra_tools: list[ToolDefinition] | None = None,
+) -> list[ToolDefinition]:
+    """Build the combined tool list: local tools + AgentCeption MCP tools + GitHub MCP tools.
 
-    Local tools (file/shell) are listed first so the model encounters them
-    before the more specialised MCP tools.
-
-    MCP tools that share a name with local tools are excluded (local tools
-    take precedence for file operations).
+    Order: local file/shell tools → AgentCeption MCP tools → GitHub MCP tools.
+    Local tools take precedence; names already present are not duplicated.
     """
     tool_defs: list[ToolDefinition] = list(FILE_TOOL_DEFS)
     tool_defs.append(SHELL_TOOL_DEF)
     tool_defs.append(SEARCH_CODEBASE_TOOL_DEF)
 
+    seen: set[str] = {t["function"]["name"] for t in tool_defs}
+
     for mcp_tool in TOOLS:
         name: object = mcp_tool.get("name")
-        if not isinstance(name, str) or name in _LOCAL_TOOL_NAMES:
+        if not isinstance(name, str) or name in seen:
             continue
         description: object = mcp_tool.get("description", "")
         input_schema: object = mcp_tool.get("inputSchema", {})
         if not isinstance(description, str) or not isinstance(input_schema, dict):
             continue
         tool_defs.append(_mcp_tool_to_openai(name, description, input_schema))
+        seen.add(name)
+
+    for gh_tool in extra_tools or []:
+        gh_name = gh_tool["function"]["name"]
+        if gh_name not in seen:
+            tool_defs.append(gh_tool)
+            seen.add(gh_name)
 
     return tool_defs
 
@@ -586,17 +628,24 @@ async def _dispatch_tool_calls(
     tool_calls: list[ToolCall],
     worktree_path: Path,
     run_id: str,
+    *,
+    github_client: GitHubMCPClient | None = None,
+    github_tool_names: frozenset[str] = frozenset(),
 ) -> list[dict[str, object]]:
     """Execute each tool call and return a list of tool-result messages.
 
-    Local file/shell tools are dispatched directly.  All other tool names are
-    forwarded to :func:`~agentception.mcp.server.call_tool_async`.
+    Routing priority:
+    1. Local file/shell tools → dispatched directly.
+    2. GitHub MCP tool names  → forwarded to :class:`GitHubMCPClient`.
+    3. Everything else         → forwarded to :func:`~agentception.mcp.server.call_tool_async`.
 
     Args:
         tool_calls: Tool calls returned by the model.
         worktree_path: Worktree root used as the default cwd for shell calls
             and the base for resolving relative file paths.
         run_id: Used for logging only.
+        github_client: Initialised GitHub MCP client (optional).
+        github_tool_names: Set of tool names routed to the GitHub MCP server.
 
     Returns:
         A list of ``{"role": "tool", "tool_call_id": str, "content": str}``
@@ -604,7 +653,13 @@ async def _dispatch_tool_calls(
     """
     results: list[dict[str, object]] = []
     for tc in tool_calls:
-        result = await _dispatch_single_tool(tc, worktree_path, run_id)
+        result = await _dispatch_single_tool(
+            tc,
+            worktree_path,
+            run_id,
+            github_client=github_client,
+            github_tool_names=github_tool_names,
+        )
         results.append(
             {
                 "role": "tool",
@@ -633,6 +688,9 @@ async def _dispatch_single_tool(
     tool_call: ToolCall,
     worktree_path: Path,
     run_id: str,
+    *,
+    github_client: GitHubMCPClient | None = None,
+    github_tool_names: frozenset[str] = frozenset(),
 ) -> dict[str, object]:
     """Dispatch a single tool call and return its result dict.
 
@@ -649,10 +707,18 @@ async def _dispatch_single_tool(
     except json.JSONDecodeError as exc:
         return {"ok": False, "error": f"Invalid tool arguments (JSON parse error): {exc}"}
 
-    if name not in _LOCAL_TOOL_NAMES:
-        return _mcp_result_to_dict(await call_tool_async(name, args))
+    if name in _LOCAL_TOOL_NAMES:
+        return await _dispatch_local_tool(name, args, worktree_path)
 
-    return await _dispatch_local_tool(name, args, worktree_path)
+    if name in github_tool_names and github_client is not None:
+        try:
+            text = await github_client.call_tool(name, args)
+            return {"ok": True, "result": text}
+        except RuntimeError as exc:
+            logger.error("❌ github_mcp tool %s failed: %s", name, exc)
+            return {"ok": False, "error": str(exc)}
+
+    return _mcp_result_to_dict(await call_tool_async(name, args))
 
 
 async def _dispatch_local_tool(

--- a/agentception/services/github_mcp_client.py
+++ b/agentception/services/github_mcp_client.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+"""Async stdio MCP client for the GitHub MCP server binary.
+
+Spawns ``github-mcp-server stdio`` as a subprocess and communicates via
+newline-delimited JSON-RPC 2.0 — the same protocol Cursor uses when it
+runs the GitHub MCP server locally.
+
+``GITHUB_PERSONAL_ACCESS_TOKEN`` is set from ``settings.github_token``
+(env var ``GITHUB_TOKEN``) so no extra configuration is required beyond
+what AgentCeption already expects.
+
+Usage (inside the agent loop)::
+
+    client = GitHubMCPClient()
+    tools = await client.list_tools()      # cached after first call
+    result = await client.call_tool("get_issue", {"owner": "...", "repo": "...", "issue_number": 42})
+    await client.close()                   # terminate subprocess at end of run
+"""
+
+import asyncio
+import json
+import logging
+import os
+
+from agentception.config import settings
+from agentception.services.llm import ToolDefinition, ToolFunction
+
+logger = logging.getLogger(__name__)
+
+_GH_MCP_BINARY = "github-mcp-server"
+_MCP_PROTOCOL_VERSION = "2024-11-05"
+_READ_TIMEOUT_SECS = 30.0
+
+# GitHub MCP tools we never expose to the agent — either dangerous (delete/fork)
+# or irrelevant to AgentCeption's workflow.
+_SKIP_TOOLS: frozenset[str] = frozenset(
+    {
+        "delete_file",
+        "fork_repository",
+        "create_repository",
+        "push_files",
+        "create_or_update_file",
+    }
+)
+
+
+class GitHubMCPClient:
+    """Async stdio MCP client for the GitHub MCP server binary.
+
+    Spawns ``github-mcp-server stdio`` once and reuses the process for the
+    lifetime of the agent run.  Messages are newline-delimited JSON-RPC 2.0.
+    Tool calls are sequential — do NOT call :meth:`call_tool` concurrently.
+    """
+
+    def __init__(self) -> None:
+        self._proc: asyncio.subprocess.Process | None = None
+        self._next_id: int = 1
+        self._tools_cache: list[ToolDefinition] | None = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _bump_id(self) -> int:
+        req_id = self._next_id
+        self._next_id += 1
+        return req_id
+
+    async def _ensure_started(self) -> None:
+        """Spawn and MCP-initialize the subprocess if not already running."""
+        if self._proc is not None and self._proc.returncode is None:
+            return
+
+        token = settings.github_token
+        if not token:
+            raise RuntimeError(
+                "GITHUB_TOKEN is not set — GitHub MCP tools are unavailable. "
+                "Set the GITHUB_TOKEN env var and restart the service."
+            )
+
+        env = {**os.environ, "GITHUB_PERSONAL_ACCESS_TOKEN": token}
+        try:
+            self._proc = await asyncio.create_subprocess_exec(
+                _GH_MCP_BINARY,
+                "stdio",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+                env=env,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"'{_GH_MCP_BINARY}' binary not found in PATH. "
+                "Ensure it is installed in the Docker image."
+            ) from exc
+
+        # MCP session handshake.
+        await self._request(
+            "initialize",
+            {
+                "protocolVersion": _MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "agentception", "version": "1.0"},
+            },
+        )
+        await self._notify("notifications/initialized", {})
+        logger.info("✅ GitHub MCP server started — pid=%d", self._proc.pid)
+
+    async def _write(self, obj: dict[str, object]) -> None:
+        assert self._proc is not None and self._proc.stdin is not None
+        self._proc.stdin.write((json.dumps(obj) + "\n").encode())
+        await self._proc.stdin.drain()
+
+    async def _read_response(self, expected_id: int) -> dict[str, object]:
+        """Read lines until we find the JSON-RPC response with *expected_id*."""
+        assert self._proc is not None and self._proc.stdout is not None
+        while True:
+            raw = await asyncio.wait_for(
+                self._proc.stdout.readline(), timeout=_READ_TIMEOUT_SECS
+            )
+            if not raw:
+                raise RuntimeError("GitHub MCP server closed stdout unexpectedly.")
+            try:
+                msg: object = json.loads(raw.decode())
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(msg, dict):
+                continue
+            # Skip notifications (no id) and messages for other request IDs.
+            if "method" in msg or msg.get("id") != expected_id:
+                continue
+            if "error" in msg:
+                raise RuntimeError(f"GitHub MCP error: {msg['error']}")
+            result: object = msg.get("result", {})
+            return result if isinstance(result, dict) else {}
+
+    async def _request(self, method: str, params: dict[str, object]) -> dict[str, object]:
+        req_id = self._bump_id()
+        await self._write({"jsonrpc": "2.0", "id": req_id, "method": method, "params": params})
+        return await self._read_response(req_id)
+
+    async def _notify(self, method: str, params: dict[str, object]) -> None:
+        await self._write({"jsonrpc": "2.0", "method": method, "params": params})
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def list_tools(self) -> list[ToolDefinition]:
+        """Return tool definitions from the GitHub MCP server (cached after first call)."""
+        if self._tools_cache is not None:
+            return self._tools_cache
+
+        await self._ensure_started()
+        result = await self._request("tools/list", {})
+        raw: object = result.get("tools", [])
+        if not isinstance(raw, list):
+            raw = []
+
+        defs: list[ToolDefinition] = []
+        for tool in raw:
+            if not isinstance(tool, dict):
+                continue
+            name: object = tool.get("name")
+            if not isinstance(name, str) or name in _SKIP_TOOLS:
+                continue
+            description: object = tool.get("description", "")
+            if not isinstance(description, str):
+                description = ""
+            schema_raw: object = tool.get("inputSchema", {})
+            schema: dict[str, object] = (
+                schema_raw if isinstance(schema_raw, dict) else {}
+            )
+            defs.append(
+                ToolDefinition(
+                    type="function",
+                    function=ToolFunction(
+                        name=name,
+                        description=description,
+                        parameters=schema,
+                    ),
+                )
+            )
+
+        self._tools_cache = defs
+        logger.info("✅ GitHub MCP tools loaded — %d tools", len(defs))
+        return defs
+
+    async def call_tool(self, name: str, arguments: dict[str, object]) -> str:
+        """Call a GitHub MCP tool and return the text content of the result."""
+        await self._ensure_started()
+        result = await self._request("tools/call", {"name": name, "arguments": arguments})
+        content: object = result.get("content", [])
+        if isinstance(content, list):
+            parts: list[str] = [
+                str(item.get("text", ""))
+                for item in content
+                if isinstance(item, dict) and item.get("type") == "text"
+            ]
+            return "\n".join(parts)
+        return str(result)
+
+    async def close(self) -> None:
+        """Terminate the subprocess gracefully."""
+        if self._proc is not None and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+            except Exception:
+                pass
+        self._proc = None
+        self._tools_cache = None

--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -9,17 +9,17 @@ giving ~90% input-token discount on turns 2-N of every agent run.
 
 Three public entry points:
 
-``call_openrouter(user_prompt, ...)``
+``call_anthropic(user_prompt, ...)``
     Waits for the full completion and returns the text.  Used by the Phase
     Planner and MCP tools where a single-turn, non-streaming response suffices.
 
-``call_openrouter_stream(user_prompt, ...)``
+``call_anthropic_stream(user_prompt, ...)``
     AsyncGenerator that yields :class:`LLMChunk` dicts as SSE-ready events:
       {"type": "thinking", "text": "..."}  -- extended-thinking token
       {"type": "content",  "text": "..."}  -- output token (the actual YAML)
     Callers map these to their own SSE event format.
 
-``call_openrouter_with_tools(messages, ...)``
+``call_anthropic_with_tools(messages, ...)``
     Multi-turn tool-use call.  Accepts an OpenAI-format message history and
     a list of OpenAI-format tool definitions; converts both to Anthropic wire
     format internally so the caller (agent_loop) does not need to change.
@@ -51,7 +51,7 @@ _MAX_RETRIES = 2
 
 
 class LLMChunk(TypedDict):
-    """A single event yielded by ``call_openrouter_stream``."""
+    """A single event yielded by ``call_anthropic_stream``."""
 
     type: Literal["thinking", "content"]
     text: str
@@ -93,11 +93,11 @@ class ToolCall(TypedDict):
 
 
 class ToolResponse(TypedDict):
-    """Return value from ``call_openrouter_with_tools``.
+    """Return value from ``call_anthropic_with_tools``.
 
     ``input_tokens`` is populated from the Anthropic ``usage.input_tokens``
     field (sum of regular + cached tokens) and is used by the agent loop's
-    token-rate guard to stay within the 30K input tokens/minute Tier 1 limit.
+    token-rate guard to stay within the Anthropic rate limit.
     """
 
     stop_reason: str  # "stop" | "tool_calls" | "length"
@@ -248,7 +248,7 @@ def _messages_to_anthropic(
 # ---------------------------------------------------------------------------
 
 
-async def call_openrouter(
+async def call_anthropic(
     user_prompt: str,
     *,
     system_prompt: str | None = None,
@@ -330,7 +330,7 @@ async def call_openrouter(
 # ---------------------------------------------------------------------------
 
 
-async def call_openrouter_stream(
+async def call_anthropic_stream(
     user_prompt: str,
     *,
     system_prompt: str | None = None,
@@ -445,7 +445,7 @@ async def call_openrouter_stream(
 # ---------------------------------------------------------------------------
 
 
-async def call_openrouter_with_tools(
+async def call_anthropic_with_tools(
     messages: list[dict[str, object]],
     *,
     system: str,

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -1,10 +1,11 @@
 """Unit tests for agentception.services.agent_loop.
 
 All external I/O is mocked:
-  - call_openrouter_with_tools  → controlled ToolResponse stubs
+  - call_anthropic_with_tools   → controlled ToolResponse stubs
   - build_complete_run / build_cancel_run / log_run_step / log_run_error → AsyncMock
   - call_tool_async             → AsyncMock returning valid ACToolResult
   - _load_task                  → AsyncMock returning a minimal AgentTaskSpec (DB-backed)
+  - GitHubMCPClient             → MagicMock returning empty tool list
   - settings.worktrees_dir      → redirected to tmp_path
   - settings.repo_dir           → redirected to tmp_path
 """
@@ -61,6 +62,20 @@ def _tool_response(name: str, args: dict[str, object]) -> ToolResponse:
 
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_github_client() -> MagicMock:
+    """Return a MagicMock GitHubMCPClient with an empty tool list."""
+    client = MagicMock()
+    client.list_tools = AsyncMock(return_value=[])
+    client.call_tool = AsyncMock(return_value="")
+    client.close = AsyncMock()
+    return client
+
+
+# ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
 
@@ -81,7 +96,7 @@ class TestRunAgentLoop:
                 return_value=task_spec,
             ),
             patch(
-                "agentception.services.agent_loop.call_openrouter_with_tools",
+                "agentception.services.agent_loop.call_anthropic_with_tools",
                 new_callable=AsyncMock,
                 return_value=_stop_response("All done."),
             ),
@@ -94,6 +109,10 @@ class TestRunAgentLoop:
                 "agentception.services.agent_loop.log_run_step",
                 new_callable=AsyncMock,
                 return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
             ),
         ):
             mock_settings.worktrees_dir = tmp_path
@@ -129,7 +148,7 @@ class TestRunAgentLoop:
                 return_value=task_spec,
             ),
             patch(
-                "agentception.services.agent_loop.call_openrouter_with_tools",
+                "agentception.services.agent_loop.call_anthropic_with_tools",
                 new_callable=AsyncMock,
                 side_effect=responses,
             ),
@@ -142,6 +161,10 @@ class TestRunAgentLoop:
                 "agentception.services.agent_loop.log_run_step",
                 new_callable=AsyncMock,
                 return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
             ),
         ):
             mock_settings.worktrees_dir = tmp_path
@@ -174,7 +197,7 @@ class TestRunAgentLoop:
                 return_value=task_spec,
             ),
             patch(
-                "agentception.services.agent_loop.call_openrouter_with_tools",
+                "agentception.services.agent_loop.call_anthropic_with_tools",
                 new_callable=AsyncMock,
                 side_effect=responses,
             ),
@@ -193,6 +216,10 @@ class TestRunAgentLoop:
                 new_callable=AsyncMock,
                 return_value=_mcp_ok_result("step recorded"),
             ) as mock_mcp,
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
         ):
             mock_settings.worktrees_dir = tmp_path
             mock_settings.repo_dir = tmp_path
@@ -218,7 +245,7 @@ class TestRunAgentLoop:
                 return_value=task_spec,
             ),
             patch(
-                "agentception.services.agent_loop.call_openrouter_with_tools",
+                "agentception.services.agent_loop.call_anthropic_with_tools",
                 new_callable=AsyncMock,
                 return_value=_tool_response("log_run_step", {"issue_number": 42, "step_name": "x"}),
             ),
@@ -241,6 +268,10 @@ class TestRunAgentLoop:
                 "agentception.services.agent_loop.call_tool_async",
                 new_callable=AsyncMock,
                 return_value=_mcp_ok_result("step"),
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
             ),
         ):
             mock_settings.worktrees_dir = tmp_path
@@ -293,9 +324,9 @@ class TestRunAgentLoop:
                 return_value=task_spec,
             ),
             patch(
-                "agentception.services.agent_loop.call_openrouter_with_tools",
+                "agentception.services.agent_loop.call_anthropic_with_tools",
                 new_callable=AsyncMock,
-                side_effect=RuntimeError("OpenRouter is down"),
+                side_effect=RuntimeError("Anthropic API is down"),
             ),
             patch(
                 "agentception.services.agent_loop.build_cancel_run",
@@ -312,6 +343,10 @@ class TestRunAgentLoop:
                 new_callable=AsyncMock,
                 return_value={"ok": True},
             ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
         ):
             mock_settings.worktrees_dir = tmp_path
             mock_settings.repo_dir = tmp_path
@@ -323,7 +358,7 @@ class TestRunAgentLoop:
         mock_cancel.assert_called_once_with("test-run-1")
         mock_error.assert_called_once()
         error_msg = str(mock_error.call_args)
-        assert "OpenRouter" in error_msg
+        assert "Anthropic" in error_msg
 
 
 class TestBuildSystemPrompt:

--- a/agentception/tests/test_plan_endpoints.py
+++ b/agentception/tests/test_plan_endpoints.py
@@ -212,7 +212,7 @@ async def test_preview_valid_input_streams_chunk_and_done_events(
 
     with (
         patch(
-            "agentception.routes.ui.plan_ui.call_openrouter_stream",
+            "agentception.routes.ui.plan_ui.call_anthropic_stream",
             side_effect=fake_llm_stream,
         ),
         patch(
@@ -256,7 +256,7 @@ async def test_preview_thinking_chunks_are_discarded(async_client: AsyncClient) 
 
     with (
         patch(
-            "agentception.routes.ui.plan_ui.call_openrouter_stream",
+            "agentception.routes.ui.plan_ui.call_anthropic_stream",
             side_effect=fake_llm_stream,
         ),
         patch(
@@ -292,7 +292,7 @@ async def test_preview_prose_response_yields_error_event(async_client: AsyncClie
 
     with (
         patch(
-            "agentception.routes.ui.plan_ui.call_openrouter_stream",
+            "agentception.routes.ui.plan_ui.call_anthropic_stream",
             side_effect=fake_llm_stream,
         ),
         patch(
@@ -332,7 +332,7 @@ async def test_preview_context_pack_is_prepended_to_dump(async_client: AsyncClie
 
     with (
         patch(
-            "agentception.routes.ui.plan_ui.call_openrouter_stream",
+            "agentception.routes.ui.plan_ui.call_anthropic_stream",
             side_effect=capture_stream,
         ),
         patch(

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -14,7 +14,7 @@ services:
       REPO_DIR: /app
       WORKTREES_DIR: /tmp/agentception-worktrees
       GH_REPO: ${GH_REPO:-cgcardona/agentception}
-      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     # volumes: [] does NOT work in Compose v2 to clear the base list.
     # Instead we remap to paths that exist unconditionally in any runner:

--- a/scripts/gen_prompts/templates/roles/developer.md.j2
+++ b/scripts/gen_prompts/templates/roles/developer.md.j2
@@ -60,21 +60,17 @@ Generate the fingerprint:
 {% include 'snippets/fingerprint-claim.md.j2' %}
 ```
 
-Post the claim comment — **always prefer MCP**:
+Post the claim comment via GitHub MCP:
 
 ```
-# Preferred (MCP — logged and auditable):
-github_add_comment(issue_number=<ISSUE_NUMBER>, body="🔖 **Claimed by agent**\n\n<CLAIM_FINGERPRINT>")
-
-# Fallback (only if MCP unavailable):
-# gh issue comment "$ISSUE_NUMBER" --repo "$GH_REPO" \
-#   --body "🔖 **Claimed by agent**\n\n$CLAIM_FINGERPRINT" 2>/dev/null || true
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+                  body="🔖 **Claimed by agent**\n\n<CLAIM_FINGERPRINT>")
 ```
 
 ### Event 2 — PR Created
 
 Include `$CLAIM_FINGERPRINT` verbatim at the end of the PR body when calling
-`create_pull_request` (via `user-github` MCP):
+`create_pull_request` via GitHub MCP:
 
 ```
 body = "## Summary\n...\n\nCloses #<ISSUE_NUMBER>\n\n<CLAIM_FINGERPRINT>"
@@ -83,10 +79,6 @@ body = "## Summary\n...\n\nCloses #<ISSUE_NUMBER>\n\n<CLAIM_FINGERPRINT>"
 ### Event 3 — Done (after PR is merged or work is complete)
 
 ```
-# Preferred (MCP):
-github_add_comment(issue_number=<ISSUE_NUMBER>, body="🤖 **Implemented by agent** — PR #<PR_NUMBER>\n\n<CLAIM_FINGERPRINT>")
-
-# Fallback:
-# gh issue comment "$ISSUE_NUMBER" --repo "$GH_REPO" \
-#   --body "🤖 **Implemented by agent** — PR #$PR_NUMBER\n\n$CLAIM_FINGERPRINT" 2>/dev/null || true
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+                  body="🤖 **Implemented by agent** — PR #<PR_NUMBER>\n\n<CLAIM_FINGERPRINT>")
 ```

--- a/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
@@ -40,7 +40,8 @@ COORD_SELF_FINGERPRINT="$CLAIM_FINGERPRINT"
 Post your start fingerprint on the parent scope issue (if scope_type == "issue"):
 
 ```
-github_add_comment(issue_number=<scope_value>, body="🌳 **Coordinator started**\n\n<COORD_SELF_FINGERPRINT>")
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<scope_value>,
+                  body="🌳 **Coordinator started**\n\n<COORD_SELF_FINGERPRINT>")
 ```
 
 ---
@@ -67,7 +68,7 @@ log_run_step(
 ```
 
 When you create new GitHub issues to track subtasks, **always include your fingerprint
-in the issue body**. Use `issue_write` (user-github MCP) and append:
+in the issue body**. Use `create_issue` (GitHub MCP) and append:
 
 ```
 \n\n---\n_Created by coordinator:_\n\n<COORD_SELF_FINGERPRINT>
@@ -133,7 +134,8 @@ When all children have terminated:
    child_run_ids in a `log_run_error` call.
 4. Post a completion fingerprint on the parent scope issue (if scope_type == "issue"):
    ```
-   github_add_comment(issue_number=<scope_value>, body="✅ **Coordinator done** — N/N children completed\n\n<COORD_SELF_FINGERPRINT>")
+   add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<scope_value>,
+                     body="✅ **Coordinator done** — N/N children completed\n\n<COORD_SELF_FINGERPRINT>")
    ```
 5. Call `log_run_step` with `step_name = "coordinator_done"`.
 

--- a/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
@@ -64,30 +64,33 @@ REVIEW_FINGERPRINT="$CLAIM_FINGERPRINT"
 ### Event 1 — Review Started (immediately when you begin)
 
 ```
-github_add_comment(issue_number=<ISSUE_NUMBER>, body="🔍 **Review started**\n\n<REVIEW_FINGERPRINT>")
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+                  body="🔍 **Review started**\n\n<REVIEW_FINGERPRINT>")
 ```
 
 ### Event 2 — Grade Assigned (A or B → merge)
 
-Include `$REVIEW_FINGERPRINT` in the merge comment posted after `github_merge_pr`:
+Include `$REVIEW_FINGERPRINT` in the merge comment posted after `merge_pull_request`:
 
 ```
-github_add_comment(issue_number=<ISSUE_NUMBER>, body="✅ **Grade: A/B — Merged**\n\n<grade summary>\n\n<REVIEW_FINGERPRINT>")
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+                  body="✅ **Grade: A/B — Merged**\n\n<grade summary>\n\n<REVIEW_FINGERPRINT>")
 ```
 
 ### Event 3 — Blocked (D or F → do not merge)
 
 ```
-github_add_comment(issue_number=<ISSUE_NUMBER>, body="🚫 **Grade: D/F — Blocked**\n\n<blocking reason>\n\n<REVIEW_FINGERPRINT>")
+add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+                  body="🚫 **Grade: D/F — Blocked**\n\n<blocking reason>\n\n<REVIEW_FINGERPRINT>")
 ```
 
 ## Approval and Merge Protocol
 
 Once you have assigned a grade:
 
-- **A or B** — approve and merge using MCP tools (never shell out):
-  1. `github_approve_pr(pr_number=PR_NUMBER)` — submit the approving review.
-  2. `github_merge_pr(pr_number=PR_NUMBER, delete_branch=true)` — squash-merge and delete the head branch.
+- **A or B** — approve and merge using GitHub MCP tools (never shell out):
+  1. `pull_request_review_write(...)` — submit the approving review.
+  2. `merge_pull_request(owner=<OWNER>, repo=<REPO>, pull_number=PR_NUMBER, merge_method="squash")` — squash-merge.
   3. Post Event 2 comment with `$REVIEW_FINGERPRINT` (see Audit Trail above).
 - **C** — fix in place, re-run mypy + tests, re-grade. Do not stop here.
 - **D** — do not merge. Post Event 3 comment with `$REVIEW_FINGERPRINT` and open a follow-up issue.


### PR DESCRIPTION
## Summary
- Installs `github-mcp-server` binary (v0.32.0) in the Dockerfile so the agent loop can spawn it as a stdio MCP subprocess
- Adds `GitHubMCPClient` — an async stdio JSON-RPC 2.0 client that initialises the GitHub MCP server at agent loop startup and routes tool calls to it
- Wires it into `agent_loop.py`: GitHub MCP tools appear in the agent's catalogue alongside local and AgentCeption MCP tools; dispatch routes by tool name
- Renames `call_openrouter*` → `call_anthropic*` throughout — the code already called Anthropic directly; names were historical artifacts
- Adds `github_token` field to `config.py` (env: `GITHUB_TOKEN`)
- Adds a Memory Discipline section to the agent system prompt: don't re-read files you've already read
- Updates developer/pr-reviewer/engineering-coordinator templates to use GitHub MCP tool names (`add_issue_comment`, `create_pull_request`, `merge_pull_request`) and removes `gh` CLI fallbacks
- Replaces stale `OPENROUTER_API_KEY` with `ANTHROPIC_API_KEY` in `docker-compose.ci.yml`
- 50/50 tests pass, zero mypy errors

## Test plan
- [x] `mypy agentception/` — zero errors
- [x] `pytest tests/test_agent_loop.py tests/test_plan_endpoints.py` — 50/50 passed
- [x] `generate.py --check` — no drift
- [ ] Rebuild Docker image to confirm `github-mcp-server` binary installs correctly
- [ ] Smoke test: dispatch an agent run and confirm GitHub MCP tools appear in the tool catalogue log line