### PR TITLE
feat(reliability): two-signal stall detection with SSE event and dash…

### DIFF
--- a/agentception/models/__init__.py
+++ b/agentception/models/__init__.py
@@ -169,6 +169,25 @@ class PlanDraftEvent(BaseModel):
     output_path: str
 
 
+class StalledAgentEvent(BaseModel):
+    """Structured record of a stalled agent emitted by the poller on every tick.
+
+    Carried in ``PipelineState.stalled_agents`` and broadcast via the existing
+    SSE stream so the dashboard can surface a Stalled badge and a re-dispatch
+    button without polling.
+
+    Primary stall signal is ``last_activity_at`` (DB heartbeat).  A secondary
+    signal — ``worktree_last_commit_time()`` — is used only for advisory
+    "active but not committing" warnings; it does NOT promote to STALLED alone.
+    """
+
+    run_id: str
+    issue_number: int
+    worktree_path: str
+    last_activity_at: str  # ISO-format UTC timestamp from the DB row
+    stalled_for_minutes: int
+
+
 class PipelineState(BaseModel):
     """Snapshot of the entire AgentCeption pipeline at a point in time.
 
@@ -205,6 +224,7 @@ class PipelineState(BaseModel):
     pending_approval: list[dict[str, object]] = []
     plan_draft_events: list[PlanDraftEvent] = []
     loop_guard_triggered: list[str] = []
+    stalled_agents: list[StalledAgentEvent] = []
 
     @classmethod
     def empty(cls) -> PipelineState:
@@ -230,6 +250,7 @@ class PipelineState(BaseModel):
             stale_branches=[],
             pending_approval=[],
             plan_draft_events=[],
+            stalled_agents=[],
         )
 
 
@@ -413,6 +434,15 @@ class PipelineConfig(BaseModel):
     phase_advance_active_label: str = "pipeline/active"
     #: Maximum message_count before an agent is flagged as looping.
     max_attempts: int = Field(default=3, gt=0, description="Max message_count before loop guard triggers.")
+    #: Minutes of DB-heartbeat silence before an agent is promoted to STALLED.
+    stall_threshold_minutes: int = Field(
+        default=30,
+        gt=0,
+        description=(
+            "Minutes of silence on last_activity_at before a worker agent is promoted "
+            "to STALLED.  Override with AC_PIPELINE_STALL_THRESHOLD_MINUTES env var."
+        ),
+    )
 
 
 class SwitchProjectRequest(BaseModel):

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from agentception.config import settings
 from agentception.intelligence.guards import detect_out_of_order_prs, detect_stale_claims
 from agentception.db.queries import RunContextRow, list_active_runs
-from agentception.models import AgentNode, AgentStatus, BoardIssue, PipelineState, PlanDraftEvent, StaleClaim
+from agentception.models import AgentNode, AgentStatus, BoardIssue, PipelineState, PlanDraftEvent, StaleClaim, StalledAgentEvent
 from agentception.readers.github import (
     get_active_label,
     get_closed_issues,
@@ -37,8 +37,9 @@ from agentception.readers.git import worktree_last_commit_time
 
 logger = logging.getLogger(__name__)
 
-# Agents whose most-recent commit is older than this threshold are flagged.
-_STUCK_THRESHOLD_SECONDS: int = 30 * 60  # 30 minutes
+# Default fallback used when PipelineConfig cannot be read.  The live value
+# comes from PipelineConfig.stall_threshold_minutes at tick time.
+_DEFAULT_STALL_THRESHOLD_SECONDS: int = 30 * 60
 
 # ---------------------------------------------------------------------------
 # Shared state — module-level singletons, mutated only by tick()
@@ -183,20 +184,26 @@ async def merge_agents(
 async def detect_alerts(
     active_runs: list[RunContextRow],
     github: GitHubBoard,
-) -> tuple[list[str], list[StaleClaim]]:
-    """Detect pipeline problems and return human-readable alert strings plus structured stale claims.
+    stall_threshold_seconds: int = _DEFAULT_STALL_THRESHOLD_SECONDS,
+) -> tuple[list[str], list[StaleClaim], list[StalledAgentEvent]]:
+    """Detect pipeline problems and return alerts, stale claims, and stalled-agent events.
 
     Three alert classes:
     1. **Stale claim** — an ``agent/wip`` issue has no live worktree.
     2. **Out-of-order PR** — an open PR's labels include an agentception phase
        that no longer matches the currently active phase.
-    3. **Stuck agent** — the most-recent commit in a worktree is > 30 min old.
+    3. **Stalled agent** — two-signal detection:
+       - *Primary (DB heartbeat):* ``last_activity_at`` is older than
+         ``stall_threshold_seconds``.  Promotes the run to ``AgentStatus.STALLED``
+         and emits a ``StalledAgentEvent``.
+       - *Secondary (git commit):* ``worktree_last_commit_time()`` is older than
+         the threshold while ``last_activity_at`` is still fresh.  Surfaces an
+         advisory warning only — no STALLED promotion.
 
-    Returns a tuple of (alert strings, stale_claims).  Alert strings include a
-    human-readable summary of each stale claim; ``stale_claims`` provides the
-    structured data used by the UI "Clear Label" action.
+    Returns ``(alerts, stale_claims, stalled_agents)``.
     """
     alerts: list[str] = []
