### PR TITLE
fix(#274): replace worktree.exists() with DB status query in get_conductor_history

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -1153,11 +1153,12 @@ async def get_conductor_history(
 ) -> list[ConductorHistoryRow]:
     """Return the last *limit* conductor spawns with current active/completed status.
 
-    Status is ``"active"`` when the worktree directory still exists on disk and
-    ``"completed"`` once it has been removed.  Falls back to ``[]`` on any DB
-    error so the UI degrades gracefully without surfacing the error to the user.
+    Status is derived from the latest agent run in each wave: ``"active"`` when
+    the run status is ``implementing`` or ``reviewing``, ``"completed"`` otherwise.
+    Falls back to ``[]`` on any DB error so the UI degrades gracefully without
+    surfacing the error to the user.
     """
-    from sqlalchemy import desc
+    from sqlalchemy import desc, func
 
     from agentception.config import settings
 
@@ -1166,26 +1167,51 @@ async def get_conductor_history(
 
     try:
         async with get_session() as session:
+            # Subquery: pick the most-recent agent run per wave (by spawned_at).
+            latest_run_subq = (
+                select(
+                    ACAgentRun.wave_id,
+                    ACAgentRun.status,
+                    func.row_number()
+                    .over(
+                        partition_by=ACAgentRun.wave_id,
+                        order_by=desc(ACAgentRun.spawned_at),
+                    )
+                    .label("rn"),
+                )
+                .where(ACAgentRun.wave_id.isnot(None))
+                .subquery()
+            )
+
             stmt = (
-                select(ACWave)
+                select(ACWave, latest_run_subq.c.status)
+                .outerjoin(
+                    latest_run_subq,
+                    (ACWave.id == latest_run_subq.c.wave_id)
+                    & (latest_run_subq.c.rn == 1),
+                )
                 .where(ACWave.role == "conductor")
                 .order_by(desc(ACWave.started_at))
                 .limit(limit)
             )
             result = await session.execute(stmt)
-            waves = result.scalars().all()
+            rows = result.all()
 
         entries: list[ConductorHistoryRow] = []
-        for wave in waves:
+        for wave, run_status in rows:
             worktree = Path(wt_dir) / wave.id
             host_worktree = Path(host_wt_dir) / wave.id
+            # Replaced filesystem worktree check — status is the authoritative signal.
+            display_status = (
+                "active" if run_status in ("implementing", "reviewing") else "completed"
+            )
             entries.append(
                 ConductorHistoryRow(
                     wave_id=wave.id,
                     worktree=str(worktree),
                     host_worktree=str(host_worktree),
                     started_at=wave.started_at.strftime("%Y-%m-%d %H:%M UTC"),
-                    status="active" if worktree.exists() else "completed",
+                    status=display_status,
                 )
             )
         return entries

--- a/agentception/tests/test_agentception_run_conductor.py
+++ b/agentception/tests/test_agentception_run_conductor.py
@@ -31,46 +31,47 @@ def client() -> Generator[TestClient, None, None]:
 # ── get_conductor_history DB query helper ─────────────────────────────────────
 
 
-@pytest.mark.anyio
-async def test_get_conductor_history_status_resolved_from_worktree_dir(
-    tmp_path: Path,
-) -> None:
-    """get_conductor_history marks a wave 'active' only when its dir exists."""
-    from agentception.db.queries import get_conductor_history
+def _make_wave(wave_id: str) -> MagicMock:
+    m = MagicMock()
+    m.id = wave_id
+    m.started_at = datetime.datetime(2026, 3, 3, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    return m
 
-    worktrees = tmp_path / "worktrees"
-    worktrees.mkdir()
-    host_worktrees = tmp_path / "host"
-    host_worktrees.mkdir()
 
-    wave_id_active = "conductor-20260303-100000"
-    wave_id_done = "conductor-20260303-110000"
-
-    # Create a directory only for the "active" wave.
-    (worktrees / wave_id_active).mkdir()
-
-    # Build fake ACWave objects the SQLAlchemy query would return.
-    def _make_wave(wave_id: str) -> MagicMock:
-        m = MagicMock()
-        m.id = wave_id
-        m.started_at = datetime.datetime(2026, 3, 3, 10, 0, 0, tzinfo=datetime.timezone.utc)
-        return m
-
-    fake_waves = [_make_wave(wave_id_active), _make_wave(wave_id_done)]
-
+def _mock_session_returning(rows: list[tuple[MagicMock, str | None]]) -> AsyncMock:
+    """Return an async context-manager session whose execute returns *rows*."""
     mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = fake_waves
-
+    mock_result.all.return_value = rows
     mock_session = AsyncMock()
     mock_session.execute = AsyncMock(return_value=mock_result)
     mock_session.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session.__aexit__ = AsyncMock(return_value=False)
+    return mock_session
 
-    with patch("agentception.db.queries.get_session", return_value=mock_session):
+
+@pytest.mark.anyio
+async def test_get_conductor_history_status_resolved_from_db(
+    tmp_path: Path,
+) -> None:
+    """get_conductor_history derives wave status from the latest DB run, not the filesystem."""
+    from agentception.db.queries import get_conductor_history
+
+    wave_id_active = "conductor-20260303-100000"
+    wave_id_done = "conductor-20260303-110000"
+
+    rows = [
+        (_make_wave(wave_id_active), "implementing"),  # active run → "active"
+        (_make_wave(wave_id_done), "completed"),        # terminal run → "completed"
+    ]
+
+    with patch(
+        "agentception.db.queries.get_session",
+        return_value=_mock_session_returning(rows),
+    ):
         entries = await get_conductor_history(
             limit=5,
-            worktrees_dir=worktrees,
-            host_worktrees_dir=host_worktrees,
+            worktrees_dir=tmp_path,
+            host_worktrees_dir=tmp_path,
         )
 
     assert len(entries) == 2
@@ -78,6 +79,54 @@ async def test_get_conductor_history_status_resolved_from_worktree_dir(
     done_entry = next(e for e in entries if e["wave_id"] == wave_id_done)
     assert active_entry["status"] == "active"
     assert done_entry["status"] == "completed"
+
+
+@pytest.mark.anyio
+async def test_get_conductor_history_reviewing_is_active(tmp_path: Path) -> None:
+    """A wave whose latest run is 'reviewing' is also considered active."""
+    from agentception.db.queries import get_conductor_history
+
+    rows = [(_make_wave("conductor-review"), "reviewing")]
+
+    with patch(
+        "agentception.db.queries.get_session",
+        return_value=_mock_session_returning(rows),
+    ):
+        entries = await get_conductor_history(limit=5, worktrees_dir=tmp_path, host_worktrees_dir=tmp_path)
+
+    assert entries[0]["status"] == "active"
+
+
+@pytest.mark.anyio
+async def test_get_conductor_history_no_run_is_completed(tmp_path: Path) -> None:
+    """A wave with no associated run (LEFT JOIN → None) is marked completed."""
+    from agentception.db.queries import get_conductor_history
+
+    rows = [(_make_wave("conductor-orphan"), None)]
+
+    with patch(
+        "agentception.db.queries.get_session",
+        return_value=_mock_session_returning(rows),
+    ):
+        entries = await get_conductor_history(limit=5, worktrees_dir=tmp_path, host_worktrees_dir=tmp_path)
+
+    assert entries[0]["status"] == "completed"
+
+
+@pytest.mark.anyio
+async def test_get_conductor_history_no_fs_access(tmp_path: Path) -> None:
+    """get_conductor_history must never call Path.exists — status comes from DB."""
+    from agentception.db.queries import get_conductor_history
+
+    rows = [(_make_wave("conductor-20260303-100000"), "implementing")]
+
+    with patch(
+        "agentception.db.queries.get_session",
+        return_value=_mock_session_returning(rows),
+    ), patch("pathlib.Path.exists") as mock_exists:
+        await get_conductor_history(limit=5, worktrees_dir=tmp_path, host_worktrees_dir=tmp_path)
+
+    mock_exists.assert_not_called()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #274

## Problem

`get_conductor_history` was calling `Path.exists()` to determine whether a conductor wave was active or completed. This is a filesystem check that breaks inside containers where the worktrees directory lives at a different path than the host expects.

## Fix

Replace it with a single SQLAlchemy query that uses `row_number()` to pick the most-recent `ACAgentRun` per wave (ordered by `spawned_at`), then `LEFT JOIN`s it to `ACWave`:

```python
# Subquery: pick the most-recent agent run per wave
latest_run_subq = (
    select(ACAgentRun.wave_id, ACAgentRun.status,
           func.row_number().over(
               partition_by=ACAgentRun.wave_id,
               order_by=desc(ACAgentRun.spawned_at)
           ).label("rn"))
    .where(ACAgentRun.wave_id.isnot(None))
    .subquery()
)
```

Status mapping: `implementing|reviewing` → `"active"`, anything else (including `None` from the LEFT JOIN) → `"completed"`.

The `worktree` and `host_worktree` path strings are preserved in `ConductorHistoryRow` — the UI still uses them for display.

## Tests

- Renamed `test_get_conductor_history_status_resolved_from_worktree_dir` → `test_get_conductor_history_status_resolved_from_db` — mock now returns `(wave, run_status)` DB rows instead of filesystem directories
- Added `test_get_conductor_history_reviewing_is_active`
- Added `test_get_conductor_history_no_run_is_completed` (LEFT JOIN → `None` case)
- Added `test_get_conductor_history_no_fs_access` — asserts `Path.exists` is never called (regression guard)

**7/7 tests passing, mypy clean.**