### PR TITLE
Remove final .agent-task references from gitignore, docker-compose, and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,6 @@ node_modules/
 package-lock.json
 
 # Agent ephemeral briefing files — never committed
-.agent-task
-
 # Runtime role-version ledger — written by the app server on every role commit.
 # This is runtime state, not source code. Tracking it causes dev to appear dirty
 # after every agent run. The DB is the canonical state store; this file is a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,12 +19,12 @@ services:
       GH_REPO: ${GH_REPO:-cgcardona/agentception}
       REPO_DIR: ${REPO_DIR:-/app}
       WORKTREES_DIR: ${WORKTREES_DIR:-/worktrees}
-      # Host-side path written into .agent-task files so spawned Cursor agents
-      # (running on the host) can find the worktree at the same path the container
-      # created it.  Must match the left-hand side of the worktrees volume mount below.
+      # Host-side path to the worktrees directory.  Persisted to the DB context row
+      # so spawned Cursor agents (running on the host) can find the worktree at
+      # the same path the container created it.  Must match the worktrees volume mount.
       HOST_WORKTREES_DIR: ${HOST_WORKTREES_DIR:-${HOME}/.agentception/worktrees/agentception}
-      # Host-side path to the repository root — written into .agent-task as
-      # HOST_ROLE_FILE so Cursor agents (on the host) can resolve role files.
+      # Host-side path to the repository root — persisted to the DB context row
+      # so Cursor agents (on the host) can resolve role files.
       # Override via HOST_REPO_DIR in .env when the repo is not at the default.
       HOST_REPO_DIR: ${HOST_REPO_DIR:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ Precise specifications for every system component.
 | Reference | Summary |
 |-----------|---------|
 | [API Routes](reference/api.md) | Complete HTTP endpoint inventory — semantic URL taxonomy, request/response shapes |
-| [Agent Task Spec](reference/agent-task.md) | `ac://runs/{run_id}/context` TOML format — every section, every field, with examples |
+| [Task Context Spec](../.agentception/agent-task-spec.md) | `RunContextRow` DB schema — every field, access patterns, and examples |
 | [Type Contracts](reference/type-contracts.md) | Pydantic models, TypedDicts, and the typed layer contracts between DB → service → route |
 | [Cognitive Architecture](reference/cognitive-arch.md) | Figures, archetypes, skill domains, atoms — how agents get their identities |
 | [YAML Configuration](reference/yaml-config.md) | `config.yaml`, `team.yaml`, `role-taxonomy.yaml` — full field reference |

--- a/docs/cognitive-arch-audit.md
+++ b/docs/cognitive-arch-audit.md
@@ -50,13 +50,9 @@ A second, independent bug exists at the root: **`cto.md` hardcodes `COGNITIVE_AR
 This route creates a worktree and `ac://runs/{run_id}/context` for a single-issue leaf engineer.
 
 ```python
-# dispatch.py:212 (historical — _build_agent_task now persists to DB)
+# dispatch.py: cognitive_arch is resolved then persisted to the DB context row
 cognitive_arch = _resolve_cognitive_arch(req.issue_body, req.role)
-agent_task = _build_agent_task(
-    ...
-    cognitive_arch=cognitive_arch,
-    ...
-)
+# ... persisted via persist_run_context(run_id=..., cognitive_arch=cognitive_arch, ...)
 ```
 
 `_resolve_cognitive_arch` is called with `req.issue_body` (may be empty) and `req.role`.  The resolved string is persisted to the DB context row as `cognitive_arch`.
@@ -357,7 +353,7 @@ The format is consistent across all tiers.
 
 The `[task]` section of every `DB context row now includes `is_resumed = false` (default). This flag is:
 
-- Persisted to DB by the dispatch layer (`_build_coordinator_task`, `_build_conductor_task`) and by `_build_child_task` in `spawn_child.py`. (`_build_agent_task` is the historical name for this operation.)
+- Persisted to DB by the dispatch layer (`_build_coordinator_task`, `_build_conductor_task`) and by `_build_child_task` in `spawn_child.py`.
 - Parsed by `_build_task_file_from_toml()` in `readers/worktrees.py` into the `TaskFile.is_resumed` field.
 - Read by STEP 0 in every role template via `ac://runs/{run_id}/context`.
 

--- a/scripts/gen_prompts/team.yaml
+++ b/scripts/gen_prompts/team.yaml
@@ -4,7 +4,7 @@
 # agent hierarchy. It is read by generate.py (for validation) and by
 # resolve_arch.py (at agent runtime) to assemble the live context block.
 #
-# COGNITIVE_ARCH string format (used in .agent-task and dispatch prompts):
+# COGNITIVE_ARCH string format (used in DB context rows and dispatch prompts):
 #   figures:skill1:skill2:...
 #
 #   - figures: comma-separated figure ids (for blends), colon-separates from skills
@@ -184,7 +184,7 @@ org:
   leaf:
     # Leaf agents are dynamically assigned by the Engineering Coordinator based on the
     # issue content. The coordinator selects one or more figures and up to max_skills
-    # skill domains, then writes the assembled COGNITIVE_ARCH to .agent-task.
+    # skill domains, then persists the assembled COGNITIVE_ARCH to the DB context row.
     selection: dynamic
 
     # Original historical figures


### PR DESCRIPTION
## Summary

- `.gitignore`: drop the `.agent-task` ignore entry — the file is no longer written by the system, and a stale `.agent-task` file that had been sitting ignored in the repo root has been deleted.
- `docker-compose.yml`: update `HOST_WORKTREES_DIR` / `HOST_REPO_DIR` comments to reflect DB-backed context delivery instead of file writing.
- `scripts/gen_prompts/team.yaml`: update two COGNITIVE_ARCH comments.
- `docs/README.md`: fix broken link to the deleted `reference/agent-task.md` → now points to `.agentception/agent-task-spec.md`.
- `docs/cognitive-arch-audit.md`: remove two remaining `_build_agent_task` historical references.

## Test plan

- [x] No Python files changed — mypy and pytest not required.
- [x] Verified zero remaining `.agent-task` file-format references across all non-CSS, non-Python-field-name locations.
