### PR TITLE
Add idempotent ensure_* helpers for git and GitHub resources

### DIFF
--- a/agentception/readers/git.py
+++ b/agentception/readers/git.py
@@ -252,3 +252,121 @@ async def list_git_stash() -> list[dict[str, object]]:
         entries.append({"ref": ref, "branch": branch, "message": description})
 
     return entries
+
+
+async def ensure_branch(branch: str, base: str = "origin/dev") -> bool:
+    """Create a git branch only if it does not already exist.
+
+    Parameters
+    ----------
+    branch:
+        Branch name to create (e.g. ``"feat/issue-123"``).
+    base:
+        Base ref to branch from (default: ``"origin/dev"``).
+
+    Returns
+    -------
+    bool
+        ``True`` if the branch was created, ``False`` if it already existed.
+
+    Raises
+    ------
+    RuntimeError
+        If ``git branch`` fails for any reason other than the branch already
+        existing.
+    """
+    # Check if branch already exists
+    existing = await _git(["branch", "--list", branch])
+    if existing.strip():
+        logger.debug("Branch %r already exists — skipping creation", branch)
+        return False
+
+    # Create the branch
+    repo = str(settings.repo_dir)
+    cmd = ["git", "-C", repo, "branch", branch, base]
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        err = stderr.decode().strip()
+        raise RuntimeError(f"git branch {branch} {base} failed: {err}")
+
+    logger.info("✅ Created branch %r from %s", branch, base)
+    return True
+
+
+async def ensure_worktree(worktree_path: Path, branch: str, base: str = "origin/dev") -> bool:
+    """Create git worktree only if it does not already exist.
+
+    Handles three cases:
+    1. Both worktree dir and branch exist — return ``False`` (no-op, fully idempotent).
+    2. Branch exists but worktree dir does not (e.g. after bad teardown) — use
+       ``git worktree add <path> <branch>`` (no ``-b`` flag). Return ``True``.
+    3. Neither exists — use ``git worktree add -b <branch> <path> <base>``. Return ``True``.
+
+    Parameters
+    ----------
+    worktree_path:
+        Absolute path where the worktree should be created.
+    branch:
+        Branch name for the worktree (e.g. ``"feat/issue-123"``).
+    base:
+        Base ref to branch from when creating a new branch (default: ``"origin/dev"``).
+
+    Returns
+    -------
+    bool
+        ``True`` if the worktree was created, ``False`` if it already existed.
+
+    Raises
+    ------
+    RuntimeError
+        If ``git worktree add`` fails for any reason other than the worktree
+        already existing.
+
+    Notes
+    -----
+    This function does NOT configure worktree auth. Callers must still call
+    ``_configure_worktree_auth()`` separately after this returns ``True``.
+    """
+    # Case 1: Worktree directory already exists — assume fully configured
+    if worktree_path.exists():
+        logger.debug("Worktree %s already exists — skipping creation", worktree_path)
+        return False
+
+    # Check if branch exists
+    existing_branch = await _git(["branch", "--list", branch])
+    branch_exists = bool(existing_branch.strip())
+
+    repo = str(settings.repo_dir)
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if branch_exists:
+        # Case 2: Branch exists but worktree dir does not — add without -b
+        cmd = ["git", "-C", repo, "worktree", "add", str(worktree_path), branch]
+    else:
+        # Case 3: Neither exists — create branch and worktree together
+        cmd = ["git", "-C", repo, "worktree", "add", "-b", branch, str(worktree_path), base]
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        err = stderr.decode().strip()
+        # If the error is "already exists", treat as idempotent success
+        if "already exists" in err.lower():
+            logger.debug("Worktree %s already exists (detected via error) — skipping", worktree_path)
+            return False
+        raise RuntimeError(f"git worktree add failed: {err}")
+
+    logger.info("✅ Created worktree %s on branch %s", worktree_path, branch)
+    return True
+

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -1101,3 +1101,97 @@ async def merge_pr(pr_number: int, delete_branch: bool = True) -> None:
                 head_ref,
                 exc,
             )
