### PR TITLE
Replace character chunking with AST-based symbol chunking

### DIFF
--- a/agentception/services/code_indexer.py
+++ b/agentception/services/code_indexer.py
@@ -4,13 +4,23 @@ Replaces Cursor's ``@Codebase`` feature with a self-hosted vector store.
 Files are chunked, embedded with a local ONNX model (FastEmbed), and stored
 in Qdrant.  The agent then searches with natural language instead of regex.
 
+Chunking Strategy
+-----------------
+Python files are chunked by top-level symbols (classes, functions, async
+functions) using AST parsing. Each symbol becomes a single chunk, including
+its decorators, docstring, and full body. This produces semantically coherent
+chunks that preserve complete definitions.
+
+Non-Python files use overlapping character-level chunks for compatibility.
+
 Public API
 ----------
 ``index_codebase(repo_path)``
-    Walk every readable source file in *repo_path*, split into overlapping
-    character-level chunks, embed with :data:`~agentception.config.settings.embed_model`
-    (default ``BAAI/bge-small-en-v1.5``), and upsert to the Qdrant
-    collection configured in :data:`~agentception.config.settings.qdrant_collection`.
+    Walk every readable source file in *repo_path*, chunk appropriately
+    (AST for Python, character-level for others), embed with
+    :data:`~agentception.config.settings.embed_model` (default
+    ``BAAI/bge-small-en-v1.5``), and upsert to the Qdrant collection
+    configured in :data:`~agentception.config.settings.qdrant_collection`.
 
 ``search_codebase(query, n_results)``
     Embed *query* with the same model and return the top *n_results* code
@@ -162,14 +172,89 @@ class _ChunkSpec(TypedDict):
     end_line: int
 
 
-def _chunk_file(path: Path, repo_root: Path) -> list[_ChunkSpec]:
-    """Split *path* into overlapping character-level chunks."""
+def _chunk_file_ast(path: Path, repo_root: Path) -> list[_ChunkSpec]:
+    """Split a Python file into chunks by top-level symbols (classes, functions).
+
+    Each top-level class or function becomes a single chunk, including its
+    decorators, docstring, and full body. This produces semantically coherent
+    chunks that preserve complete definitions.
+
+    Falls back to character-based chunking if AST parsing fails.
+    """
+    import ast
+
     try:
         raw = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return []
 
     rel = str(path.relative_to(repo_root))
+
+    # Try to parse as Python AST.
+    try:
+        tree = ast.parse(raw, filename=str(path))
+    except SyntaxError:
+        # Fall back to character chunking for malformed Python.
+        return _chunk_file_char(path, repo_root, raw, rel)
+
+    chunks: list[_ChunkSpec] = []
+    lines = raw.splitlines(keepends=True)
+
+    for idx, node in enumerate(tree.body):
+        # Only chunk top-level classes and functions.
+        if not isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        # Extract the full source for this node, including decorators.
+        start_line = node.lineno
+        end_line = node.end_lineno or start_line
+
+        # Include decorators if present.
+        if node.decorator_list:
+            first_decorator = node.decorator_list[0]
+            start_line = first_decorator.lineno
+
+        # Extract text from the original source (1-indexed lines).
+        text = "".join(lines[start_line - 1 : end_line])
+
+        # Generate deterministic chunk ID.
+        raw_hash = hashlib.md5(f"{rel}:{node.name}".encode()).hexdigest()
+        chunk_id = int(raw_hash, 16) % (2**62)
+
+        chunks.append(
+            _ChunkSpec(
+                chunk_id=chunk_id,
+                file=rel,
+                text=text,
+                start_line=start_line,
+                end_line=end_line,
+            )
+        )
+
+    # If no top-level symbols found, fall back to character chunking.
+    if not chunks:
+        return _chunk_file_char(path, repo_root, raw, rel)
+
+    return chunks
+
+
+def _chunk_file_char(
+    path: Path, repo_root: Path, raw: str | None = None, rel: str | None = None
+) -> list[_ChunkSpec]:
+    """Split a file into overlapping character-level chunks.
+
+    This is the fallback strategy for non-Python files or Python files
+    that cannot be parsed with AST.
+    """
+    if raw is None:
+        try:
+            raw = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return []
+
+    if rel is None:
+        rel = str(path.relative_to(repo_root))
+
     chunks: list[_ChunkSpec] = []
     start = 0
     chunk_idx = 0
@@ -196,6 +281,17 @@ def _chunk_file(path: Path, repo_root: Path) -> list[_ChunkSpec]:
         chunk_idx += 1
 
     return chunks
+
+
+def _chunk_file(path: Path, repo_root: Path) -> list[_ChunkSpec]:
+    """Split *path* into chunks using the appropriate strategy.
+
+    Python files are chunked by top-level symbols (classes, functions) via AST.
+    All other files use overlapping character-level chunks.
+    """
+    if path.suffix == ".py":
+        return _chunk_file_ast(path, repo_root)
+    return _chunk_file_char(path, repo_root)
 
 
 # ── Qdrant helpers ────────────────────────────────────────────────────────────

