### PR TITLE
feat: four agent context improvements — memory, truncation, search, pre-injection

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -22,11 +22,10 @@ import re
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-
-from typing import Literal
 
 
 class OrgNodeSpec(BaseModel):
@@ -53,6 +52,7 @@ OrgNodeSpec.model_rebuild()
 from agentception.config import settings
 from agentception.db.persist import persist_agent_run_dispatch
 from agentception.db.queries import get_label_context
+from agentception.services.code_indexer import search_codebase
 from agentception.services.cognitive_arch import _resolve_cognitive_arch
 from agentception.services.spawn_child import (
     SpawnChildError,
@@ -236,6 +236,39 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
         if req.issue_body:
             parts.append(req.issue_body.strip())
         task_description = "\n\n".join(parts)
+
+    # Pre-inject semantically relevant code context from the main Qdrant index.
+    # Searching at dispatch time (not agent-turn time) amortises the embedding
+    # cost once and gives the agent oriented code context from turn 1.
+    # Cap: top 3 chunks, 800 chars each, total ≤ 3 000 chars added.
+    if task_description:
+        search_query = f"{req.issue_title} {req.issue_body}"[:800]
+        try:
+            code_matches = await search_codebase(search_query, n_results=3)
+            if code_matches:
+                ctx_blocks: list[str] = []
+                remaining = 3_000
+                for m in code_matches:
+                    block = (
+                        f"**{m['file']}** (lines {m['start_line']}–{m['end_line']})\n"
+                        f"```\n{m['chunk'][:800]}\n```"
+                    )
+                    if remaining <= 0:
+                        break
+                    ctx_blocks.append(block)
+                    remaining -= len(block)
+                if ctx_blocks:
+                    task_description += (
+                        "\n\n---\n\n## Pre-injected Code Context\n\n"
+                        + "\n\n".join(ctx_blocks)
+                    )
+                    logger.info(
+                        "✅ dispatch: pre-injected %d code chunks for run_id=%s",
+                        len(ctx_blocks),
+                        run_id,
+                    )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("⚠️ dispatch: context pre-injection failed — %s", exc)
 
     # Persist all task context to DB; agents read via ac://runs/{run_id}/context.
     await persist_agent_run_dispatch(

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -58,6 +58,14 @@ from agentception.tools.definitions import (
     GIT_COMMIT_AND_PUSH_TOOL_DEF,
     SEARCH_CODEBASE_TOOL_DEF,
     SHELL_TOOL_DEF,
+    UPDATE_WORKING_MEMORY_TOOL_DEF,
+)
+from agentception.services.working_memory import (
+    WorkingMemory,
+    merge_memory,
+    read_memory,
+    render_memory,
+    write_memory,
 )
 from agentception.tools.file_tools import (
     insert_after_in_file,
@@ -84,10 +92,22 @@ if str(_RESOLVE_ARCH_DIR) not in sys.path:
 # Hard cap on conversation turns.  Each iteration is one LLM call.
 _DEFAULT_MAX_ITERATIONS = 100
 
-# Tool results longer than this are truncated before being stored in history.
-# read_file / run_command can easily dump 50k+ chars; keeping them unbounded
-# inflates every subsequent input token count linearly.
-_MAX_TOOL_RESULT_CHARS: int = 3_000
+# Per-tool character limits applied before tool results enter history.
+# File-read outputs can be 10-50k chars; search outputs 5-15k.  Applying a
+# single flat cap of 3k was the root cause of agents re-reading files they
+# had already fetched — the first read was truncated and looked incomplete.
+# These limits are generous but finite; the agent still sees the full start
+# of every result with a clear truncation marker when the limit is hit.
+_TOOL_RESULT_CHAR_LIMITS: dict[str, int] = {
+    "read_file": 12_000,
+    "read_file_lines": 12_000,
+    "search_codebase": 8_000,
+    "search_text": 5_000,
+    "run_command": 5_000,
+    "git_commit_and_push": 3_000,
+    "list_directory": 2_000,
+}
+_DEFAULT_TOOL_RESULT_CHARS: int = 3_000
 
 # When the message history (excluding system) exceeds this count, old turns
 # are dropped from the middle.  The first user message (task briefing) and the
@@ -145,6 +165,7 @@ _LOCAL_TOOL_NAMES: frozenset[str] = frozenset(
         "run_command",
         "git_commit_and_push",
         "search_codebase",
+        "update_working_memory",
     }
 )
 
@@ -234,12 +255,23 @@ async def run_agent_loop(
         # of one LLM interaction and the start of the next.
         await _enforce_turn_delay()
 
+        # Read working memory and render it as a secondary system block.
+        # This is injected fresh every turn OUTSIDE the prunable history so
+        # the agent always has its scratch-pad regardless of how many turns
+        # have been pruned.  The main system-prompt cache is not invalidated
+        # because the working memory is a separate, un-cached block.
+        memory = read_memory(worktree_path)
+        extra_blocks: list[dict[str, object]] = []
+        if memory:
+            extra_blocks.append({"type": "text", "text": render_memory(memory)})
+
         try:
             bounded = _prune_history(_truncate_tool_results(messages))
             response: ToolResponse = await call_anthropic_with_tools(
                 bounded,
                 system=system_prompt,
                 tools=tool_defs,
+                extra_system_blocks=extra_blocks or None,
             )
         except Exception as exc:
             _record_llm_call()  # stamp even on error so next delay is measured correctly
@@ -567,6 +599,7 @@ def _build_tool_definitions(
     tool_defs.append(SHELL_TOOL_DEF)
     tool_defs.append(GIT_COMMIT_AND_PUSH_TOOL_DEF)
     tool_defs.append(SEARCH_CODEBASE_TOOL_DEF)
+    tool_defs.append(UPDATE_WORKING_MEMORY_TOOL_DEF)
 
     seen: set[str] = {t["function"]["name"] for t in tool_defs}
 
@@ -595,25 +628,61 @@ def _build_tool_definitions(
 # ---------------------------------------------------------------------------
 
 
+def _build_tool_id_map(messages: list[dict[str, object]]) -> dict[str, str]:
+    """Build a mapping from tool_call_id → tool_name by scanning assistant messages.
+
+    Required by :func:`_truncate_tool_results` to look up which tool produced
+    each result so the correct per-tool character limit can be applied.
+    """
+    mapping: dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        calls = msg.get("tool_calls")
+        if not isinstance(calls, list):
+            continue
+        for tc in calls:
+            if not isinstance(tc, dict):
+                continue
+            tc_id = tc.get("id", "")
+            fn = tc.get("function", {})
+            if isinstance(fn, dict) and isinstance(tc_id, str) and tc_id:
+                name = fn.get("name", "")
+                if isinstance(name, str):
+                    mapping[tc_id] = name
+    return mapping
+
+
 def _truncate_tool_results(
     messages: list[dict[str, object]],
 ) -> list[dict[str, object]]:
-    """Truncate oversized tool-result content to ``_MAX_TOOL_RESULT_CHARS``.
+    """Truncate oversized tool-result content using per-tool character limits.
 
-    Tool calls such as ``read_file`` and ``run_command`` can return tens of
-    thousands of characters.  Every subsequent LLM turn pays full input-token
-    price for that content, so we cap it here.  The model still sees the
-    beginning and a clear truncation marker.
+    Applies generous but finite caps per tool type so the agent is never
+    blinded by truncation while still keeping tokens bounded:
+
+    - File reads (``read_file``, ``read_file_lines``): 12 000 chars
+    - Semantic search (``search_codebase``): 8 000 chars
+    - Shell / text search: 5 000 chars
+    - Everything else: 3 000 chars
+
+    The tool name is resolved via the ``tool_call_id`` ↔ name mapping built
+    from the preceding assistant messages.  The model still sees the beginning
+    of every result with a clear truncation marker at the cut point.
     """
+    tool_id_map = _build_tool_id_map(messages)
     out: list[dict[str, object]] = []
     for msg in messages:
         if msg.get("role") == "tool":
+            tc_id = str(msg.get("tool_call_id", ""))
+            tool_name = tool_id_map.get(tc_id, "")
+            limit = _TOOL_RESULT_CHAR_LIMITS.get(tool_name, _DEFAULT_TOOL_RESULT_CHARS)
             raw = msg.get("content", "")
-            if isinstance(raw, str) and len(raw) > _MAX_TOOL_RESULT_CHARS:
+            if isinstance(raw, str) and len(raw) > limit:
                 msg = dict(msg)
                 msg["content"] = (
-                    raw[:_MAX_TOOL_RESULT_CHARS]
-                    + f"\n... [truncated — {len(raw) - _MAX_TOOL_RESULT_CHARS} chars omitted]"
+                    raw[:limit]
+                    + f"\n... [truncated — {len(raw) - limit} chars omitted]"
                 )
         out.append(msg)
     return out
@@ -903,5 +972,32 @@ async def _dispatch_local_tool(
         collection_arg: str | None = collection_raw if isinstance(collection_raw, str) else None
         matches = await search_codebase(query_raw, n_results, collection=collection_arg)
         return {"ok": True, "matches": matches}
+
+    if name == "update_working_memory":
+        update = WorkingMemory()
+        plan_raw = args.get("plan")
+        if isinstance(plan_raw, str):
+            update["plan"] = plan_raw
+        files_raw = args.get("files_examined")
+        if isinstance(files_raw, list) and all(isinstance(f, str) for f in files_raw):
+            update["files_examined"] = list(files_raw)
+        findings_raw = args.get("findings")
+        if isinstance(findings_raw, dict) and all(
+            isinstance(k, str) and isinstance(v, str) for k, v in findings_raw.items()
+        ):
+            update["findings"] = dict(findings_raw)
+        decisions_raw = args.get("decisions")
+        if isinstance(decisions_raw, list) and all(isinstance(d, str) for d in decisions_raw):
+            update["decisions"] = list(decisions_raw)
+        next_steps_raw = args.get("next_steps")
+        if isinstance(next_steps_raw, list) and all(isinstance(s, str) for s in next_steps_raw):
+            update["next_steps"] = list(next_steps_raw)
+        blockers_raw = args.get("blockers")
+        if isinstance(blockers_raw, list) and all(isinstance(b, str) for b in blockers_raw):
+            update["blockers"] = list(blockers_raw)
+        existing = read_memory(worktree_path)
+        merged = merge_memory(existing, update)
+        write_memory(worktree_path, merged)
+        return {"ok": True, "result": "Working memory updated."}
 
     return {"ok": False, "error": f"Unknown local tool: {name!r}"}

--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -489,6 +489,7 @@ async def call_anthropic_with_tools(
     model: str = _MODEL,
     temperature: float = 0.0,
     max_tokens: int = 16384,
+    extra_system_blocks: list[dict[str, object]] | None = None,
 ) -> ToolResponse:
     """Call Claude via the Anthropic API with tool-use support.
 
@@ -507,6 +508,9 @@ async def call_anthropic_with_tools(
         model: Anthropic model ID.
         temperature: Sampling temperature.  Defaults to 0 for determinism.
         max_tokens: Maximum tokens the model may emit per turn.
+        extra_system_blocks: Additional Anthropic content blocks appended
+            after the cached system prompt block.  Used to inject dynamic
+            context (e.g. working memory) without invalidating the cache.
 
     Returns:
         :class:`ToolResponse` with ``stop_reason``, ``content``, and a
@@ -521,6 +525,8 @@ async def call_anthropic_with_tools(
 
     # System prompt as a cacheable content-block array.
     # cache_control: ephemeral → 5-minute TTL; charged at ~10% on cache hits.
+    # extra_system_blocks (e.g. working memory) are appended WITHOUT cache_control
+    # so they are re-evaluated fresh every turn without busting the main cache.
     system_block: list[dict[str, object]] = [
         {
             "type": "text",
@@ -528,6 +534,8 @@ async def call_anthropic_with_tools(
             "cache_control": {"type": "ephemeral"},
         }
     ]
+    if extra_system_blocks:
+        system_block.extend(extra_system_blocks)
 
     payload: dict[str, object] = {
         "model": model,

--- a/agentception/services/working_memory.py
+++ b/agentception/services/working_memory.py
@@ -1,0 +1,191 @@
+"""Persistent working memory for agent runs.
+
+A lightweight JSON file stored at ``.ac/memory.json`` inside the worktree.
+The agent loop reads it at the start of every iteration and injects a compact
+rendering as a secondary system block so the model always has its current state
+— without touching the prunable conversation history.
+
+Agents update their memory via the ``update_working_memory`` tool.  Supplied
+fields are merged into the stored JSON; omitted fields are preserved.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+_MEMORY_FILENAME = ".ac/memory.json"
+
+
+class WorkingMemory(TypedDict, total=False):
+    """Structured scratch-pad the agent maintains across iterations.
+
+    All fields are optional so the agent can update only what changed.
+    """
+
+    plan: str
+    """High-level implementation plan for this session."""
+
+    files_examined: list[str]
+    """Paths of files already read or inspected — skip re-reading these."""
+
+    findings: dict[str, str]
+    """Per-file or per-topic findings: key = file/topic, value = short note."""
+
+    decisions: list[str]
+    """Architecture or approach decisions already locked in."""
+
+    next_steps: list[str]
+    """Ordered queue of remaining work items."""
+
+    blockers: list[str]
+    """Anything blocking progress (unclear spec, awaiting result, etc.)."""
+
+
+def _memory_path(worktree_path: Path) -> Path:
+    return worktree_path / _MEMORY_FILENAME
+
+
+def read_memory(worktree_path: Path) -> WorkingMemory | None:
+    """Load the agent's working memory file.
+
+    Returns ``None`` when the file does not exist or is corrupt.
+    Never raises — memory failure degrades gracefully to an empty context.
+    """
+    path = _memory_path(worktree_path)
+    if not path.exists():
+        return None
+    try:
+        raw: object = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return None
+        result = WorkingMemory()
+        plan = raw.get("plan")
+        if isinstance(plan, str):
+            result["plan"] = plan
+        files_examined = raw.get("files_examined")
+        if (
+            isinstance(files_examined, list)
+            and all(isinstance(f, str) for f in files_examined)
+        ):
+            result["files_examined"] = list(files_examined)
+        findings = raw.get("findings")
+        if isinstance(findings, dict) and all(
+            isinstance(k, str) and isinstance(v, str) for k, v in findings.items()
+        ):
+            result["findings"] = dict(findings)
+        decisions = raw.get("decisions")
+        if isinstance(decisions, list) and all(isinstance(d, str) for d in decisions):
+            result["decisions"] = list(decisions)
+        next_steps = raw.get("next_steps")
+        if isinstance(next_steps, list) and all(isinstance(s, str) for s in next_steps):
+            result["next_steps"] = list(next_steps)
+        blockers = raw.get("blockers")
+        if isinstance(blockers, list) and all(isinstance(b, str) for b in blockers):
+            result["blockers"] = list(blockers)
+        return result or None
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("⚠️ working_memory.read — error: %s", exc)
+        return None
+
+
+def write_memory(worktree_path: Path, memory: WorkingMemory) -> None:
+    """Persist *memory* to the worktree's ``.ac/memory.json`` file.
+
+    Creates ``.ac/`` if it does not exist yet.  Never raises — write failures
+    are logged and ignored so the agent loop is not interrupted.
+    """
+    path = _memory_path(worktree_path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(memory, indent=2), encoding="utf-8")
+    except OSError as exc:
+        logger.warning("⚠️ working_memory.write — error: %s", exc)
+
+
+def merge_memory(existing: WorkingMemory | None, update: WorkingMemory) -> WorkingMemory:
+    """Merge *update* fields into *existing*, returning a new :class:`WorkingMemory`.
+
+    Only fields present in *update* are changed; absent fields from *existing*
+    are preserved.  ``findings`` dicts are union-merged so individual keys can
+    be added or updated without resending the entire dict.
+    """
+    result = WorkingMemory()
+
+    if existing is not None:
+        if "plan" in existing:
+            result["plan"] = existing["plan"]
+        if "files_examined" in existing:
+            result["files_examined"] = existing["files_examined"]
+        if "findings" in existing:
+            result["findings"] = existing["findings"]
+        if "decisions" in existing:
+            result["decisions"] = existing["decisions"]
+        if "next_steps" in existing:
+            result["next_steps"] = existing["next_steps"]
+        if "blockers" in existing:
+            result["blockers"] = existing["blockers"]
+
+    if "plan" in update:
+        result["plan"] = update["plan"]
+    if "files_examined" in update:
+        result["files_examined"] = update["files_examined"]
+    if "findings" in update:
+        prior: dict[str, str] = result.get("findings", {})
+        result["findings"] = {**prior, **update["findings"]}
+    if "decisions" in update:
+        result["decisions"] = update["decisions"]
+    if "next_steps" in update:
+        result["next_steps"] = update["next_steps"]
+    if "blockers" in update:
+        result["blockers"] = update["blockers"]
+
+    return result
+
+
+def render_memory(memory: WorkingMemory) -> str:
+    """Render *memory* as compact Markdown for injection into the system prompt.
+
+    The rendering is intentionally terse — one line per item — to minimise the
+    token cost while keeping the model oriented.
+    """
+    lines: list[str] = ["## Working Memory"]
+
+    plan = memory.get("plan")
+    if plan:
+        lines.append(f"**Plan:** {plan}")
+
+    files_examined = memory.get("files_examined")
+    if files_examined:
+        files_str = ", ".join(f"`{f}`" for f in files_examined)
+        lines.append(f"**Files read (skip re-reading):** {files_str}")
+
+    findings = memory.get("findings")
+    if findings:
+        lines.append("**Findings:**")
+        for key, note in findings.items():
+            lines.append(f"- `{key}`: {note}")
+
+    decisions = memory.get("decisions")
+    if decisions:
+        lines.append("**Decisions:**")
+        for d in decisions:
+            lines.append(f"- {d}")
+
+    next_steps = memory.get("next_steps")
+    if next_steps:
+        lines.append("**Next steps:**")
+        for i, s in enumerate(next_steps, 1):
+            lines.append(f"{i}. {s}")
+
+    blockers = memory.get("blockers")
+    if blockers:
+        lines.append("**Blockers:**")
+        for b in blockers:
+            lines.append(f"- ⚠️ {b}")
+
+    return "\n".join(lines)

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -781,3 +781,129 @@ class TestTerminalStateGuard:
         mock_llm.assert_not_called()
         # The loop exits gracefully without re-cancelling.
         mock_cancel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Type-aware truncation — _build_tool_id_map + _truncate_tool_results
+# ---------------------------------------------------------------------------
+
+
+def test_build_tool_id_map_extracts_tool_names() -> None:
+    """_build_tool_id_map should produce id → name for every tool_call in history."""
+    from agentception.services.agent_loop import _build_tool_id_map
+
+    messages: list[dict[str, object]] = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "tc_1", "type": "function", "function": {"name": "read_file", "arguments": "{}"}},
+                {"id": "tc_2", "type": "function", "function": {"name": "run_command", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "tc_1", "content": "file content"},
+        {"role": "tool", "tool_call_id": "tc_2", "content": "cmd output"},
+    ]
+    mapping = _build_tool_id_map(messages)
+    assert mapping == {"tc_1": "read_file", "tc_2": "run_command"}
+
+
+def test_build_tool_id_map_ignores_non_assistant_messages() -> None:
+    from agentception.services.agent_loop import _build_tool_id_map
+
+    messages: list[dict[str, object]] = [
+        {"role": "user", "content": "hello"},
+        {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+    ]
+    assert _build_tool_id_map(messages) == {}
+
+
+def test_truncate_applies_generous_limit_for_read_file() -> None:
+    """read_file results are truncated at 12 000 chars (not the old 3 000 limit)."""
+    from agentception.services.agent_loop import _truncate_tool_results
+
+    big_content = "x" * 20_000
+    messages: list[dict[str, object]] = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "tc_1", "type": "function", "function": {"name": "read_file", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "tc_1", "content": big_content},
+    ]
+    result = _truncate_tool_results(messages)
+    tool_msg = next(m for m in result if m.get("role") == "tool")
+    content = tool_msg["content"]
+    assert isinstance(content, str)
+    assert "truncated" in content
+    # Should preserve the first 12 000 chars and truncate the rest.
+    assert content.startswith("x" * 12_000)
+    # Must not reach the old 3 000 limit pattern (confirm generous limit applied).
+    assert len(content) > 3_000
+
+
+def test_truncate_applies_tight_limit_for_unknown_tool() -> None:
+    """Unknown tool names use the default 3 000-char cap."""
+    from agentception.services.agent_loop import _truncate_tool_results
+
+    big_content = "y" * 4_000
+    messages: list[dict[str, object]] = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "tc_x", "type": "function", "function": {"name": "some_mcp_tool", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "tc_x", "content": big_content},
+    ]
+    result = _truncate_tool_results(messages)
+    tool_msg = next(m for m in result if m.get("role") == "tool")
+    content = tool_msg["content"]
+    assert isinstance(content, str)
+    assert content.startswith("y" * 3_000)
+    assert "truncated" in content
+
+
+def test_truncate_does_not_modify_short_content() -> None:
+    """Results under the per-tool limit are passed through unchanged."""
+    from agentception.services.agent_loop import _truncate_tool_results
+
+    messages: list[dict[str, object]] = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "tc_1", "type": "function", "function": {"name": "read_file", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "tc_1", "content": "short content"},
+    ]
+    result = _truncate_tool_results(messages)
+    tool_msg = next(m for m in result if m.get("role") == "tool")
+    assert tool_msg["content"] == "short content"
+
+
+def test_truncate_search_codebase_limit() -> None:
+    """search_codebase results get 8 000-char limit (between read_file and default)."""
+    from agentception.services.agent_loop import _truncate_tool_results
+
+    big_content = "s" * 9_000
+    messages: list[dict[str, object]] = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "tc_s", "type": "function", "function": {"name": "search_codebase", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "tc_s", "content": big_content},
+    ]
+    result = _truncate_tool_results(messages)
+    tool_msg = next(m for m in result if m.get("role") == "tool")
+    content = tool_msg["content"]
+    assert isinstance(content, str)
+    assert content.startswith("s" * 8_000)
+    assert "truncated" in content

--- a/agentception/tests/test_working_memory.py
+++ b/agentception/tests/test_working_memory.py
@@ -1,0 +1,186 @@
+"""Unit tests for the persistent working-memory module.
+
+Covers read/write/merge/render at the unit level.  No DB or network required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentception.services.working_memory import (
+    WorkingMemory,
+    merge_memory,
+    read_memory,
+    render_memory,
+    write_memory,
+)
+
+
+# ---------------------------------------------------------------------------
+# read_memory
+# ---------------------------------------------------------------------------
+
+
+def test_read_memory_missing_file_returns_none(tmp_path: Path) -> None:
+    assert read_memory(tmp_path) is None
+
+
+def test_read_memory_corrupt_json_returns_none(tmp_path: Path) -> None:
+    (tmp_path / ".ac").mkdir()
+    (tmp_path / ".ac" / "memory.json").write_text("not json", encoding="utf-8")
+    assert read_memory(tmp_path) is None
+
+
+def test_read_memory_non_dict_returns_none(tmp_path: Path) -> None:
+    (tmp_path / ".ac").mkdir()
+    (tmp_path / ".ac" / "memory.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    assert read_memory(tmp_path) is None
+
+
+def test_read_memory_full_object(tmp_path: Path) -> None:
+    (tmp_path / ".ac").mkdir()
+    payload = {
+        "plan": "implement X",
+        "files_examined": ["a.py", "b.py"],
+        "findings": {"a.py": "found bug"},
+        "decisions": ["use TypedDict"],
+        "next_steps": ["write tests"],
+        "blockers": ["unclear spec"],
+    }
+    (tmp_path / ".ac" / "memory.json").write_text(json.dumps(payload), encoding="utf-8")
+    memory = read_memory(tmp_path)
+    assert memory is not None
+    assert memory["plan"] == "implement X"
+    assert memory["files_examined"] == ["a.py", "b.py"]
+    assert memory["findings"] == {"a.py": "found bug"}
+    assert memory["decisions"] == ["use TypedDict"]
+    assert memory["next_steps"] == ["write tests"]
+    assert memory["blockers"] == ["unclear spec"]
+
+
+def test_read_memory_ignores_wrong_type_fields(tmp_path: Path) -> None:
+    (tmp_path / ".ac").mkdir()
+    # plan is an int instead of str — should be silently skipped
+    payload = {"plan": 42, "decisions": ["ok"]}
+    (tmp_path / ".ac" / "memory.json").write_text(json.dumps(payload), encoding="utf-8")
+    memory = read_memory(tmp_path)
+    assert memory is not None
+    assert "plan" not in memory
+    assert memory["decisions"] == ["ok"]
+
+
+# ---------------------------------------------------------------------------
+# write_memory
+# ---------------------------------------------------------------------------
+
+
+def test_write_memory_creates_ac_directory(tmp_path: Path) -> None:
+    mem: WorkingMemory = WorkingMemory(plan="test plan")
+    write_memory(tmp_path, mem)
+    assert (tmp_path / ".ac" / "memory.json").exists()
+
+
+def test_write_memory_roundtrip(tmp_path: Path) -> None:
+    mem: WorkingMemory = WorkingMemory(
+        plan="p",
+        files_examined=["x.py"],
+        findings={"x.py": "note"},
+        decisions=["d1"],
+        next_steps=["s1"],
+        blockers=["b1"],
+    )
+    write_memory(tmp_path, mem)
+    loaded = read_memory(tmp_path)
+    assert loaded == mem
+
+
+# ---------------------------------------------------------------------------
+# merge_memory
+# ---------------------------------------------------------------------------
+
+
+def test_merge_memory_no_existing_returns_update() -> None:
+    update: WorkingMemory = WorkingMemory(plan="new plan", decisions=["d1"])
+    result = merge_memory(None, update)
+    assert result["plan"] == "new plan"
+    assert result["decisions"] == ["d1"]
+    assert "files_examined" not in result
+
+
+def test_merge_memory_preserves_unmentioned_fields() -> None:
+    existing: WorkingMemory = WorkingMemory(plan="old", files_examined=["a.py"])
+    update: WorkingMemory = WorkingMemory(next_steps=["step1"])
+    result = merge_memory(existing, update)
+    assert result["plan"] == "old"
+    assert result["files_examined"] == ["a.py"]
+    assert result["next_steps"] == ["step1"]
+
+
+def test_merge_memory_overwrites_plan() -> None:
+    existing: WorkingMemory = WorkingMemory(plan="old plan")
+    update: WorkingMemory = WorkingMemory(plan="new plan")
+    result = merge_memory(existing, update)
+    assert result["plan"] == "new plan"
+
+
+def test_merge_memory_findings_are_union_merged() -> None:
+    existing: WorkingMemory = WorkingMemory(findings={"a.py": "note a", "b.py": "note b"})
+    update: WorkingMemory = WorkingMemory(findings={"b.py": "updated", "c.py": "note c"})
+    result = merge_memory(existing, update)
+    assert result["findings"] == {
+        "a.py": "note a",
+        "b.py": "updated",
+        "c.py": "note c",
+    }
+
+
+def test_merge_memory_empty_update_preserves_everything() -> None:
+    existing: WorkingMemory = WorkingMemory(plan="keep", decisions=["d"])
+    update: WorkingMemory = WorkingMemory()
+    result = merge_memory(existing, update)
+    assert result["plan"] == "keep"
+    assert result["decisions"] == ["d"]
+
+
+# ---------------------------------------------------------------------------
+# render_memory
+# ---------------------------------------------------------------------------
+
+
+def test_render_memory_empty_shows_heading_only() -> None:
+    rendered = render_memory(WorkingMemory())
+    assert rendered.startswith("## Working Memory")
+    assert "Plan" not in rendered
+    assert "Findings" not in rendered
+
+
+def test_render_memory_plan_appears() -> None:
+    rendered = render_memory(WorkingMemory(plan="implement caching layer"))
+    assert "implement caching layer" in rendered
+
+
+def test_render_memory_files_examined_appear() -> None:
+    rendered = render_memory(WorkingMemory(files_examined=["foo.py", "bar.py"]))
+    assert "`foo.py`" in rendered
+    assert "`bar.py`" in rendered
+
+
+def test_render_memory_next_steps_numbered() -> None:
+    rendered = render_memory(WorkingMemory(next_steps=["alpha", "beta"]))
+    assert "1. alpha" in rendered
+    assert "2. beta" in rendered
+
+
+def test_render_memory_blockers_have_warning_emoji() -> None:
+    rendered = render_memory(WorkingMemory(blockers=["spec unclear"]))
+    assert "⚠️" in rendered
+    assert "spec unclear" in rendered
+
+
+def test_render_memory_findings_key_value() -> None:
+    rendered = render_memory(WorkingMemory(findings={"agent_loop.py": "loop starts at line 157"}))
+    assert "`agent_loop.py`" in rendered
+    assert "loop starts at line 157" in rendered

--- a/agentception/tools/definitions.py
+++ b/agentception/tools/definitions.py
@@ -330,8 +330,10 @@ SEARCH_CODEBASE_TOOL_DEF: ToolDefinition = ToolDefinition(
             "The index covers every .py, .md, .j2, .yaml, .toml, .json file in the repo. "
             "Call this BEFORE any grep, rg, cat, or read_file_lines when you need to "
             "locate a class, function, pattern, or concept. "
-            "The results include exact file paths and line numbers — use read_file_lines "
-            "to fetch only that specific range, never the whole file. "
+            "Results include the matched code block with its file path and line numbers. "
+            "READ THE CHUNK CONTENT DIRECTLY — it already contains the relevant code. "
+            "DO NOT follow up with read_file_lines on the same region; the chunk is the code. "
+            "Only use read_file_lines if you need lines adjacent to the matched region. "
             "Examples of what to search: 'where is AgentStatus defined', "
             "'how does the poller detect stalled agents', 'pattern for adding a persist helper', "
             "'alembic migration that adds a column'. "
@@ -364,6 +366,66 @@ SEARCH_CODEBASE_TOOL_DEF: ToolDefinition = ToolDefinition(
                 },
             },
             "required": ["query"],
+            "additionalProperties": False,
+        },
+    ),
+)
+
+UPDATE_WORKING_MEMORY_TOOL_DEF: ToolDefinition = ToolDefinition(
+    type="function",
+    function=ToolFunction(
+        name="update_working_memory",
+        description=(
+            "Update your persistent working memory — a structured scratch-pad that "
+            "survives history pruning and is injected fresh into every turn. "
+            "Call this IMMEDIATELY after any discovery so you never lose a finding. "
+            "Call it BEFORE complex reasoning to record your plan and next steps. "
+            "Only supply the fields you want to change; others are preserved. "
+            "The 'findings' dict is union-merged so you can add individual keys. "
+            "Use 'files_examined' to record every file you read so you can skip re-reads. "
+            "Memory is rendered in your system context at the start of every turn."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "type": "string",
+                    "description": "High-level implementation plan for this session.",
+                },
+                "files_examined": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Complete list of file paths you have read or examined. "
+                        "Replaces the stored list — include all files, not just new ones."
+                    ),
+                },
+                "findings": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"},
+                    "description": (
+                        "Key/value findings to record. Keys are file paths or topic slugs; "
+                        "values are short notes. Merged into existing findings — "
+                        "you only need to supply new or updated entries."
+                    ),
+                },
+                "decisions": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Architecture or approach decisions locked in this session.",
+                },
+                "next_steps": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Ordered queue of remaining work items (replaces stored list).",
+                },
+                "blockers": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Anything blocking progress. Clear when resolved.",
+                },
+            },
+            "required": [],
             "additionalProperties": False,
         },
     ),


