### PR TITLE
revert: remove Google DNS override from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,6 @@ services:
       # git worktrees created inside the container are immediately visible to Cursor
       # agents running on the host at the same absolute path.
       - ${HOME}/.agentception/worktrees/agentception:/worktrees
-    dns:
-      - 8.8.8.8
-      - 8.8.4.4
     networks:
       - agentception-net
     command: >


### PR DESCRIPTION
8.8.8.8 returns the broken api.github.com node (.6). Docker's default bridge resolver forwards to the host DNS which returns the working node (.5). Reverting the google DNS pin.