### PR TITLE
feat: add Qdrant as a first-class cognitive architecture skill domain

### DIFF
--- a/agentception/tests/test_resolve_arch.py
+++ b/agentception/tests/test_resolve_arch.py
@@ -24,6 +24,7 @@ RESOLVE_ARCH = Path(__file__).parent.parent.parent / "scripts" / "gen_prompts" /
         "hopper",
         "the_architect:python",
         "the_pragmatist:devops",
+        "guido_van_rossum:qdrant:python",
     ],
 )
 def test_resolve_arch_produces_non_empty_output(arch_string: str) -> None:
@@ -64,6 +65,20 @@ def test_resolve_arch_fingerprint_flag_produces_fingerprint_table() -> None:
     assert result.returncode == 0
     assert "developer" in result.stdout
     assert "test-session-1" in result.stdout
+
+
+def test_resolve_arch_qdrant_skill_content_present() -> None:
+    """Output for a qdrant arch string must include the Qdrant skill section header and key concepts."""
+    result = subprocess.run(
+        [sys.executable, str(RESOLVE_ARCH), "guido_van_rossum:qdrant:python"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "Qdrant Vector Search" in result.stdout
+    assert "AsyncQdrantClient" in result.stdout
+    assert "_ensure_collection" in result.stdout
+    assert "symbol" in result.stdout
 
 
 def test_resolve_arch_unknown_figure_exits_nonzero() -> None:

--- a/scripts/gen_prompts/cognitive_archetypes/skill_domains/qdrant.yaml
+++ b/scripts/gen_prompts/cognitive_archetypes/skill_domains/qdrant.yaml
@@ -1,0 +1,77 @@
+# Skill Domain: Qdrant
+id: qdrant
+display_name: "Qdrant Vector Search"
+description: "Qdrant vector database: collection schema, payload indexes, hybrid search, async client usage in AgentCeption."
+
+prompt_fragment: |
+  ## Skill Domain: Qdrant Vector Search
+
+  You work with Qdrant as the primary vector store in AgentCeption.
+  Qdrant stores code chunks indexed by FastEmbed dense vectors and
+  searched by the `search_codebase` tool at agent dispatch time.
+
+  ## Stack facts
+
+  - Client: `qdrant-client` async (`AsyncQdrantClient`). All operations are async.
+  - Collection: configured in `settings.qdrant_collection` (default `"code"`).
+  - Vector size: `settings.embed_model_dim` (default 384 for BAAI/bge-small-en-v1.5).
+  - Distance metric: `Distance.COSINE`.
+  - Chunking: Python files → AST symbol chunks (`_chunk_file_ast`);
+    all others → overlapping character chunks (`_chunk_file_char`).
+  - Payload schema (every point): `file` (str), `chunk` (str), `start_line` (int),
+    `end_line` (int), `symbol` (str — e.g. `"class Foo"` or `"def bar"`,
+    empty string for character chunks).
+  - Payload indexes: `KeywordIndexType.KEYWORD` on `file` and `symbol` for O(1)
+    exact-match filtering without a full collection scan.
+
+  ## Collection lifecycle
+
+  `_ensure_collection()` in `agentception/services/code_indexer.py` is the
+  single entry point for collection setup. It is idempotent: it checks
+  `get_collections()` first and only calls `create_collection()` when the
+  collection is absent. Payload indexes are declared at creation time via
+  `payload_indexes_config` — they cannot be added retroactively without
+  a collection rebuild.
+
+  ## Coding rules for this codebase
+
+  - Never call `recreate_collection` — it is deprecated in qdrant-client ≥ 1.7.
+    Use `delete_collection` + `create_collection` only when a full rebuild is
+    explicitly requested (e.g. the `force_full` flag in `index_codebase`).
+  - All Qdrant I/O must be `await`ed. Never block the event loop with sync calls.
+  - Upserts use `PointStruct` with a deterministic `int` ID derived from
+    `md5(file:symbol_name)` for AST chunks or `md5(file:chunk_index)` for
+    character chunks. Re-indexing the same file produces the same IDs → safe upsert.
+  - Batch size: `_UPSERT_BATCH = 64` points per `client.upsert()` call.
+  - Errors from Qdrant are caught at the `index_codebase` / `search_codebase`
+    boundary and returned as `IndexStats(ok=False)` or `[]` — never propagated
+    to the agent loop.
+
+  ## Search
+
+  `search_codebase(query, n_results)` embeds the query via `_embed()` and calls
+  `client.query_points()` with the dense vector. Returns `list[SearchMatch]`
+  (TypedDict with `file`, `chunk`, `start_line`, `end_line`, `score`).
+
+  Planned: hybrid search (dense + sparse BM25) via named vectors. When
+  implementing, add a second `sparse` named vector at collection creation time
+  and use `client.query_points()` with `prefetch` + `fusion=Fusion.RRF`.
+
+  ## Testing
+
+  Never make live Qdrant calls in unit tests. Mock `AsyncQdrantClient` with
+  `unittest.mock.AsyncMock`. Use `SimpleNamespace` to fake
+  `CollectionsResponse` and `ScoredPoint` payloads. See
+  `agentception/tests/test_code_indexer.py` for the established patterns.
+
+review_checklist: |
+  - No `recreate_collection` calls (deprecated — delete + create instead)
+  - All Qdrant I/O is async (`await`ed)
+  - `symbol` field populated in every `_ChunkSpec` before upsert
+  - Payload indexes declared at collection creation, not retrofitted
+  - Unit tests mock `AsyncQdrantClient` — no live Qdrant dependency
+  - `_ensure_collection` remains idempotent (checks before creates)
+  - Batch size respected; no single-document upserts in bulk indexing paths
+
+quality_gates:
+  test_runner: "pytest agentception/tests/test_code_indexer.py -v"

--- a/scripts/gen_prompts/team.yaml
+++ b/scripts/gen_prompts/team.yaml
@@ -226,6 +226,9 @@ org:
       - python
       - fastapi
       - postgresql
+      # Vector search
+      - qdrant
+      - rag
       # Frontend / UI
       - htmx
       - jinja2
@@ -257,6 +260,8 @@ org:
       - python
       - fastapi
       - postgresql
+      - qdrant
+      - rag
       - htmx
       - jinja2
       - alpine
@@ -289,6 +294,10 @@ heuristics:
     skills: [midi, python]
   - keywords: [ml, ai, model, inference, huggingface, gradio]
     skills: [llm, python]
+  - keywords: [qdrant, vector, embedding, fastembed, search_codebase, index_codebase, chunk, payload_index]
+    skills: [qdrant, python]
+  - keywords: [rag, retrieval, hybrid search, bm25, rerank, semantic search]
+    skills: [qdrant, rag, python]
   - keywords: [docker, compose, nginx, deployment, ci, github actions]
     skills: [devops]
   - keywords: [javascript, fetch, dom, browser]


### PR DESCRIPTION
## Summary

- Adds `qdrant.yaml` skill domain with a comprehensive `prompt_fragment` covering AsyncQdrantClient usage, collection lifecycle, `_ensure_collection` idempotency, `_ChunkSpec` payload schema (including the `symbol` field), deterministic chunk IDs, batch upsert rules, and the planned hybrid-search path. Includes a `review_checklist` and `quality_gate` pointing at `test_code_indexer.py`.
- Adds `qdrant` and `rag` to the `skill_pool` for both `leaf` agents and `reviewers` in `team.yaml`.
- Adds two heuristic rules so the Engineering Coordinator auto-assigns `qdrant:python` for vector/embedding/search issues and `qdrant:rag:python` for retrieval/hybrid-search issues.
- Extends `test_resolve_arch.py` with a parametrized smoke test for `guido_van_rossum:qdrant:python` and a content-assertion test verifying the rendered context block contains `AsyncQdrantClient`, `_ensure_collection`, and `symbol`.

## Test plan

- [x] `pytest agentception/tests/test_resolve_arch.py -v` → 12 passed
- [x] `generate.py --check` → 0 drift
- [x] Skill loads and renders correctly via `resolve_arch.py`