### PR TITLE
fix: rename .ac/ to .agentception/ and cache tool catalogue

### DIFF
--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -154,10 +154,16 @@ def _api_key() -> str:
 
 
 def _base_headers() -> dict[str, str]:
-    """Build the HTTP headers required by every Anthropic API request."""
+    """Build the HTTP headers required by every Anthropic API request.
+
+    ``anthropic-beta: prompt-caching-2024-07-31`` is required to enable
+    ``cache_control`` on both the system prompt and the tool catalogue.
+    Without this header, cache_control blocks are silently ignored.
+    """
     return {
         "x-api-key": _api_key(),
         "anthropic-version": _ANTHROPIC_VERSION,
+        "anthropic-beta": "prompt-caching-2024-07-31",
         "content-type": "application/json",
     }
 
@@ -179,7 +185,17 @@ def _get_client() -> httpx.AsyncClient:
 
 
 def _tools_to_anthropic(tools: list[ToolDefinition]) -> list[dict[str, object]]:
-    """Convert OpenAI-format tool definitions to Anthropic's input_schema format."""
+    """Convert OpenAI-format tool definitions to Anthropic's input_schema format.
+
+    The last tool in the converted list receives ``cache_control: ephemeral`` so
+    Anthropic caches the entire tool catalogue after turn 1.  Without this, every
+    turn pays full input-token price for all tool schemas — with 40+ GitHub MCP
+    tools included that is easily 8–15K tokens per turn.  Caching cuts it to the
+    cache-read rate (~10% of normal cost) from turn 2 onward.
+
+    This is the server-side answer to "on-demand tool discovery": tools are
+    loaded once, cached, and referenced cheaply on every subsequent turn.
+    """
     result: list[dict[str, object]] = []
     for tool in tools:
         fn = tool["function"]
@@ -190,6 +206,9 @@ def _tools_to_anthropic(tools: list[ToolDefinition]) -> list[dict[str, object]]:
                 "input_schema": fn["parameters"],
             }
         )
+    # Mark the last tool as the cache boundary so the full list is cached.
+    if result:
+        result[-1] = {**result[-1], "cache_control": {"type": "ephemeral"}}
     return result
 
 