+
+
+async def ensure_pull_request(
+    head: str,
+    base: str,
+    title: str,
+    body: str,
+) -> tuple[int, bool]:
+    """Create a pull request only if one does not already exist for the head branch.
+
+    Idempotent: checks for an existing open PR with the same head branch before
+    creating. If found, returns the existing PR number with ``created=False``.
+    If not found, creates a new PR and returns its number with ``created=True``.
+
+    Parameters
+    ----------
+    head:
+        Head branch name (e.g. ``"feat/issue-123"``).
+    base:
+        Base branch to merge into (e.g. ``"dev"``).
+    title:
+        PR title.
+    body:
+        PR body (Markdown).
+
+    Returns
+    -------
+    tuple[int, bool]
+        ``(pr_number, created)`` where ``created`` is ``True`` if a new PR was
+        created, ``False`` if an existing PR was found.
+
+    Raises
+    ------
+    RuntimeError
+        If the GitHub API call fails.
+
+    Notes
+    -----
+    This function only checks for open PRs. Closed PRs with the same head branch
+    are ignored, and a new PR will be created.
+    """
+    repo = settings.gh_repo
+
+    # Check for existing open PR with the same head branch
+    async with httpx.AsyncClient() as client:
+        r = await client.get(
+            f"{_BASE_URL}/repos/{repo}/pulls",
+            params={"state": "open", "head": f"{repo.split('/')[0]}:{head}"},
+            headers=_headers(),
+            timeout=_TIMEOUT,
+        )
+        try:
+            r.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise RuntimeError(
+                f"GitHub API GET /repos/{repo}/pulls failed "
+                f"({exc.response.status_code}): {exc.response.text[:400]}"
+            ) from exc
+
+        prs = r.json()
+        if prs:
+            # Found existing PR
+            pr_number = prs[0]["number"]
+            logger.info("✅ Found existing PR #%d for branch %r — skipping creation", pr_number, head)
+            return (pr_number, False)
+
+    # No existing PR — create one
+    payload: dict[str, object] = {
+        "title": title,
+        "body": body,
+        "head": head,
+        "base": base,
+    }
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            f"{_BASE_URL}/repos/{repo}/pulls",
+            json=payload,
+            headers=_headers(),
+            timeout=_TIMEOUT,
+        )
+        try:
+            r.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise RuntimeError(
+                f"GitHub API POST /repos/{repo}/pulls failed "
+                f"({exc.response.status_code}): {exc.response.text[:400]}"
+            ) from exc
+
+        pr_data = r.json()
+        pr_number = pr_data["number"]
+        _cache_invalidate()
+        logger.info("✅ Created PR #%d: %s → %s", pr_number, head, base)
+        return (pr_number, True)
+

--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -225,31 +225,15 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     worktree_path = str(Path(settings.worktrees_dir) / slug)
     host_worktree_path = str(Path(settings.host_worktrees_dir) / slug)
 
-    if Path(worktree_path).exists():
-        raise HTTPException(
-            status_code=409,
-            detail=f"Worktree already exists at {worktree_path}. Remove it before re-dispatching.",
-        )
+    # Create git worktree anchored to origin/dev
+    from agentception.readers.git import ensure_worktree  # noqa: PLC0415
 
     try:
-        dev_sha = await _resolve_dev_sha()
+        await ensure_worktree(Path(worktree_path), branch, "origin/dev")
+        logger.info("✅ dispatch: worktree created at %s", worktree_path)
     except RuntimeError as exc:
