### PR TITLE
fix: serialize GitHub MCP stdio calls with an asyncio.Lock

### DIFF
--- a/agentception/services/github_mcp_client.py
+++ b/agentception/services/github_mcp_client.py
@@ -53,13 +53,19 @@ class GitHubMCPClient:
 
     Spawns ``github-mcp-server stdio`` once and reuses the process for the
     lifetime of the agent run.  Messages are newline-delimited JSON-RPC 2.0.
-    Tool calls are sequential — do NOT call :meth:`call_tool` concurrently.
+
+    ``_lock`` serializes all JSON-RPC round-trips.  The stdio transport is a
+    single pipe — concurrent ``readline()`` calls from different coroutines
+    produce ``readuntil() called while another coroutine is already waiting``
+    errors.  The lock converts parallel agent tool calls into a queue so each
+    request completes before the next one starts reading.
     """
 
     def __init__(self) -> None:
         self._proc: asyncio.subprocess.Process | None = None
         self._next_id: int = 1
         self._tools_cache: list[ToolDefinition] | None = None
+        self._lock: asyncio.Lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -140,9 +146,10 @@ class GitHubMCPClient:
             return result if isinstance(result, dict) else {}
 
     async def _request(self, method: str, params: dict[str, object]) -> dict[str, object]:
-        req_id = self._bump_id()
-        await self._write({"jsonrpc": "2.0", "id": req_id, "method": method, "params": params})
-        return await self._read_response(req_id)
+        async with self._lock:
+            req_id = self._bump_id()
+            await self._write({"jsonrpc": "2.0", "id": req_id, "method": method, "params": params})
+            return await self._read_response(req_id)
 
     async def _notify(self, method: str, params: dict[str, object]) -> None:
         await self._write({"jsonrpc": "2.0", "method": method, "params": params})


### PR DESCRIPTION
Concurrent agent tool calls raced on the shared stdio pipe, causing readuntil() errors that made GitHub unavailable for the entire run. Added asyncio.Lock to GitHubMCPClient._request so parallel calls queue instead of racing. 1709 tests pass.