+    stalled_agents: list[StalledAgentEvent] = []
     now = time.time()
 
     # ── Alert 1: agent/wip issue with no matching worktree ─────────────────
@@ -237,12 +244,9 @@ async def detect_alerts(
                     alerts.append(f"Out-of-order PR #{pr_num}")
                 break  # one alert per PR is enough
 
-    # ── Alert 3: worktree last commit > 30 min ago (async path) ────────────
-    # Skip coordinator runs — they have no commits of their own; all work
-    # happens in sub-agent worktrees they spawn.
-    #
-    # Skip freshly spawned runs (spawned_at within threshold) — a brand-new
-    # worktree has no agent activity yet and is not stuck.
+    # ── Alert 3: two-signal stall detection ────────────────────────────────
+    # Skip coordinator runs — they have no commits of their own.
+    # Skip freshly-spawned runs — a brand-new worktree has no activity yet.
     import datetime as _dt
     for run in active_runs:
         worktree = run["worktree_path"]
@@ -253,24 +257,56 @@ async def detect_alerts(
         path = Path(worktree)
         if not path.exists():
             continue
+
         # Skip if spawned within the threshold window.
         spawned_at_str = run["spawned_at"]
         try:
             spawned_ts = _dt.datetime.fromisoformat(spawned_at_str).timestamp()
-            if (now - spawned_ts) < _STUCK_THRESHOLD_SECONDS:
+            if (now - spawned_ts) < stall_threshold_seconds:
                 continue
         except (ValueError, OSError):
             pass
-        last_commit = await worktree_last_commit_time(path)
-        if last_commit > 0.0 and (now - last_commit) > _STUCK_THRESHOLD_SECONDS:
-            issue_num: int = run["issue_number"] or 0
-            label = f"issue #{issue_num}" if issue_num else path.name
+
+        issue_num: int = run["issue_number"] or 0
+        label = f"issue #{issue_num}" if issue_num else path.name
+        run_id = run["run_id"]
+
+        # ── Primary signal: DB heartbeat (last_activity_at) ────────────────
+        # Agents update last_activity_at on every LLM turn; silence here means
+        # the LLM loop itself has stalled — promote to STALLED immediately.
+        last_activity_raw = run.get("last_activity_at")
+        heartbeat_cold = False
+        last_activity_iso = ""
+        stalled_for_minutes = 0
+
+        if last_activity_raw is not None:
+            try:
+                last_activity_ts = _dt.datetime.fromisoformat(str(last_activity_raw)).timestamp()
+                silence_seconds = now - last_activity_ts
+                if silence_seconds > stall_threshold_seconds:
+                    heartbeat_cold = True
+                    stalled_for_minutes = int(silence_seconds / 60)
+                    last_activity_iso = str(last_activity_raw)
+            except (ValueError, OSError):
+                pass
+        else:
+            # No heartbeat recorded yet; agent has been running past threshold —
+            # treat as cold heartbeat (agent may have crashed before first turn).
+            heartbeat_cold = True
+            last_activity_iso = ""
+            # spawned_ts was already parsed above; reparse defensively.
+            try:
+                spawned_ts_fallback = _dt.datetime.fromisoformat(spawned_at_str).timestamp()
+                stalled_for_minutes = int((now - spawned_ts_fallback) / 60)
+            except (ValueError, OSError):
+                stalled_for_minutes = 0
+
+        if heartbeat_cold:
             alerts.append(f"Possible stuck agent on {label}")
 
-            # Persist STALLED state to the DB (non-blocking — never raises).
             from agentception.db.persist import update_agent_status  # noqa: PLC0415
             from agentception.workflow.status import AgentStatus  # noqa: PLC0415
-            await update_agent_status(run["run_id"], AgentStatus.STALLED)
+            await update_agent_status(run_id, AgentStatus.STALLED)
 
             stale_claims.append(StaleClaim(
                 issue_number=issue_num,
@@ -278,15 +314,33 @@ async def detect_alerts(
                 worktree_path=str(path),
             ))
 
-            # Emit agent_stalled SSE event so the dashboard and any listeners
-            # can react (e.g. surface a "re-dispatch" button).
-            stalled_for_minutes = int((now - last_commit) / 60)
+            stalled_agents.append(StalledAgentEvent(
+                run_id=run_id,
+                issue_number=issue_num,
+                worktree_path=str(path),
+                last_activity_at=last_activity_iso,
+                stalled_for_minutes=stalled_for_minutes,
+            ))
+
             logger.warning(
-                "⚠️  agent_stalled — run_id=%s issue=%s worktree=%s stalled_for=%dm",
-                run["run_id"],
+                "⚠️  agent_stalled — run_id=%s issue=%s stalled_for=%dm (DB heartbeat cold)",
+                run_id,
                 label,
-                path,
                 stalled_for_minutes,
+            )
+            continue  # Primary signal fired — skip secondary check for this run.
+
+        # ── Secondary signal: git commit age (advisory only) ───────────────
+        # Agent is turning (heartbeat warm) but hasn't committed in a while.
+        # Surface a soft warning; do NOT promote to STALLED.
+        last_commit = await worktree_last_commit_time(path)
+        if last_commit > 0.0 and (now - last_commit) > stall_threshold_seconds:
+            advisory_minutes = int((now - last_commit) / 60)
+            logger.warning(
+                "⚠️  agent_active_no_commit — run_id=%s issue=%s no_commit_for=%dm (heartbeat warm)",
+                run_id,
+                label,
+                advisory_minutes,
             )
 
     # ── Alert 4: structured out-of-order PR violations (linked-issue check) ─
@@ -303,7 +357,7 @@ async def detect_alerts(
     except Exception as exc:
         logger.warning("⚠️  detect_out_of_order_prs failed: %s", exc)
 
-    return alerts, stale_claims
+    return alerts, stale_claims, stalled_agents
 
 
 # ---------------------------------------------------------------------------
@@ -578,17 +632,16 @@ async def tick() -> PipelineState:
     active_runs = await list_active_runs()
     github = await build_github_board()
     agents = await merge_agents(active_runs, github)
-    alerts, stale_claims = await detect_alerts(active_runs, github)
     plan_draft_events: list[PlanDraftEvent] = []
 
-    # ── Loop guard detection ────────────────────────────────────────────────
-    # Check message_count against max_attempts from PipelineConfig.
-    # Agents exceeding the ceiling are flagged in loop_guard_triggered.
+    # ── Read PipelineConfig once — drives loop guard and stall thresholds ──
     loop_guard_triggered: list[str] = []
+    stall_threshold_seconds = _DEFAULT_STALL_THRESHOLD_SECONDS
     try:
         from agentception.readers.pipeline_config import read_pipeline_config
         config = await read_pipeline_config()
         max_attempts = config.max_attempts
+        stall_threshold_seconds = config.stall_threshold_minutes * 60
         for run in active_runs:
             msg_count_raw = run.get("message_count", 0)
             msg_count = int(msg_count_raw) if isinstance(msg_count_raw, (int, float)) else 0
@@ -605,7 +658,12 @@ async def tick() -> PipelineState:
                     max_attempts,
                 )
     except Exception as exc:
-        logger.warning("⚠️  Loop guard detection failed (non-fatal): %s", exc)
+        logger.warning("⚠️  Loop guard / config read failed (non-fatal): %s", exc)
+
+    # ── Detect stale claims / stalled agents / out-of-order PRs ────────────
+    alerts, stale_claims, stalled_agents = await detect_alerts(
+        active_runs, github, stall_threshold_seconds
+    )
 
     # ── Persist raw tick data to Postgres ────────────────────────────────────
     # Non-blocking: a DB outage cannot crash the poller or stall the SSE stream.
@@ -623,6 +681,7 @@ async def tick() -> PipelineState:
                 polled_at=time.time(),
                 plan_draft_events=plan_draft_events,
                 loop_guard_triggered=loop_guard_triggered,
+                stalled_agents=stalled_agents,
             ),
             open_issues=github.open_issues,
             open_prs=github.open_prs,
@@ -689,6 +748,7 @@ async def tick() -> PipelineState:
         stale_branches=stale_branches,
         plan_draft_events=plan_draft_events,
         loop_guard_triggered=loop_guard_triggered,
+        stalled_agents=stalled_agents,
     )
     _state = state
 

--- a/agentception/templates/overview.html
+++ b/agentception/templates/overview.html
@@ -586,6 +586,14 @@
       <span class="summary-label">Loop Guard</span>
       <span class="summary-value" x-text="(state.loop_guard_triggered || []).length"></span>
     </div>
+    <div
+      class="summary-item"
+      :class="(state.stalled_agents || []).length > 0 ? 'summary-item--warn' : 'summary-item--dim'"
+      :title="(state.stalled_agents || []).length > 0 ? '⏸ Stalled: ' + (state.stalled_agents || []).map(a => 'issue #' + a.issue_number).join(', ') : 'No stalled agents'"
+    >
+      <span class="summary-label">⏸ Stalled</span>
+      <span class="summary-value" x-text="(state.stalled_agents || []).length"></span>
+    </div>
     <div class="summary-item">
       <span class="summary-label">Msgs</span>
       <span class="summary-value summary-value--accent" x-text="totalMsgCount()"></span>

--- a/agentception/tests/test_agentception_guards.py
+++ b/agentception/tests/test_agentception_guards.py
@@ -274,7 +274,7 @@ async def test_stale_claim_shows_in_alerts(tmp_path: Path) -> None:
         ),
     ):
         poller_mock.worktrees_dir = tmp_path
