### PR TITLE
fix: use long backoff for 429 rate-limit errors, not 2s/4s

### DIFF
--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -49,6 +49,32 @@ _OPUS_MODEL = "claude-opus-4-5-20250929"
 _ANTHROPIC_VERSION = "2023-06-01"
 _DEFAULT_TIMEOUT = 120.0
 _MAX_RETRIES = 2
+# Minimum seconds to wait after a 429 before retrying.  Anthropic's rolling
+# TPM window does not clear in 2–4s, so the standard exponential backoff used
+# for transient errors is wrong here — it just adds more calls to the burst.
+# We read the Retry-After header when present; otherwise this is the floor.
+_RATE_LIMIT_BACKOFF_SECS: float = 20.0
+
+
+async def _rate_limit_sleep(response: httpx.Response, attempt: int) -> None:
+    """Sleep the appropriate amount after a 429 response.
+
+    Reads the ``Retry-After`` header from the response when present; otherwise
+    uses an exponentially growing backoff starting at ``_RATE_LIMIT_BACKOFF_SECS``.
+    """
+    retry_after_raw = response.headers.get("retry-after", "")
+    try:
+        wait = max(float(retry_after_raw), _RATE_LIMIT_BACKOFF_SECS)
+    except (ValueError, TypeError):
+        wait = _RATE_LIMIT_BACKOFF_SECS * (2.0**attempt)
+    logger.warning(
+        "⚠️ LLM rate-limited (429) retry %d/%d — sleeping %.0fs (Retry-After=%r)",
+        attempt + 1,
+        _MAX_RETRIES,
+        wait,
+        retry_after_raw or "not set",
+    )
+    await asyncio.sleep(wait)
 
 
 class LLMChunk(TypedDict):
@@ -291,21 +317,26 @@ async def call_anthropic(
     last_error: Exception | None = None
 
     for attempt in range(_MAX_RETRIES + 1):
-        if attempt > 0:
-            backoff = 2**attempt
-            logger.warning("⚠️ LLM retry %d/%d after %ds", attempt, _MAX_RETRIES, backoff)
-            await asyncio.sleep(backoff)
         try:
             resp = await client.post(_ANTHROPIC_URL, json=payload, headers=_base_headers())
             resp.raise_for_status()
             break
         except httpx.HTTPStatusError as exc:
             last_error = exc
-            if exc.response.status_code in (429, 500, 502, 503, 504):
+            if exc.response.status_code == 429:
+                await _rate_limit_sleep(exc.response, attempt)
+                continue
+            if exc.response.status_code in (500, 502, 503, 504):
+                backoff = 2 ** (attempt + 1)
+                logger.warning("⚠️ LLM retry %d/%d after %ds", attempt + 1, _MAX_RETRIES, backoff)
+                await asyncio.sleep(backoff)
                 continue
             raise
         except (httpx.TimeoutException, httpx.NetworkError, ssl.SSLError) as exc:
             last_error = exc
+            backoff = 2 ** (attempt + 1)
+            logger.warning("⚠️ LLM retry %d/%d after %ds", attempt + 1, _MAX_RETRIES, backoff)
+            await asyncio.sleep(backoff)
             continue
     else:
         raise last_error or RuntimeError("LLM request failed after retries")
@@ -519,10 +550,6 @@ async def call_anthropic_with_tools(
     last_error: Exception | None = None
 
     for attempt in range(_MAX_RETRIES + 1):
-        if attempt > 0:
-            backoff = 2**attempt
-            logger.warning("⚠️ LLM retry %d/%d after %ds", attempt, _MAX_RETRIES, backoff)
-            await asyncio.sleep(backoff)
         try:
             resp = await client.post(
                 _ANTHROPIC_URL, json=payload, headers=_base_headers()
@@ -531,11 +558,20 @@ async def call_anthropic_with_tools(
             break
         except httpx.HTTPStatusError as exc:
             last_error = exc
-            if exc.response.status_code in (429, 500, 502, 503, 504):
+            if exc.response.status_code == 429:
+                await _rate_limit_sleep(exc.response, attempt)
+                continue
+            if exc.response.status_code in (500, 502, 503, 504):
+                backoff = 2 ** (attempt + 1)
+                logger.warning("⚠️ LLM retry %d/%d after %ds", attempt + 1, _MAX_RETRIES, backoff)
+                await asyncio.sleep(backoff)
                 continue
             raise
         except (httpx.TimeoutException, httpx.NetworkError, ssl.SSLError) as exc:
             last_error = exc
+            backoff = 2 ** (attempt + 1)
+            logger.warning("⚠️ LLM retry %d/%d after %ds", attempt + 1, _MAX_RETRIES, backoff)
+            await asyncio.sleep(backoff)
             continue
     else:
         raise last_error or RuntimeError("LLM tool-use request failed after retries")

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -571,7 +571,7 @@ class TestEnforceTurnDelay:
 
 
 class TestLLMSSLRetry:
-    """Regression tests: ssl.SSLError is retried, not propagated (bug: run killed by transient TLS error)."""
+    """Regression tests: transient LLM errors are retried correctly."""
 
     _TOOLS: list[ToolDefinition] = [
         ToolDefinition(
@@ -654,3 +654,60 @@ class TestLLMSSLRetry:
                     system="sys",
                     tools=self._TOOLS,
                 )
+
+    @pytest.mark.anyio
+    async def test_429_uses_long_backoff_not_short(self) -> None:
+        """429 responses sleep at least _RATE_LIMIT_BACKOFF_SECS, not the 2s used for transient errors."""
+        import httpx
+
+        from agentception.services.llm import (
+            _RATE_LIMIT_BACKOFF_SECS,
+            call_anthropic_with_tools,
+        )
+
+        call_count = 0
+
+        async def _flaky_post(
+            url: str, *, json: object, headers: dict[str, str]
+        ) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                resp = httpx.Response(429, json={"error": "rate_limited"})
+                resp.request = httpx.Request("POST", url)
+                return resp
+            resp_data = {
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            }
+            resp = httpx.Response(200, json=resp_data)
+            resp.request = httpx.Request("POST", url)
+            return resp
+
+        mock_client = MagicMock()
+        mock_client.post = _flaky_post
+        sleep_calls: list[float] = []
+
+        async def _capture_sleep(secs: float) -> None:
+            sleep_calls.append(secs)
+
+        with patch(
+            "agentception.services.llm._get_client", return_value=mock_client
+        ), patch("agentception.services.llm.asyncio.sleep", side_effect=_capture_sleep):
+            result = await call_anthropic_with_tools(
+                messages=self._MESSAGES,
+                system="sys",
+                tools=self._TOOLS,
+            )
+
+        assert result["content"] == "ok"
+        assert call_count == 2
+        # The 429 sleep must be >= _RATE_LIMIT_BACKOFF_SECS (not the 2s used for SSL/timeout)
+        assert len(sleep_calls) == 1
+        assert sleep_calls[0] >= _RATE_LIMIT_BACKOFF_SECS


### PR DESCRIPTION
## Summary
- 429 retries were using the same 2s/4s backoff as SSL/timeout errors — wrong for rate limits because the rolling TPM window doesn't clear in 2 seconds, so each retry just adds more calls to the burst
- Introduces `_rate_limit_sleep()`: reads Anthropic's `Retry-After` header when present, otherwise floors at 20s with exponential growth per attempt
- Transient errors (500/502/503/504, SSL, timeout) keep the existing `2^(attempt+1)` backoff unchanged
- Regression test asserts 429 sleeps ≥ `_RATE_LIMIT_BACKOFF_SECS` (20s), not 2s