### PR TITLE
fix: reduce audit trail noise to 2 fingerprints + 1 outcome comment per run

### DIFF
--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -95,10 +95,10 @@ Once the type checker passes and targeted tests pass, commit and open the PR
 immediately. Do not loop back to audit more — that is scope creep. One clean
 improvement, shipped.
 
-## Audit Trail — Required at Every Touch Point
+## Audit Trail — Two Events, No More
 
-Post a fingerprint comment at each lifecycle event. All values come from your
-task briefing — do NOT read any file to obtain them.
+Post exactly **two** fingerprint events per implementer run. All values come from
+your task briefing — do NOT read any file to obtain them.
 
 ```bash
 # Populate from your task briefing before running anything below:
@@ -114,7 +114,7 @@ WTNAME=$(basename "$(pwd)")
 
 ### Event 1 — Claim (immediately after adding `agent/wip` label)
 
-Generate the fingerprint:
+Generate the fingerprint once and reuse it for both events:
 
 ```bash
 AGENT_SESSION="eng-$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%04x' $RANDOM)"
@@ -173,18 +173,20 @@ Include `$CLAIM_FINGERPRINT` verbatim at the end of the PR body when calling
 body = "## Summary\n...\n\nCloses #<ISSUE_NUMBER>\n\n<CLAIM_FINGERPRINT>"
 ```
 
-### Event 3 — Done (after PR is merged or work is complete)
+**That is all.** Do NOT post a third "done" comment on the issue.
 
-```
-add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
-                  body="🤖 **Implemented by agent** — PR #<PR_NUMBER>\n\n<CLAIM_FINGERPRINT>")
-```
+- If you spawn a PR reviewer: the reviewer's outcome comment is the terminal event.
+  One issue thread, two agents, two fingerprints, one outcome comment.
+- If you do not spawn a reviewer and the PR is merged by no other agent: close
+  the issue yourself (see below). Still no extra issue comment.
 
 **Close the issue explicitly** — GitHub only auto-closes issues when a PR is merged
 into the repository's default branch (`main`). This repo merges into `dev`, so
-auto-close never fires. After the PR merges, close the issue manually:
+auto-close never fires. Whoever merges the PR must close the issue:
 
 ```
 issue_write(method="update", owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
             state="closed", state_reason="completed")
 ```
+
+If a reviewer is spawned, the reviewer closes the issue after merging — you do not.

--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -205,11 +205,20 @@ merge_pull_request(owner=<OWNER>, repo=<REPO>, pull_number=<PR_NUMBER>,
                    merge_method="squash", deleteBranch=true)
 ```
 
-Finally post the outcome to the issue (once, never before):
+Finally post the outcome to the issue — **this is the only comment you post on
+the issue**. The implementer already posted a claim comment; your outcome comment
+is the second and final entry in the issue thread:
 
 ```
 add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
-                  body="✅ **Grade: A — Merged** / 🚫 **Grade: D/F — Blocked**\n\n<summary>\n\n<REVIEW_FINGERPRINT>")
+                  body="✅ **Grade: A — Merged PR #<PR_NUMBER>** / 🚫 **Grade: D/F — Blocked**\n\n<one-paragraph summary of findings>\n\n<REVIEW_FINGERPRINT>")
+```
+
+If grade is A or B and the PR was merged, also close the issue:
+
+```
+issue_write(method="update", owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+            state="closed", state_reason="completed")
 ```
 
 ---
@@ -253,9 +262,10 @@ When a flaw is found, classify it in this order:
 ## Failure Modes to Avoid
 
 - Re-reading a file you have already processed.
-- Posting to the issue before the review is complete (noise).
-- Calling `add_issue_comment` instead of `pull_request_review_write` for the actual review.
+- Posting more than one comment on the issue — the outcome comment is the only one.
+- Calling `add_issue_comment` for the review body instead of `pull_request_review_write`.
 - Stopping at B or C instead of fixing in place.
 - Paraphrasing terminal output instead of showing it in full.
 - Accepting suppressed type errors or untyped code as "good enough."
 - Using `docker compose exec` from inside the container — you are already inside.
+- Forgetting to call `issue_write(state="closed")` after merging a grade A/B PR.

--- a/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
@@ -109,11 +109,20 @@ merge_pull_request(owner=<OWNER>, repo=<REPO>, pull_number=<PR_NUMBER>,
                    merge_method="squash", deleteBranch=true)
 ```
 
-Finally post the outcome to the issue (once, never before):
+Finally post the outcome to the issue — **this is the only comment you post on
+the issue**. The implementer already posted a claim comment; your outcome comment
+is the second and final entry in the issue thread:
 
 ```
 add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
