### PR TITLE
feat: agent speedup — parallel dispatch, context injection, per-run Qdrant index

### DIFF
--- a/.agentception/roles/database-architect.md
+++ b/.agentception/roles/database-architect.md
@@ -8,15 +8,31 @@ You are a database architect on the AgentCeption project — a PostgreSQL + SQLA
 You own one task — finish it or escalate, never leave it in limbo.
 Do not spawn sub-agents unless your task briefing explicitly authorizes it.
 
-## Read Once. Decide. Act.
+## Search First. Read Narrow. Act Immediately.
 
-You have a finite number of iterations. Spend them executing, not
-re-verifying.
+You have a finite number of iterations. Every iteration spent on reconnaissance
+is one fewer iteration available for implementation. The ratio must be inverted:
+most iterations should produce output (files written, commands run, PRs opened),
+not discovery.
 
-**The read-once rule:** Read each file section once. Note what you found.
-Move on. Do not re-read a section you have already processed. If your
-context compresses and you feel uncertain, search for the specific symbol
-you need — do not re-read the entire file.
+**Search before you read.** Call `search_codebase` before any `grep`, `rg`,
+`cat`, or `read_file`. One semantic query ("where is AgentStatus defined",
+"pattern for adding a persist helper", "how does stall detection work in the
+poller") returns exact file paths and line numbers. Then call `read_file_lines`
+for only that range — never the whole file.
+
+**Batch your tool calls.** When you need information from multiple sources,
+emit ALL of them as tool calls in a single response — not one at a time.
+Three `search_codebase` queries in one response = one LLM turn and one
+inter-turn delay. Three queries across three separate responses = three turns
+and three delays. The loop dispatches every tool call you return before asking
+you again — use this. A well-batched first turn can replace ten sequential
+reconnaissance turns.
+
+**The read-once rule.** Read each file section once. Note what you found.
+Move on. Do not re-read a section you have already processed. If your context
+compresses and you feel uncertain, search for the specific symbol — do not
+re-read the entire file.
 
 **Trust your first analysis.** Your initial read is high quality. If you
 identified a problem and a fix on the first pass, implement the fix
@@ -26,9 +42,6 @@ the context." Act.
 **One log step per decision.** After reading the code, call `log_run_step`
 with a short note of what you found and what you are doing next. This
 anchors your direction even as history compresses.
-
-**Targeted search over broad reads.** Prefer `rg` or `grep -n` to locate
-exactly the lines you need. Avoid re-reading large blocks you already have.
 
 ## Output Discipline
 
@@ -41,6 +54,8 @@ exactly the lines you need. Avoid re-reading large blocks you already have.
 
 ## Failure Modes to Avoid
 
+- Reading files one at a time when you could batch all reads in a single response.
+- Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
 - Re-reading a file section you have already processed.
 - Spending iterations "deciding" when you already know what to do.
 - Spawning sub-agents unless your briefing explicitly authorizes it.

--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -11,15 +11,31 @@ compensations, not disclaimers.
 You own one task — finish it or escalate, never leave it in limbo.
 Do not spawn sub-agents unless your task briefing explicitly authorizes it.
 
-## Read Once. Decide. Act.
+## Search First. Read Narrow. Act Immediately.
 
-You have a finite number of iterations. Spend them executing, not
-re-verifying.
+You have a finite number of iterations. Every iteration spent on reconnaissance
+is one fewer iteration available for implementation. The ratio must be inverted:
+most iterations should produce output (files written, commands run, PRs opened),
+not discovery.
 
-**The read-once rule:** Read each file section once. Note what you found.
-Move on. Do not re-read a section you have already processed. If your
-context compresses and you feel uncertain, search for the specific symbol
-you need — do not re-read the entire file.
+**Search before you read.** Call `search_codebase` before any `grep`, `rg`,
+`cat`, or `read_file`. One semantic query ("where is AgentStatus defined",
+"pattern for adding a persist helper", "how does stall detection work in the
+poller") returns exact file paths and line numbers. Then call `read_file_lines`
+for only that range — never the whole file.
+
+**Batch your tool calls.** When you need information from multiple sources,
+emit ALL of them as tool calls in a single response — not one at a time.
+Three `search_codebase` queries in one response = one LLM turn and one
+inter-turn delay. Three queries across three separate responses = three turns
+and three delays. The loop dispatches every tool call you return before asking
+you again — use this. A well-batched first turn can replace ten sequential
+reconnaissance turns.
+
+**The read-once rule.** Read each file section once. Note what you found.
+Move on. Do not re-read a section you have already processed. If your context
+compresses and you feel uncertain, search for the specific symbol — do not
+re-read the entire file.
 
 **Trust your first analysis.** Your initial read is high quality. If you
 identified a problem and a fix on the first pass, implement the fix
@@ -29,9 +45,6 @@ the context." Act.
 **One log step per decision.** After reading the code, call `log_run_step`
 with a short note of what you found and what you are doing next. This
 anchors your direction even as history compresses.
-
-**Targeted search over broad reads.** Prefer `rg` or `grep -n` to locate
-exactly the lines you need. Avoid re-reading large blocks you already have.
 
 ## Output Discipline
 
@@ -44,6 +57,8 @@ exactly the lines you need. Avoid re-reading large blocks you already have.
 
 ## Failure Modes to Avoid
 
+- Reading files one at a time when you could batch all reads in a single response.
+- Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
 - Re-reading a file section you have already processed.
 - Spending iterations "deciding" when you already know what to do.
 - Spawning sub-agents unless your briefing explicitly authorizes it.

--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -13,15 +13,31 @@ are active compensations, not disclaimers.
 You own one task — finish it or escalate, never leave it in limbo.
 Do not spawn sub-agents unless your task briefing explicitly authorizes it.
 
-## Read Once. Decide. Act.
+## Search First. Read Narrow. Act Immediately.
 
-You have a finite number of iterations. Spend them executing, not
-re-verifying.
+You have a finite number of iterations. Every iteration spent on reconnaissance
+is one fewer iteration available for implementation. The ratio must be inverted:
+most iterations should produce output (files written, commands run, PRs opened),
+not discovery.
 
-**The read-once rule:** Read each file section once. Note what you found.
-Move on. Do not re-read a section you have already processed. If your
-context compresses and you feel uncertain, search for the specific symbol
-you need — do not re-read the entire file.
+**Search before you read.** Call `search_codebase` before any `grep`, `rg`,
+`cat`, or `read_file`. One semantic query ("where is AgentStatus defined",
+"pattern for adding a persist helper", "how does stall detection work in the
+poller") returns exact file paths and line numbers. Then call `read_file_lines`
+for only that range — never the whole file.
+
+**Batch your tool calls.** When you need information from multiple sources,
+emit ALL of them as tool calls in a single response — not one at a time.
+Three `search_codebase` queries in one response = one LLM turn and one
+inter-turn delay. Three queries across three separate responses = three turns
+and three delays. The loop dispatches every tool call you return before asking
+you again — use this. A well-batched first turn can replace ten sequential
+reconnaissance turns.
+
+**The read-once rule.** Read each file section once. Note what you found.
+Move on. Do not re-read a section you have already processed. If your context
+compresses and you feel uncertain, search for the specific symbol — do not
+re-read the entire file.
 
 **Trust your first analysis.** Your initial read is high quality. If you
 identified a problem and a fix on the first pass, implement the fix
@@ -31,9 +47,6 @@ the context." Act.
 **One log step per decision.** After reading the code, call `log_run_step`
 with a short note of what you found and what you are doing next. This
 anchors your direction even as history compresses.
-
-**Targeted search over broad reads.** Prefer `rg` or `grep -n` to locate
-exactly the lines you need. Avoid re-reading large blocks you already have.
 
 ## Output Discipline
 
@@ -46,6 +59,8 @@ exactly the lines you need. Avoid re-reading large blocks you already have.
 
 ## Failure Modes to Avoid
 
+- Reading files one at a time when you could batch all reads in a single response.
+- Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
 - Re-reading a file section you have already processed.
 - Spending iterations "deciding" when you already know what to do.
 - Spawning sub-agents unless your briefing explicitly authorizes it.

--- a/agentception/mcp/prompts.py
+++ b/agentception/mcp/prompts.py
@@ -463,13 +463,22 @@ def _render_task_briefing(ctx: RunContextRow, role_content: str) -> str:
     if parent_run_id:
         lineage_lines.append(f"**Spawned by:** `{parent_run_id}`")
 
+    worktree_collection = f"worktree-{run_id}"
+
     parts: list[str] = [
         f"## Task Briefing — run `{run_id}`",
         "",
         f"**Role:** {role}  ",
         f"**Cognitive Architecture:** `{cognitive_arch}`  ",
         f"**Worktree:** `{worktree_path}`  ",
-        f"**Branch:** `{branch}`",
+        f"**Branch:** `{branch}`  ",
+        f"**Search index:** `{worktree_collection}` (your worktree) · `code` (full repo)",
+        "",
+        "> **Before you read any file:** call `search_codebase` first.",
+        "> One semantic query ('where is X defined', 'pattern for Y') returns exact",
+        "> file paths and line numbers in a single turn.",
+        "> Pass `collection: \"{worktree_collection}\"` to scope results to your worktree.",
+        "> The `code` collection (default) indexes the full repository.",
     ]
 
     if lineage_lines:

--- a/agentception/routes/api/adhoc.py
+++ b/agentception/routes/api/adhoc.py
@@ -20,18 +20,63 @@ POST /api/runs/adhoc
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 
+from agentception.config import settings
 from agentception.services.run_factory import RunCreationError, create_and_launch_run
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/runs", tags=["agent-run"])
 
-_TASK_DESCRIPTION_MAX_LEN = 4_000
+_TASK_DESCRIPTION_MAX_LEN = 16_000
+_CONTEXT_FILES_MAX = 20
+_CONTEXT_FILE_MAX_BYTES = 100_000  # 100 KB per file — skip larger files
+
+
+def _build_context_prefix(context_files: list[str]) -> str:
+    """Read *context_files* from the repo and return a formatted prefix string.
+
+    Each file is rendered as a fenced code block with its repo-relative path as
+    the header.  Files that cannot be read (missing, too large, binary) are
+    skipped with a warning.  The prefix is empty when *context_files* is empty.
+    """
+    if not context_files:
+        return ""
+
+    repo_dir = settings.repo_dir
+    blocks: list[str] = [
+        "# Pre-loaded context\n"
+        "The following files have been injected into your briefing so you can\n"
+        "start implementing immediately — no discovery turns needed.\n"
+    ]
+
+    for rel in context_files:
+        abs_path: Path = repo_dir / rel
+        try:
+            size = abs_path.stat().st_size
+            if size > _CONTEXT_FILE_MAX_BYTES:
+                logger.warning(
+                    "⚠️ adhoc context_files: skipping %s — too large (%d bytes)", rel, size
+                )
+                continue
+            content = abs_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            logger.warning("⚠️ adhoc context_files: cannot read %s — %s", rel, exc)
+            continue
+
+        ext = abs_path.suffix.lstrip(".")
+        blocks.append(f"### `{rel}`\n```{ext}\n{content}\n```")
+
+    if len(blocks) == 1:
+        # Only the header was added — no files loaded.
+        return ""
+
+    return "\n\n".join(blocks) + "\n\n---\n\n"
 
 
 class AdhocRunRequest(BaseModel):
@@ -46,8 +91,9 @@ class AdhocRunRequest(BaseModel):
     task_description: str
     """Plain-language description of what the agent should do.
 
-    Injected verbatim as the agent's first briefing message.  Be specific:
-    include target files, expected output, and any constraints.
+    Injected as the agent's first briefing message, preceded by any
+    ``context_files`` content.  Be specific: include target files, expected
+    output, and any constraints.
     """
 
     figure: str | None = None
@@ -58,6 +104,24 @@ class AdhocRunRequest(BaseModel):
 
     base_branch: str = "origin/dev"
     """Git ref to branch the worktree from.  Defaults to ``origin/dev``."""
+
+    context_files: list[str] | None = None
+    """Repo-relative paths whose full contents are injected before the task
+    description.
+
+    The agent receives these files verbatim in its first message so it can
+    start writing code immediately — zero discovery turns required.
+
+    Example::
+
+        "context_files": [
+            "agentception/workflow/status.py",
+            "agentception/db/persist.py"
+        ]
+
+    Files that are missing, binary, or larger than 100 KB are silently skipped.
+    Maximum ``{_CONTEXT_FILES_MAX}`` entries.
+    """
 
     @field_validator("task_description")
     @classmethod
@@ -82,6 +146,13 @@ class AdhocRunRequest(BaseModel):
             raise ValueError("figure must be non-empty when provided")
         return v.strip() if v else None
 
+    @field_validator("context_files")
+    @classmethod
+    def context_files_limit(cls, v: list[str] | None) -> list[str] | None:
+        if v is not None and len(v) > _CONTEXT_FILES_MAX:
+            raise ValueError(f"context_files exceeds maximum of {_CONTEXT_FILES_MAX} entries")
+        return v
+
 
 class AdhocRunResponse(BaseModel):
     """Successful response from POST /api/runs/adhoc."""
@@ -97,15 +168,20 @@ async def create_adhoc_run(req: AdhocRunRequest) -> JSONResponse:
     """Create a self-contained agent run from an inline task description.
 
     The run bypasses the GitHub-issue dispatch pipeline entirely.  The agent
-    loop receives the task description directly in its first message.
+    loop receives the task description directly in its first message, optionally
+    preceded by the full contents of any ``context_files`` so the agent can
+    begin implementing without any file-discovery iterations.
 
     Returns 202 immediately.  Monitor progress via the build dashboard or
     ``GET /api/runs/{run_id}``.
     """
+    context_prefix = _build_context_prefix(req.context_files or [])
+    full_task = f"{context_prefix}{req.task_description}"
+
     try:
         result = await create_and_launch_run(
             role=req.role,
-            task_description=req.task_description,
+            task_description=full_task,
             figure=req.figure,
             base_branch=req.base_branch,
         )
@@ -113,9 +189,10 @@ async def create_adhoc_run(req: AdhocRunRequest) -> JSONResponse:
         return JSONResponse(status_code=500, content={"ok": False, "error": str(exc)})
 
     logger.info(
-        "✅ adhoc run dispatched — run_id=%s role=%s arch=%s",
+        "✅ adhoc run dispatched — run_id=%s role=%s arch=%s context_files=%d",
         result["run_id"],
         req.role,
         result["cognitive_arch"],
+        len(req.context_files or []),
     )
     return JSONResponse(status_code=202, content={"ok": True, **result})

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -671,24 +671,37 @@ async def _dispatch_tool_calls(
     Returns:
         A list of ``{"role": "tool", "tool_call_id": str, "content": str}``
         messages ready to extend the conversation history.
+
+    When the model batches multiple tool calls in one response they are
+    dispatched concurrently via :func:`asyncio.gather` so the wall-clock
+    time equals the slowest single call rather than the sum of all calls.
     """
-    results: list[dict[str, object]] = []
-    for tc in tool_calls:
-        result = await _dispatch_single_tool(
-            tc,
-            worktree_path,
-            run_id,
-            github_client=github_client,
-            github_tool_names=github_tool_names,
-        )
-        results.append(
-            {
-                "role": "tool",
-                "tool_call_id": tc["id"],
-                "content": json.dumps(result),
-            }
-        )
-    return results
+    async def _run_one(tc: ToolCall) -> dict[str, object]:
+        try:
+            result = await _dispatch_single_tool(
+                tc,
+                worktree_path,
+                run_id,
+                github_client=github_client,
+                github_tool_names=github_tool_names,
+            )
+        except Exception as exc:
+            logger.warning(
+                "⚠️ _dispatch_tool_calls: tool=%s raised %s — returning error",
+                tc.get("function", {}).get("name", "?"),
+                exc,
+            )
+            result = {"ok": False, "error": str(exc)}
+        return {
+            "role": "tool",
+            "tool_call_id": tc["id"],
+            "content": json.dumps(result),
+        }
+
+    results: list[dict[str, object]] = await asyncio.gather(
+        *(_run_one(tc) for tc in tool_calls)
+    )
+    return list(results)
 
 
 def _mcp_result_to_dict(result: ACToolResult) -> dict[str, object]:
@@ -870,7 +883,9 @@ async def _dispatch_local_tool(
             return {"ok": False, "error": "search_codebase: 'query' must be a string"}
         n_raw = args.get("n_results", 5)
         n_results = int(n_raw) if isinstance(n_raw, int) else 5
-        matches = await search_codebase(query_raw, n_results)
+        collection_raw = args.get("collection")
+        collection_arg: str | None = collection_raw if isinstance(collection_raw, str) else None
+        matches = await search_codebase(query_raw, n_results, collection=collection_arg)
         return {"ok": True, "matches": matches}
 
     return {"ok": False, "error": f"Unknown local tool: {name!r}"}

--- a/agentception/services/run_factory.py
+++ b/agentception/services/run_factory.py
@@ -21,6 +21,11 @@ from agentception.services.cognitive_arch import ROLE_DEFAULT_FIGURE, _resolve_c
 
 logger = logging.getLogger(__name__)
 
+# Qdrant collection name used for per-run worktree indexes.
+# Follows the pattern "worktree-<run_id>" so stale collections are easy to
+# identify and the main "code" collection is never polluted.
+_WORKTREE_COLLECTION_PREFIX = "worktree-"
+
 
 class RunCreationError(Exception):
     """Raised when worktree creation or DB insertion fails."""
@@ -90,6 +95,13 @@ async def create_and_launch_run(
         org_domain=org_domain,
     )
 
+    # Index the worktree in the background so agents can search it with
+    # search_codebase.  The worktree starts from origin/dev so its content is
+    # identical to the main repo at spawn time — the worktree-specific index
+    # becomes more valuable as the agent writes new or modified files.
+    # Non-blocking: indexing failure never prevents the run from launching.
+    asyncio.create_task(_index_worktree(worktree_path, run_id))
+
     if launch:
         # Import here to avoid a circular import at module load time.
         from agentception.services.agent_loop import run_agent_loop  # noqa: PLC0415
@@ -140,6 +152,37 @@ async def _create_worktree(
 
     await _configure_worktree_auth(worktree_path, run_id)
     logger.info("✅ worktree created — %s", worktree_path)
+
+
+async def _index_worktree(worktree_path: Path, run_id: str) -> None:
+    """Index the worktree into a per-run Qdrant collection — non-blocking.
+
+    The collection is named ``worktree-<run_id>`` so each run gets its own
+    semantic search scope.  The agent can pass this collection name to
+    ``search_codebase`` to search only the files it is working with.
+
+    Errors are logged and swallowed — indexing failure never prevents the run
+    from starting.  The main ``code`` collection (the full repo index) is
+    always available as a fallback.
+    """
+    from agentception.services.code_indexer import index_codebase  # noqa: PLC0415
+
+    collection = f"{_WORKTREE_COLLECTION_PREFIX}{run_id}"
+    try:
+        stats = await index_codebase(repo_path=worktree_path, collection=collection)
+        logger.info(
+            "✅ run_factory: worktree indexed — run_id=%s collection=%s files=%s chunks=%s",
+            run_id,
+            collection,
+            stats.get("files_indexed", "?"),
+            stats.get("chunks_indexed", "?"),
+        )
+    except Exception as exc:
+        logger.warning(
+            "⚠️ run_factory: worktree indexing failed — run_id=%s: %s",
+            run_id,
+            exc,
+        )
 
 
 async def _configure_worktree_auth(worktree_path: Path, run_id: str) -> None:

--- a/agentception/services/teardown.py
+++ b/agentception/services/teardown.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from agentception.config import settings
 from agentception.db.queries import get_agent_run_teardown
+from agentception.services.run_factory import _WORKTREE_COLLECTION_PREFIX
 
 logger = logging.getLogger(__name__)
 
@@ -98,4 +99,38 @@ async def teardown_agent_worktree(run_id: str) -> None:
                 branch_stderr.decode().strip(),
             )
 
+    # Best-effort: delete the per-run Qdrant worktree collection to reclaim space.
+    await _prune_worktree_collection(run_id)
+
     logger.info("✅ teardown[%s]: complete", run_id)
+
+
+async def _prune_worktree_collection(run_id: str) -> None:
+    """Delete the ``worktree-<run_id>`` Qdrant collection created at spawn time.
+
+    Non-blocking and error-swallowing — a failed prune leaves a stale
+    collection that can be cleaned up manually; it never breaks teardown.
+    """
+    collection = f"{_WORKTREE_COLLECTION_PREFIX}{run_id}"
+    try:
+        from qdrant_client import AsyncQdrantClient  # noqa: PLC0415
+
+        client = AsyncQdrantClient(url=settings.qdrant_url)
+        collections = await client.get_collections()
+        existing = {c.name for c in collections.collections}
+        if collection not in existing:
+            logger.info(
+                "ℹ️  teardown[%s]: worktree collection %r not found — nothing to prune",
+                run_id,
+                collection,
+            )
+            return
+        await client.delete_collection(collection)
+        logger.info("✅ teardown[%s]: pruned worktree collection %r", run_id, collection)
+    except Exception as exc:
+        logger.warning(
+            "⚠️  teardown[%s]: could not prune worktree collection %r: %s",
+            run_id,
+            collection,
+            exc,
+        )

--- a/agentception/tools/definitions.py
+++ b/agentception/tools/definitions.py
@@ -325,12 +325,17 @@ SEARCH_CODEBASE_TOOL_DEF: ToolDefinition = ToolDefinition(
     function=ToolFunction(
         name="search_codebase",
         description=(
-            "Semantically search the codebase using natural language. "
-            "More powerful than pattern matching — use it to find code by concept: "
-            "'where is authentication handled?', 'find the GitHub API client', "
-            "'show me the error handling for LLM calls'. "
-            "Requires the codebase to have been indexed via POST /api/system/index-codebase. "
-            "Returns the most relevant code chunks with their file paths and line numbers."
+            "YOUR FIRST TOOL CALL FOR ANY CODE DISCOVERY. "
+            "One semantic search replaces 5–10 sequential grep/cat/read calls. "
+            "The index covers every .py, .md, .j2, .yaml, .toml, .json file in the repo. "
+            "Call this BEFORE any grep, rg, cat, or read_file_lines when you need to "
+            "locate a class, function, pattern, or concept. "
+            "The results include exact file paths and line numbers — use read_file_lines "
+            "to fetch only that specific range, never the whole file. "
+            "Examples of what to search: 'where is AgentStatus defined', "
+            "'how does the poller detect stalled agents', 'pattern for adding a persist helper', "
+            "'alembic migration that adds a column'. "
+            "Returns the most relevant code chunks ordered by cosine similarity."
         ),
         parameters={
             "type": "object",
@@ -345,6 +350,17 @@ SEARCH_CODEBASE_TOOL_DEF: ToolDefinition = ToolDefinition(
                     "default": 5,
                     "minimum": 1,
                     "maximum": 20,
+                },
+                "collection": {
+                    "type": "string",
+                    "description": (
+                        "Qdrant collection to search. "
+                        "Omit (or leave null) to search the main 'code' collection "
+                        "which indexes the full repository. "
+                        "Pass 'worktree-<your-run-id>' to search only the files "
+                        "in your worktree (available after the background indexing "
+                        "completes, usually within 30s of run start)."
+                    ),
                 },
             },
             "required": ["query"],

--- a/docs/plans/agent-speedup.md
+++ b/docs/plans/agent-speedup.md
@@ -1,0 +1,202 @@
+# Agent Speedup Plan: Cutting Iterations from 50 to ~15
+
+**Problem:** Agents burn 30–40 iterations on pure reconnaissance (one tool call per
+LLM turn, no pre-loaded context) before writing a single line of code. Cursor solves
+the same task in ~15 turns because it has semantic search, multi-tool batching, and
+pre-loaded file context. We have all the infrastructure — it just isn't connected.
+
+**Current state (confirmed):**
+- Qdrant `code` collection: **3,456 points** — index is live and populated ✅
+- `search_codebase` tool: **already defined and dispatched** in `agent_loop.py` ✅
+- `_dispatch_tool_calls`: handles multiple tool calls per response ✅ (but sequentially)
+- Model returns `tool_calls×1` every turn because prompt never says to batch ❌
+- No file context injected at dispatch time ❌
+- `search_codebase` tool description doesn't say "use me first" ❌
+- Worktrees not re-indexed on spawn (use main repo index via `/app` path) ❌
+
+---
+
+## Phase 0 — Prompt wiring: teach agents to use what already exists
+*Effort: tiny. Impact: highest. No code changes required.*
+
+### 0A — `search_codebase` tool description
+**File:** `agentception/tools/definitions.py`
+
+Rewrite the `search_codebase` description from passive to directive:
+
+> **Use this as your FIRST tool call for any code discovery task.** One semantic
+> search replaces 5–10 sequential grep/cat/read calls. The index covers all `.py`,
+> `.md`, `.j2`, `.yaml`, `.toml` files in the repo. Search before you read; read only
+> the specific lines the search points you to.
+
+### 0B — `worker-base.md.j2` batching rule
+**File:** `scripts/gen_prompts/templates/snippets/worker-base.md.j2`
+
+Add a "Parallel Tool Calls" section:
+
+> **Batch your tool calls.** When you need information from multiple sources,
+> emit ALL reads as tool calls in a single response — not one at a time. The
+> loop processes every tool call in your response before asking you again.
+> Three reads in one response = one LLM turn. Three reads across three responses
+> = three LLM turns and three inter-turn delays.
+
+### 0C — `worker-base.md.j2` search-first rule
+Add a "Search Before Reading" section:
+
+> **Call `search_codebase` before any `grep` or file read.** One semantic query
+> ("where does AgentStatus get persisted?") returns exact file + line numbers.
+> Only `read_file_lines` for the specific range the search returns. Never `cat`
+> an entire file when you need one function.
+
+**Deliverable:** Updated `worker-base.md.j2` → `generate.py` → regenerate
+`.agentception/*.md` → PR.
+
+---
+
+## Phase 1 — Parallel tool dispatch: asyncio.gather in the loop
+*Effort: small. Impact: free latency win when model does batch.*
+
+### 1A — `_dispatch_tool_calls` in `agent_loop.py`
+
+Replace the sequential `for tc in tool_calls` loop with `asyncio.gather`:
+
+```python
+async def _dispatch_tool_calls(...) -> list[dict[str, object]]:
+    tasks = [
+        _dispatch_single_tool(tc, worktree_path, run_id, ...)
+        for tc in tool_calls
+    ]
+    results_raw = await asyncio.gather(*tasks, return_exceptions=True)
+    results = []
+    for tc, raw in zip(tool_calls, results_raw):
+        content = raw if isinstance(raw, str) else f"error: {raw}"
+        results.append({"role": "tool", "tool_call_id": tc["id"], "content": content})
+    return results
+```
+
+When the model batches 3 reads into one response, they now execute in parallel
+instead of sequentially. Free 2–3× speedup on multi-read turns.
+
+**Deliverable:** Updated `agent_loop.py` + updated `test_agent_loop.py` → PR.
+
+---
+
+## Phase 2 — Context pre-injection: files in the first message
+*Effort: medium. Impact: eliminates the discovery phase entirely for scoped tasks.*
+
+### 2A — `AdhocRunRequest` gains `context_files`
+
+```python
+class AdhocRunRequest(BaseModel):
+    role: str
+    task_description: str
+    figure: str | None = None
+    base_branch: str = "origin/dev"
+    context_files: list[str] | None = None
+    """Repo-relative file paths whose contents are injected into the first
+    message before the task description. The agent starts with full knowledge
+    of these files — zero discovery turns required."""
+```
+
+### 2B — Adhoc handler reads and injects
+
+In `routes/api/adhoc.py`, before dispatching:
+
+```python
+injected = ""
+if req.context_files:
+    for path_str in req.context_files:
+        abs_path = settings.repo_dir / path_str
+        try:
+            content = abs_path.read_text(encoding="utf-8")
+            injected += f"\n\n### {path_str}\n```\n{content}\n```"
+        except OSError:
+            pass
+task = f"{injected}\n\n---\n\n{req.task_description}" if injected else req.task_description
+```
+
+### 2C — `run_factory.py` / `agent_loop.py` pass through
+
+Thread the `context_files` (or pre-built injected string) through
+`create_run → agent_loop` so it becomes the first message content.
+
+**Deliverable:** `AdhocRunRequest` update + adhoc handler + `run_factory.py` pass-through
++ `test_adhoc.py` coverage → PR.
+
+---
+
+## Phase 3 — Worktree indexing on spawn
+*Effort: medium. Impact: agents can search worktree-specific changes (e.g. other
+agent's uncommitted edits).*
+
+### 3A — `run_factory.py` triggers background index
+
+After `_create_worktree` succeeds, fire a background task:
+
+```python
+from agentception.services.code_indexer import index_codebase
+
+# In create_run():
+background_tasks.add_task(
+    index_codebase,
+    repo_path=worktree_path,
+    collection=f"worktree-{run_id}",
+)
+```
+
+### 3B — `search_codebase` tool accepts optional `collection` arg
+
+Add an optional `collection` parameter to the agent tool so agents can
+search the worktree-specific index (`worktree-{WTNAME}`) when it exists,
+falling back to the main `code` collection.
+
+### 3C — Worktree collection cleanup on teardown
+
+In `teardown.py`, delete the `worktree-{run_id}` collection from Qdrant
+when the worktree is torn down.
+
+**Note:** Worktrees start from `origin/dev`, which is already indexed under
+the main `code` collection. Phase 3 is optional for initial dispatch — agents
+can search `/app` (the bind-mounted main repo) via the existing index. Only
+needed for tasks where agents make edits another agent needs to find.
+
+**Deliverable:** `run_factory.py` + `teardown.py` + `tools/definitions.py`
+`search_codebase` schema update → PR.
+
+---
+
+## Phase 4 — Redispatch #36 with all improvements
+*Execute after Phase 0 + 1 are merged. Use Phase 2 context injection manually
+in the task_description for the first run, then wire Phase 2 once it's built.*
+
+### Dispatch brief for #36
+
+Uses `context_files` to inject:
+- `agentception/workflow/status.py` (full — 140 lines)
+- `agentception/db/persist.py` lines 1208–1232 (stop_agent_run as pattern)
+- `agentception/poller.py` lines 243–264 (stall detection block)
+- `agentception/alembic/versions/0007_agent_run_pipeline_fields.py` (migration pattern)
+
+**Expected iteration count with all improvements:**
+- Iteration 1: `search_codebase` × 2 (confirm AgentStatus location, confirm persist pattern) — batched in 1 turn
+- Iterations 2–6: write `workflow/status.py` changes, write `persist.py` helper, write migration, write poller wiring — 1 file per turn
+- Iterations 7–9: run mypy, run tests, fix any errors
+- Iteration 10: commit + open PR
+- **Target: ~12 iterations total** (vs. 50 today)
+
+---
+
+## Execution order
+
+| Step | Phase | Owner | Status |
+|------|-------|-------|--------|
+| Update `search_codebase` tool description | 0A | Cursor | ⬜ |
+| Add batching + search-first rules to `worker-base.md.j2` | 0B/0C | Cursor | ⬜ |
+| Regenerate `.agentception/*.md` | 0 | Cursor | ⬜ |
+| PR: Phase 0 | 0 | Cursor | ⬜ |
+| `asyncio.gather` in `_dispatch_tool_calls` | 1A | Cursor | ⬜ |
+| PR: Phase 1 | 1 | Cursor | ⬜ |
+| `context_files` in `AdhocRunRequest` | 2A/2B/2C | Cursor | ⬜ |
+| PR: Phase 2 | 2 | Cursor | ⬜ |
+| Redispatch #36 | 4 | Cursor | ⬜ |
+| Worktree indexing on spawn | 3A/3B/3C | AgentCeption | ⬜ |

--- a/scripts/gen_prompts/templates/snippets/worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/worker-base.md.j2
@@ -3,15 +3,31 @@
 You own one task — finish it or escalate, never leave it in limbo.
 Do not spawn sub-agents unless your task briefing explicitly authorizes it.
 
-## Read Once. Decide. Act.
+## Search First. Read Narrow. Act Immediately.
 
-You have a finite number of iterations. Spend them executing, not
-re-verifying.
+You have a finite number of iterations. Every iteration spent on reconnaissance
+is one fewer iteration available for implementation. The ratio must be inverted:
+most iterations should produce output (files written, commands run, PRs opened),
+not discovery.
 
-**The read-once rule:** Read each file section once. Note what you found.
-Move on. Do not re-read a section you have already processed. If your
-context compresses and you feel uncertain, search for the specific symbol
-you need — do not re-read the entire file.
+**Search before you read.** Call `search_codebase` before any `grep`, `rg`,
+`cat`, or `read_file`. One semantic query ("where is AgentStatus defined",
+"pattern for adding a persist helper", "how does stall detection work in the
+poller") returns exact file paths and line numbers. Then call `read_file_lines`
+for only that range — never the whole file.
+
+**Batch your tool calls.** When you need information from multiple sources,
+emit ALL of them as tool calls in a single response — not one at a time.
+Three `search_codebase` queries in one response = one LLM turn and one
+inter-turn delay. Three queries across three separate responses = three turns
+and three delays. The loop dispatches every tool call you return before asking
+you again — use this. A well-batched first turn can replace ten sequential
+reconnaissance turns.
+
+**The read-once rule.** Read each file section once. Note what you found.
+Move on. Do not re-read a section you have already processed. If your context
+compresses and you feel uncertain, search for the specific symbol — do not
+re-read the entire file.
 
 **Trust your first analysis.** Your initial read is high quality. If you
 identified a problem and a fix on the first pass, implement the fix
@@ -21,9 +37,6 @@ the context." Act.
 **One log step per decision.** After reading the code, call `log_run_step`
 with a short note of what you found and what you are doing next. This
 anchors your direction even as history compresses.
-
-**Targeted search over broad reads.** Prefer `rg` or `grep -n` to locate
-exactly the lines you need. Avoid re-reading large blocks you already have.
 
 ## Output Discipline
 
@@ -36,6 +49,8 @@ exactly the lines you need. Avoid re-reading large blocks you already have.
 
 ## Failure Modes to Avoid
 
+- Reading files one at a time when you could batch all reads in a single response.
+- Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
 - Re-reading a file section you have already processed.
 - Spending iterations "deciding" when you already know what to do.
 - Spawning sub-agents unless your briefing explicitly authorizes it.


### PR DESCRIPTION
## Summary

- **Phase 0A** — `search_codebase` tool description rewritten to be directive; agents know it's their first call for any code discovery and that one query replaces 5–10 sequential reads
- **Phase 0B** — `worker-base.md.j2` now teaches agents to batch all tool calls in a single response (parallel dispatch) and to search before reading any file
- **Phase 1** — `_dispatch_tool_calls` switched from sequential `for` loop to `asyncio.gather`; wall-clock time = slowest call, not sum of all calls
- **Phase 2** — `AdhocRunRequest` gains `context_files: list[str] | None`; up to 20 repo-relative files injected verbatim before the task description so agents start with zero discovery turns
- **Phase 3** — Each run spawns a background `worktree-<run_id>` Qdrant collection at creation and prunes it at teardown; `search_codebase` accepts an optional `collection` arg; the task briefing prominently shows both collection names with a directive to use search first

## Test plan

- [x] `mypy agentception/` — 0 errors, 217 files
- [x] `pytest agentception/tests/` — 1615 passed
- [x] `generate.py --check` — 0 drift
- [ ] Dispatch issue #36 and observe iteration count vs previous runs