### PR TITLE
feat: Tier-2 agent improvements — recon phase, symbol tools, auto-memory

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -49,13 +49,17 @@ from agentception.services.llm import (
     ToolDefinition,
     ToolFunction,
     ToolResponse,
+    call_anthropic,
     call_anthropic_with_tools,
 )
 from agentception.services.code_indexer import search_codebase
 from agentception.services.github_mcp_client import GitHubMCPClient
 from agentception.tools.definitions import (
     FILE_TOOL_DEFS,
+    FIND_CALL_SITES_TOOL_DEF,
     GIT_COMMIT_AND_PUSH_TOOL_DEF,
+    READ_SYMBOL_TOOL_DEF,
+    READ_WINDOW_TOOL_DEF,
     SEARCH_CODEBASE_TOOL_DEF,
     SHELL_TOOL_DEF,
     UPDATE_WORKING_MEMORY_TOOL_DEF,
@@ -68,10 +72,13 @@ from agentception.services.working_memory import (
     write_memory,
 )
 from agentception.tools.file_tools import (
+    find_call_sites,
     insert_after_in_file,
     list_directory,
     read_file,
     read_file_lines,
+    read_symbol,
+    read_window,
     replace_in_file,
     search_text,
     write_file,
@@ -101,6 +108,9 @@ _DEFAULT_MAX_ITERATIONS = 100
 _TOOL_RESULT_CHAR_LIMITS: dict[str, int] = {
     "read_file": 12_000,
     "read_file_lines": 12_000,
+    "read_symbol": 8_000,   # full function bodies; generous but bounded
+    "read_window": 10_000,  # centered window, slightly more than read_file_lines
+    "find_call_sites": 5_000,
     "search_codebase": 8_000,
     "search_text": 5_000,
     "run_command": 5_000,
@@ -157,6 +167,9 @@ _LOCAL_TOOL_NAMES: frozenset[str] = frozenset(
     {
         "read_file",
         "read_file_lines",
+        "read_symbol",
+        "read_window",
+        "find_call_sites",
         "replace_in_file",
         "insert_after_in_file",
         "write_file",
@@ -227,6 +240,11 @@ async def run_agent_loop(
         len(tool_defs),
         len(github_tool_names),
     )
+
+    # Pre-loop recon phase: model emits an exploration plan; runtime executes
+    # all reads/searches concurrently and injects results into the initial
+    # message.  This collapses 5-10 discovery turns into a zero-turn warm-up.
+    await _run_recon_phase(run_id, worktree_path, messages, system_prompt)
 
     for iteration in range(1, max_iterations + 1):
         await log_run_step(
@@ -599,6 +617,9 @@ def _build_tool_definitions(
     tool_defs.append(SHELL_TOOL_DEF)
     tool_defs.append(GIT_COMMIT_AND_PUSH_TOOL_DEF)
     tool_defs.append(SEARCH_CODEBASE_TOOL_DEF)
+    tool_defs.append(READ_SYMBOL_TOOL_DEF)
+    tool_defs.append(READ_WINDOW_TOOL_DEF)
+    tool_defs.append(FIND_CALL_SITES_TOOL_DEF)
     tool_defs.append(UPDATE_WORKING_MEMORY_TOOL_DEF)
 
     seen: set[str] = {t["function"]["name"] for t in tool_defs}
@@ -621,6 +642,231 @@ def _build_tool_definitions(
             seen.add(gh_name)
 
     return tool_defs
+
+
+# ---------------------------------------------------------------------------
+# Recon phase — structured exploration before the main execution loop
+# ---------------------------------------------------------------------------
+
+# System addendum injected for the single pre-loop planning call.
+# The model is asked to emit a compact JSON plan — no implementation yet.
+_RECON_SYSTEM_ADDENDUM = """
+---
+
+## RECON MODE — output a JSON exploration plan ONLY
+
+Before any implementation, emit exactly ONE JSON object:
+
+```json
+{
+  "files": ["<relative paths of files most likely to need editing or serve as patterns — max 5>"],
+  "searches": ["<natural language queries for search_codebase — focus on patterns/helpers to copy — max 5>"],
+  "plan": "<one sentence: your implementation approach>"
+}
+```
+
+Rules:
+- Output ONLY the JSON object, nothing else.
+- Do not implement anything yet.
+- Maximum 5 files and 5 searches.
+- Prefer files you know you will edit over files you are merely curious about.
+"""
+
+
+class _ReconPlan:
+    """Parsed output of the recon planning call."""
+
+    __slots__ = ("files", "searches", "plan")
+
+    def __init__(self, files: list[str], searches: list[str], plan: str) -> None:
+        self.files = files
+        self.searches = searches
+        self.plan = plan
+
+
+def _parse_recon_json(raw: str) -> _ReconPlan | None:
+    """Extract and parse the JSON exploration plan from the model response.
+
+    The model may wrap the JSON in markdown fences — we strip those first.
+    Returns ``None`` when the response cannot be parsed.
+    """
+    text = raw.strip()
+    # Strip ```json ... ``` fences if present.
+    if text.startswith("```"):
+        lines = text.splitlines()
+        inner = [l for l in lines if not l.startswith("```")]
+        text = "\n".join(inner).strip()
+
+    # Find the outermost JSON object.
+    start = text.find("{")
+    end = text.rfind("}") + 1
+    if start == -1 or end <= start:
+        return None
+    try:
+        data: object = json.loads(text[start:end])
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    files_raw = data.get("files", [])
+    searches_raw = data.get("searches", [])
+    plan_raw = data.get("plan", "")
+
+    files: list[str] = (
+        [f for f in files_raw if isinstance(f, str)][:5]
+        if isinstance(files_raw, list)
+        else []
+    )
+    searches: list[str] = (
+        [s for s in searches_raw if isinstance(s, str)][:5]
+        if isinstance(searches_raw, list)
+        else []
+    )
+    plan_str = str(plan_raw) if isinstance(plan_raw, str) else ""
+
+    if not files and not searches:
+        return None
+
+    return _ReconPlan(files=files, searches=searches, plan=plan_str)
+
+
+async def _run_recon_phase(
+    run_id: str,
+    worktree_path: Path,
+    messages: list[dict[str, object]],
+    system_prompt: str,
+) -> None:
+    """Execute a structured recon phase before the main agent loop begins.
+
+    1. Call the LLM once with a planning-only system addendum to obtain a
+       JSON exploration plan: which files to read, which searches to run.
+    2. Execute all requested reads and searches concurrently.
+    3. Append a compact bundle of results to ``messages[0]`` so the model
+       starts iteration 1 with context already in view.
+    4. Update working memory with discovered files and the high-level plan.
+
+    This phase runs outside the iteration counter and the inter-turn delay.
+    A failure at any point is non-fatal: the loop proceeds without recon context.
+    """
+    # Grab the task briefing text from the initial message.
+    task_text_raw = messages[0].get("content", "") if messages else ""
+    task_text = str(task_text_raw)[:4_000]  # cap for the planning prompt
+
+    try:
+        raw_plan = await call_anthropic(
+            task_text,
+            system_prompt=system_prompt + _RECON_SYSTEM_ADDENDUM,
+            max_tokens=400,
+            temperature=0.0,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("⚠️ recon phase: planning call failed — %s", exc)
+        return
+
+    plan = _parse_recon_json(raw_plan)
+    if plan is None:
+        logger.warning("⚠️ recon phase: could not parse plan from LLM response")
+        return
+
+    logger.info(
+        "✅ recon: files=%d searches=%d — %s",
+        len(plan.files),
+        len(plan.searches),
+        plan.plan,
+    )
+
+    # ── Execute all reads and searches concurrently ──────────────────────────
+
+    async def _read_one(rel_path: str) -> str | None:
+        path = worktree_path / rel_path
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+            return text[:4_000]  # cap per file in the bundle
+        except OSError:
+            return None
+
+    async def _search_one(query: str) -> list[dict[str, object]]:
+        try:
+            results = await search_codebase(query, 3)
+            return [
+                {"file": m["file"], "chunk": m["chunk"][:600], "score": m["score"]}
+                for m in results
+            ]
+        except Exception:  # noqa: BLE001
+            return []
+
+    file_tasks = [_read_one(f) for f in plan.files]
+    search_tasks = [_search_one(q) for q in plan.searches]
+
+    raw_file_results: list[str | None | BaseException] = list(
+        await asyncio.gather(*file_tasks, return_exceptions=True)
+    )
+    raw_search_results: list[object] = list(
+        await asyncio.gather(*search_tasks, return_exceptions=True)
+    )
+
+    # ── Bundle results ────────────────────────────────────────────────────────
+
+    sections: list[str] = []
+
+    if plan.plan:
+        sections.append(f"**Recon plan:** {plan.plan}")
+
+    discovered_files: list[str] = []
+
+    for rel_path, result in zip(plan.files, raw_file_results):
+        if isinstance(result, str):
+            sections.append(f"### `{rel_path}`\n```\n{result}\n```")
+            discovered_files.append(rel_path)
+        else:
+            sections.append(f"### `{rel_path}`\n_(could not read)_")
+
+    for query, raw_sr in zip(plan.searches, raw_search_results):
+        if not isinstance(raw_sr, list):
+            continue
+        search_hits: list[dict[str, object]] = [
+            item for item in raw_sr if isinstance(item, dict)
+        ]
+        if search_hits:
+            chunks = "\n\n".join(
+                f"**{m.get('file', '?')}** (score={m.get('score', 0.0)!s:.5})\n"
+                f"```\n{m.get('chunk', '')}\n```"
+                for m in search_hits
+            )
+            sections.append(f"### Search: _{query}_\n{chunks}")
+
+    if not sections:
+        logger.info("✅ recon: no usable results; skipping context injection")
+        return
+
+    bundle = "## Pre-execution Recon Bundle\n\n" + "\n\n".join(sections)
+
+    # Append to the initial user message (no alternation issues — still one user msg).
+    original_content = str(messages[0].get("content", ""))
+    messages[0] = {
+        **dict(messages[0]),
+        "content": original_content + "\n\n---\n\n" + bundle,
+    }
+
+    # ── Update working memory ─────────────────────────────────────────────────
+
+    existing_memory = read_memory(worktree_path)
+    mem_update = WorkingMemory()
+    if plan.plan:
+        mem_update["plan"] = plan.plan
+    if discovered_files:
+        mem_update["files_examined"] = discovered_files
+    if mem_update:
+        merged = merge_memory(existing_memory, mem_update)
+        write_memory(worktree_path, merged)
+
+    logger.info(
+        "✅ recon phase complete — injected %d sections, %d files in memory",
+        len(sections),
+        len(discovered_files),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -728,6 +974,32 @@ def _prune_history(
 # ---------------------------------------------------------------------------
 # Tool dispatch
 # ---------------------------------------------------------------------------
+
+
+def _auto_track_file_read(file_path: Path, worktree_path: Path) -> None:
+    """Record *file_path* in the agent's working memory after a successful read.
+
+    This is runtime-owned state: the loop updates ``files_examined`` after
+    every successful read without depending on the agent to remember to call
+    ``update_working_memory``.  Never raises — tracking failure is silently
+    ignored so the caller's result is unaffected.
+
+    Paths are stored relative to *worktree_path* when possible (shorter, cleaner).
+    """
+    try:
+        try:
+            rel = str(file_path.relative_to(worktree_path))
+        except ValueError:
+            rel = str(file_path)
+        existing = read_memory(worktree_path)
+        current: list[str] = list(existing.get("files_examined", [])) if existing else []
+        if rel not in current:
+            current.append(rel)
+            update = WorkingMemory(files_examined=current)
+            merged = merge_memory(existing, update)
+            write_memory(worktree_path, merged)
+    except Exception:  # noqa: BLE001
+        pass
 
 
 async def _dispatch_tool_calls(
@@ -856,7 +1128,10 @@ async def _dispatch_local_tool(
 
     if name == "read_file":
         path = _resolve(args.get("path"), worktree_path)
-        return read_file(path)
+        result = read_file(path)
+        if result.get("ok"):
+            _auto_track_file_read(path, worktree_path)
+        return result
 
     if name == "read_file_lines":
         path_raw = args.get("path")
@@ -868,7 +1143,11 @@ async def _dispatch_local_tool(
             return {"ok": False, "error": "read_file_lines: 'start_line' must be an integer"}
         if not isinstance(end_raw, int):
             return {"ok": False, "error": "read_file_lines: 'end_line' must be an integer"}
-        return read_file_lines(_resolve(path_raw, worktree_path), start_raw, end_raw)
+        resolved = _resolve(path_raw, worktree_path)
+        result = read_file_lines(resolved, start_raw, end_raw)
+        if result.get("ok"):
+            _auto_track_file_read(resolved, worktree_path)
+        return result
 
     if name == "replace_in_file":
         path_raw = args.get("path")
@@ -972,6 +1251,44 @@ async def _dispatch_local_tool(
         collection_arg: str | None = collection_raw if isinstance(collection_raw, str) else None
         matches = await search_codebase(query_raw, n_results, collection=collection_arg)
         return {"ok": True, "matches": matches}
+
+    if name == "read_symbol":
+        path_raw = args.get("path")
+        symbol_raw = args.get("symbol_name")
+        if not isinstance(path_raw, str):
+            return {"ok": False, "error": "read_symbol: 'path' must be a string"}
+        if not isinstance(symbol_raw, str):
+            return {"ok": False, "error": "read_symbol: 'symbol_name' must be a string"}
+        resolved = _resolve(path_raw, worktree_path)
+        result = read_symbol(resolved, symbol_raw)
+        if result.get("ok"):
+            _auto_track_file_read(resolved, worktree_path)
+        return result
+
+    if name == "read_window":
+        path_raw = args.get("path")
+        center_raw = args.get("center_line")
+        if not isinstance(path_raw, str):
+            return {"ok": False, "error": "read_window: 'path' must be a string"}
+        if not isinstance(center_raw, int):
+            return {"ok": False, "error": "read_window: 'center_line' must be an integer"}
+        before_raw = args.get("before", 80)
+        after_raw = args.get("after", 120)
+        before = int(before_raw) if isinstance(before_raw, int) else 80
+        after = int(after_raw) if isinstance(after_raw, int) else 120
+        resolved = _resolve(path_raw, worktree_path)
+        result = read_window(resolved, center_raw, before=before, after=after)
+        if result.get("ok"):
+            _auto_track_file_read(resolved, worktree_path)
+        return result
+
+    if name == "find_call_sites":
+        symbol_raw = args.get("symbol_name")
+        if not isinstance(symbol_raw, str):
+            return {"ok": False, "error": "find_call_sites: 'symbol_name' must be a string"}
+        n_raw = args.get("n_results", 30)
+        n_results_fc = int(n_raw) if isinstance(n_raw, int) else 30
+        return await find_call_sites(symbol_raw, worktree_path, n_results=n_results_fc)
 
     if name == "update_working_memory":
         update = WorkingMemory()

--- a/agentception/tests/test_file_tools_symbol.py
+++ b/agentception/tests/test_file_tools_symbol.py
@@ -1,0 +1,219 @@
+"""Unit tests for the symbol-aware file navigation tools.
+
+Tests for read_symbol, read_window, and find_call_sites added in the
+Tier-2 context improvements.  All I/O uses tmp_path; no network required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentception.tools.file_tools import read_symbol, read_window
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture — a small Python module written to tmp_path
+# ---------------------------------------------------------------------------
+
+SAMPLE_PY = """\
+\"\"\"Sample module for testing.\"\"\"
+
+from __future__ import annotations
+
+
+def helper(x: int) -> int:
+    return x + 1
+
+
+class Processor:
+    \"\"\"A processor class.\"\"\"
+
+    def run(self, value: int) -> int:
+        return helper(value) * 2
+
+    def reset(self) -> None:
+        pass
+
+
+async def async_handler(payload: str) -> str:
+    return payload.strip()
+"""
+
+
+@pytest.fixture()
+def sample_py(tmp_path: Path) -> Path:
+    p = tmp_path / "sample.py"
+    p.write_text(SAMPLE_PY, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# read_symbol
+# ---------------------------------------------------------------------------
+
+
+def test_read_symbol_finds_top_level_function(sample_py: Path) -> None:
+    result = read_symbol(sample_py, "helper")
+    assert result["ok"] is True
+    content = result["content"]
+    assert isinstance(content, str)
+    assert "def helper" in content
+    assert "return x + 1" in content
+
+
+def test_read_symbol_finds_class(sample_py: Path) -> None:
+    result = read_symbol(sample_py, "Processor")
+    assert result["ok"] is True
+    content = result["content"]
+    assert isinstance(content, str)
+    assert "class Processor" in content
+    assert "def run" in content
+    assert "def reset" in content
+
+
+def test_read_symbol_finds_async_function(sample_py: Path) -> None:
+    result = read_symbol(sample_py, "async_handler")
+    assert result["ok"] is True
+    content = result["content"]
+    assert isinstance(content, str)
+    assert "async def async_handler" in content
+    assert "payload.strip()" in content
+
+
+def test_read_symbol_returns_error_for_missing_symbol(sample_py: Path) -> None:
+    result = read_symbol(sample_py, "nonexistent_function")
+    assert result["ok"] is False
+    assert "not found" in str(result.get("error", "")).lower()
+
+
+def test_read_symbol_returns_error_for_missing_file(tmp_path: Path) -> None:
+    result = read_symbol(tmp_path / "ghost.py", "anything")
+    assert result["ok"] is False
+    assert "not found" in str(result.get("error", "")).lower()
+
+
+def test_read_symbol_returns_line_numbers(sample_py: Path) -> None:
+    result = read_symbol(sample_py, "helper")
+    assert result["ok"] is True
+    assert isinstance(result["start_line"], int)
+    assert isinstance(result["end_line"], int)
+    assert result["start_line"] >= 1
+    assert result["end_line"] >= result["start_line"]
+
+
+def test_read_symbol_total_lines_correct(sample_py: Path) -> None:
+    result = read_symbol(sample_py, "Processor")
+    assert result["ok"] is True
+    total = result["total_lines"]
+    assert isinstance(total, int)
+    assert total == len(SAMPLE_PY.splitlines())
+
+
+# ---------------------------------------------------------------------------
+# read_window
+# ---------------------------------------------------------------------------
+
+
+def test_read_window_returns_centered_lines(sample_py: Path) -> None:
+    result = read_window(sample_py, 8, before=2, after=3)
+    assert result["ok"] is True
+    content = result["content"]
+    assert isinstance(content, str)
+    # Line 8 of SAMPLE_PY is `    return x + 1`; window should include it.
+    assert "return x + 1" in content
+
+
+def test_read_window_clamps_to_file_boundaries(sample_py: Path) -> None:
+    total = len(SAMPLE_PY.splitlines())
+    # Center near end — should not exceed file.
+    result = read_window(sample_py, total - 1, before=5, after=100)
+    assert result["ok"] is True
+    assert result["end_line"] == total
+
+
+def test_read_window_clamps_start_to_1(sample_py: Path) -> None:
+    result = read_window(sample_py, 2, before=50, after=5)
+    assert result["ok"] is True
+    assert result["start_line"] == 1
+
+
+def test_read_window_returns_center_line(sample_py: Path) -> None:
+    result = read_window(sample_py, 10, before=3, after=3)
+    assert result["ok"] is True
+    assert result["center_line"] == 10
+
+
+def test_read_window_returns_error_for_missing_file(tmp_path: Path) -> None:
+    result = read_window(tmp_path / "ghost.py", 5)
+    assert result["ok"] is False
+    assert "not found" in str(result.get("error", "")).lower()
+
+
+def test_read_window_full_file_when_before_after_large(sample_py: Path) -> None:
+    total = len(SAMPLE_PY.splitlines())
+    result = read_window(sample_py, total // 2, before=10_000, after=10_000)
+    assert result["ok"] is True
+    assert result["start_line"] == 1
+    assert result["end_line"] == total
+
+
+# ---------------------------------------------------------------------------
+# _parse_recon_json — recon plan parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_recon_json_valid() -> None:
+    from agentception.services.agent_loop import _parse_recon_json
+
+    raw = json.dumps({
+        "files": ["agentception/foo.py", "tests/test_foo.py"],
+        "searches": ["how is Foo defined"],
+        "plan": "Implement X by patching Y",
+    })
+    plan = _parse_recon_json(raw)
+    assert plan is not None
+    assert plan.files == ["agentception/foo.py", "tests/test_foo.py"]
+    assert plan.searches == ["how is Foo defined"]
+    assert plan.plan == "Implement X by patching Y"
+
+
+def test_parse_recon_json_with_markdown_fences() -> None:
+    from agentception.services.agent_loop import _parse_recon_json
+
+    raw = '```json\n{"files": ["a.py"], "searches": [], "plan": "do stuff"}\n```'
+    plan = _parse_recon_json(raw)
+    assert plan is not None
+    assert plan.files == ["a.py"]
+
+
+def test_parse_recon_json_caps_at_five() -> None:
+    from agentception.services.agent_loop import _parse_recon_json
+
+    raw = json.dumps({
+        "files": [f"file{i}.py" for i in range(10)],
+        "searches": [f"query {i}" for i in range(10)],
+        "plan": "do lots",
+    })
+    plan = _parse_recon_json(raw)
+    assert plan is not None
+    assert len(plan.files) == 5
+    assert len(plan.searches) == 5
+
+
+def test_parse_recon_json_returns_none_for_garbage() -> None:
+    from agentception.services.agent_loop import _parse_recon_json
+
+    assert _parse_recon_json("not json at all") is None
+    assert _parse_recon_json('{"files": [], "searches": []}') is None  # both empty
+
+
+def test_parse_recon_json_json_in_prose() -> None:
+    from agentception.services.agent_loop import _parse_recon_json
+
+    raw = 'Sure! Here is the plan:\n{"files": ["x.py"], "searches": ["q"], "plan": "p"}\nDone.'
+    plan = _parse_recon_json(raw)
+    assert plan is not None
+    assert plan.files == ["x.py"]

--- a/agentception/tools/definitions.py
+++ b/agentception/tools/definitions.py
@@ -371,6 +371,110 @@ SEARCH_CODEBASE_TOOL_DEF: ToolDefinition = ToolDefinition(
     ),
 )
 
+READ_SYMBOL_TOOL_DEF: ToolDefinition = ToolDefinition(
+    type="function",
+    function=ToolFunction(
+        name="read_symbol",
+        description=(
+            "Return the complete body of a function or class by name — including decorators. "
+            "PREFER this over read_file_lines when you know the symbol name: "
+            "it uses the Python AST for exact boundaries and returns the whole definition. "
+            "No follow-up read needed. "
+            "If the symbol is not found, falls back to a heuristic line scan. "
+            "Relative paths are resolved from the worktree root."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the source file (relative or absolute).",
+                },
+                "symbol_name": {
+                    "type": "string",
+                    "description": "Exact function or class name, e.g. '_truncate_tool_results'.",
+                },
+            },
+            "required": ["path", "symbol_name"],
+            "additionalProperties": False,
+        },
+    ),
+)
+
+READ_WINDOW_TOOL_DEF: ToolDefinition = ToolDefinition(
+    type="function",
+    function=ToolFunction(
+        name="read_window",
+        description=(
+            "Read a generous window of lines centered on a given line number. "
+            "PREFER this over read_file_lines for exploration: plug in the line "
+            "number from a search result and receive 80 lines before + 120 after "
+            "— enough to capture most complete function definitions without knowing "
+            "exact boundaries. "
+            "Relative paths are resolved from the worktree root."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file (relative or absolute).",
+                },
+                "center_line": {
+                    "type": "integer",
+                    "description": "1-indexed line to center the window on (e.g. from a search result).",
+                    "minimum": 1,
+                },
+                "before": {
+                    "type": "integer",
+                    "description": "Lines to include before center_line (default 80).",
+                    "default": 80,
+                    "minimum": 1,
+                },
+                "after": {
+                    "type": "integer",
+                    "description": "Lines to include after center_line (default 120).",
+                    "default": 120,
+                    "minimum": 1,
+                },
+            },
+            "required": ["path", "center_line"],
+            "additionalProperties": False,
+        },
+    ),
+)
+
+FIND_CALL_SITES_TOOL_DEF: ToolDefinition = ToolDefinition(
+    type="function",
+    function=ToolFunction(
+        name="find_call_sites",
+        description=(
+            "Find all call sites and import locations of a function or class using ripgrep. "
+            "Use this AFTER read_symbol to understand usage patterns before editing — "
+            "knowing call sites prevents breaking changes. "
+            "Returns file paths and matching lines."
+        ),
+        parameters={
+            "type": "object",
+            "properties": {
+                "symbol_name": {
+                    "type": "string",
+                    "description": "Function or class name to find (e.g. 'persist_agent_run_dispatch').",
+                },
+                "n_results": {
+                    "type": "integer",
+                    "description": "Max matching lines to return (default 30).",
+                    "default": 30,
+                    "minimum": 1,
+                    "maximum": 100,
+                },
+            },
+            "required": ["symbol_name"],
+            "additionalProperties": False,
+        },
+    ),
+)
+
 UPDATE_WORKING_MEMORY_TOOL_DEF: ToolDefinition = ToolDefinition(
     type="function",
     function=ToolFunction(

--- a/agentception/tools/file_tools.py
+++ b/agentception/tools/file_tools.py
@@ -7,6 +7,7 @@ receives structured feedback rather than a Python exception traceback.
 
 from __future__ import annotations
 
+import ast as _ast
 import logging
 from pathlib import Path
 
@@ -349,3 +350,227 @@ async def search_text(
         return {"ok": False, "error": f"rg failed (exit {proc.returncode}): {err_text}"}
 
     return {"ok": True, "matches": output or "(no matches)"}
+
+
+# ---------------------------------------------------------------------------
+# Symbol-aware navigation tools
+# ---------------------------------------------------------------------------
+
+
+def _find_symbol_lines_py(text: str, symbol_name: str) -> tuple[int, int] | None:
+    """Return (start_line, end_line) for *symbol_name* using the Python AST.
+
+    Walks every function/class definition in the parsed tree and returns the
+    first match.  Includes decorator lines in the start.  Returns ``None`` on
+    a parse error or when the symbol is not found.
+    """
+    try:
+        tree = _ast.parse(text)
+    except SyntaxError:
+        return None
+
+    for node in _ast.walk(tree):
+        if not isinstance(
+            node, (_ast.FunctionDef, _ast.AsyncFunctionDef, _ast.ClassDef)
+        ):
+            continue
+        if node.name != symbol_name:
+            continue
+        end_line: int | None = getattr(node, "end_lineno", None)
+        if end_line is None:
+            continue
+        start_line = node.lineno
+        if node.decorator_list:
+            start_line = min(d.lineno for d in node.decorator_list)
+        return start_line, end_line
+
+    return None
+
+
+def read_symbol(path: str | Path, symbol_name: str) -> dict[str, object]:
+    """Return the complete body of a function or class by name.
+
+    For ``.py`` files, uses the Python AST to find exact symbol boundaries
+    (including decorators).  Returns the full definition so the model can act
+    on it without a follow-up ``read_file_lines`` call.
+
+    Args:
+        path: Source file to search.
+        symbol_name: Exact function or class name (e.g. ``_truncate_tool_results``).
+
+    Returns:
+        ``{"ok": True, "content": str, "start_line": int, "end_line": int,
+        "total_lines": int}`` — the symbol body with its line range.  Or
+        ``{"ok": False, "error": str}`` when the symbol is not found or the
+        file cannot be read.
+    """
+    p = Path(path)
+    try:
+        text = p.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {"ok": False, "error": f"File not found: {p}"}
+    except PermissionError:
+        return {"ok": False, "error": f"Permission denied: {p}"}
+    except OSError as exc:
+        return {"ok": False, "error": str(exc)}
+
+    lines = text.splitlines(keepends=True)
+    total = len(lines)
+
+    if p.suffix == ".py":
+        bounds = _find_symbol_lines_py(text, symbol_name)
+        if bounds is not None:
+            start, end = bounds
+            content = "".join(lines[start - 1 : end])
+            logger.info("✅ read_symbol — %s::%s lines %d-%d", p, symbol_name, start, end)
+            return {
+                "ok": True,
+                "content": content,
+                "start_line": start,
+                "end_line": end,
+                "total_lines": total,
+            }
+        # AST found nothing — fall through to string scan below.
+
+    # Non-Python or AST miss: scan for `def name` / `class name`.
+    for i, line in enumerate(lines, 1):
+        stripped = line.lstrip()
+        if stripped.startswith(f"def {symbol_name}(") or stripped.startswith(
+            f"class {symbol_name}("
+        ) or stripped.startswith(f"class {symbol_name}:"):
+            # Heuristic end: next non-indented non-empty line at same or
+            # lower indent level.  Good enough for most source files.
+            base_indent = len(line) - len(stripped)
+            end = i
+            for j in range(i, total):
+                following = lines[j]
+                if following.strip() == "":
+                    end = j + 1
+                    continue
+                curr_indent = len(following) - len(following.lstrip())
+                if curr_indent <= base_indent and j > i:
+                    break
+                end = j + 1
+            content = "".join(lines[i - 1 : end])
+            logger.info("✅ read_symbol — %s::%s lines %d-%d (heuristic)", p, symbol_name, i, end)
+            return {
+                "ok": True,
+                "content": content,
+                "start_line": i,
+                "end_line": end,
+                "total_lines": total,
+            }
+
+    return {"ok": False, "error": f"Symbol '{symbol_name}' not found in {p}"}
+
+
+def read_window(
+    path: str | Path,
+    center_line: int,
+    *,
+    before: int = 80,
+    after: int = 120,
+) -> dict[str, object]:
+    """Read a window of lines centered on *center_line*.
+
+    More ergonomic than ``read_file_lines`` for exploration: plug in a line
+    number from search results and receive enough surrounding context to act
+    without a follow-up read.  The default window (80 before, 120 after)
+    captures most complete function definitions.
+
+    Args:
+        path: File to read.
+        center_line: 1-indexed line to center the window on.
+        before: Lines to include before *center_line* (default 80).
+        after: Lines to include after *center_line* (default 120).
+
+    Returns:
+        ``{"ok": True, "content": str, "start_line": int, "end_line": int,
+        "center_line": int, "total_lines": int}`` or ``{"ok": False, "error": str}``.
+    """
+    p = Path(path)
+    try:
+        text = p.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {"ok": False, "error": f"File not found: {p}"}
+    except PermissionError:
+        return {"ok": False, "error": f"Permission denied: {p}"}
+    except OSError as exc:
+        return {"ok": False, "error": str(exc)}
+
+    lines = text.splitlines(keepends=True)
+    total = len(lines)
+
+    start = max(1, center_line - before)
+    end = min(total, center_line + after)
+    content = "".join(lines[start - 1 : end])
+
+    logger.info("✅ read_window — %s center=%d (%d-%d/%d)", p, center_line, start, end, total)
+    return {
+        "ok": True,
+        "content": content,
+        "start_line": start,
+        "end_line": end,
+        "center_line": center_line,
+        "total_lines": total,
+    }
+
+
+async def find_call_sites(
+    symbol_name: str,
+    directory: str | Path,
+    *,
+    n_results: int = 30,
+) -> dict[str, object]:
+    """Find all call sites of *symbol_name* using ripgrep.
+
+    Searches for ``symbol_name(`` to catch function calls, plus ``symbol_name``
+    in import lines.  Returns file paths, line numbers, and the matching line
+    so the model can see usage patterns before editing.
+
+    Args:
+        symbol_name: Function or class name to search for.
+        directory: Root directory to search (defaults to worktree root).
+        n_results: Maximum matching lines to return.
+
+    Returns:
+        ``{"ok": True, "matches": str}`` — ripgrep-formatted output — or
+        ``{"ok": False, "error": str}`` on failure.
+    """
+    import asyncio
+
+    d = Path(directory)
+    if not d.exists():
+        return {"ok": False, "error": f"Directory does not exist: {d}"}
+
+    # Match call sites `name(` AND import lines `import name` / `from x import name`.
+    pattern = rf"\b{symbol_name}[\(\s]|import\s+{symbol_name}"
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "rg",
+            "--heading",
+            "--line-number",
+            "--max-count",
+            str(n_results),
+            "-e",
+            pattern,
+            str(d),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30.0)
+    except FileNotFoundError:
+        return {"ok": False, "error": "rg (ripgrep) not found on PATH"}
+    except asyncio.TimeoutError:
+        return {"ok": False, "error": "find_call_sites timed out after 30s"}
+    except OSError as exc:
+        return {"ok": False, "error": str(exc)}
+
+    output = stdout.decode("utf-8", errors="replace")
+    if proc.returncode not in (0, 1):
+        err_text = stderr.decode("utf-8", errors="replace").strip()
+        return {"ok": False, "error": f"rg failed (exit {proc.returncode}): {err_text}"}
+
+    logger.info("✅ find_call_sites — %s in %s", symbol_name, d)
+    return {"ok": True, "matches": output or "(no call sites found)"}


### PR DESCRIPTION
## Summary

- **E — Recon/planning phase**: Before the main iteration loop, ask the LLM once for a JSON exploration plan (files to read, searches to run). Runtime executes everything concurrently via `asyncio.gather`, injects results into the initial message, and writes discovered files to working memory. Collapses 5-10 discovery turns into a zero-turn warm-up.
- **F — Symbol-aware tools**: Three new local tools: `read_symbol` (Python AST + heuristic fallback for exact function/class bodies), `read_window` (centered context window, default 80+120 lines), `find_call_sites` (ripgrep-powered call site finder). All wired into `_TOOL_RESULT_CHAR_LIMITS` with appropriate caps.
- **G — Runtime-owned auto-tracking**: `_auto_track_file_read()` called after every successful `read_file`, `read_file_lines`, `read_symbol`, and `read_window`. Appends the relative file path to `files_examined` in working memory without depending on the agent to remember to call `update_working_memory`.

## Test plan

- [ ] 18 new tests in `test_file_tools_symbol.py` covering `read_symbol`, `read_window`, and `_parse_recon_json`
- [ ] 1666 total tests passing, 0 failures
- [ ] mypy strict: 0 errors across 220+97 source files
- [ ] `generate.py --check`: no drift