### PR TITLE
perf: reduce inter-turn delay from 7s to 5s

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -107,7 +107,7 @@ _HISTORY_TAIL: int = 14
 # realistic agent turn.  Input TPM is not the constraint: system-prompt cache
 # reads are excluded from the 450K limit, so uncached input per turn is only
 # new messages and tool results (~1–5K).
-_MIN_TURN_DELAY_SECS: float = 7.0
+_MIN_TURN_DELAY_SECS: float = 5.0
 _last_llm_call_at: float = 0.0
 
 


### PR DESCRIPTION
Reduces `_MIN_TURN_DELAY_SECS` from 7.0 to 5.0. At Tier 2 (400K TPM), this is well within limits even at worst-case token counts. The `_rate_limit_sleep` handler manages any occasional 429s gracefully via Retry-After backoff.