### PR TITLE
fix: agent dispatch reliability — 4s delay, 100 iter limit, issue body in briefing

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -972,6 +972,7 @@ async def persist_agent_run_dispatch(
     gh_repo: str | None = None,
     is_resumed: bool = False,
     coord_fingerprint: str | None = None,
+    task_description: str | None = None,
 ) -> None:
     """Insert an ``ACAgentRun`` row with status ``pending_launch`` at dispatch time.
 
@@ -1022,6 +1023,8 @@ async def persist_agent_run_dispatch(
                 existing.is_resumed = is_resumed
                 if coord_fingerprint is not None:
                     existing.coord_fingerprint = coord_fingerprint
+                if task_description is not None:
+                    existing.task_description = task_description
             else:
                 logger.warning(
                     "💾 persist_agent_run_dispatch: run_id=%r is new — inserting with status=pending_launch",
@@ -1047,6 +1050,7 @@ async def persist_agent_run_dispatch(
                         gh_repo=gh_repo,
                         is_resumed=is_resumed,
                         coord_fingerprint=coord_fingerprint,
+                        task_description=task_description,
                         spawned_at=_now(),
                         last_activity_at=_now(),
                     )

--- a/agentception/mcp/prompts.py
+++ b/agentception/mcp/prompts.py
@@ -451,8 +451,10 @@ def _render_task_briefing(ctx: RunContextRow, role_content: str) -> str:
     elif issue_number:
         assignment = (
             f"Implement GitHub issue **#{issue_number}**.\n\n"
-            f"Read `ac://runs/{run_id}/context` for full task context, "
-            f"then read the issue body on GitHub to understand the requirements."
+            f"The full issue body was not injected into this briefing. "
+            f"Read `ac://runs/{run_id}/context` for available task context. "
+            f"Use `gh issue view {issue_number}` (shell) to fetch the issue body — "
+            f"this is more reliable than the `issue_read` MCP tool for initial context loading."
         )
     else:
         assignment = f"Read `ac://runs/{run_id}/context` for your full task context."

--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -226,6 +226,17 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
 
     cognitive_arch = _resolve_cognitive_arch(req.issue_body, req.role)
 
+    # Build task_description from the issue title + body so the agent briefing
+    # includes the full issue text and never needs to call issue_read for context.
+    task_description: str | None = None
+    if req.issue_title or req.issue_body:
+        parts = []
+        if req.issue_title:
+            parts.append(f"# {req.issue_title}")
+        if req.issue_body:
+            parts.append(req.issue_body.strip())
+        task_description = "\n\n".join(parts)
+
     # Persist all task context to DB; agents read via ac://runs/{run_id}/context.
     await persist_agent_run_dispatch(
         run_id=run_id,
@@ -237,6 +248,7 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
         host_worktree_path=host_worktree_path,
         cognitive_arch=cognitive_arch,
         gh_repo=settings.gh_repo,
+        task_description=task_description,
     )
 
     return DispatchResponse(

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -82,7 +82,7 @@ if str(_RESOLVE_ARCH_DIR) not in sys.path:
     sys.path.insert(0, str(_RESOLVE_ARCH_DIR))
 
 # Hard cap on conversation turns.  Each iteration is one LLM call.
-_DEFAULT_MAX_ITERATIONS = 50
+_DEFAULT_MAX_ITERATIONS = 100
 
 # Tool results longer than this are truncated before being stored in history.
 # read_file / run_command can easily dump 50k+ chars; keeping them unbounded
@@ -107,7 +107,7 @@ _HISTORY_TAIL: int = 14
 # realistic agent turn.  Input TPM is not the constraint: system-prompt cache
 # reads are excluded from the 450K limit, so uncached input per turn is only
 # new messages and tool results (~1–5K).
-_MIN_TURN_DELAY_SECS: float = 5.0
+_MIN_TURN_DELAY_SECS: float = 4.0
 _last_llm_call_at: float = 0.0
 
 

--- a/agentception/services/spawn_child.py
+++ b/agentception/services/spawn_child.py
@@ -312,7 +312,7 @@ async def spawn_child(
 
     # Create git worktree anchored to the resolved SHA
     proc = await asyncio.create_subprocess_exec(
-        "git", "worktree", "add", worktree_path, "-b", branch, dev_sha,
+        "git", "worktree", "add", "-b", branch, worktree_path, dev_sha,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         cwd=str(settings.repo_dir),

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -523,10 +523,10 @@ class TestEnforceTurnDelay:
 
     @pytest.mark.anyio
     async def test_recent_call_waits_remainder(self) -> None:
-        """A call made 3s ago should wait ~2s (5s target - 3s elapsed)."""
+        """A call made 2s ago should wait ~2s (4s target - 2s elapsed)."""
         import time
         import agentception.services.agent_loop as al
-        al._last_llm_call_at = time.monotonic() - 3.0
+        al._last_llm_call_at = time.monotonic() - 2.0
         t0 = time.monotonic()
         from agentception.services.agent_loop import _enforce_turn_delay
         await _enforce_turn_delay()
@@ -535,7 +535,7 @@ class TestEnforceTurnDelay:
 
     @pytest.mark.anyio
     async def test_old_call_skips_wait(self) -> None:
-        """A call made 15s ago (> 5s target) incurs no extra wait."""
+        """A call made 15s ago (> 4s target) incurs no extra wait."""
         import time
         import agentception.services.agent_loop as al
         al._last_llm_call_at = time.monotonic() - 15.0
@@ -567,7 +567,7 @@ class TestEnforceTurnDelay:
         await _enforce_turn_delay()
         # Should wait close to _MIN_TURN_DELAY_SECS, not skip due to stale timestamp
         elapsed = time.monotonic() - t0
-        assert elapsed >= 4.0  # within 1s tolerance of the 5s target
+        assert elapsed >= 3.0  # within 1s tolerance of the 4s target
 
 
 class TestLLMSSLRetry:


### PR DESCRIPTION
## Summary

- **4s inter-turn delay** (down from 5s): zero 429s observed across multiple runs; rate-limit headroom confirmed at ~128K effective TPM vs 200K Tier 2 limit
- **100 max iterations** (up from 50): complex multi-file tasks with tests need more room; 50 caused the issue-35 agent to fail mid-implementation
- **Issue body in briefing**: dispatch route now writes `issue_title + issue_body` as `task_description` so agents start with full context and never need `issue_read` — eliminates 5–10 wasted turns per run from MCP connection failures
- **`spawn_child.py` git arg order**: `git worktree add <path> -b <branch>` → `git worktree add -b <branch> <path>` (canonical flag-before-positional order; agent discovered this during the issue-35 run)

## Test plan

- [x] `mypy agentception/` — 0 errors
- [x] `pytest agentception/tests/` — 1624 passed
- Updated timing assertions in `test_agent_loop.py` to reflect 4s target