### PR DESCRIPTION
## Summary

- **1C — Type-aware truncation**: Replace flat 3K cap with per-tool limits (file reads: 12K, semantic search: 8K, shell/rg: 5K, default: 3K). Adds `_build_tool_id_map` to resolve tool names from `tool_call_id` so the correct limit is applied per result.
- **1D — No-read-after-search directive**: Update `search_codebase` tool description to say "READ THE CHUNK CONTENT DIRECTLY" instead of directing agents to follow up with `read_file_lines`. Eliminates the systematic 2-turn overhead every semantic search was costing.
- **1B — Dispatch-time context pre-injection**: At `POST /api/dispatch/issue`, after building `task_description`, search the main Qdrant collection for the top-3 relevant code chunks and append them as pre-injected context. Agent gets oriented code from turn 1 at zero LLM-turn cost.
- **1A — Persistent working memory**: New `agentception/services/working_memory.py` with `WorkingMemory` TypedDict, `read/write/merge/render` helpers. Memory lives at `.ac/memory.json` in the worktree. The loop reads it each iteration and injects a compact Markdown rendering as a secondary (un-cached) system block so the agent always has its scratch-pad regardless of history pruning. New `update_working_memory` local tool for agents to record plan, findings, decisions, next_steps, blockers.

## Test plan

- [ ] 24 new tests added (`test_working_memory.py` full coverage, `test_agent_loop.py` type-aware truncation)
- [ ] 1648 total tests passing, 0 failures
- [ ] mypy strict: 0 errors across 315 source files
- [ ] `generate.py --check`: no drift