### PR TITLE
feat(#267): define TaskRunner protocol

### DIFF
--- a/agentception/services/__init__.py
+++ b/agentception/services/__init__.py
@@ -1,1 +1,5 @@
 from __future__ import annotations
+
+from agentception.services.task_runner import TaskRunner
+
+__all__ = ["TaskRunner"]

--- a/agentception/services/task_runner.py
+++ b/agentception/services/task_runner.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Everything above TaskRunner.run is runner-agnostic.
+Nothing below the protocol boundary may import agentception.services.task_runner
+without also implementing the protocol."""
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class TaskRunner(Protocol):
+    """Protocol for task execution engines.
+    
+    Implementations spawn agent processes with the given prompt and context.
+    The protocol decouples coordinators from specific runner implementations
+    (Cursor, Anthropic, etc.).
+    """
+
+    def run(
+        self,
+        prompt: str,
+        worktree_path: Path,
+        mcp_server: str,
+        role: str,
+        run_id: str,
+    ) -> str | None:
+        """Execute a task with the given prompt and context.
+        
+        Args:
+            prompt: Task description and instructions for the agent
+            worktree_path: Path to the git worktree for this task
+            mcp_server: MCP server endpoint for tool access
+            role: Agent role (e.g., 'developer', 'reviewer')
+            run_id: Unique identifier for this run
+            
+        Returns:
+            Run result or None if execution failed
+        """
+        ...

--- a/agentception/tests/test_task_runner_protocol.py
+++ b/agentception/tests/test_task_runner_protocol.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agentception.services import TaskRunner
+
+
+class MinimalTaskRunner:
+    """Minimal implementation for structural subtyping test."""
+
+    def run(
+        self,
+        prompt: str,
+        worktree_path: Path,
+        mcp_server: str,
+        role: str,
+        run_id: str,
+    ) -> str | None:
+        """Matches TaskRunner.run signature."""
+        return None
+
+
+def test_task_runner_protocol_structural_subtyping() -> None:
+    """Verify that a class with matching signature satisfies the protocol."""
+    instance = MinimalTaskRunner()
+    assert isinstance(instance, TaskRunner)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,6 +258,12 @@ phases:
 
 ---
 
+## TaskRunner Abstraction
+
+The `TaskRunner` protocol (`agentception/services/task_runner.py`) defines a runner-agnostic interface for executing agent tasks. It decouples coordinators from specific execution engines (Cursor, Anthropic, etc.), allowing the system to swap implementations without changing orchestration logic. Concrete implementations live in sibling modules and are selected via the `ac_task_runner` config setting. The protocol uses structural subtyping (`@runtime_checkable`) to verify implementations at runtime without requiring explicit inheritance.
+
+---
+
 ## Further Reading
 
 - [Plan Spec format](plan-spec.md)


### PR DESCRIPTION
## Summary

Implements the `TaskRunner` protocol to decouple coordinators from specific task execution engines (Cursor, Anthropic, etc.).

### Changes

- Created `agentception/services/task_runner.py` with `@runtime_checkable` protocol
- Exported `TaskRunner` from `agentception/services/__init__.py`
- Added structural subtyping test in `test_task_runner_protocol.py`
- Documented the abstraction in `docs/architecture.md`

### Verification

- ✅ `mypy` passes with zero errors
- ✅ Test passes: `test_task_runner_protocol_structural_subtyping`

Closes #267

<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Role** | `developer` |
| **Architecture** | `guidovanrossum:python` |
| **Session** | `eng-20260309T173324Z-0000` |
| **Claimed at** | `2026-03-09T17:33:24Z` |

</details>