### PR TITLE
fix: close issues explicitly after merge + strengthen Fagan review artifacts

### DIFF
--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -179,3 +179,12 @@ body = "## Summary\n...\n\nCloses #<ISSUE_NUMBER>\n\n<CLAIM_FINGERPRINT>"
 add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
                   body="🤖 **Implemented by agent** — PR #<PR_NUMBER>\n\n<CLAIM_FINGERPRINT>")
 ```
+
+**Close the issue explicitly** — GitHub only auto-closes issues when a PR is merged
+into the repository's default branch (`main`). This repo merges into `dev`, so
+auto-close never fires. After the PR merges, close the issue manually:
+
+```
+issue_write(method="update", owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+            state="closed", state_reason="completed")
+```

--- a/scripts/gen_prompts/cognitive_archetypes/figures/michael_fagan.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/figures/michael_fagan.yaml
@@ -84,6 +84,20 @@ prompt_injection:
     Cs. Find them, document them specifically (file, line, what must change,
     why), and request corrections.
 
+    After completing the checklist, **post your full defect log and grade as a
+    GitHub PR review comment** using `add_issue_comment` on the PR's issue or
+    `pull_request_review_write`. Do not keep findings in your internal
+    reasoning — Fagan's process requires a written record that outlives the
+    review session. The comment is the inspection artifact.
+
+    Then act on your grade:
+    - **A or B** → call `merge_pull_request` (squash, `deleteBranch: true`),
+      then call `issue_write(state="closed")` to close the linked issue.
+    - **C** → post the defect log comment, do NOT call `merge_pull_request`,
+      call `build_complete_run` with status `blocked`.
+    - **D or F** → post the defect log comment with explicit escalation note,
+      do NOT merge, call `build_complete_run` with status `blocked`.
+
   suffix: |
     ## Before submitting — Michael Fagan checklist
     - Have I checked every category on the defect checklist, or did I stop at the first finding?
@@ -93,3 +107,6 @@ prompt_injection:
     - Is my grade justified by specific evidence, not by impression?
     - Would I be comfortable explaining this grade and every finding to the author in writing?
     - Is there a defect in this PR that would be harder to find after merge? If yes, I have not found it yet.
+    - Have I posted the defect log and grade as a GitHub comment (not just internal reasoning)?
+    - If grade A/B: did I call merge_pull_request AND issue_write(state="closed")?
+    - If grade C+: did I post the blocking comment and call build_complete_run(blocked)?

--- a/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
@@ -76,3 +76,12 @@ body = "## Summary\n...\n\nCloses #<ISSUE_NUMBER>\n\n<CLAIM_FINGERPRINT>"
 add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
                   body="🤖 **Implemented by agent** — PR #<PR_NUMBER>\n\n<CLAIM_FINGERPRINT>")
 ```
+
+**Close the issue explicitly** — GitHub only auto-closes issues when a PR is merged
+into the repository's default branch (`main`). This repo merges into `dev`, so
+auto-close never fires. After the PR merges, close the issue manually:
+
+```
+issue_write(method="update", owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+            state="closed", state_reason="completed")
+```


### PR DESCRIPTION
## Summary

- **Issue auto-close fix**: GitHub only fires auto-close when a PR merges into the default branch (`main`). This repo merges into `dev`, so `Closes #N` in PR bodies never actually closes anything. Added an explicit `issue_write(state="closed")` step to `developer-worker-base.md.j2` — all implementer agents now close the issue themselves after the PR merges. Regenerated `developer.md`.
- **Fagan archetype**: Added explicit instruction to post the defect log as a GitHub PR comment (not just internal reasoning — the written record is the inspection artifact). Added grade-to-action mapping: A/B → merge + close issue, C → post comment + `build_complete_run(blocked)`, D/F → escalate + blocked. Added three matching checklist items to the suffix.
- Manually closed issue #35 which was left open for this exact reason.

## Test plan
- [x] `generate.py --check` — zero drift
- [x] No Python changes — mypy/tests not applicable