### PR TITLE
fix: raise asyncio readline limit for GitHub MCP server subprocess

### DIFF
--- a/agentception/services/github_mcp_client.py
+++ b/agentception/services/github_mcp_client.py
@@ -31,6 +31,9 @@ logger = logging.getLogger(__name__)
 _GH_MCP_BINARY = "github-mcp-server"
 _MCP_PROTOCOL_VERSION = "2024-11-05"
 _READ_TIMEOUT_SECS = 30.0
+# GitHub MCP tools/list response can exceed asyncio's default 64 KB readline
+# buffer.  Set a generous limit (16 MB) to accommodate it.
+_STREAM_LIMIT = 16 * 1024 * 1024
 
 # GitHub MCP tools we never expose to the agent — either dangerous (delete/fork)
 # or irrelevant to AgentCeption's workflow.
@@ -88,6 +91,7 @@ class GitHubMCPClient:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.DEVNULL,
                 env=env,
+                limit=_STREAM_LIMIT,
             )
         except FileNotFoundError as exc:
             raise RuntimeError(


### PR DESCRIPTION
## Summary

- The `tools/list` response from `github-mcp-server` is a single JSON line containing 100+ tool descriptions, exceeding asyncio's default 64 KB `StreamReader` limit
- Added `_STREAM_LIMIT = 16 * 1024 * 1024` constant and passed `limit=_STREAM_LIMIT` to `asyncio.create_subprocess_exec`
- Without this fix the agent loop crashes immediately on startup with `ValueError: Separator is found, but chunk is longer than limit`

## Test plan
- [x] mypy clean
- [x] Re-dispatch issue-27 to verify GitHub MCP tools load successfully