### PR TITLE
fix: show agent reply text in watch_run logs

### DIFF
--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -645,6 +645,14 @@ async def call_anthropic_with_tools(
         )
 
     content = "".join(text_parts)
+
+    # Log a readable snippet of the agent's text reply so watch_run.py can
+    # display what the model said between tool calls.  Newlines are collapsed
+    # to spaces so the snippet stays on one log line.
+    if content.strip():
+        snippet = content[:400].replace("\n", " ").strip()
+        logger.info("✅ LLM reply — chars=%d text=%s", len(content), snippet)
+
     logger.info(
         "✅ LLM tool-use done — stop_reason=%s content_chars=%d tool_calls=%d",
         stop_reason,

--- a/scripts/watch_run.py
+++ b/scripts/watch_run.py
@@ -85,6 +85,7 @@ _RE_LLM_USAGE = re.compile(
 _RE_LLM_DONE = re.compile(
     r"LLM tool-use done — stop_reason=(?P<reason>\S+) content_chars=(?P<chars>\d+) tool_calls=(?P<calls>\d+)"
 )
+_RE_LLM_REPLY = re.compile(r"LLM reply — chars=(?P<chars>\d+) text=(?P<text>.+)")
 _RE_DELAY = re.compile(r"inter-turn delay — sleeping (?P<secs>[\d.]+)s")
 
 # run start / teardown / indexing
@@ -345,12 +346,20 @@ def process_line(raw: str, run_id_filter: str | None) -> str | None:
             f"{cr_col}cache_read={cr}{RESET}  {GREY}history={hist}msgs{RESET}"
         )
 
+    # ── agent text reply (before tool calls or at end_turn) ────────────────────
+    rlm = _RE_LLM_REPLY.search(msg)
+    if rlm:
+        chars = int(rlm.group("chars"))
+        text = rlm.group("text").strip()
+        # Truncate long replies for display — full text is in the raw log.
+        display = text[:200] + ("…" if len(text) > 200 else "")
+        return f"{ts}  {GREY}💬 ({chars:,}ch) {display}{RESET}"
+
     # ── LLM done / stop reason ─────────────────────────────────────────────────
     ldm = _RE_LLM_DONE.search(msg)
     if ldm:
         reason = ldm.group("reason")
         calls = ldm.group("calls")
-        chars = int(ldm.group("chars"))
         if reason == "end_turn":
             tag = f"{GREEN}end_turn{RESET}"
         elif reason.startswith("tool_calls"):
@@ -358,8 +367,7 @@ def process_line(raw: str, run_id_filter: str | None) -> str | None:
             tag = f"{CYAN}→ {n} tool call{'s' if n != 1 else ''}{RESET}"
         else:
             tag = f"{YELLOW}{reason}{RESET}"
-        thought = f"  {GREY}({chars:,}ch thinking){RESET}" if chars > 0 else ""
-        return f"{ts}  {MAGENTA}╚══ {tag}{thought}{RESET}"
+        return f"{ts}  {MAGENTA}╚══ {tag}{RESET}"
 
     # ── inter-turn pacing ─────────────────────────────────────────────────────
     dlm = _RE_DELAY.search(msg)


### PR DESCRIPTION
## Summary

- `llm.py`: Log a truncated snippet of the agent's text reply as a separate `LLM reply — chars=N text=...` log line so `watch_run.py` can display it.
- `watch_run.py`: Render the reply as `💬 (Nch) <first 200 chars>` in grey, appearing immediately before the `╚══` stop-reason line. Remove the misleading `(Nch thinking)` suffix — `content_chars` was the text reply length, not a thinking budget.

## Test plan
- [ ] Run an agent and confirm `watch_run.py` shows the agent's reasoning text between tool calls.