### PR TITLE
fix: add pr_branch field and return 422 for deleted reviewer branches

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -18,9 +18,10 @@ Three endpoints drive the Ship page launch modal:
 
 **Lifecycle for ``POST /api/dispatch/issue``:**
 
-1. Create git worktree at ``{worktrees_dir}/issue-{N}`` branching from ``origin/dev``
-   (implementers) or ``origin/feat/issue-{N}`` (``pr-reviewer`` role — remote branch
-   is fetched first so the reviewer starts on the implementer's code immediately).
+    1. Create git worktree at ``{worktrees_dir}/issue-{N}`` branching from ``origin/dev``
+   (implementers) or from the PR branch (``pr-reviewer`` role — remote branch
+   is fetched first; branch name is ``pr_branch`` if provided, otherwise
+   ``feat/issue-{N}``; reviewer starts on the implementer's code immediately).
 2. Configure worktree remote to embed ``GITHUB_TOKEN`` (enables ``git push``
    without a separate credential helper).
 3. Pre-inject semantically relevant code chunks into ``task_description``
@@ -179,10 +180,24 @@ class DispatchRequest(BaseModel):
     """PR number to associate with this run.
 
     Required for ``pr-reviewer`` dispatches — the worktree is anchored to the
-    PR branch (``origin/feat/issue-{N}``) instead of ``origin/dev``, so the
-    reviewer starts on the implementer's code without any manual branch-switching.
+    PR branch instead of ``origin/dev``, so the reviewer starts on the
+    implementer's code without any manual branch-switching.
     Optional for implementer dispatches; when omitted, the DB field is left
     ``NULL`` until the agent self-reports the PR via ``build_complete_run``.
+    """
+    pr_branch: str | None = None
+    """Exact remote branch name for the PR being reviewed.
+
+    For ``pr-reviewer`` dispatches only.  When omitted the endpoint derives
+    the branch as ``feat/issue-{issue_number}``, which is the standard naming
+    convention for AgentCeption agent branches.
+
+    Provide this field when the PR branch does not follow the standard naming
+    convention — e.g. ``feat/reviewer-branch-orientation`` (not tied to a
+    single issue number).
+
+    The ``run_id`` and worktree slug are always derived from ``issue_number``
+    regardless of what ``pr_branch`` is set to.
     """
 
 
@@ -229,12 +244,15 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     No Cursor session or external Dispatcher is required.
 
     Raises:
-        HTTPException 409: Worktree already exists at the target path.
+        HTTPException 422: PR branch not found on remote (already deleted after merge,
+            or non-standard name not passed via ``pr_branch``).
         HTTPException 500: git worktree add or git auth configuration failed.
     """
     run_id = f"issue-{req.issue_number}"
     slug = f"issue-{req.issue_number}"
-    branch = f"feat/issue-{req.issue_number}"
+    # For reviewer dispatches the PR branch may not follow feat/issue-{N} naming
+    # (e.g. feat/reviewer-branch-orientation).  pr_branch overrides the default.
+    branch = req.pr_branch if req.pr_branch else f"feat/issue-{req.issue_number}"
     batch_id = _make_batch_id(req.issue_number)
     worktree_path = str(Path(settings.worktrees_dir) / slug)
     host_worktree_path = str(Path(settings.host_worktrees_dir) / slug)
@@ -245,10 +263,9 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
 
     if is_reviewer:
         # For reviewers the relevant code lives on the implementer's branch, not
-        # dev.  Fetch the remote branch so `origin/feat/issue-{N}` is up to date,
-        # then create the worktree from that ref instead of origin/dev.  The agent
-        # is on the correct branch from its very first turn — no wasted turns
-        # fetching, resetting, or detecting that it is on the wrong branch.
+        # dev.  Fetch the remote branch so `origin/<branch>` is up to date, then
+        # create the worktree from that ref.  The agent is on the correct branch
+        # from its very first turn — no wasted turns detecting the wrong branch.
         fetch_proc = await asyncio.create_subprocess_exec(
             "git", "fetch", "origin", branch,
             cwd=str(settings.repo_dir),
@@ -260,8 +277,14 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
             err_msg = _fetch_err.decode(errors="replace").strip()
             logger.error("❌ dispatch: fetch of %s failed — %s", branch, err_msg)
             raise HTTPException(
-                status_code=500,
-                detail=f"git fetch origin {branch} failed: {err_msg}",
+                status_code=422,
+                detail=(
+                    f"Remote branch '{branch}' not found. "
+                    "If the PR was already merged and the branch deleted, reviewers "
+                    "must be dispatched before merge. "
+                    "If the branch uses a non-standard name, pass it in 'pr_branch'. "
+                    f"git error: {err_msg}"
+                ),
             )
         worktree_base = f"origin/{branch}"
         logger.info("✅ dispatch: fetched %s for reviewer worktree", branch)

--- a/agentception/tests/test_ensure_helpers.py
+++ b/agentception/tests/test_ensure_helpers.py
@@ -317,3 +317,100 @@ async def test_dispatch_implementer_uses_origin_dev_as_base(tmp_path: Path) -> N
     assert captured_base == ["origin/dev"], (
         f"Expected ensure_worktree to be called with base='origin/dev', got {captured_base}"
     )
+
+
+@pytest.mark.anyio
+async def test_dispatch_reviewer_pr_branch_override_respected(tmp_path: Path) -> None:
+    """When pr_branch is provided, it overrides the feat/issue-{N} default branch name.
+
+    This covers PRs whose branch doesn't follow the standard naming convention
+    (e.g. feat/reviewer-branch-orientation vs feat/issue-35).
+    """
+    from agentception.routes.api.dispatch import dispatch_agent, DispatchRequest
+
+    fetch_proc = AsyncMock()
+    fetch_proc.returncode = 0
+    fetch_proc.communicate.return_value = (b"", b"")
+
+    captured_bases: list[str] = []
+    captured_branches: list[str] = []
+
+    async def mock_ensure_worktree(path: Path, branch: str, base: str = "origin/dev") -> bool:
+        captured_bases.append(base)
+        captured_branches.append(branch)
+        return True
+
+    with (
+        patch("agentception.routes.api.dispatch.asyncio.create_subprocess_exec", return_value=fetch_proc),
+        patch("agentception.readers.git.ensure_worktree", side_effect=mock_ensure_worktree),
+        patch("agentception.routes.api.dispatch._configure_worktree_auth", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch._resolve_cognitive_arch", return_value=None),
+        patch("agentception.routes.api.dispatch.search_codebase", new_callable=AsyncMock, return_value=[]),
+        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.acknowledge_agent_run", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.asyncio.create_task", return_value=asyncio.Future()),
+        patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.settings") as mock_settings,
+    ):
+        mock_settings.worktrees_dir = str(tmp_path / "worktrees")
+        mock_settings.host_worktrees_dir = str(tmp_path / "host_worktrees")
+        mock_settings.repo_dir = str(tmp_path)
+        mock_settings.gh_repo = "cgcardona/agentception"
+
+        req = DispatchRequest(
+            issue_number=35,
+            issue_title="PR review for non-standard branch",
+            issue_body="",
+            role="pr-reviewer",
+            repo="agentception",
+            pr_number=437,
+            pr_branch="feat/reviewer-branch-orientation",
+        )
+        await dispatch_agent(req)
+
+    # The custom pr_branch must be fetched and used as the worktree base
+    assert captured_branches == ["feat/reviewer-branch-orientation"], (
+        f"Expected branch 'feat/reviewer-branch-orientation', got {captured_branches}"
+    )
+    assert captured_bases == ["origin/feat/reviewer-branch-orientation"], (
+        f"Expected base 'origin/feat/reviewer-branch-orientation', got {captured_bases}"
+    )
+
+
+@pytest.mark.anyio
+async def test_dispatch_reviewer_deleted_branch_returns_422(tmp_path: Path) -> None:
+    """When the remote branch is gone (already merged + deleted), dispatch returns 422 not 500."""
+    from fastapi import HTTPException
+    from agentception.routes.api.dispatch import dispatch_agent, DispatchRequest
+
+    # Simulate git fetch failing because the branch was deleted after merge
+    fetch_proc = AsyncMock()
+    fetch_proc.returncode = 128
+    fetch_proc.communicate.return_value = (
+        b"",
+        b"fatal: couldn't find remote ref feat/issue-35",
+    )
+
+    with (
+        patch("agentception.routes.api.dispatch.asyncio.create_subprocess_exec", return_value=fetch_proc),
+        patch("agentception.routes.api.dispatch.settings") as mock_settings,
+    ):
+        mock_settings.worktrees_dir = str(tmp_path / "worktrees")
+        mock_settings.host_worktrees_dir = str(tmp_path / "host_worktrees")
+        mock_settings.repo_dir = str(tmp_path)
+        mock_settings.gh_repo = "cgcardona/agentception"
+
+        req = DispatchRequest(
+            issue_number=35,
+            issue_title="PR review for already-merged PR",
+            issue_body="",
+            role="pr-reviewer",
+            repo="agentception",
+            pr_number=436,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await dispatch_agent(req)
+
+    assert exc_info.value.status_code == 422
+    assert "already merged" in exc_info.value.detail or "pr_branch" in exc_info.value.detail

--- a/docs/guides/dispatch.md
+++ b/docs/guides/dispatch.md
@@ -64,18 +64,41 @@ curl -s -X POST http://localhost:10003/api/dispatch/issue \
   }'
 ```
 
-The endpoint fetches `origin/feat/issue-35` automatically and creates the worktree
-from that ref.  The reviewer is on the implementer's branch from its very first turn —
-no fetching, no hard-resetting, no wasted turns detecting the wrong branch.
+If the PR branch does **not** follow the `feat/issue-{N}` convention (e.g. it is named
+`feat/reviewer-branch-orientation`), pass `pr_branch` explicitly:
+
+```bash
+curl -s -X POST http://localhost:10003/api/dispatch/issue \
+  -H "Content-Type: application/json" \
+  -d '{
+    "issue_number": 35,
+    "issue_title":  "PR review for feat/reviewer-branch-orientation (#437)",
+    "issue_body":   "Review PR #437. Run mypy, typing_audit, pytest. Fagan analysis. Merge if acceptable.",
+    "role":         "pr-reviewer",
+    "repo":         "agentception",
+    "pr_number":    437,
+    "pr_branch":    "feat/reviewer-branch-orientation"
+  }'
+```
+
+The endpoint fetches the remote branch automatically and creates the worktree from it.
+The reviewer is on the implementer's branch from its very first turn — no fetching,
+no hard-resetting, no wasted turns detecting the wrong branch.
+
+> **Reviewers must be dispatched before the PR is merged.** Once a PR is merged and
+> the branch deleted, `git fetch` will return `fatal: couldn't find remote ref …` and
+> the endpoint returns HTTP 422. The correct workflow: implementer creates PR →
+> dispatcher launches reviewer → reviewer verifies and merges.
 
 | Field | Required | Notes |
 |-------|----------|-------|
-| `issue_number` | yes | GitHub issue number — used for `run_id = "issue-{N}"` and the branch `feat/issue-{N}` |
+| `issue_number` | yes | GitHub issue number — used for `run_id = "issue-{N}"` and the worktree slug |
 | `issue_title` | yes | Injected into the agent's task briefing and used as the Qdrant search query |
 | `issue_body` | no | Full issue body text; drives cognitive arch selection and task briefing. Pass `""` to let the agent read the body itself via `issue_read` |
 | `role` | yes | Role slug matching a file in `.agentception/roles/` — `"developer"` for implementers, `"pr-reviewer"` for reviewers |
 | `repo` | yes | `owner/repo` string — e.g. `"agentception"` (short form resolved against `settings.gh_repo`) |
-| `pr_number` | no | PR number to associate with this run. **Required for `pr-reviewer` dispatches** so the DB row is pre-linked and the worktree can be anchored to the right branch. For implementers, omit — the agent self-reports it via `build_complete_run` |
+| `pr_number` | no | PR number to associate with this run. **Required for `pr-reviewer` dispatches** so the DB row is pre-linked. Implementers omit — the agent self-reports it via `build_complete_run` |
+| `pr_branch` | no | Exact remote branch name for the PR. **Only for `pr-reviewer` when the branch does not follow `feat/issue-{N}` naming.** Omit for standard-named branches |
 
 ### Re-dispatching a failed or cancelled run
 


### PR DESCRIPTION
## Summary

- Adds `pr_branch: str | None` to `DispatchRequest` so reviewers can supply the exact remote branch when it doesn't follow `feat/issue-{N}` naming (e.g. `feat/reviewer-branch-orientation`).
- Changes the fetch-failure response from HTTP 500 to HTTP 422 with a human-readable message explaining the branch may have been deleted after merge, and how to pass `pr_branch` for non-standard names.
- Adds two new tests: `test_dispatch_reviewer_pr_branch_override_respected` and `test_dispatch_reviewer_deleted_branch_returns_422`.

## Test plan
- [x] `mypy agentception/` — zero errors
- [x] `pytest agentception/tests/test_ensure_helpers.py` — 13/13 passed