@@ -498,8 +517,10 @@ async def call_anthropic_with_tools(
     wire format — content-block arrays, tool_use/tool_result blocks,
     input_schema instead of parameters — happens internally.
 
-    Prompt caching is applied to the system prompt (cache_control: ephemeral).
-    Turn 1 writes the cache; turns 2-N read it at ~10% of normal input cost.
+    Prompt caching is applied to both the system prompt and the tool catalogue
+    (cache_control: ephemeral on each).  Turn 1 writes both caches; turns 2-N
+    read them at ~10% of normal input cost.  With 40+ GitHub MCP tools included,
+    tool-list caching alone saves 8–15K tokens per turn.
 
     Args:
         messages: OpenAI-format conversation history (user/assistant/tool).

--- a/agentception/services/working_memory.py
+++ b/agentception/services/working_memory.py
@@ -1,6 +1,10 @@
 """Persistent working memory for agent runs.
 
-A lightweight JSON file stored at ``.ac/memory.json`` inside the worktree.
+A lightweight JSON file stored at ``.agentception/memory.json`` inside the
+worktree — alongside the repo's role files and prompt templates, so all
+AgentCeption runtime state is co-located under the project's canonical config
+directory rather than a one-off ``.ac/`` prefix.
+
 The agent loop reads it at the start of every iteration and injects a compact
 rendering as a secondary system block so the model always has its current state
 — without touching the prunable conversation history.
@@ -18,7 +22,7 @@ from typing import TypedDict
 
 logger = logging.getLogger(__name__)
 
-_MEMORY_FILENAME = ".ac/memory.json"
+_MEMORY_FILENAME = ".agentception/memory.json"
 
 
 class WorkingMemory(TypedDict, total=False):

--- a/agentception/tests/test_working_memory.py
+++ b/agentception/tests/test_working_memory.py
@@ -29,19 +29,19 @@ def test_read_memory_missing_file_returns_none(tmp_path: Path) -> None:
 
 
 def test_read_memory_corrupt_json_returns_none(tmp_path: Path) -> None:
-    (tmp_path / ".ac").mkdir()
-    (tmp_path / ".ac" / "memory.json").write_text("not json", encoding="utf-8")
+    (tmp_path / ".agentception").mkdir()
+    (tmp_path / ".agentception" / "memory.json").write_text("not json", encoding="utf-8")
     assert read_memory(tmp_path) is None
 
 
 def test_read_memory_non_dict_returns_none(tmp_path: Path) -> None:
-    (tmp_path / ".ac").mkdir()
-    (tmp_path / ".ac" / "memory.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    (tmp_path / ".agentception").mkdir()
+    (tmp_path / ".agentception" / "memory.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")
     assert read_memory(tmp_path) is None
 
 
 def test_read_memory_full_object(tmp_path: Path) -> None:
-    (tmp_path / ".ac").mkdir()
+    (tmp_path / ".agentception").mkdir()
     payload = {
         "plan": "implement X",
         "files_examined": ["a.py", "b.py"],
@@ -50,7 +50,7 @@ def test_read_memory_full_object(tmp_path: Path) -> None:
         "next_steps": ["write tests"],
         "blockers": ["unclear spec"],
     }
-    (tmp_path / ".ac" / "memory.json").write_text(json.dumps(payload), encoding="utf-8")
+    (tmp_path / ".agentception" / "memory.json").write_text(json.dumps(payload), encoding="utf-8")
     memory = read_memory(tmp_path)
     assert memory is not None
     assert memory["plan"] == "implement X"
@@ -62,10 +62,10 @@ def test_read_memory_full_object(tmp_path: Path) -> None:
 
 
 def test_read_memory_ignores_wrong_type_fields(tmp_path: Path) -> None:
-    (tmp_path / ".ac").mkdir()
+    (tmp_path / ".agentception").mkdir()
     # plan is an int instead of str — should be silently skipped
     payload = {"plan": 42, "decisions": ["ok"]}
-    (tmp_path / ".ac" / "memory.json").write_text(json.dumps(payload), encoding="utf-8")
+    (tmp_path / ".agentception" / "memory.json").write_text(json.dumps(payload), encoding="utf-8")
     memory = read_memory(tmp_path)
     assert memory is not None
     assert "plan" not in memory
@@ -77,10 +77,10 @@ def test_read_memory_ignores_wrong_type_fields(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_write_memory_creates_ac_directory(tmp_path: Path) -> None:
+def test_write_memory_creates_agentception_directory(tmp_path: Path) -> None:
     mem: WorkingMemory = WorkingMemory(plan="test plan")
     write_memory(tmp_path, mem)
-    assert (tmp_path / ".ac" / "memory.json").exists()
+    assert (tmp_path / ".agentception" / "memory.json").exists()
 
 
 def test_write_memory_roundtrip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- **`.ac/memory.json` → `.agentception/memory.json`**: idiomatic with the project's existing `.agentception/` convention (co-located with `roles/`, `prompts/`, etc.) — no more one-off prefix
- **Tool catalogue caching**: adds `cache_control: ephemeral` to the last tool definition so Anthropic caches the full tool list after turn 1. With 40+ GitHub MCP tools in every call, this is 8–15K tokens saved per turn at ~10% of normal cost from turn 2 onward — the direct answer to MCP context bloat
- **`anthropic-beta` header**: explicitly enables prompt-caching for tool definitions in `_base_headers`

## Test plan

- [x] `mypy agentception/ tests/` — 0 errors
- [x] `test_working_memory.py` — all passing with updated `.agentception/` paths
- [x] `test_agent_loop.py` — all passing