### PR TITLE
fix: raise inter-turn delay to 5s to respect output TPM ceiling

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -100,11 +100,12 @@ _HISTORY_TAIL: int = 14
 
 # Minimum seconds between consecutive LLM calls.  A proactive fixed cadence
 # beats a reactive burst-then-sleep TPM guard.  At Tier 2 limits (450K input /
-# 90K output TPM, 1K RPM) a 2s floor is the practical safety net: agents rarely
-# emit more than 2K tokens/turn, so real throughput stays well under the output
-# ceiling, and the 2s guard prevents runaway error loops without slowing down
-# legitimate multi-turn work.
-_MIN_TURN_DELAY_SECS: float = 2.0
+# 90K output TPM, 1K RPM) a 5s floor keeps throughput at ~12 turns/min, giving
+# 7.5K average output tokens per turn of headroom — comfortably above any
+# realistic agent turn.  Input TPM is not the constraint: system-prompt cache
+# reads are excluded from the 450K limit, so uncached input per turn is only
+# new messages and tool results (~1–5K).
+_MIN_TURN_DELAY_SECS: float = 5.0
 _last_llm_call_at: float = 0.0
 
 

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -523,22 +523,22 @@ class TestEnforceTurnDelay:
 
     @pytest.mark.anyio
     async def test_recent_call_waits_remainder(self) -> None:
-        """A call made 1s ago should wait ~1s (2s target - 1s elapsed)."""
+        """A call made 3s ago should wait ~2s (5s target - 3s elapsed)."""
         import time
         import agentception.services.agent_loop as al
-        al._last_llm_call_at = time.monotonic() - 1.0
+        al._last_llm_call_at = time.monotonic() - 3.0
         t0 = time.monotonic()
         from agentception.services.agent_loop import _enforce_turn_delay
         await _enforce_turn_delay()
         elapsed = time.monotonic() - t0
-        assert 0.5 < elapsed < 2.0  # ~1s wait, with tolerance
+        assert 1.5 < elapsed < 3.0  # ~2s wait, with tolerance
 
     @pytest.mark.anyio
     async def test_old_call_skips_wait(self) -> None:
-        """A call made 5s ago (> 2s target) incurs no extra wait."""
+        """A call made 10s ago (> 5s target) incurs no extra wait."""
         import time
         import agentception.services.agent_loop as al
-        al._last_llm_call_at = time.monotonic() - 5.0
+        al._last_llm_call_at = time.monotonic() - 10.0
         t0 = time.monotonic()
         from agentception.services.agent_loop import _enforce_turn_delay
         await _enforce_turn_delay()


### PR DESCRIPTION
## Summary
- Raises `_MIN_TURN_DELAY_SECS` from 2s to 5s
- At Tier 2 (90K output TPM), 2s → 30 turns/min → only 3K avg output tokens/turn before hitting the ceiling. 5s → 12 turns/min → 7.5K avg headroom — well above any realistic agent turn
- Input TPM is not the constraint: system-prompt cache reads are excluded from the 450K limit
- Updates `TestEnforceTurnDelay` timing assertions for the 5s target

## Test plan
- [x] mypy clean
- [x] 9/9 relevant tests pass