### PR TITLE
fix: anchor pr-reviewer worktree to origin/feat/issue-N at dispatch time

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -973,6 +973,7 @@ async def persist_agent_run_dispatch(
     is_resumed: bool = False,
     coord_fingerprint: str | None = None,
     task_description: str | None = None,
+    pr_number: int | None = None,
 ) -> None:
     """Insert an ``ACAgentRun`` row with status ``pending_launch`` at dispatch time.
 
@@ -1029,6 +1030,8 @@ async def persist_agent_run_dispatch(
                     existing.coord_fingerprint = coord_fingerprint
                 if task_description is not None:
                     existing.task_description = task_description
+                if pr_number is not None:
+                    existing.pr_number = pr_number
             else:
                 logger.warning(
                     "💾 persist_agent_run_dispatch: run_id=%r is new — inserting with status=pending_launch",
@@ -1039,7 +1042,7 @@ async def persist_agent_run_dispatch(
                         id=run_id,
                         wave_id=None,
                         issue_number=issue_number,
-                        pr_number=None,
+                        pr_number=pr_number,
                         branch=branch,
                         worktree_path=worktree_path,
                         role=role,

--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -18,7 +18,9 @@ Three endpoints drive the Ship page launch modal:
 
 **Lifecycle for ``POST /api/dispatch/issue``:**
 
-1. Create git worktree at ``{worktrees_dir}/issue-{N}`` branching from ``origin/dev``.
+1. Create git worktree at ``{worktrees_dir}/issue-{N}`` branching from ``origin/dev``
+   (implementers) or ``origin/feat/issue-{N}`` (``pr-reviewer`` role — remote branch
+   is fetched first so the reviewer starts on the implementer's code immediately).
 2. Configure worktree remote to embed ``GITHUB_TOKEN`` (enables ``git push``
    without a separate credential helper).
 3. Pre-inject semantically relevant code chunks into ``task_description``
@@ -170,9 +172,18 @@ class DispatchRequest(BaseModel):
     issue_body: str = ""
     """Issue body text used to derive skill domains for the cognitive arch."""
     role: str
-    """Role slug from ``.agentception/roles/`` (e.g. ``developer``)."""
+    """Role slug from ``.agentception/roles/`` (e.g. ``developer``, ``pr-reviewer``)."""
     repo: str
     """``owner/repo`` string (e.g. ``cgcardona/agentception``)."""
+    pr_number: int | None = None
+    """PR number to associate with this run.
+
+    Required for ``pr-reviewer`` dispatches — the worktree is anchored to the
+    PR branch (``origin/feat/issue-{N}``) instead of ``origin/dev``, so the
+    reviewer starts on the implementer's code without any manual branch-switching.
+    Optional for implementer dispatches; when omitted, the DB field is left
+    ``NULL`` until the agent self-reports the PR via ``build_complete_run``.
+    """
 
 
 class DispatchResponse(BaseModel):
@@ -204,10 +215,13 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     Full lifecycle (all steps complete before the response is returned except
     the agent loop and indexing, which run as asyncio background tasks):
 
-    1. Create git worktree at ``{worktrees_dir}/issue-{N}``.
+    1. Create git worktree — anchored to ``origin/dev`` for implementers;
+       anchored to ``origin/feat/issue-{N}`` for ``pr-reviewer`` dispatches
+       (after fetching the remote branch so the reviewer starts on the
+       implementer's code from turn 1 with no manual branch-switching needed).
     2. Configure worktree remote to embed ``GITHUB_TOKEN`` for push access.
     3. Pre-inject semantically relevant code chunks into ``task_description``.
-    4. Persist DB row as ``pending_launch``.
+    4. Persist DB row as ``pending_launch`` (``pr_number`` written if provided).
     5. Acknowledge → ``implementing``.
     6. Fire ``run_agent_loop`` as an asyncio background task (calls Anthropic).
     7. Fire worktree Qdrant indexing as an asyncio background task.
@@ -225,12 +239,38 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     worktree_path = str(Path(settings.worktrees_dir) / slug)
     host_worktree_path = str(Path(settings.host_worktrees_dir) / slug)
 
-    # Create git worktree anchored to origin/dev
     from agentception.readers.git import ensure_worktree  # noqa: PLC0415
 
+    is_reviewer = req.role == "pr-reviewer"
+
+    if is_reviewer:
+        # For reviewers the relevant code lives on the implementer's branch, not
+        # dev.  Fetch the remote branch so `origin/feat/issue-{N}` is up to date,
+        # then create the worktree from that ref instead of origin/dev.  The agent
+        # is on the correct branch from its very first turn — no wasted turns
+        # fetching, resetting, or detecting that it is on the wrong branch.
+        fetch_proc = await asyncio.create_subprocess_exec(
+            "git", "fetch", "origin", branch,
+            cwd=str(settings.repo_dir),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _fetch_out, _fetch_err = await fetch_proc.communicate()
+        if fetch_proc.returncode != 0:
+            err_msg = _fetch_err.decode(errors="replace").strip()
+            logger.error("❌ dispatch: fetch of %s failed — %s", branch, err_msg)
+            raise HTTPException(
+                status_code=500,
+                detail=f"git fetch origin {branch} failed: {err_msg}",
+            )
+        worktree_base = f"origin/{branch}"
+        logger.info("✅ dispatch: fetched %s for reviewer worktree", branch)
+    else:
+        worktree_base = "origin/dev"
+
     try:
-        await ensure_worktree(Path(worktree_path), branch, "origin/dev")
-        logger.info("✅ dispatch: worktree created at %s", worktree_path)
+        await ensure_worktree(Path(worktree_path), branch, worktree_base)
+        logger.info("✅ dispatch: worktree created at %s (base=%s)", worktree_path, worktree_base)
     except RuntimeError as exc:
         logger.error("❌ dispatch: worktree creation failed — %s", exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -298,6 +338,7 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
         cognitive_arch=cognitive_arch,
         gh_repo=settings.gh_repo,
         task_description=task_description,
+        pr_number=req.pr_number,
     )
 
     # Transition pending_launch → implementing and fire the agent loop.

--- a/agentception/tests/test_agentception_spawn_child.py
+++ b/agentception/tests/test_agentception_spawn_child.py
@@ -252,25 +252,15 @@ async def test_spawn_child_skills_hint_overrides_body_extraction() -> None:
 
 @pytest.mark.anyio
 async def test_spawn_child_worktree_failure_raises_spawn_child_error() -> None:
-    # spawn_child now calls create_subprocess_exec twice:
-    #   1. git rev-parse origin/dev  → succeeds (returns a SHA)
-    #   2. git worktree add ...      → fails (the case under test)
-    sha_proc = MagicMock()
-    sha_proc.returncode = 0
-    sha_proc.communicate = AsyncMock(
-        return_value=(b"abc1234abc1234abc1234abc1234abc1234abc1234\n", b"")
-    )
-
-    fail_proc = MagicMock()
-    fail_proc.returncode = 1
-    fail_proc.communicate = AsyncMock(return_value=(b"", b"fatal: branch already exists"))
-
+    # spawn_child delegates worktree creation to ensure_worktree (readers.git).
+    # Simulate a failure by having ensure_worktree raise RuntimeError — spawn_child
+    # must convert that into a SpawnChildError with a "worktree creation failed" message.
     with (
         patch(
-            "agentception.services.spawn_child.asyncio.create_subprocess_exec",
-            side_effect=[sha_proc, fail_proc],
+            "agentception.readers.git.ensure_worktree",
+            AsyncMock(side_effect=RuntimeError("git worktree add failed: fatal: branch already exists")),
         ),
-        pytest.raises(SpawnChildError, match="git worktree add failed"),
+        pytest.raises(SpawnChildError, match="worktree creation failed"),
     ):
         await spawn_child(
             parent_run_id="coord-xyz",

--- a/agentception/tests/test_ensure_helpers.py
+++ b/agentception/tests/test_ensure_helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -216,3 +216,104 @@ async def test_ensure_pull_request_raises_on_creation_failure() -> None:
     with patch("agentception.readers.github.httpx.AsyncClient", return_value=mock_client):
         with pytest.raises(Exception):
             await ensure_pull_request(head, base, title, body)
+
+
+# ---------------------------------------------------------------------------
+# dispatch_agent — reviewer branch orientation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_dispatch_reviewer_fetches_pr_branch_and_uses_it_as_base(tmp_path: Path) -> None:
+    """PR-reviewer dispatch fetches the PR branch and passes origin/<branch> as base.
+
+    The critical invariant: ensure_worktree is called with base="origin/feat/issue-35"
+    (not "origin/dev") so the reviewer worktree starts on the implementer's code
+    without any manual branch-switching turns.
+    """
+    from agentception.routes.api.dispatch import dispatch_agent, DispatchRequest
+
+    fetch_proc = AsyncMock()
+    fetch_proc.returncode = 0
+    fetch_proc.communicate.return_value = (b"", b"")
+
+    captured_base: list[str] = []
+
+    async def mock_ensure_worktree(path: Path, branch: str, base: str = "origin/dev") -> bool:
+        captured_base.append(base)
+        return True
+
+    with (
+        patch("agentception.routes.api.dispatch.asyncio.create_subprocess_exec", return_value=fetch_proc),
+        patch("agentception.readers.git.ensure_worktree", side_effect=mock_ensure_worktree),
+        patch("agentception.routes.api.dispatch._configure_worktree_auth", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch._resolve_cognitive_arch", return_value=None),
+        patch("agentception.routes.api.dispatch.search_codebase", new_callable=AsyncMock, return_value=[]),
+        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.acknowledge_agent_run", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.asyncio.create_task", return_value=asyncio.Future()),
+        patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.settings") as mock_settings,
+    ):
+        mock_settings.worktrees_dir = str(tmp_path / "worktrees")
+        mock_settings.host_worktrees_dir = str(tmp_path / "host_worktrees")
+        mock_settings.repo_dir = str(tmp_path)
+        mock_settings.gh_repo = "cgcardona/agentception"
+
+        req = DispatchRequest(
+            issue_number=35,
+            issue_title="PR review for feat/issue-35",
+            issue_body="Review this PR.",
+            role="pr-reviewer",
+            repo="agentception",
+            pr_number=436,
+        )
+        await dispatch_agent(req)
+
+    # The worktree base must be the PR branch on origin, not origin/dev
+    assert captured_base == ["origin/feat/issue-35"], (
+        f"Expected ensure_worktree to be called with base='origin/feat/issue-35', got {captured_base}"
+    )
+
+
+@pytest.mark.anyio
+async def test_dispatch_implementer_uses_origin_dev_as_base(tmp_path: Path) -> None:
+    """Implementer dispatch uses origin/dev as the worktree base (no fetch step)."""
+    from agentception.routes.api.dispatch import dispatch_agent, DispatchRequest
+
+    captured_base: list[str] = []
+
+    async def mock_ensure_worktree(path: Path, branch: str, base: str = "origin/dev") -> bool:
+        captured_base.append(base)
+        return True
+
+    with (
+        patch("agentception.readers.git.ensure_worktree", side_effect=mock_ensure_worktree),
+        patch("agentception.routes.api.dispatch._configure_worktree_auth", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch._resolve_cognitive_arch", return_value=None),
+        patch("agentception.routes.api.dispatch.search_codebase", new_callable=AsyncMock, return_value=[]),
+        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.acknowledge_agent_run", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.asyncio.create_task", return_value=asyncio.Future()),
+        patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.settings") as mock_settings,
+    ):
+        mock_settings.worktrees_dir = str(tmp_path / "worktrees")
+        mock_settings.host_worktrees_dir = str(tmp_path / "host_worktrees")
+        mock_settings.repo_dir = str(tmp_path)
+        mock_settings.gh_repo = "cgcardona/agentception"
+
+        req = DispatchRequest(
+            issue_number=42,
+            issue_title="Implement some feature",
+            issue_body="",
+            role="developer",
+            repo="agentception",
+        )
+        await dispatch_agent(req)
+
+    assert captured_base == ["origin/dev"], (
+        f"Expected ensure_worktree to be called with base='origin/dev', got {captured_base}"
+    )

--- a/docs/guides/dispatch.md
+++ b/docs/guides/dispatch.md
@@ -10,11 +10,17 @@ This guide covers the one canonical way to launch an agent in AgentCeption: `POS
 POST /api/dispatch/issue
         │
         ├─ 1. git worktree add   (isolated checkout at /worktrees/issue-{N})
+        │        • implementers  → branches from origin/dev
+        │        • pr-reviewer   → git fetch origin feat/issue-{N}, then
+        │                          branches from origin/feat/issue-{N}
+        │                          (reviewer starts on the implementer's code
+        │                           from turn 1 — no wasted branch-switching turns)
         ├─ 2. configure worktree auth  (_configure_worktree_auth embeds GITHUB_TOKEN
         │                              so git push works inside the container)
         ├─ 3. Qdrant pre-inject  (top-3 semantically relevant code chunks added
         │                         to task_description at dispatch time)
-        ├─ 4. persist DB row     (status = pending_launch, all context stored)
+        ├─ 4. persist DB row     (status = pending_launch, all context stored,
+        │                         pr_number written if provided)
         ├─ 5. acknowledge        (pending_launch → implementing)
         ├─ 6. asyncio.create_task(run_agent_loop)   ← Anthropic agent starts here
         └─ 7. asyncio.create_task(_index_worktree)  ← background Qdrant index
@@ -29,6 +35,8 @@ By the time you get the JSON response, the agent is already running against Anth
 
 ## Request shape
 
+### Implementer (developer)
+
 ```bash
 curl -s -X POST http://localhost:10003/api/dispatch/issue \
   -H "Content-Type: application/json" \
@@ -41,13 +49,33 @@ curl -s -X POST http://localhost:10003/api/dispatch/issue \
   }'
 ```
 
+### PR Reviewer
+
+```bash
+curl -s -X POST http://localhost:10003/api/dispatch/issue \
+  -H "Content-Type: application/json" \
+  -d '{
+    "issue_number": 35,
+    "issue_title":  "PR review for feat/issue-35 (#436)",
+    "issue_body":   "Review PR #436 (feat/issue-35). Run mypy, typing_audit, pytest. Fagan analysis. Merge if acceptable.",
+    "role":         "pr-reviewer",
+    "repo":         "agentception",
+    "pr_number":    436
+  }'
+```
+
+The endpoint fetches `origin/feat/issue-35` automatically and creates the worktree
+from that ref.  The reviewer is on the implementer's branch from its very first turn —
+no fetching, no hard-resetting, no wasted turns detecting the wrong branch.
+
 | Field | Required | Notes |
 |-------|----------|-------|
 | `issue_number` | yes | GitHub issue number — used for `run_id = "issue-{N}"` and the branch `feat/issue-{N}` |
 | `issue_title` | yes | Injected into the agent's task briefing and used as the Qdrant search query |
 | `issue_body` | no | Full issue body text; drives cognitive arch selection and task briefing. Pass `""` to let the agent read the body itself via `issue_read` |
-| `role` | yes | Role slug matching a file in `.agentception/roles/` — typically `"developer"` for leaf workers |
+| `role` | yes | Role slug matching a file in `.agentception/roles/` — `"developer"` for implementers, `"pr-reviewer"` for reviewers |
 | `repo` | yes | `owner/repo` string — e.g. `"agentception"` (short form resolved against `settings.gh_repo`) |
+| `pr_number` | no | PR number to associate with this run. **Required for `pr-reviewer` dispatches** so the DB row is pre-linked and the worktree can be anchored to the right branch. For implementers, omit — the agent self-reports it via `build_complete_run` |
 
 ### Re-dispatching a failed or cancelled run
 
@@ -119,7 +147,9 @@ The tool catalogue and system prompt are cached after turn 1. A `cache_read` ≥
 
 The agent reads its full task context from the DB at startup via the `task/briefing` MCP prompt — it never needs to call `issue_read` for the issue body if `issue_body` was passed at dispatch time. The recon phase (pre-loop) runs one LLM call that produces a JSON exploration plan; the runtime executes all reads and searches concurrently and injects the results into the initial user message, collapsing 5-10 discovery turns into zero.
 
-Typical successful run shape:
+For **reviewers**, the worktree is already on `feat/issue-{N}` — the agent verifies tools directly without any branch orientation steps.
+
+Typical implementer run shape:
 
 | Phase | Turns | What happens |
 |-------|-------|--------------|
@@ -128,6 +158,15 @@ Typical successful run shape:
 | Implement | 4–N | Writes functions, updates callers |
 | Verify | N+1 to N+5 | `mypy`, `typing_audit`, `pytest` inside the container |
 | Ship | last 2 | `git_commit_and_push`, `create_pull_request`, `merge_pull_request` |
+
+Typical reviewer run shape:
+
+| Phase | Turns | What happens |
+|-------|-------|--------------|
+| Recon | 0 (pre-loop) | Diff, changed files, tests injected as context |
+| Verify | 1–5 | `mypy`, `typing_audit`, `pytest` — confirms green |
+| Review | 6–12 | Fagan defect analysis, grade, inline comments |
+| Ship | last 1–2 | `merge_pull_request` (or block with comment if defects found) |
 
 ---
 
@@ -178,6 +217,7 @@ pending_launch  →  implementing  →  completed   (happy path)
 | Concern | File |
 |---------|------|
 | Dispatch endpoint | `agentception/routes/api/dispatch.py::dispatch_agent` |
+| Idempotent worktree creation | `agentception/readers/git.py::ensure_worktree` |
 | Agent loop | `agentception/services/agent_loop.py::run_agent_loop` |
 | Worktree auth | `agentception/services/run_factory.py::_configure_worktree_auth` |
 | Worktree indexing | `agentception/services/run_factory.py::_index_worktree` |


### PR DESCRIPTION
## Summary

- For `role=pr-reviewer` dispatches, the endpoint now runs `git fetch origin feat/issue-{N}` before creating the worktree, then passes `origin/feat/issue-{N}` as the base to `ensure_worktree`. The reviewer starts on the implementer's code from turn 1 with zero wasted branch-switching turns.
- Adds `pr_number` to `DispatchRequest` and `persist_agent_run_dispatch` — the DB row is pre-linked to the PR at dispatch time, eliminating the manual `UPDATE` step previously needed after dispatching a reviewer.
- Fixes `test_spawn_child_worktree_failure_raises_spawn_child_error`, which was silently broken by PR #436 (spawn_child now uses `ensure_worktree` from `readers.git` instead of calling subprocess directly — test now patches at the correct location).
- Updates `docs/guides/dispatch.md` with the reviewer `curl` example including `pr_number`, the new lifecycle diagram showing the reviewer branch path, and typical reviewer run shape.

## Test plan
- [x] `mypy agentception/` — zero errors
- [x] `typing_audit --max-any 0` — passes
- [x] `pytest agentception/tests/` — 1677 passed (was 1676 with 1 pre-existing failure)
- [x] New tests: `test_dispatch_reviewer_fetches_pr_branch_and_uses_it_as_base`, `test_dispatch_implementer_uses_origin_dev_as_base`