--- a/agentception/tests/test_code_indexer.py
+++ b/agentception/tests/test_code_indexer.py
@@ -147,6 +147,114 @@ def test_chunk_file_missing_file_returns_empty(tmp_path: Path) -> None:
     assert _chunk_file(f, tmp_path) == []
 
 
+def test_chunk_file_ast_extracts_functions(tmp_path: Path) -> None:
+    """AST chunking extracts each top-level function as a separate chunk."""
+    f = tmp_path / "funcs.py"
+    f.write_text(
+        "def foo():\n"
+        "    '''Docstring for foo.'''\n"
+        "    return 1\n"
+        "\n"
+        "def bar():\n"
+        "    return 2\n"
+    )
+    chunks = _chunk_file(f, tmp_path)
+    assert len(chunks) == 2
+    assert "def foo():" in chunks[0]["text"]
+    assert "Docstring for foo" in chunks[0]["text"]
+    assert "def bar():" in chunks[1]["text"]
+
+
+def test_chunk_file_ast_extracts_classes(tmp_path: Path) -> None:
+    """AST chunking extracts each top-level class as a separate chunk."""
+    f = tmp_path / "classes.py"
+    f.write_text(
+        "class Alpha:\n"
+        "    '''Class docstring.'''\n"
+        "    def method(self):\n"
+        "        pass\n"
+        "\n"
+        "class Beta:\n"
+        "    pass\n"
+    )
+    chunks = _chunk_file(f, tmp_path)
+    assert len(chunks) == 2
+    assert "class Alpha:" in chunks[0]["text"]
+    assert "Class docstring" in chunks[0]["text"]
+    assert "def method" in chunks[0]["text"]
+    assert "class Beta:" in chunks[1]["text"]
+
+
+def test_chunk_file_ast_includes_decorators(tmp_path: Path) -> None:
+    """AST chunking includes decorators in the chunk."""
+    f = tmp_path / "decorated.py"
+    f.write_text(
+        "@decorator\n"
+        "@another_decorator(arg=1)\n"
+        "def decorated_func():\n"
+        "    pass\n"
+    )
+    chunks = _chunk_file(f, tmp_path)
+    assert len(chunks) == 1
+    assert "@decorator" in chunks[0]["text"]
+    assert "@another_decorator" in chunks[0]["text"]
+    assert chunks[0]["start_line"] == 1
+
+
+def test_chunk_file_ast_preserves_async_functions(tmp_path: Path) -> None:
+    """AST chunking handles async functions correctly."""
+    f = tmp_path / "async_code.py"
+    f.write_text(
+        "async def fetch_data():\n"
+        "    '''Async docstring.'''\n"
+        "    return await something()\n"
+    )
+    chunks = _chunk_file(f, tmp_path)
+    assert len(chunks) == 1
+    assert "async def fetch_data" in chunks[0]["text"]
+    assert "Async docstring" in chunks[0]["text"]
+
+
+def test_chunk_file_ast_falls_back_on_syntax_error(tmp_path: Path) -> None:
+    """AST chunking falls back to character chunking for malformed Python."""
+    f = tmp_path / "broken.py"
+    f.write_text("def incomplete(\n")  # Syntax error
+    chunks = _chunk_file(f, tmp_path)
+    # Should fall back to character chunking and produce at least one chunk.
+    assert len(chunks) >= 1
+    assert "def incomplete" in chunks[0]["text"]
+
+
+def test_chunk_file_ast_falls_back_when_no_symbols(tmp_path: Path) -> None:
+    """AST chunking falls back to character chunking when no top-level symbols exist."""
+    f = tmp_path / "only_imports.py"
+    f.write_text("import os\nimport sys\n\nx = 1\n")
+    chunks = _chunk_file(f, tmp_path)
+    # No top-level functions/classes, so should fall back to character chunking.
+    assert len(chunks) >= 1
+    assert "import os" in chunks[0]["text"]
+
+
+def test_chunk_file_ast_chunk_ids_use_symbol_names(tmp_path: Path) -> None:
+    """AST chunking generates deterministic IDs based on symbol names."""
+    f = tmp_path / "named.py"
+    f.write_text("def stable_name():\n    pass\n")
+    ids_first = [c["chunk_id"] for c in _chunk_file(f, tmp_path)]
+    ids_second = [c["chunk_id"] for c in _chunk_file(f, tmp_path)]
+    assert ids_first == ids_second
+    assert len(ids_first) == 1
+
+
+def test_chunk_file_non_python_uses_character_chunking(tmp_path: Path) -> None:
+    """Non-Python files always use character-based chunking."""
+    f = tmp_path / "readme.md"
+    f.write_text("# Title\n\nSome content.\n")
+    chunks = _chunk_file(f, tmp_path)
+    assert len(chunks) >= 1
+    assert "# Title" in chunks[0]["text"]
+
+
+
 # ── index_codebase tests ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
- Add _chunk_file_ast() that parses Python files with ast module
- Extract top-level classes and functions as individual chunks
- Preserve decorators, docstrings, and full symbol bodies
- Fall back to character chunking for non-Python files
- Update _chunk_file() to dispatch based on file extension
- Add 8 new tests covering AST chunking behavior
- Update module docstring to document chunking strategy

Closes #457