### PR TITLE
fix: stop token rotation cycle — use http.extraHeader instead of remote URL embedding

### DIFF
--- a/agentception/services/run_factory.py
+++ b/agentception/services/run_factory.py
@@ -192,12 +192,18 @@ async def _index_worktree(worktree_path: Path, run_id: str) -> None:
 
 
 async def _configure_worktree_auth(worktree_path: Path, run_id: str) -> None:
-    """Embed GITHUB_TOKEN in the worktree remote URL so git push works natively.
+    """Configure git auth for the worktree using http.extraHeader.
 
-    Transforms ``https://github.com/owner/repo.git`` into
-    ``https://x-access-token:<token>@github.com/owner/repo.git`` and writes
-    it to the worktree's local git config only.  If ``GITHUB_TOKEN`` is not
-    set, logs a warning and leaves the remote unchanged.
+    Uses ``git config --worktree http.https://github.com/.extraHeader`` to
+    inject the GITHUB_TOKEN as a Bearer authorization header.  This writes
+    only to the worktree-specific config file
+    (``.git/worktrees/<name>/config.worktree``) and never touches
+    ``remote.origin.url`` or the shared ``.git/config``.
+
+    The old approach of embedding the token in the remote URL wrote to the
+    shared ``.git/config`` (git worktrees share one config), polluting the
+    main repo's remote URL and potentially triggering GitHub secret scanning
+    which auto-revokes exposed tokens.
     """
     import os  # noqa: PLC0415
 
@@ -206,43 +212,36 @@ async def _configure_worktree_auth(worktree_path: Path, run_id: str) -> None:
         logger.warning("⚠️ GITHUB_TOKEN not set — git push will require manual auth in worktrees")
         return
 
-    # Read the current remote URL.
-    url_proc = await asyncio.create_subprocess_exec(
-        "git", "remote", "get-url", "origin",
+    # Enable per-worktree config in the shared .git/config (idempotent).
+    # Required for --worktree flag to write to the worktree-specific file
+    # rather than the shared config.
+    ext_proc = await asyncio.create_subprocess_exec(
+        "git", "config", "--local", "extensions.worktreeConfig", "true",
         cwd=str(worktree_path),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    url_out, _ = await url_proc.communicate()
-    remote_url = url_out.decode().strip()
+    await ext_proc.communicate()
 
-    if not remote_url.startswith("https://"):
-        # SSH remotes already handle auth via ssh-agent — nothing to do.
-        return
-
-    # Inject token into URL, avoiding double-injection if already present.
-    if "@" not in remote_url.split("://", 1)[-1]:
-        authed_url = remote_url.replace(
-            "https://", f"https://x-access-token:{token}@", 1
-        )
-    else:
-        authed_url = remote_url
-
-    set_proc = await asyncio.create_subprocess_exec(
-        "git", "remote", "set-url", "origin", authed_url,
+    # Write the Authorization header into the worktree-specific config only.
+    # Scoped to github.com so it never leaks to other hosts.
+    hdr_proc = await asyncio.create_subprocess_exec(
+        "git", "config", "--worktree",
+        "http.https://github.com/.extraHeader",
+        f"Authorization: Bearer {token}",
         cwd=str(worktree_path),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    _, set_err = await set_proc.communicate()
-    if set_proc.returncode != 0:
+    _, hdr_err = await hdr_proc.communicate()
+    if hdr_proc.returncode != 0:
         logger.warning(
-            "⚠️ _configure_worktree_auth — could not set remote URL for run_id=%s: %s",
-            run_id, set_err.decode().strip(),
+            "⚠️ _configure_worktree_auth — could not set extraHeader for run_id=%s: %s",
+            run_id, hdr_err.decode().strip(),
         )
         return
 
-    logger.info("✅ worktree auth configured — run_id=%s", run_id)
+    logger.info("✅ worktree auth configured via extraHeader — run_id=%s", run_id)
 
 
 async def _insert_run(

--- a/agentception/tests/test_run_factory.py
+++ b/agentception/tests/test_run_factory.py
@@ -1,0 +1,97 @@
+"""Unit tests for agentception.services.run_factory._configure_worktree_auth."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+
+def _make_proc(returncode: int = 0, stderr: bytes = b"") -> AsyncMock:
+    """Return a mock subprocess whose communicate() resolves to (b'', stderr)."""
+    proc = AsyncMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(b"", stderr))
+    return proc
+
+
+@pytest.mark.anyio
+async def test_configure_worktree_auth_sets_extraheader_not_remote_url() -> None:
+    """Happy path: token present → extensions.worktreeConfig enabled, extraHeader written.
+
+    Critically, remote.origin.url must never be touched — that was the old
+    behaviour that polluted the shared .git/config and caused token revocation.
+    """
+    from agentception.services.run_factory import _configure_worktree_auth
+
+    ext_proc = _make_proc()
+    hdr_proc = _make_proc()
+
+    call_args: list[tuple[object, ...]] = []
+
+    async def fake_exec(*args: object, **_kwargs: object) -> AsyncMock:
+        call_args.append(args)
+        if "extensions.worktreeConfig" in args:
+            return ext_proc
+        return hdr_proc
+
+    with (
+        patch("agentception.services.run_factory.asyncio.create_subprocess_exec", side_effect=fake_exec),
+        patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_testtoken123"}, clear=False),
+    ):
+        await _configure_worktree_auth(Path("/worktrees/issue-99"), "issue-99")
+
+    # Must have made exactly two git config calls.
+    assert len(call_args) == 2
+
+    # First call: enable extensions.worktreeConfig.
+    assert call_args[0] == ("git", "config", "--local", "extensions.worktreeConfig", "true")
+
+    # Second call: set extraHeader — NOT remote set-url.
+    assert call_args[1] == (
+        "git", "config", "--worktree",
+        "http.https://github.com/.extraHeader",
+        "Authorization: Bearer ghp_testtoken123",
+    )
+
+    # Sanity-check: remote.origin.url was never touched.
+    for args in call_args:
+        assert "set-url" not in args, "remote.origin.url must not be modified"
+
+
+@pytest.mark.anyio
+async def test_configure_worktree_auth_no_token_skips_git_calls() -> None:
+    """No GITHUB_TOKEN → warning logged, no git subprocess spawned."""
+    from agentception.services.run_factory import _configure_worktree_auth
+
+    with (
+        patch("agentception.services.run_factory.asyncio.create_subprocess_exec") as mock_exec,
+        patch.dict("os.environ", {}, clear=False),
+        patch("os.environ.get", return_value=""),
+    ):
+        await _configure_worktree_auth(Path("/worktrees/issue-99"), "issue-99")
+
+    mock_exec.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_configure_worktree_auth_extraheader_failure_logs_warning() -> None:
+    """extraHeader git config fails → warning logged, no exception raised."""
+    from agentception.services.run_factory import _configure_worktree_auth
+
+    ext_proc = _make_proc(returncode=0)
+    hdr_proc = _make_proc(returncode=1, stderr=b"error: not in a git repo")
+
+    async def fake_exec(*args: object, **_kwargs: object) -> AsyncMock:
+        if "extensions.worktreeConfig" in args:
+            return ext_proc
+        return hdr_proc
+
+    with (
+        patch("agentception.services.run_factory.asyncio.create_subprocess_exec", side_effect=fake_exec),
+        patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_testtoken123"}, clear=False),
+    ):
+        # Must not raise — failure is logged as a warning only.
+        await _configure_worktree_auth(Path("/worktrees/issue-99"), "issue-99")


### PR DESCRIPTION
Replaces token-in-URL worktree auth with git config --worktree http.extraHeader. The old approach wrote GITHUB_TOKEN into the shared .git/config via remote.origin.url on every dispatch, contaminating the main repo remote and triggering GitHub secret scanning which auto-revokes exposed tokens. Adds 3 unit tests. Also drops --reload from docker-compose.override.yml (local-only, not committed) to prevent agent hot-kill.