### PR TITLE
chore: remove remaining OpenRouter refs from TS, spec, and mcp doc

### DIFF
--- a/agentception/static/js/plan.ts
+++ b/agentception/static/js/plan.ts
@@ -3,7 +3,7 @@
  *
  * State machine:
  *   write      — textarea, user composes their plan
- *   generating — POST /api/plan/preview → OpenRouter → Claude streaming (SSE)
+ *   generating — POST /api/plan/preview → Anthropic → Claude streaming (SSE)
  *   review     — CodeMirror 6 YAML editor, editable, validate-on-change
  *   launching  — streaming POST /api/plan/file-issues, progress shown
  *   done       — GitHub issues created, summary shown
@@ -386,7 +386,7 @@ export function planForm(props: { ghRepo?: string } = {}): PlanFormComponent {
       this.errorMsg = '';
     },
 
-    // ── Phase 1A: POST /api/plan/preview — direct OpenRouter → Claude stream ──
+    // ── Phase 1A: POST /api/plan/preview — direct Anthropic → Claude stream ──
 
     async submit(): Promise<void> {
       const trimmed = this.text.trim();

--- a/agentception/tests/e2e/plan.spec.ts
+++ b/agentception/tests/e2e/plan.spec.ts
@@ -8,14 +8,14 @@
  *   docker compose up -d
  *   npm run test:e2e
  *
- * External dependencies (OpenRouter LLM, GitHub gh CLI) are fully intercepted
+ * External dependencies (Anthropic LLM, GitHub) are fully intercepted
  * via page.route() so no real API keys or network access are required.  The
  * tests exercise the real FastAPI server, real Jinja2 templates, real Alpine.js
  * component, and real HTMX — only the slow/external SSE endpoints are stubbed.
  *
  * Network mocking strategy
  * ------------------------
- * - POST /api/plan/preview  → fake SSE stream (avoids OpenRouter call)
+ * - POST /api/plan/preview  → fake SSE stream (avoids Anthropic call)
  * - POST /api/plan/file-issues → fake SSE stream (avoids gh CLI)
  * - POST /api/plan/validate → hits the REAL backend (pure YAML computation)
  * - GET  /plan, /plan/recent-runs → hits the REAL backend

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -50,7 +50,7 @@ When `AC_API_KEY` is configured, Cursor's HTTP MCP client must include the key:
 }
 ```
 
-LLM calls from AgentCeption to OpenRouter/Anthropic always use HTTPS — there is no plaintext LLM traffic.
+LLM calls from AgentCeption to Anthropic always use HTTPS — there is no plaintext LLM traffic.
 
 ## stdio configuration (`~/.cursor/mcp.json`)
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ import { defineConfig, devices } from '@playwright/test';
  * Run all E2E tests:      npm run test:e2e
  * Run with UI explorer:   npm run test:e2e:ui
  *
- * All external dependencies (OpenRouter, GitHub) are intercepted via
+ * All external dependencies (Anthropic API, GitHub) are intercepted via
  * page.route() in each test — no real API keys are required.
  */
 export default defineConfig({


### PR DESCRIPTION
Catches the 6 instances missed in PR #383:
- `playwright.config.ts` — comment
- `agentception/static/js/plan.ts` — 2 comments; JS bundle rebuilt
- `agentception/tests/e2e/plan.spec.ts` — 2 comments
- `docs/guides/mcp.md` — prose

Zero OpenRouter references remain anywhere in the codebase.