-        alerts, stale_claims = await detect_alerts(worktrees, board)
+        alerts, stale_claims, _stalled = await detect_alerts(worktrees, board)
 
     assert any("Stale claim on #42" in a for a in alerts), (
         f"Expected 'Stale claim on #42' in alerts, got: {alerts}"

--- a/agentception/tests/test_agentception_poller.py
+++ b/agentception/tests/test_agentception_poller.py
@@ -21,7 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from agentception.db.queries import RunContextRow
-from agentception.models import AgentStatus, PipelineState
+from agentception.models import AgentStatus, PipelineState, StalledAgentEvent
 from agentception.poller import (
     GitHubBoard,
     broadcast,
@@ -215,7 +215,7 @@ async def test_stale_claim_alert_detected(tmp_path: Path) -> None:
         ),
     ):
         mock_settings.worktrees_dir = tmp_path
-        alerts, stale_claims = await detect_alerts([], board)
+        alerts, stale_claims, _stalled = await detect_alerts([], board)
 
     assert any("Stale claim on #42" in a for a in alerts), f"Expected stale-claim alert, got: {alerts}"
     assert len(stale_claims) == 1
@@ -243,7 +243,7 @@ async def test_no_stale_claim_when_worktree_exists(tmp_path: Path) -> None:
         ),
     ):
         mock_settings.worktrees_dir = tmp_path