-                  body="✅ **Grade: A — Merged** / 🚫 **Grade: D/F — Blocked**\n\n<summary>\n\n<REVIEW_FINGERPRINT>")
+                  body="✅ **Grade: A — Merged PR #<PR_NUMBER>** / 🚫 **Grade: D/F — Blocked**\n\n<one-paragraph summary of findings>\n\n<REVIEW_FINGERPRINT>")
+```
+
+If grade is A or B and the PR was merged, also close the issue:
+
+```
+issue_write(method="update", owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
+            state="closed", state_reason="completed")
 ```
 
 ---
@@ -157,9 +166,10 @@ When a flaw is found, classify it in this order:
 ## Failure Modes to Avoid
 
 - Re-reading a file you have already processed.
-- Posting to the issue before the review is complete (noise).
-- Calling `add_issue_comment` instead of `pull_request_review_write` for the actual review.
+- Posting more than one comment on the issue — the outcome comment is the only one.
+- Calling `add_issue_comment` for the review body instead of `pull_request_review_write`.
 - Stopping at B or C instead of fixing in place.
 - Paraphrasing terminal output instead of showing it in full.
 - Accepting suppressed type errors or untyped code as "good enough."
 - Using `docker compose exec` from inside the container — you are already inside.
+- Forgetting to call `issue_write(state="closed")` after merging a grade A/B PR.

--- a/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
@@ -29,10 +29,10 @@ Once the type checker passes and targeted tests pass, commit and open the PR
 immediately. Do not loop back to audit more — that is scope creep. One clean
 improvement, shipped.
 
-## Audit Trail — Required at Every Touch Point
+## Audit Trail — Two Events, No More
 
-Post a fingerprint comment at each lifecycle event. All values come from your
-task briefing — do NOT read any file to obtain them.
+Post exactly **two** fingerprint events per implementer run. All values come from
+your task briefing — do NOT read any file to obtain them.
 
 ```bash
 # Populate from your task briefing before running anything below:
@@ -48,7 +48,7 @@ WTNAME=$(basename "$(pwd)")
 
 ### Event 1 — Claim (immediately after adding `{{ claim_label }}` label)
 
-Generate the fingerprint:
+Generate the fingerprint once and reuse it for both events:
 
 ```bash
 {% include 'snippets/fingerprint-claim.md.j2' %}
@@ -70,18 +70,20 @@ Include `$CLAIM_FINGERPRINT` verbatim at the end of the PR body when calling
 body = "## Summary\n...\n\nCloses #<ISSUE_NUMBER>\n\n<CLAIM_FINGERPRINT>"
 ```
 
-### Event 3 — Done (after PR is merged or work is complete)
+**That is all.** Do NOT post a third "done" comment on the issue.
 
-```
-add_issue_comment(owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
-                  body="🤖 **Implemented by agent** — PR #<PR_NUMBER>\n\n<CLAIM_FINGERPRINT>")
-```
+- If you spawn a PR reviewer: the reviewer's outcome comment is the terminal event.
+  One issue thread, two agents, two fingerprints, one outcome comment.
+- If you do not spawn a reviewer and the PR is merged by no other agent: close
+  the issue yourself (see below). Still no extra issue comment.
 
 **Close the issue explicitly** — GitHub only auto-closes issues when a PR is merged
 into the repository's default branch (`main`). This repo merges into `dev`, so
-auto-close never fires. After the PR merges, close the issue manually:
+auto-close never fires. Whoever merges the PR must close the issue:
 
 ```
 issue_write(method="update", owner=<OWNER>, repo=<REPO>, issue_number=<ISSUE_NUMBER>,
             state="closed", state_reason="completed")
 ```
+
+If a reviewer is spawned, the reviewer closes the issue after merging — you do not.


### PR DESCRIPTION
## Summary

- **Problem**: implementer+reviewer flow produced 4 fingerprints and 2 "done"-style comments on the issue (Event 1 claim + Event 3 done + reviewer outcome = 3 issue comments; PR body + PR review = 2 more artifacts).
- **Fix**: implementer now posts exactly 2 events — issue claim comment and fingerprint in PR body. The old "Event 3 — Done" issue comment is removed. Reviewer posts exactly 1 issue comment (outcome summary) plus the Fagan analysis via `pull_request_review_write`.
- Both templates now explicitly state who closes the issue (`issue_write(state="closed")`): the reviewer for paired runs, the implementer for solo runs.
- Regenerated `developer.md` and `pr-reviewer.md` from updated templates.

**Result per paired run**: 2 issue comments (implementer claim + reviewer outcome), 2 PR artifacts (implementer fingerprint in body + reviewer full review). Clean, traceable, no noise.

## Test plan
- [x] `generate.py --check` — zero drift
- [x] No Python changes — mypy/tests not applicable