### PR TITLE
fix: reset working memory on redispatch to prevent stale context bleed

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -26,11 +26,14 @@ Three endpoints drive the Ship page launch modal:
    without a separate credential helper).
 3. Pre-inject semantically relevant code chunks into ``task_description``
    (Qdrant search at dispatch time — not agent-turn time).
-4. Persist DB row as ``pending_launch``.
-5. Acknowledge (``pending_launch`` → ``implementing``).
-6. Fire ``run_agent_loop`` as an asyncio background task.
-7. Fire worktree Qdrant indexing as a background task.
-8. Return immediately — the agent is now running.
+4. Reset ``memory.json`` in the worktree — clears any stale memory from a
+   prior run sharing the same ``run_id``, seeds ``plan`` from ``task_description``
+   so the agent has its briefing from turn 1 without calling ``issue_read``.
+5. Persist DB row as ``pending_launch``.
+6. Acknowledge (``pending_launch`` → ``implementing``).
+7. Fire ``run_agent_loop`` as an asyncio background task.
+8. Fire worktree Qdrant indexing as a background task.
+9. Return immediately — the agent is now running.
 
 See ``docs/agent-tree-protocol.md`` for the full tier spec.
 """
@@ -75,6 +78,7 @@ from agentception.services.agent_loop import run_agent_loop
 from agentception.services.code_indexer import search_codebase
 from agentception.services.cognitive_arch import _resolve_cognitive_arch
 from agentception.services.run_factory import _configure_worktree_auth, _index_worktree
+from agentception.services.working_memory import WorkingMemory, write_memory
 from agentception.services.spawn_child import (
     SpawnChildError,
     ScopeType,
@@ -348,6 +352,17 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
                     )
         except Exception as exc:  # noqa: BLE001
             logger.warning("⚠️ dispatch: context pre-injection failed — %s", exc)
+
+    # Reset working memory so re-dispatches always start with a clean slate.
+    # If the worktree was reused from a prior run (same issue_number, same run_id),
+    # a stale memory.json would be injected into the first turn and confuse the
+    # agent about its own task.  Seed plan from task_description so the agent has
+    # its briefing in memory without needing to call issue_read on turn 1.
+    write_memory(
+        Path(worktree_path),
+        WorkingMemory(plan=task_description or ""),
+    )
+    logger.info("✅ dispatch: working memory reset for run_id=%s", run_id)
 
     # Persist all task context to DB; agents read via ac://runs/{run_id}/context.
     await persist_agent_run_dispatch(

--- a/agentception/tests/test_ensure_helpers.py
+++ b/agentception/tests/test_ensure_helpers.py
@@ -414,3 +414,70 @@ async def test_dispatch_reviewer_deleted_branch_returns_422(tmp_path: Path) -> N
 
     assert exc_info.value.status_code == 422
     assert "already merged" in exc_info.value.detail or "pr_branch" in exc_info.value.detail
+
+
+@pytest.mark.anyio
+async def test_dispatch_resets_stale_working_memory_on_redispatch(tmp_path: Path) -> None:
+    """dispatch_agent overwrites memory.json so a re-dispatched run does not inherit
+    stale context from a prior run sharing the same run_id.
+
+    Regression test for: agent woke up with loop-guard memory when dispatched for
+    stall-detection work because the issue-33 worktree was reused and its old
+    memory.json was read on turn 1.
+    """
+    import json
+    from agentception.routes.api.dispatch import dispatch_agent, DispatchRequest
+    from agentception.services.working_memory import WorkingMemory, write_memory
+
+    # Simulate a worktree that already exists with stale memory from a prior run.
+    worktree_path = tmp_path / "worktrees" / "issue-99"
+    worktree_path.mkdir(parents=True)
+    stale = WorkingMemory(
+        plan="Implement loop guard detection (old task)",
+        findings={"agentception/poller.py": "loop guard is already implemented"},
+    )
+    write_memory(worktree_path, stale)
+
+    async def mock_ensure_worktree(path: Path, branch: str, base: str = "origin/dev") -> bool:
+        return True  # worktree "already exists" — no-op
+
+    with (
+        patch("agentception.readers.git.ensure_worktree", side_effect=mock_ensure_worktree),
+        patch("agentception.routes.api.dispatch._configure_worktree_auth", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch._resolve_cognitive_arch", return_value=None),
+        patch("agentception.routes.api.dispatch.search_codebase", new_callable=AsyncMock, return_value=[]),
+        patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.acknowledge_agent_run", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.asyncio.create_task", return_value=asyncio.Future()),
+        patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.settings") as mock_settings,
+    ):
+        mock_settings.worktrees_dir = str(tmp_path / "worktrees")
+        mock_settings.host_worktrees_dir = str(tmp_path / "host_worktrees")
+        mock_settings.repo_dir = str(tmp_path)
+        mock_settings.gh_repo = "cgcardona/agentception"
+
+        req = DispatchRequest(
+            issue_number=99,
+            issue_title="New task: stall detection",
+            issue_body="Implement two-signal stall detection.",
+            role="developer",
+            repo="agentception",
+        )
+        await dispatch_agent(req)
+
+    # The memory file must be rewritten with the new task's plan, not the old one.
+    memory_file = worktree_path / ".agentception" / "memory.json"
+    assert memory_file.exists(), "dispatch_agent must write memory.json into the worktree"
+    raw = json.loads(memory_file.read_text())
+    assert "loop guard" not in raw.get("plan", ""), (
+        "Stale loop-guard plan must not survive a re-dispatch"
+    )
+    assert "stall" in raw.get("plan", "").lower(), (
+        "New plan must be seeded from the new task_description"
+    )
+    # Stale findings from the old run must be gone.
+    assert raw.get("findings") in (None, {}), (
+        "Stale findings from prior run must be cleared on re-dispatch"
+    )


### PR DESCRIPTION
## Summary

- `dispatch_agent` now calls `write_memory()` after `ensure_worktree` to reset `.agentception/memory.json` on every dispatch
- Stale plan/findings from a prior run sharing the same `run_id` can no longer bleed into the new agent's first turn
- The plan field is seeded from `task_description` so the agent has its briefing from turn 1 without needing to call `issue_read`

## Root cause

When issue-33 was re-dispatched, `ensure_worktree` reused the existing directory. The old `memory.json` (from a prior loop-guard run) was still on disk. `agent_loop.py` calls `read_memory()` on every turn, including turn 1 — so the agent opened with stale loop-guard context, spent iterations reasoning about the mismatch, then self-corrected.

## Test plan

- [x] `test_dispatch_resets_stale_working_memory_on_redispatch` — regression test verifies stale plan/findings do not survive a re-dispatch
- [x] All 14 dispatch/ensure tests green