### PR TITLE
fix: agent_loop exits when run transitions to terminal state mid-loop

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -36,8 +36,10 @@ from sqlalchemy import select
 from agentception.config import settings
 from agentception.db.engine import get_session
 from agentception.db.models import ACAgentRun
+from agentception.db.queries import get_run_by_id
 from agentception.mcp.build_commands import build_cancel_run, build_complete_run
 from agentception.mcp.log_tools import log_run_error, log_run_step
+from agentception.workflow.status import is_terminal
 from agentception.mcp.prompts import get_prompt
 from agentception.mcp.server import TOOLS, call_tool_async
 from agentception.mcp.types import ACToolResult
@@ -211,6 +213,20 @@ async def run_agent_loop(
             f"Iteration {iteration}/{max_iterations}",
             run_id,
         )
+
+        # Guard: if an MCP tool (e.g. build_cancel_run called by the agent
+        # itself) has already transitioned this run to a terminal state, stop
+        # the loop before the next LLM call.  Without this check the reaper
+        # would eventually kill the worktree while the loop is still running.
+        _run_row = await get_run_by_id(run_id)
+        if _run_row is not None and is_terminal(_run_row["status"]):
+            logger.info(
+                "✅ agent_loop: run %s is already in terminal state %r — stopping loop",
+                run_id,
+                _run_row["status"],
+            )
+            await github_client.close()
+            return
 
         # Proactive inter-turn pacing.  _last_llm_call_at is stamped *after*
         # call_anthropic_with_tools returns (including any retry backoff), so

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -711,3 +711,73 @@ class TestLLMSSLRetry:
         # The 429 sleep must be >= _RATE_LIMIT_BACKOFF_SECS (not the 2s used for SSL/timeout)
         assert len(sleep_calls) == 1
         assert sleep_calls[0] >= _RATE_LIMIT_BACKOFF_SECS
+
+
+# ---------------------------------------------------------------------------
+# Regression: loop exits when run is already in a terminal state
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalStateGuard:
+    """Regression: agent_loop must exit when the DB run status is terminal.
+
+    An agent can call build_cancel_run (or build_complete_run) as an MCP
+    tool during its turn.  This transitions the DB status to a terminal state
+    but the loop itself has no other signal to stop.  Without this guard the
+    loop continues executing in a worktree that the reaper may tear down at
+    any moment.
+    """
+
+    @pytest.mark.anyio
+    async def test_loop_exits_when_run_is_terminal(self, tmp_path: Path) -> None:
+        """Loop exits immediately at the status check if the run is terminal."""
+        worktree = tmp_path / "test-run-cancel"
+        worktree.mkdir()
+        task_spec = _make_task_spec(worktree, issue_number=99)
+
+        # Simulate a run that is already cancelled in the DB (e.g. the agent
+        # called build_cancel_run as a tool in the previous turn).
+        terminal_row: dict[str, object] = {"status": "cancelled"}
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
+            patch(
+                "agentception.services.agent_loop.get_run_by_id",
+                new_callable=AsyncMock,
+                return_value=terminal_row,
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic_with_tools",
+                new_callable=AsyncMock,
+                return_value=_stop_response("should not be called"),
+            ) as mock_llm,
+            patch(
+                "agentception.services.agent_loop.build_cancel_run",
+                new_callable=AsyncMock,
+            ) as mock_cancel,
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+
+            from agentception.services.agent_loop import run_agent_loop
+
+            await run_agent_loop("test-run-cancel", max_iterations=10)
+
+        # The LLM must NOT have been called — loop should exit before that.
+        mock_llm.assert_not_called()
+        # The loop exits gracefully without re-cancelling.
+        mock_cancel.assert_not_called()


### PR DESCRIPTION
## Summary

- An agent can call `build_cancel_run` as an MCP tool during its turn. This sets DB status to `"cancelled"` (terminal) but the loop had no signal to stop — it would keep executing in a worktree the reaper could tear down at any moment.
- Add a `get_run_by_id` + `is_terminal` check at the top of each loop iteration. If the run is already terminal, the loop closes the GitHub client and exits immediately — no re-cancel, no LLM call.
- Regression test: `TestTerminalStateGuard` verifies the LLM is never called when the DB row is already `"cancelled"`.

## What was observed

At iteration 24, the agent made 1 tool call (`build_cancel_run`). DB status flipped to `cancelled`. The 7-second inter-turn delay started. Three seconds in, the worktree reaper (running at startup or at the 15-minute interval) found a `cancelled` run with a live worktree and tore it down — killing the agent's workspace mid-run.