### PR TITLE
fix: stamp LLM call time after response, not before

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -110,17 +110,23 @@ _last_llm_call_at: float = 0.0
 
 
 async def _enforce_turn_delay() -> None:
-    """Sleep only as long as needed to maintain the minimum inter-turn interval.
+    """Sleep until _MIN_TURN_DELAY_SECS has elapsed since the last LLM call completed.
 
-    If the previous turn's tool calls already took longer than
-    ``_MIN_TURN_DELAY_SECS``, this returns immediately — no extra wait.
+    The timestamp is updated by the caller *after* call_anthropic_with_tools
+    returns, so retry backoff inside the LLM call does not eat into the next
+    window.  If the previous turn's tool dispatch already consumed the full
+    window this returns immediately.
     """
-    global _last_llm_call_at
     elapsed = time.monotonic() - _last_llm_call_at
     wait = _MIN_TURN_DELAY_SECS - elapsed
     if wait > 0.0:
         logger.info("⏳ agent_loop: inter-turn delay — sleeping %.1fs", wait)
         await asyncio.sleep(wait)
+
+
+def _record_llm_call() -> None:
+    """Stamp the completion time of the most recent LLM call."""
+    global _last_llm_call_at
     _last_llm_call_at = time.monotonic()
 
 
@@ -206,10 +212,10 @@ async def run_agent_loop(
             run_id,
         )
 
-        # Proactive inter-turn pacing: ensure at least _MIN_TURN_DELAY_SECS
-        # between LLM calls.  Turn 1 is always instant (no prior call).
-        # If tool calls on the previous turn already consumed the window,
-        # _enforce_turn_delay returns immediately with no extra wait.
+        # Proactive inter-turn pacing.  _last_llm_call_at is stamped *after*
+        # call_anthropic_with_tools returns (including any retry backoff), so
+        # the full _MIN_TURN_DELAY_SECS gap is always preserved between the end
+        # of one LLM interaction and the start of the next.
         await _enforce_turn_delay()
 
         try:
@@ -220,11 +226,14 @@ async def run_agent_loop(
                 tools=tool_defs,
             )
         except Exception as exc:
+            _record_llm_call()  # stamp even on error so next delay is measured correctly
             logger.exception("❌ agent_loop LLM error on iteration %d", iteration)
             await github_client.close()
             await log_run_error(issue_number, f"LLM error: {exc}", run_id)
             await build_cancel_run(run_id)
             return
+
+        _record_llm_call()  # stamp after successful response — this is the reference point for the next delay
 
         # Append assistant message to history.
         assistant_msg: dict[str, object] = {"role": "assistant", "content": response["content"]}

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -544,6 +544,31 @@ class TestEnforceTurnDelay:
         await _enforce_turn_delay()
         assert time.monotonic() - t0 < 1.0
 
+    def test_record_llm_call_updates_timestamp(self) -> None:
+        """_record_llm_call stamps _last_llm_call_at so the next delay is measured correctly."""
+        import time
+        import agentception.services.agent_loop as al
+        from agentception.services.agent_loop import _record_llm_call
+        al._last_llm_call_at = 0.0
+        before = time.monotonic()
+        _record_llm_call()
+        assert al._last_llm_call_at >= before
+
+    @pytest.mark.anyio
+    async def test_retry_backoff_does_not_eat_next_window(self) -> None:
+        """Delay is measured from after the LLM call, not before — retries don't collapse the gap."""
+        import time
+        import agentception.services.agent_loop as al
+        from agentception.services.agent_loop import _enforce_turn_delay, _record_llm_call
+
+        # Simulate: _record_llm_call() called just now (LLM call just completed)
+        _record_llm_call()
+        t0 = time.monotonic()
+        await _enforce_turn_delay()
+        # Should wait close to _MIN_TURN_DELAY_SECS, not skip due to stale timestamp
+        elapsed = time.monotonic() - t0
+        assert elapsed >= 6.0  # within 1s tolerance of the 7s target
+
 
 class TestLLMSSLRetry:
     """Regression tests: ssl.SSLError is retried, not propagated (bug: run killed by transient TLS error)."""


### PR DESCRIPTION
## Summary
- `_last_llm_call_at` was set *before* `call_anthropic_with_tools`, so retry backoff (2s + 4s) counted against the next window, collapsing it to zero and producing 429 bursts
- Introduces `_record_llm_call()`, called immediately after `call_anthropic_with_tools` returns on both success and error paths
- `_enforce_turn_delay` is now a pure "sleep until ready" function with no side effects
- The 7s gap is now measured from when the last LLM interaction *completed*, matching the pattern in `debug_loop.py`

## Test plan
- [x] mypy clean
- [x] 5/5 `TestEnforceTurnDelay` tests pass, including new regression tests for `_record_llm_call` and window preservation after an immediate call