+        logger.error("❌ dispatch: worktree creation failed — %s", exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    proc = await asyncio.create_subprocess_exec(
-        "git", "worktree", "add", worktree_path, "-b", branch, dev_sha,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=str(settings.repo_dir),
-    )
-    stdout, stderr = await proc.communicate()
-
-    if proc.returncode != 0:
-        err = stderr.decode().strip()
-        logger.error("❌ dispatch: git worktree add failed — %s", err)
-        raise HTTPException(status_code=500, detail=f"git worktree add failed: {err}")
-
-    logger.info("✅ dispatch: worktree created at %s", worktree_path)
 
     # Embed GITHUB_TOKEN in the worktree remote so git push works without a
     # separate credential helper.  The adhoc path always did this; the issue

--- a/agentception/services/run_factory.py
+++ b/agentception/services/run_factory.py
@@ -86,7 +86,9 @@ async def create_and_launch_run(
         figure_override=resolved_figure,
     )
 
-    await _create_worktree(worktree_path, branch_name, base_branch, run_id)
+    from agentception.readers.git import ensure_worktree  # noqa: PLC0415
+
+    await ensure_worktree(worktree_path, branch_name, base_branch)
     await _insert_run(
         run_id=run_id,
         role=role,

--- a/agentception/services/spawn_child.py
+++ b/agentception/services/spawn_child.py
@@ -293,37 +293,15 @@ async def spawn_child(
             role, tier, org_domain, scope_type, scope_value, resolved_arch,
         )
 
-    # Resolve origin/dev SHA to pin the worktree start point.
-    # Using a concrete SHA instead of the main repo's HEAD prevents agents
-    # from inheriting local commits not yet on origin/dev and decouples the
-    # worktree from whatever branch the main repo currently has checked out.
-    sha_proc = await asyncio.create_subprocess_exec(
-        "git", "rev-parse", "origin/dev",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=str(settings.repo_dir),
-    )
-    sha_out, sha_err = await sha_proc.communicate()
-    if sha_proc.returncode != 0:
-        err = sha_err.decode().strip()
-        logger.error("❌ spawn_child: git rev-parse origin/dev failed — %s", err)
-        raise SpawnChildError(f"git rev-parse origin/dev failed: {err}")
-    dev_sha = sha_out.decode().strip()
+    # Create git worktree anchored to origin/dev
+    from agentception.readers.git import ensure_worktree  # noqa: PLC0415
 
-    # Create git worktree anchored to the resolved SHA
-    proc = await asyncio.create_subprocess_exec(
-        "git", "worktree", "add", "-b", branch, worktree_path, dev_sha,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=str(settings.repo_dir),
-    )
-    _, stderr_bytes = await proc.communicate()
-    if proc.returncode != 0:
-        err = stderr_bytes.decode().strip()
-        logger.error("❌ spawn_child: git worktree add failed — %s", err)
-        raise SpawnChildError(f"git worktree add failed: {err}")
-
-    logger.info("✅ spawn_child: worktree created at %s", worktree_path)
+    try:
+        await ensure_worktree(Path(worktree_path), branch, "origin/dev")
+        logger.info("✅ spawn_child: worktree created at %s", worktree_path)
+    except RuntimeError as exc:
+        logger.error("❌ spawn_child: worktree creation failed — %s", exc)
+        raise SpawnChildError(f"worktree creation failed: {exc}") from exc
 
     # Embed GITHUB_TOKEN in the worktree remote URL so git push works inside
     # the container without a separate credential helper.

--- a/agentception/tests/test_ensure_helpers.py
+++ b/agentception/tests/test_ensure_helpers.py
@@ -1,0 +1,218 @@
+"""Tests for idempotent ensure_* helpers in readers.git and readers.github."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentception.readers.git import ensure_branch, ensure_worktree
+from agentception.readers.github import ensure_pull_request
+
+
+# ---------------------------------------------------------------------------
+# ensure_worktree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ensure_worktree_creates_new_worktree(tmp_path: Path) -> None:
+    """ensure_worktree creates a new worktree when it does not exist."""
+    worktree_path = tmp_path / "issue-123"
+    branch = "feat/issue-123"
+    base_ref = "origin/dev"
+
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate.return_value = (b"", b"")
+
+    with patch("agentception.readers.git.asyncio.create_subprocess_exec", return_value=mock_proc):
+        await ensure_worktree(worktree_path, branch, base_ref)
+
+    # Verify git worktree add was called
+    assert mock_proc.communicate.called
+
+
+@pytest.mark.anyio
+async def test_ensure_worktree_idempotent_when_exists(tmp_path: Path) -> None:
+    """ensure_worktree returns immediately when worktree already exists."""
+    worktree_path = tmp_path / "issue-123"
+    worktree_path.mkdir(parents=True)
+    branch = "feat/issue-123"
+    base_ref = "origin/dev"
+
+    mock_proc = AsyncMock()
+
+    with patch("agentception.readers.git.asyncio.create_subprocess_exec", return_value=mock_proc):
+        await ensure_worktree(worktree_path, branch, base_ref)
+
+    # Verify git was NOT called
+    assert not mock_proc.communicate.called
+
+
+@pytest.mark.anyio
+async def test_ensure_worktree_raises_on_git_failure(tmp_path: Path) -> None:
+    """ensure_worktree raises RuntimeError when git worktree add fails."""
+    worktree_path = tmp_path / "issue-123"
+    branch = "feat/issue-123"
+    base_ref = "origin/dev"
+
+    # Mock _git to return empty (branch doesn't exist)
+    # Mock create_subprocess_exec to fail on worktree add
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 1
+    mock_proc.communicate.return_value = (b"", b"fatal: invalid reference")
+
+    with (
+        patch("agentception.readers.git._git", new_callable=AsyncMock, return_value=""),
+        patch("agentception.readers.git.asyncio.create_subprocess_exec", return_value=mock_proc),
+    ):
+        with pytest.raises(RuntimeError, match="git worktree add failed"):
+            await ensure_worktree(worktree_path, branch, base_ref)
+
+
+# ---------------------------------------------------------------------------
+# ensure_branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ensure_branch_creates_new_branch() -> None:
+    """ensure_branch creates a new branch when it does not exist."""
+    branch = "feat/issue-123"
+    base_ref = "origin/dev"
+
+    # Mock list_git_branches to return empty list (branch does not exist)
+    # Mock create_subprocess_exec to succeed
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate.return_value = (b"", b"")
+
+    with (
+        patch("agentception.readers.git.list_git_branches", new_callable=AsyncMock, return_value=[]),
+        patch("agentception.readers.git.asyncio.create_subprocess_exec", return_value=mock_proc),
+    ):
+        await ensure_branch(branch, base_ref)
+
+    # Verify git branch was called
+    assert mock_proc.communicate.called
+
+
+@pytest.mark.anyio
+async def test_ensure_branch_idempotent_when_exists() -> None:
+    """ensure_branch returns immediately when branch already exists."""
+    branch = "feat/issue-123"
+    base_ref = "origin/dev"
+
+    # Mock _git to return the branch name (branch exists)
+    with patch("agentception.readers.git._git", new_callable=AsyncMock, return_value=branch):
+        created = await ensure_branch(branch, base_ref)
+
+    # Verify branch was not created
+    assert created is False
+
+
+@pytest.mark.anyio
+async def test_ensure_branch_raises_on_git_failure() -> None:
+    """ensure_branch raises RuntimeError when git branch creation fails."""
+    branch = "feat/issue-123"
+    base_ref = "origin/dev"
+
+    # Mock _git to return empty (branch doesn't exist)
+    # Mock create_subprocess_exec to fail on branch creation
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 1
+    mock_proc.communicate.return_value = (b"", b"fatal: not a valid object name")
+
+    with (
+        patch("agentception.readers.git._git", new_callable=AsyncMock, return_value=""),
+        patch("agentception.readers.git.asyncio.create_subprocess_exec", return_value=mock_proc),
+    ):
+        with pytest.raises(RuntimeError, match="git branch .* failed"):
+            await ensure_branch(branch, base_ref)
+
+
+# ---------------------------------------------------------------------------
+# ensure_pull_request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ensure_pull_request_creates_new_pr() -> None:
+    """ensure_pull_request creates a new PR when none exists."""
+    head = "feat/issue-123"
+    base = "dev"
+    title = "Fix issue 123"
+    body = "Closes #123"
+
+    # Mock httpx.AsyncClient to return empty list (no PR exists), then success on create
+    mock_get_response = MagicMock()
+    mock_get_response.json.return_value = []
+    mock_get_response.raise_for_status = MagicMock()
+
+    mock_post_response = MagicMock()
+    mock_post_response.json.return_value = {"number": 456}
+    mock_post_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_get_response
+    mock_client.__aenter__.return_value.post.return_value = mock_post_response
+
+    with patch("agentception.readers.github.httpx.AsyncClient", return_value=mock_client):
+        pr_number, created = await ensure_pull_request(head, base, title, body)
+
+    assert pr_number == 456
+    assert created is True
+
+
+@pytest.mark.anyio
+async def test_ensure_pull_request_idempotent_when_exists() -> None:
+    """ensure_pull_request returns existing PR when one already exists."""
+    head = "feat/issue-123"
+    base = "dev"
+    title = "Fix issue 123"
+    body = "Closes #123"
+
+    # Mock httpx.AsyncClient to return an existing PR
+    mock_get_response = MagicMock()
+    mock_get_response.json.return_value = [{"number": 456}]
+    mock_get_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_get_response
+
+    with patch("agentception.readers.github.httpx.AsyncClient", return_value=mock_client):
+        pr_number, created = await ensure_pull_request(head, base, title, body)
+
+    # Verify we got the existing PR
+    assert pr_number == 456
+    assert created is False
+
+
+@pytest.mark.anyio
+async def test_ensure_pull_request_raises_on_creation_failure() -> None:
+    """ensure_pull_request raises RuntimeError when PR creation fails."""
+    head = "feat/issue-123"
+    base = "dev"
+    title = "Fix issue 123"
+    body = "Closes #123"
+
+    # Mock httpx.AsyncClient to return empty list, then fail on create
+    mock_get_response = MagicMock()
+    mock_get_response.json.return_value = []
+    mock_get_response.raise_for_status = MagicMock()
+
+    mock_post_response = MagicMock()
+    mock_post_response.status_code = 422
+    mock_post_response.text = "Validation failed"
+    mock_post_response.raise_for_status.side_effect = Exception("API error")
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value.get.return_value = mock_get_response
+    mock_client.__aenter__.return_value.post.return_value = mock_post_response
+
+    with patch("agentception.readers.github.httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(Exception):
+            await ensure_pull_request(head, base, title, body)


### PR DESCRIPTION
## Summary

Implements three idempotent helper functions following the canonical pattern from `ensure_label_exists`:

- **`ensure_worktree`** — creates git worktree only if it doesn't exist
- **`ensure_branch`** — creates git branch only if it doesn't exist  
- **`ensure_pull_request`** — creates GitHub PR only if it doesn't exist

All three follow the same contract:
- Check for existence first
- Create only if missing
- Return consistent result whether creating or finding existing
- Raise `RuntimeError` with context on failure

## Changes

### New Functions

**`agentception/readers/git.py`:**
- `ensure_worktree(worktree_path, branch, base_ref)` — idempotent worktree creation
- `ensure_branch(branch, base_ref)` — idempotent branch creation

**`agentception/readers/github.py`:**
- `ensure_pull_request(owner, repo, head, base, title, body)` — idempotent PR creation

### Updated Call Sites

Replaced inline worktree creation with `ensure_worktree` in:
- `agentception/services/run_factory.py` (`_create_worktree`)
- `agentception/services/spawn_child.py` (`spawn_child`)
- `agentception/routes/api/dispatch.py` (`POST /api/dispatch`)

### Tests

**`agentception/tests/test_ensure_helpers.py`** — comprehensive coverage:
- Happy path (creation)
- Idempotency (already exists)
- Error handling (git/GitHub failures)

All 9 tests pass. Mypy passes with no issues.

Closes #35

<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Role** | `developer` |
| **Architecture** | `guidovanrossum:python` |
| **Session** | `eng-20260310T010920Z-0000` |
| **Batch** | `issue-35-20260309T231653Z-3fd6` |
| **Claimed at** | `2026-03-10T01:09:20Z` |

</details>