### PR TITLE
feat: read_file_lines, insert_after_in_file, git_commit_and_push

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -52,15 +52,22 @@ from agentception.services.llm import (
 )
 from agentception.services.code_indexer import search_codebase
 from agentception.services.github_mcp_client import GitHubMCPClient
-from agentception.tools.definitions import FILE_TOOL_DEFS, SEARCH_CODEBASE_TOOL_DEF, SHELL_TOOL_DEF
+from agentception.tools.definitions import (
+    FILE_TOOL_DEFS,
+    GIT_COMMIT_AND_PUSH_TOOL_DEF,
+    SEARCH_CODEBASE_TOOL_DEF,
+    SHELL_TOOL_DEF,
+)
 from agentception.tools.file_tools import (
+    insert_after_in_file,
     list_directory,
     read_file,
+    read_file_lines,
     replace_in_file,
     search_text,
     write_file,
 )
-from agentception.tools.shell_tools import run_command
+from agentception.tools.shell_tools import git_commit_and_push, run_command
 
 logger = logging.getLogger(__name__)
 
@@ -125,11 +132,14 @@ def _tpm_record_and_get_sleep(input_tokens: int) -> float:
 _LOCAL_TOOL_NAMES: frozenset[str] = frozenset(
     {
         "read_file",
+        "read_file_lines",
         "replace_in_file",
+        "insert_after_in_file",
         "write_file",
         "list_directory",
         "search_text",
         "run_command",
+        "git_commit_and_push",
         "search_codebase",
     }
 )
