### PR TITLE
fix: reset spawned_at when re-arming pending_launch on re-dispatch

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -1009,6 +1009,10 @@ async def persist_agent_run_dispatch(
                 )
                 existing.status = "pending_launch"
                 existing.spawn_mode = spawn_mode_json
+                # Reset spawned_at so the pending_launch TTL sweep (15 min window)
+                # does not immediately re-fail a re-dispatched run whose original
+                # spawned_at is older than the cutoff.
+                existing.spawned_at = _now()
                 existing.last_activity_at = _now()
                 if cognitive_arch is not None:
                     existing.cognitive_arch = cognitive_arch


### PR DESCRIPTION
## Summary

When `persist_agent_run_dispatch` re-arms an existing `failed`/`cancelled` row to `pending_launch` it was updating `last_activity_at` but leaving `spawned_at` unchanged. The pending-launch TTL sweep uses `spawned_at <= cutoff` (15 min window) — so any re-dispatch of a run whose first attempt was more than 15 minutes ago got immediately re-failed by the next poller tick.

**Fix:** also reset `spawned_at = now()` when re-arming, so the TTL sweep sees a fresh timestamp.

## Root cause discovered during

Repeated dispatches of issue #35 appeared to accept (`pending_launch` returned) but the run silently flipped back to `failed` within 30 seconds — exactly one poller tick.