-        alerts, _stale_claims = await detect_alerts(worktrees, board)
+        alerts, _stale_claims, _stalled = await detect_alerts(worktrees, board)
 
     assert not any("Stale claim on #99" in a for a in alerts)
 
@@ -272,7 +272,7 @@ async def test_out_of_order_pr_alert(tmp_path: Path) -> None:
         ),
     ):
         mock_settings.worktrees_dir = tmp_path
-        alerts, _stale_claims = await detect_alerts([], board)
+        alerts, _stale_claims, _stalled = await detect_alerts([], board)
 
     assert any("Out-of-order PR #77" in a for a in alerts), f"Expected out-of-order alert, got: {alerts}"
 
@@ -321,9 +321,162 @@ async def test_stuck_agent_alert_detected(tmp_path: Path) -> None:
         ),
     ):
         mock_settings.worktrees_dir = tmp_path / "worktrees"
-        alerts, _stale_claims = await detect_alerts(worktrees, board)
+        alerts, _stale_claims, _stalled = await detect_alerts(worktrees, board)
 
     assert any("stuck agent" in a.lower() for a in alerts), f"Expected stuck-agent alert, got: {alerts}"
+
+
+@pytest.mark.anyio
+async def test_stall_detection_primary_signal_cold_heartbeat(tmp_path: Path) -> None:
+    """Poller marks STALLED and emits StalledAgentEvent when last_activity_at is beyond threshold."""
+    stale_ts = time.time() - (35 * 60)  # 35 minutes ago
+    stale_iso = "2024-01-01T00:35:00"
+
+    worktrees = [
+        RunContextRow(
+            run_id="issue-99",
+            status="implementing",
+            role="developer",
+            cognitive_arch=None,
+            task_description=None,
+            issue_number=99,
+            pr_number=None,
+            branch="feat/issue-99",
+            worktree_path=str(tmp_path),
+            batch_id=None,
+            tier="worker",
+            org_domain=None,
+            parent_run_id=None,
+            gh_repo=None,
+            is_resumed=False,
+            coord_fingerprint=None,
+            spawned_at="2024-01-01T00:00:00",
+            last_activity_at=stale_iso,
+            completed_at=None,
+        )
+    ]
+    board = _empty_board()
+    threshold = 30 * 60  # 30 minutes
+
+    with (
+        patch("agentception.poller.settings") as mock_settings,
+        patch(
+            "agentception.poller.worktree_last_commit_time",
+            new_callable=AsyncMock,
+            return_value=stale_ts,
+        ),
+        patch(
+            "agentception.poller.detect_out_of_order_prs",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("agentception.db.persist.update_agent_status", new_callable=AsyncMock),
+    ):
+        mock_settings.worktrees_dir = tmp_path / "worktrees"
+        # Freeze now so elapsed calculation is deterministic.
+        with patch("agentception.poller.time") as mock_time:
+            mock_time.time.return_value = stale_ts + 35 * 60
+            alerts, _claims, stalled = await detect_alerts(worktrees, board, threshold)
+
+    assert any("stuck agent" in a.lower() for a in alerts), alerts
+    assert len(stalled) == 1
+    assert isinstance(stalled[0], StalledAgentEvent)
+    assert stalled[0].run_id == "issue-99"
+    assert stalled[0].issue_number == 99
+    assert stalled[0].stalled_for_minutes >= 30
+
+
+@pytest.mark.anyio
+async def test_stall_detection_no_stall_when_heartbeat_warm(tmp_path: Path) -> None:
+    """Poller does NOT mark STALLED when last_activity_at is within the threshold window."""
+    recent_iso = "2024-01-01T00:55:00"  # only 5 min ago relative to mocked now
+    now_ts = 1704067200.0 + 60 * 60  # arbitrary base + 1 hour
+
+    worktrees = [
+        RunContextRow(
+            run_id="issue-88",
+            status="implementing",
+            role="developer",
+            cognitive_arch=None,
+            task_description=None,
+            issue_number=88,
+            pr_number=None,
+            branch="feat/issue-88",
+            worktree_path=str(tmp_path),
+            batch_id=None,
+            tier="worker",
+            org_domain=None,
+            parent_run_id=None,
+            gh_repo=None,
+            is_resumed=False,
+            coord_fingerprint=None,
+            spawned_at="2024-01-01T00:00:00",
+            last_activity_at=recent_iso,
+            completed_at=None,
+        )
+    ]
+    board = _empty_board()
+    threshold = 30 * 60
+
+    with (
+        patch("agentception.poller.settings") as mock_settings,
+        patch(
+            "agentception.poller.worktree_last_commit_time",
+            new_callable=AsyncMock,
+            # Old commit — but heartbeat is warm, so should only be advisory.
+            return_value=now_ts - 45 * 60,
+        ),
+        patch(
+            "agentception.poller.detect_out_of_order_prs",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        mock_settings.worktrees_dir = tmp_path / "worktrees"
+        import datetime as _dt
+
+        with patch("agentception.poller.time") as mock_time:
+            # now_ts is 5 min after recent_iso → heartbeat warm
+            recent_ts = _dt.datetime.fromisoformat(recent_iso).timestamp()
+            mock_time.time.return_value = recent_ts + 5 * 60
+            alerts, _claims, stalled = await detect_alerts(worktrees, board, threshold)
+
+    assert len(stalled) == 0, f"Expected no stalled agents, got: {stalled}"
+    assert not any("stuck agent" in a.lower() for a in alerts), alerts
+
+
+@pytest.mark.anyio
+async def test_stalled_agents_in_pipeline_state(tmp_path: Path) -> None:
+    """PipelineState.stalled_agents is populated from detect_alerts and broadcast via SSE."""
+    stale_iso = "2024-01-01T00:00:00"
+    stalled_event = StalledAgentEvent(
+        run_id="issue-77",
+        issue_number=77,
+        worktree_path=str(tmp_path),
+        last_activity_at=stale_iso,
+        stalled_for_minutes=45,
+    )
+
+    # Patch only the three surfaces that tick() calls at module-level;
+    # all DB/SSE-expansion imports are lazy and fail silently via try/except.
+    with (
+        patch("agentception.poller.list_active_runs", new_callable=AsyncMock, return_value=[]),
+        patch(
+            "agentception.poller.build_github_board",
+            new_callable=AsyncMock,
+            return_value=_empty_board(),
+        ),
+        patch(
+            "agentception.poller.detect_alerts",
+            new_callable=AsyncMock,
+            return_value=([], [], [stalled_event]),
+        ),
+    ):
+        state = await tick()
+
+    assert len(state.stalled_agents) == 1
+    assert state.stalled_agents[0].run_id == "issue-77"
+    assert state.stalled_agents[0].stalled_for_minutes == 45
 
 
 # ---------------------------------------------------------------------------

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -46,6 +46,7 @@ Open `.env` and fill in the required values:
 | `REPO_DIR` | Optional | Absolute path to the cloned agentception repo on the host. Used for git operations inside the container. | Default: `/app` (the container working directory) |
 | `PORT` | Optional | Port the FastAPI app listens on. | Default: `10003` |
 | `LOG_LEVEL` | Optional | Log verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`. | Default: `INFO` |
+| `AC_PIPELINE_STALL_THRESHOLD_MINUTES` | Optional | Minutes of DB-heartbeat silence before a worker agent is promoted to `STALLED`. Stored in `PipelineConfig.stall_threshold_minutes`; also settable via `pipeline-config.json`. | Default: `30` |
 
 Minimal `.env` that works for a basic smoke test (no LLM features):
 


### PR DESCRIPTION
…board badge (closes #33)

Replace the single-signal git-commit stall detector with a two-signal approach:

Primary (DB heartbeat): last_activity_at silence > stall_threshold_minutes promotes the run to AgentStatus.STALLED and emits a StalledAgentEvent in PipelineState.

Secondary (git commit age): when last_activity_at is warm but worktree hasn't committed past the threshold, surface an advisory WARNING only — no STALLED promotion.

Changes:
- Add StalledAgentEvent Pydantic model to agentception/models/__init__.py
- Add PipelineState.stalled_agents: list[StalledAgentEvent]
- Add PipelineConfig.stall_threshold_minutes: int = 30 (replaces _STUCK_THRESHOLD_SECONDS)
- Update detect_alerts() signature to return (alerts, stale_claims, stalled_agents)
- Wire stall_threshold_seconds from PipelineConfig in tick() before detect_alerts()
- Add ⏸ Stalled summary badge to overview.html (same pattern as Loop Guard)
- Document AC_PIPELINE_STALL_THRESHOLD_MINUTES in docs/guides/setup.md
- Add three new tests: cold heartbeat fires, warm heartbeat suppressed, tick propagates stalled_agents
- Fix all existing detect_alerts unpack sites (2 in test_agentception_poller, 1 in test_agentception_guards)