@@ -538,6 +548,7 @@ def _build_tool_definitions(
     """
     tool_defs: list[ToolDefinition] = list(FILE_TOOL_DEFS)
     tool_defs.append(SHELL_TOOL_DEF)
+    tool_defs.append(GIT_COMMIT_AND_PUSH_TOOL_DEF)
     tool_defs.append(SEARCH_CODEBASE_TOOL_DEF)
 
     seen: set[str] = {t["function"]["name"] for t in tool_defs}
@@ -748,6 +759,18 @@ async def _dispatch_local_tool(
         path = _resolve(args.get("path"), worktree_path)
         return read_file(path)
 
+    if name == "read_file_lines":
+        path_raw = args.get("path")
+        if not isinstance(path_raw, str):
+            return {"ok": False, "error": "read_file_lines: 'path' must be a string"}
+        start_raw = args.get("start_line")
+        end_raw = args.get("end_line")
+        if not isinstance(start_raw, int):
+            return {"ok": False, "error": "read_file_lines: 'start_line' must be an integer"}
+        if not isinstance(end_raw, int):
+            return {"ok": False, "error": "read_file_lines: 'end_line' must be an integer"}
+        return read_file_lines(_resolve(path_raw, worktree_path), start_raw, end_raw)
+
     if name == "replace_in_file":
         path_raw = args.get("path")
         old_raw = args.get("old_string")
@@ -765,6 +788,22 @@ async def _dispatch_local_tool(
             old_raw,
             new_raw,
             allow_multiple=allow,
+        )
+
+    if name == "insert_after_in_file":
+        path_raw = args.get("path")
+        anchor_raw = args.get("anchor")
+        new_content_raw = args.get("new_content")
+        if not isinstance(path_raw, str):
+            return {"ok": False, "error": "insert_after_in_file: 'path' must be a string"}
+        if not isinstance(anchor_raw, str):
+            return {"ok": False, "error": "insert_after_in_file: 'anchor' must be a string"}
+        if not isinstance(new_content_raw, str):
+            return {"ok": False, "error": "insert_after_in_file: 'new_content' must be a string"}
+        return insert_after_in_file(
+            _resolve(path_raw, worktree_path),
+            anchor_raw,
+            new_content_raw,
         )
 
     if name == "write_file":
@@ -796,6 +835,29 @@ async def _dispatch_local_tool(
         cwd_raw = args.get("cwd")
         cwd = _resolve(cwd_raw, worktree_path) if cwd_raw is not None else worktree_path
         return await run_command(command_raw, cwd)
+
+    if name == "git_commit_and_push":
+        branch_raw = args.get("branch")
+        msg_raw = args.get("commit_message")
+        paths_raw = args.get("paths")
+        base_raw = args.get("base", "origin/dev")
+        if not isinstance(branch_raw, str):
+            return {"ok": False, "error": "git_commit_and_push: 'branch' must be a string"}
+        if not isinstance(msg_raw, str):
+            return {"ok": False, "error": "git_commit_and_push: 'commit_message' must be a string"}
+        if not isinstance(paths_raw, list) or not paths_raw:
+            return {"ok": False, "error": "git_commit_and_push: 'paths' must be a non-empty array"}
+        str_paths = [p for p in paths_raw if isinstance(p, str)]
+        if len(str_paths) != len(paths_raw):
+            return {"ok": False, "error": "git_commit_and_push: all entries in 'paths' must be strings"}
+        base = base_raw if isinstance(base_raw, str) else "origin/dev"
+        return await git_commit_and_push(
+            branch_raw,
+            msg_raw,
+            str_paths,
+            worktree_path,
+            base=base,
+        )
 
     if name == "search_codebase":
         query_raw = args.get("query")

--- a/agentception/tests/test_file_tools.py
+++ b/agentception/tests/test_file_tools.py
@@ -13,7 +13,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from agentception.tools.file_tools import list_directory, read_file, replace_in_file, search_text, write_file
+from agentception.tools.file_tools import (
+    insert_after_in_file,
+    list_directory,
+    read_file,
+    read_file_lines,
+    replace_in_file,
+    search_text,
+    write_file,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -283,3 +291,102 @@ class TestSearchText:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc):
             result = await search_text("pattern", tmp_path)
         assert result["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# read_file_lines
+# ---------------------------------------------------------------------------
+
+
+class TestReadFileLines:
+    def test_reads_exact_range(self, tmp_path: Path) -> None:
+        p = tmp_path / "f.txt"
+        p.write_text("line1\nline2\nline3\nline4\n", encoding="utf-8")
+        result = read_file_lines(p, 2, 3)
+        assert result["ok"] is True
+        assert result["content"] == "line2\nline3\n"
+        assert result["start_line"] == 2
+        assert result["end_line"] == 3
+        assert result["total_lines"] == 4
+
+    def test_clamps_end_beyond_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "f.txt"
+        p.write_text("a\nb\nc\n", encoding="utf-8")
+        result = read_file_lines(p, 2, 999)
+        assert result["ok"] is True
+        assert result["end_line"] == 3
+        assert "b\n" in str(result["content"])
+
+    def test_clamps_start_below_one(self, tmp_path: Path) -> None:
+        p = tmp_path / "f.txt"
+        p.write_text("a\nb\n", encoding="utf-8")
+        result = read_file_lines(p, -5, 1)
+        assert result["ok"] is True
+        assert result["start_line"] == 1
+
+    def test_single_line(self, tmp_path: Path) -> None:
+        p = tmp_path / "f.txt"
+        p.write_text("only\n", encoding="utf-8")
+        result = read_file_lines(p, 1, 1)
+        assert result["ok"] is True
+        assert result["content"] == "only\n"
+
+    def test_missing_file_returns_error(self, tmp_path: Path) -> None:
+        result = read_file_lines(tmp_path / "missing.txt", 1, 5)
+        assert result["ok"] is False
+        assert "not found" in str(result["error"]).lower()
+
+    def test_start_beyond_end_after_clamp_returns_error(self, tmp_path: Path) -> None:
+        p = tmp_path / "f.txt"
+        p.write_text("one\n", encoding="utf-8")
+        result = read_file_lines(p, 5, 3)
+        assert result["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# insert_after_in_file
+# ---------------------------------------------------------------------------
+
+
+class TestInsertAfterInFile:
+    def test_inserts_after_anchor(self, tmp_path: Path) -> None:
+        p = tmp_path / "f.py"
+        p.write_text("import os\nimport sys\n", encoding="utf-8")
+        result = insert_after_in_file(p, "import os\n", "import re\n")
+        assert result["ok"] is True
+        assert p.read_text(encoding="utf-8") == "import os\nimport re\nimport sys\n"
+
+    def test_anchor_not_found_returns_error(self, tmp_path: Path) -> None:
+        p = tmp_path / "f.txt"
+        p.write_text("hello world\n", encoding="utf-8")
+        result = insert_after_in_file(p, "MISSING", "new line\n")
+        assert result["ok"] is False
+        assert "not found" in str(result["error"])
+
+    def test_ambiguous_anchor_returns_error(self, tmp_path: Path) -> None:
+        p = tmp_path / "f.txt"
+        p.write_text("foo\nfoo\n", encoding="utf-8")
+        result = insert_after_in_file(p, "foo", "bar")
+        assert result["ok"] is False
+        assert "2 times" in str(result["error"])
+
+    def test_inserts_at_end_of_file(self, tmp_path: Path) -> None:
+        p = tmp_path / "f.txt"
+        p.write_text("the end", encoding="utf-8")
+        result = insert_after_in_file(p, "the end", "\nextra")
+        assert result["ok"] is True
+        assert p.read_text(encoding="utf-8") == "the end\nextra"
+
+    def test_missing_file_returns_error(self, tmp_path: Path) -> None:
+        result = insert_after_in_file(tmp_path / "nope.txt", "anchor", "content")
+        assert result["ok"] is False
+        assert "not found" in str(result["error"]).lower()
+
+    def test_multiline_anchor(self, tmp_path: Path) -> None:
+        p = tmp_path / "f.py"
+        p.write_text("def foo():\n    pass\n\ndef bar():\n    pass\n", encoding="utf-8")
+        result = insert_after_in_file(p, "def foo():\n    pass\n", "\ndef baz():\n    pass\n")
+        assert result["ok"] is True
+        text = p.read_text(encoding="utf-8")
+        assert "def baz" in text
+        assert text.index("def baz") < text.index("def bar")

--- a/agentception/tests/test_shell_tools.py
+++ b/agentception/tests/test_shell_tools.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from agentception.tools.shell_tools import _is_safe, run_command
+from agentception.tools.shell_tools import _is_safe, git_commit_and_push, run_command
 
 
 # ---------------------------------------------------------------------------
@@ -169,3 +169,100 @@ class TestRunCommand:
     async def test_string_cwd(self, tmp_path: Path) -> None:
         result = await run_command("echo ok", str(tmp_path))
         assert result["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# git_commit_and_push — mocked subprocess to avoid real git/network calls
+# ---------------------------------------------------------------------------
+
+
+def _make_git_proc(stdout: bytes, stderr: bytes, returncode: int) -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    return proc
+
+
+class TestGitCommitAndPush:
+    @pytest.mark.anyio
+    async def test_full_happy_path(self, tmp_path: Path) -> None:
+        """All git sub-commands succeed — returns ok with branch and sha."""
+        sha = b"abc1234\n"
+        responses = [
+            # rev-parse --abbrev-ref HEAD → current branch is "main" (not target)
+            _make_git_proc(b"main\n", b"", 0),
+            # checkout -b feat/x origin/dev → success
+            _make_git_proc(b"", b"", 0),
+            # add -- .
+            _make_git_proc(b"", b"", 0),
+            # commit -m "msg"
+            _make_git_proc(b"[feat/x abc1234] msg\n", b"", 0),
+            # push -u origin feat/x
+            _make_git_proc(b"", b"", 0),
+            # rev-parse HEAD → sha
+            _make_git_proc(sha, b"", 0),
+        ]
+        call_iter = iter(responses)
+
+        async def fake_exec(*_args: object, **_kwargs: object) -> MagicMock:
+            return next(call_iter)
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            result = await git_commit_and_push(
+                "feat/x", "my commit", ["."], tmp_path
+            )
+
+        assert result["ok"] is True
+        assert result["branch"] == "feat/x"
+        assert "abc1234" in str(result["sha"])
+
+    @pytest.mark.anyio
+    async def test_already_on_branch_skips_checkout(self, tmp_path: Path) -> None:
+        """If already on the target branch, checkout is skipped."""
+        responses = [
+            _make_git_proc(b"feat/x\n", b"", 0),   # rev-parse → already on feat/x
+            _make_git_proc(b"", b"", 0),             # add
+            _make_git_proc(b"[feat/x abc]\n", b"", 0),  # commit
+            _make_git_proc(b"", b"", 0),             # push
+            _make_git_proc(b"abc\n", b"", 0),        # rev-parse HEAD
+        ]
+        call_iter = iter(responses)
+
+        async def fake_exec(*_args: object, **_kwargs: object) -> MagicMock:
+            return next(call_iter)
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            result = await git_commit_and_push(
+                "feat/x", "skip checkout", ["."], tmp_path
+            )
+
+        assert result["ok"] is True
+
+    @pytest.mark.anyio
+    async def test_push_failure_returns_error(self, tmp_path: Path) -> None:
+        responses = [
+            _make_git_proc(b"main\n", b"", 0),        # rev-parse
+            _make_git_proc(b"", b"", 0),               # checkout
+            _make_git_proc(b"", b"", 0),               # add
+            _make_git_proc(b"[feat/x abc]\n", b"", 0), # commit
+            _make_git_proc(b"", b"fatal: push failed\n", 1),  # push fails
+        ]
+        call_iter = iter(responses)
+
+        async def fake_exec(*_args: object, **_kwargs: object) -> MagicMock:
+            return next(call_iter)
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            result = await git_commit_and_push(
+                "feat/x", "will fail", ["."], tmp_path
+            )
+
+        assert result["ok"] is False
+        assert "push" in str(result["error"]).lower()
+
+    @pytest.mark.anyio
+    async def test_empty_paths_returns_error(self, tmp_path: Path) -> None:
+        # Validation fires before any git subprocess — no mock needed.
+        result = await git_commit_and_push("feat/x", "msg", [], tmp_path)
+        assert result["ok"] is False
+        assert "non-empty" in str(result["error"]).lower()

--- a/agentception/tools/definitions.py
+++ b/agentception/tools/definitions.py
@@ -14,6 +14,43 @@ FILE_TOOL_DEFS: list[ToolDefinition] = [
     ToolDefinition(
         type="function",
         function=ToolFunction(
+            name="read_file_lines",
+            description=(
+                "Read a specific line range from a file (1-indexed, inclusive). "
+                "PREFER this over read_file when you only need a section of a large file — "
+                "it returns only the requested lines, keeping the context window small. "
+                "Use search_text first to locate the relevant line numbers, then call "
+                "read_file_lines to fetch just that region. "
+                "Bounds are clamped to the actual file length; total_lines is always returned "
+                "so you can plan follow-up reads. "
+                "Relative paths are resolved from the worktree root."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the file to read (relative or absolute).",
+                    },
+                    "start_line": {
+                        "type": "integer",
+                        "description": "First line to return (1-indexed).",
+                        "minimum": 1,
+                    },
+                    "end_line": {
+                        "type": "integer",
+                        "description": "Last line to return (1-indexed, inclusive).",
+                        "minimum": 1,
+                    },
+                },
+                "required": ["path", "start_line", "end_line"],
+                "additionalProperties": False,
+            },
+        ),
+    ),
+    ToolDefinition(
+        type="function",
+        function=ToolFunction(
             name="read_file",
             description=(
                 "Read the text content of a file. "
@@ -71,6 +108,44 @@ FILE_TOOL_DEFS: list[ToolDefinition] = [
                     },
                 },
                 "required": ["path", "old_string", "new_string"],
+                "additionalProperties": False,
+            },
+        ),
+    ),
+    ToolDefinition(
+        type="function",
+        function=ToolFunction(
+            name="insert_after_in_file",
+            description=(
+                "Insert new content immediately after an anchor string in a file. "
+                "Use this when you want to ADD new lines after a specific point without "
+                "changing the anchor itself — for example, adding a new function after an "
+                "import block, or inserting a new route after an existing one. "
+                "The anchor must appear exactly once; use a longer anchor if it matches "
+                "multiple times. "
+                "Relative paths are resolved from the worktree root."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the file to edit (relative or absolute).",
+                    },
+                    "anchor": {
+                        "type": "string",
+                        "description": (
+                            "Exact text that marks the insertion point. "
+                            "New content is inserted immediately after this text. "
+                            "Must appear exactly once in the file."
+                        ),
+                    },
+                    "new_content": {
+                        "type": "string",
+                        "description": "Text to insert after the anchor.",
+                    },
+                },
+                "required": ["path", "anchor", "new_content"],
                 "additionalProperties": False,
             },
         ),
@@ -189,6 +264,52 @@ SHELL_TOOL_DEF: ToolDefinition = ToolDefinition(
                 },
             },
             "required": ["command"],
+            "additionalProperties": False,
+        },
+    ),
+)
+
+GIT_COMMIT_AND_PUSH_TOOL_DEF: ToolDefinition = ToolDefinition(
+    type="function",
+    function=ToolFunction(
+        name="git_commit_and_push",
+        description=(
+            "Create a git branch, stage files, commit, and push to origin in one call. "
+            "USE THIS instead of four separate run_command calls for the standard "
+            "end-of-task git workflow. "
+            "If the worktree is already on the target branch, the checkout step is skipped. "
+            "After this call succeeds, open a pull request against dev using the GitHub MCP "
+            "create_pull_request tool."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string",
+                    "description": (
+                        "Feature branch name to create, e.g. 'fix/issue-42' or 'feat/my-feature'."
+                    ),
+                },
+                "commit_message": {
+                    "type": "string",
+                    "description": "Commit message string.",
+                },
+                "paths": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "List of file paths to stage (passed to git add). "
+                        "Use ['.'] to stage all changes in the worktree."
+                    ),
+                    "minItems": 1,
+                },
+                "base": {
+                    "type": "string",
+                    "description": "Ref to branch from. Defaults to 'origin/dev'.",
+                    "default": "origin/dev",
+                },
+            },
+            "required": ["branch", "commit_message", "paths"],
             "additionalProperties": False,
         },
     ),

--- a/agentception/tools/file_tools.py
+++ b/agentception/tools/file_tools.py
@@ -172,6 +172,130 @@ def replace_in_file(
     return {"ok": True, "replacements": replacements}
 
 
+def read_file_lines(
+    path: str | Path,
+    start_line: int,
+    end_line: int,
+) -> dict[str, object]:
+    """Return lines *start_line* through *end_line* (1-indexed, inclusive) from *path*.
+
+    Cheaper than ``read_file`` for large files when only a specific region is
+    needed.  Out-of-range bounds are clamped to the actual file length rather
+    than returning an error.
+
+    Args:
+        path: File to read.  Relative paths are resolved from the caller's cwd.
+        start_line: First line to return (1-indexed).
+        end_line: Last line to return (1-indexed, inclusive).
+
+    Returns:
+        ``{"ok": True, "content": str, "start_line": int, "end_line": int,
+        "total_lines": int}`` on success, or ``{"ok": False, "error": str}``
+        on any failure.
+    """
+    p = Path(path)
+    try:
+        text = p.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        logger.warning("⚠️ read_file_lines — not found: %s", p)
+        return {"ok": False, "error": f"File not found: {p}"}
+    except PermissionError:
+        logger.warning("⚠️ read_file_lines — permission denied: %s", p)
+        return {"ok": False, "error": f"Permission denied: {p}"}
+    except OSError as exc:
+        logger.warning("⚠️ read_file_lines — OS error: %s", exc)
+        return {"ok": False, "error": str(exc)}
+
+    lines = text.splitlines(keepends=True)
+    total = len(lines)
+
+    clamped_start = max(1, start_line)
+    clamped_end = min(total, end_line)
+
+    if clamped_start > clamped_end:
+        return {
+            "ok": False,
+            "error": (
+                f"read_file_lines: start_line {start_line} is beyond end_line "
+                f"{end_line} after clamping to file length {total}"
+            ),
+        }
+
+    content = "".join(lines[clamped_start - 1 : clamped_end])
+    logger.info(
+        "✅ read_file_lines — %s lines %d-%d/%d", p, clamped_start, clamped_end, total
+    )
+    return {
+        "ok": True,
+        "content": content,
+        "start_line": clamped_start,
+        "end_line": clamped_end,
+        "total_lines": total,
+    }
+
+
+def insert_after_in_file(
+    path: str | Path,
+    anchor: str,
+    new_content: str,
+) -> dict[str, object]:
+    """Insert *new_content* immediately after the first occurrence of *anchor* in *path*.
+
+    Complements ``replace_in_file`` for pure-insertion tasks where the anchor
+    text should be preserved.  Fails if the anchor is not found or appears more
+    than once, so the caller must use a unique anchor.
+
+    Args:
+        path: File to edit.
+        anchor: Exact text that marks the insertion point.  Must appear exactly
+            once in the file.
+        new_content: Text to insert immediately after *anchor*.
+
+    Returns:
+        ``{"ok": True, "inserted_at": int}`` — byte offset of the insertion
+        point — or ``{"ok": False, "error": str}`` on any failure.
+    """
+    p = Path(path)
+    try:
+        original = p.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        logger.warning("⚠️ insert_after_in_file — not found: %s", p)
+        return {"ok": False, "error": f"File not found: {p}"}
+    except PermissionError:
+        logger.warning("⚠️ insert_after_in_file — permission denied: %s", p)
+        return {"ok": False, "error": f"Permission denied: {p}"}
+    except OSError as exc:
+        logger.warning("⚠️ insert_after_in_file — OS error: %s", exc)
+        return {"ok": False, "error": str(exc)}
+
+    count = original.count(anchor)
+    if count == 0:
+        return {"ok": False, "error": "insert_after_in_file: anchor not found in file"}
+    if count > 1:
+        return {
+            "ok": False,
+            "error": (
+                f"insert_after_in_file: anchor matches {count} times — "
+                "use a longer anchor to make it unique"
+            ),
+        }
+
+    insert_pos = original.index(anchor) + len(anchor)
+    updated = original[:insert_pos] + new_content + original[insert_pos:]
+
+    try:
+        p.write_text(updated, encoding="utf-8")
+    except PermissionError:
+        logger.warning("⚠️ insert_after_in_file — permission denied writing: %s", p)
+        return {"ok": False, "error": f"Permission denied writing: {p}"}
+    except OSError as exc:
+        logger.warning("⚠️ insert_after_in_file — OS write error: %s", exc)
+        return {"ok": False, "error": str(exc)}
+
+    logger.info("✅ insert_after_in_file — %s (inserted at byte %d)", p, insert_pos)
+    return {"ok": True, "inserted_at": insert_pos}
+
+
 async def search_text(
     pattern: str,
     directory: str | Path,

--- a/agentception/tools/shell_tools.py
+++ b/agentception/tools/shell_tools.py
@@ -1,7 +1,12 @@
-"""Shell-execution tool exposed to the agent loop.
+"""Shell-execution tools exposed to the agent loop.
 
-``run_command`` runs a shell command inside the AgentCeption container and
-returns its stdout, stderr, and exit code as a structured dict.
+``run_command`` runs an arbitrary shell command inside the AgentCeption
+container and returns stdout, stderr, and exit code as a structured dict.
+
+``git_commit_and_push`` is a higher-level helper that consolidates the
+four-step git workflow (checkout branch, add, commit, push) into one atomic
+tool call, reducing the turn cost of the standard commit-and-PR pattern from
+four turns to one.
 
 Safety is enforced via a denylist of obviously destructive patterns rather
 than an allowlist — the model needs broad access (git, pytest, mypy, rg, gh,
@@ -140,3 +145,101 @@ async def run_command(
         "stdout_truncated": out_truncated,
         "stderr_truncated": err_truncated,
     }
+
+
+async def _git(args: list[str], cwd: Path) -> tuple[int, str, str]:
+    """Run a git sub-command and return *(exit_code, stdout, stderr)*."""
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
+    )
+    raw_out, raw_err = await asyncio.wait_for(proc.communicate(), timeout=120.0)
+    code: int = proc.returncode if proc.returncode is not None else -1
+    return code, raw_out.decode("utf-8", errors="replace"), raw_err.decode("utf-8", errors="replace")
+
+
+async def git_commit_and_push(
+    branch: str,
+    commit_message: str,
+    paths: list[str],
+    worktree_path: Path,
+    *,
+    base: str = "origin/dev",
+) -> dict[str, object]:
+    """Create a branch, stage files, commit, and push in one atomic call.
+
+    Replaces the four-turn run_command pattern::
+
+        git checkout -b <branch> <base>
+        git add <paths>
+        git commit -m <message>
+        git push -u origin <branch>
+
+    If the worktree is already on *branch*, the checkout step is skipped so
+    the tool is idempotent when called twice.
+
+    Args:
+        branch: Name of the feature branch to create (e.g. ``fix/typo``).
+        commit_message: Commit message string.
+        paths: List of paths to stage (passed to ``git add``).
+        worktree_path: Absolute path to the git worktree root.
+        base: Ref to branch from (default ``origin/dev``).
+
+    Returns:
+        ``{"ok": True, "branch": str, "sha": str, "stdout": str}`` on
+        success, or ``{"ok": False, "error": str, "stderr": str}`` on any
+        git failure.
+    """
+    if not paths:
+        return {"ok": False, "error": "git_commit_and_push: 'paths' must be a non-empty list"}
+
+    logger.info(
+        "✅ git_commit_and_push — branch=%s paths=%s cwd=%s",
+        branch,
+        paths,
+        worktree_path,
+    )
+
+    # Determine current branch.
+    code, current, err = await _git(["rev-parse", "--abbrev-ref", "HEAD"], worktree_path)
+    if code != 0:
+        return {"ok": False, "error": "git_commit_and_push: could not determine current branch", "stderr": err}
+    current = current.strip()
+
+    if current != branch:
+        # Try to create the branch from base; if it already exists, just switch.
+        code, out, err = await _git(["checkout", "-b", branch, base], worktree_path)
+        if code != 0:
+            # Branch might already exist locally — try plain checkout.
+            code2, out2, err2 = await _git(["checkout", branch], worktree_path)
+            if code2 != 0:
+                return {
+                    "ok": False,
+                    "error": f"git_commit_and_push: checkout failed",
+                    "stderr": err + "\n" + err2,
+                }
+
+    # Stage the requested paths.
+    code, out, err = await _git(["add", "--", *paths], worktree_path)
+    if code != 0:
+        return {"ok": False, "error": "git_commit_and_push: git add failed", "stderr": err}
+
+    # Commit.
+    code, out, err = await _git(["commit", "-m", commit_message], worktree_path)
+    if code != 0:
+        return {"ok": False, "error": "git_commit_and_push: git commit failed", "stderr": err}
+
+    # Push and set upstream.
+    code, push_out, push_err = await _git(["push", "-u", "origin", branch], worktree_path)
+    if code != 0:
+        return {"ok": False, "error": "git_commit_and_push: git push failed", "stderr": push_err}
+
+    # Retrieve the new commit SHA.
+    code, sha, _ = await _git(["rev-parse", "HEAD"], worktree_path)
+    sha = sha.strip() if code == 0 else "(unknown)"
+
+    logger.info("✅ git_commit_and_push — pushed %s → origin/%s", sha[:12], branch)
+    return {"ok": True, "branch": branch, "sha": sha, "stdout": push_out}


### PR DESCRIPTION
## Summary

Adds three new agent tools that give the model precise, atomic vocabulary for the most common task patterns — cutting multi-step `run_command` chains down to single calls.

### `read_file_lines(path, start_line, end_line)`
- Fetches a specific line range from a file without pulling the whole thing into context.
- Replaces the current grep-then-sed two-step pattern agents use to locate and read a region.
- Bounds clamped to actual file length; `total_lines` always returned so the agent can plan follow-up reads.
- Tool description explicitly tells the model to prefer this over `read_file` for large files.

### `insert_after_in_file(path, anchor, new_content)`
- Inserts new text immediately after a unique anchor string, preserving the anchor itself.
- Complements `replace_in_file` for pure-insertion tasks (e.g. adding a new import, a new route, a new function).
- Fails fast if anchor is absent or ambiguous, same pattern as `replace_in_file`.

### `git_commit_and_push(branch, commit_message, paths, base="origin/dev")`
- Consolidates the four-turn end-of-task git workflow into one atomic call: `checkout -b`, `add`, `commit`, `push -u`.
- Idempotent: if already on the target branch, checkout is skipped.
- Tool description tells the agent to follow up with the GitHub MCP `create_pull_request` call.

## What changed
- `agentception/tools/file_tools.py` — two new sync functions
- `agentception/tools/shell_tools.py` — `git_commit_and_push` + private `_git` helper
- `agentception/tools/definitions.py` — three new `ToolDefinition` entries + `GIT_COMMIT_AND_PUSH_TOOL_DEF` constant
- `agentception/services/agent_loop.py` — imports, `_LOCAL_TOOL_NAMES`, tool catalogue, `_dispatch_local_tool` cases
- `agentception/tests/test_file_tools.py` — 12 new unit tests (6 per new file tool)
- `agentception/tests/test_shell_tools.py` — 4 new unit tests for `git_commit_and_push`

## Test plan
- [x] `mypy agentception/` — 0 errors
- [x] `pytest agentception/tests/` — 1607 passed, 0 failed