### PR TITLE
fix: raise inter-turn delay to 7s to eliminate 429 bursts

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -100,12 +100,12 @@ _HISTORY_TAIL: int = 14
 
 # Minimum seconds between consecutive LLM calls.  A proactive fixed cadence
 # beats a reactive burst-then-sleep TPM guard.  At Tier 2 limits (450K input /
-# 90K output TPM, 1K RPM) a 5s floor keeps throughput at ~12 turns/min, giving
-# 7.5K average output tokens per turn of headroom — comfortably above any
+# 90K output TPM, 1K RPM) a 7s floor keeps throughput at ~8.5 turns/min, giving
+# ~10.5K average output tokens per turn of headroom — comfortably above any
 # realistic agent turn.  Input TPM is not the constraint: system-prompt cache
 # reads are excluded from the 450K limit, so uncached input per turn is only
 # new messages and tool results (~1–5K).
-_MIN_TURN_DELAY_SECS: float = 5.0
+_MIN_TURN_DELAY_SECS: float = 7.0
 _last_llm_call_at: float = 0.0
 
 

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -523,10 +523,10 @@ class TestEnforceTurnDelay:
 
     @pytest.mark.anyio
     async def test_recent_call_waits_remainder(self) -> None:
-        """A call made 3s ago should wait ~2s (5s target - 3s elapsed)."""
+        """A call made 5s ago should wait ~2s (7s target - 5s elapsed)."""
         import time
         import agentception.services.agent_loop as al
-        al._last_llm_call_at = time.monotonic() - 3.0
+        al._last_llm_call_at = time.monotonic() - 5.0
         t0 = time.monotonic()
         from agentception.services.agent_loop import _enforce_turn_delay
         await _enforce_turn_delay()
@@ -535,10 +535,10 @@ class TestEnforceTurnDelay:
 
     @pytest.mark.anyio
     async def test_old_call_skips_wait(self) -> None:
-        """A call made 10s ago (> 5s target) incurs no extra wait."""
+        """A call made 15s ago (> 7s target) incurs no extra wait."""
         import time
         import agentception.services.agent_loop as al
-        al._last_llm_call_at = time.monotonic() - 10.0
+        al._last_llm_call_at = time.monotonic() - 15.0
         t0 = time.monotonic()
         from agentception.services.agent_loop import _enforce_turn_delay
         await _enforce_turn_delay()


### PR DESCRIPTION
## Summary
- Raises `_MIN_TURN_DELAY_SECS` 5s → 7s
- 7s → ~8.5 turns/min → ~10.5K avg output headroom per turn, well above realistic agent output
- Empirically: 2s and 5s both produced 429s under sustained reviewer load; 7s is the next calibration point