### PR TITLE
fix: address agent tooling gaps (rg, paths coercion, doc path, anchor guidance)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -252,7 +252,7 @@ The browser loads **compiled bundles**, not source files directly:
 | Setup/deploy | `docs/guides/setup.md` |
 | MCP integration | `docs/guides/integrate.md` |
 | API reference | `docs/reference/api.md` |
-| Architecture | `docs/reference/architecture.md` |
+| Architecture | `docs/architecture.md` |
 | Cognitive arch | `docs/reference/cognitive-arch.md` |
 | Testing | `docs/guides/testing.md` |
 | Security | `docs/guides/security.md` |

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install git, curl, and the GitHub CLI (gh) — needed for subprocess git/gh calls.
+# Install git, curl, ripgrep, and the GitHub CLI (gh).
+# ripgrep (rg) is used by the search_text agent tool for fast codebase search.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
+    ripgrep \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
        | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -845,6 +845,10 @@ async def _dispatch_local_tool(
             return {"ok": False, "error": "git_commit_and_push: 'branch' must be a string"}
         if not isinstance(msg_raw, str):
             return {"ok": False, "error": "git_commit_and_push: 'commit_message' must be a string"}
+        # Coerce a bare string (e.g. ".") to a single-element list so the model
+        # doesn't have to retry just because it forgot the JSON array brackets.
+        if isinstance(paths_raw, str):
+            paths_raw = [paths_raw]
         if not isinstance(paths_raw, list) or not paths_raw:
             return {"ok": False, "error": "git_commit_and_push: 'paths' must be a non-empty array"}
         str_paths = [p for p in paths_raw if isinstance(p, str)]

--- a/agentception/tests/test_agentception_run_conductor.py
+++ b/agentception/tests/test_agentception_run_conductor.py
@@ -59,7 +59,7 @@ async def test_get_conductor_history_status_resolved_from_db(
     wave_id_active = "conductor-20260303-100000"
     wave_id_done = "conductor-20260303-110000"
 
-    rows = [
+    rows: list[tuple[MagicMock, str | None]] = [
         (_make_wave(wave_id_active), "implementing"),  # active run → "active"
         (_make_wave(wave_id_done), "completed"),        # terminal run → "completed"
     ]
@@ -86,7 +86,7 @@ async def test_get_conductor_history_reviewing_is_active(tmp_path: Path) -> None
     """A wave whose latest run is 'reviewing' is also considered active."""
     from agentception.db.queries import get_conductor_history
 
-    rows = [(_make_wave("conductor-review"), "reviewing")]
+    rows: list[tuple[MagicMock, str | None]] = [(_make_wave("conductor-review"), "reviewing")]
 
     with patch(
         "agentception.db.queries.get_session",
@@ -102,7 +102,7 @@ async def test_get_conductor_history_no_run_is_completed(tmp_path: Path) -> None
     """A wave with no associated run (LEFT JOIN → None) is marked completed."""
     from agentception.db.queries import get_conductor_history
 
-    rows = [(_make_wave("conductor-orphan"), None)]
+    rows: list[tuple[MagicMock, str | None]] = [(_make_wave("conductor-orphan"), None)]
 
     with patch(
         "agentception.db.queries.get_session",
@@ -118,7 +118,7 @@ async def test_get_conductor_history_no_fs_access(tmp_path: Path) -> None:
     """get_conductor_history must never call Path.exists — status comes from DB."""
     from agentception.db.queries import get_conductor_history
 
-    rows = [(_make_wave("conductor-20260303-100000"), "implementing")]
+    rows: list[tuple[MagicMock, str | None]] = [(_make_wave("conductor-20260303-100000"), "implementing")]
 
     with patch(
         "agentception.db.queries.get_session",

--- a/agentception/tools/definitions.py
+++ b/agentception/tools/definitions.py
@@ -121,6 +121,10 @@ FILE_TOOL_DEFS: list[ToolDefinition] = [
                 "Use this when you want to ADD new lines after a specific point without "
                 "changing the anchor itself — for example, adding a new function after an "
                 "import block, or inserting a new route after an existing one. "
+                "IMPORTANT: the anchor must be an exact substring of the file. "
+                "If you are unsure what text is near the insertion point, use "
+                "read_file_lines first to read the surrounding lines, then copy the exact "
+                "text as your anchor. "
                 "The anchor must appear exactly once; use a longer anchor if it matches "
                 "multiple times. "
                 "Relative paths are resolved from the worktree root."
@@ -298,8 +302,9 @@ GIT_COMMIT_AND_PUSH_TOOL_DEF: ToolDefinition = ToolDefinition(
                     "type": "array",
                     "items": {"type": "string"},
                     "description": (
-                        "List of file paths to stage (passed to git add). "
-                        "Use ['.'] to stage all changes in the worktree."
+                        "JSON array of file paths to stage (passed to git add). "
+                        "MUST be an array, not a string — e.g. [\".\"] not \".\". "
+                        "Use [\".\"] to stage all changes in the worktree."
                     ),
                     "minItems": 1,
                 },


### PR DESCRIPTION
## Summary

- **Add ripgrep to Dockerfile** — `rg` was absent from the container, causing `search_text` tool calls to fail with "rg not found on PATH" and forcing agents to fall back to `grep` via `run_command`
- **Coerce `git_commit_and_push` `paths` string → array** — when the model passes `"."` instead of `["."]`, the dispatch layer now silently coerces it, saving the agent a retry turn
- **Improve tool descriptions** — `git_commit_and_push` now explicitly states `paths` must be a JSON array with an example; `insert_after_in_file` now tells the agent to use `read_file_lines` first to find a real anchor before calling the tool
- **Fix `.cursorrules` doc path** — architecture doc table pointed to `docs/reference/architecture.md`; actual file is `docs/architecture.md`
- **Fix pre-existing mypy errors** in conductor tests: annotate `rows` locals with `list[tuple[MagicMock, str | None]]` to satisfy list invariance under strict mode

## Test plan
- [x] `mypy agentception/` — 0 errors (217 files)
- [x] 75 tests pass (conductor, shell_tools, file_tools)
- [x] `rg --version` in container confirms ripgrep 14.1.1 installed