### PR TITLE
fix: poller must not overwrite adhoc run status with computed display status

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -820,7 +820,13 @@ async def _upsert_agent_runs(
             # endpoint may transition out of that state.  The poller can see the
             # worktree on disk and would clobber it with "stale" otherwise, which
             # would drain the queue before the Dispatcher ever reads it.
-            if existing.status != "pending_launch":
+            #
+            # Never overwrite adhoc runs (issue_number is None) — they are
+            # managed entirely by their asyncio task lifecycle.  The poller
+            # derives a synthetic display status for them that is not an accurate
+            # reflection of real run state, so writing it back would corrupt the
+            # DB row and cause the agent loop's terminal-state guard to fire.
+            if existing.status != "pending_launch" and existing.issue_number is not None:
                 existing.status = agent.status.value
             # Only advance pr_number — never regress it to None.
             # persist_agent_event(done) writes pr_number from the agent's

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -144,7 +144,11 @@ async def merge_agents(
             # Coordinator agents may have no issue/PR during planning.
             status = AgentStatus.IMPLEMENTING
         else:
-            status = AgentStatus.FAILED
+            # Ad-hoc runs (issue_number is None, not a coordinator) are
+            # managed by their asyncio task lifecycle, not by GitHub signals.
+            # Treat them as IMPLEMENTING so the poller never stamps FAILED
+            # onto a live adhoc run that simply has no associated issue.
+            status = AgentStatus.IMPLEMENTING
 
         worktree = run["worktree_path"]
         node_id = (

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -523,10 +523,10 @@ class TestEnforceTurnDelay:
 
     @pytest.mark.anyio
     async def test_recent_call_waits_remainder(self) -> None:
-        """A call made 5s ago should wait ~2s (7s target - 5s elapsed)."""
+        """A call made 3s ago should wait ~2s (5s target - 3s elapsed)."""
         import time
         import agentception.services.agent_loop as al
-        al._last_llm_call_at = time.monotonic() - 5.0
+        al._last_llm_call_at = time.monotonic() - 3.0
         t0 = time.monotonic()
         from agentception.services.agent_loop import _enforce_turn_delay
         await _enforce_turn_delay()
@@ -535,7 +535,7 @@ class TestEnforceTurnDelay:
 
     @pytest.mark.anyio
     async def test_old_call_skips_wait(self) -> None:
-        """A call made 15s ago (> 7s target) incurs no extra wait."""
+        """A call made 15s ago (> 5s target) incurs no extra wait."""
         import time
         import agentception.services.agent_loop as al
         al._last_llm_call_at = time.monotonic() - 15.0
@@ -567,7 +567,7 @@ class TestEnforceTurnDelay:
         await _enforce_turn_delay()
         # Should wait close to _MIN_TURN_DELAY_SECS, not skip due to stale timestamp
         elapsed = time.monotonic() - t0
-        assert elapsed >= 6.0  # within 1s tolerance of the 7s target
+        assert elapsed >= 4.0  # within 1s tolerance of the 5s target
 
 
 class TestLLMSSLRetry:


### PR DESCRIPTION
## Summary

Every adhoc run (`issue_number=None`) was being killed at iteration 5 by the new terminal-state guard added in #420. Root cause: the persist tick was overwriting the DB `status` column with the display status computed by `merge_agents()`, which maps all adhoc runs to `AgentStatus.FAILED` (no GitHub issue or PR to correlate against). This happened on every poller tick — typically within ~5 seconds of dispatch.

**Fix 1 (`poller.py`):** `merge_agents()` maps adhoc runs (no issue, not a coordinator) to `IMPLEMENTING` for the display tree instead of `FAILED`.

**Fix 2 (`persist.py`):** The status overwrite in the persist tick is skipped for adhoc runs (`issue_number IS NULL`) as defence-in-depth — their lifecycle is owned by the asyncio task, not the GitHub polling loop.

**Also:** Updated two `test_agent_loop.py` assertions that were hardcoded to the old 7s inter-turn delay.