### PR TITLE
fix: pin api.github.com to working node via extra_hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,12 @@ services:
       # git worktrees created inside the container are immediately visible to Cursor
       # agents running on the host at the same absolute path.
       - ${HOME}/.agentception/worktrees/agentception:/worktrees
+    # api.github.com has a dead node (140.82.116.6) in DNS rotation that refuses
+    # all connections. Docker's embedded DNS caches whichever node it gets first,
+    # causing intermittent GitHub MCP failures. Pin to the working node until
+    # GitHub removes the dead node from rotation. Remove this entry once resolved.
+    extra_hosts:
+      - "api.github.com:140.82.116.5"
     networks:
       - agentception-net
     command: >


### PR DESCRIPTION
GitHub node 140.82.116.6 has been refusing connections for days but stays in DNS rotation. Docker's embedded DNS caches it, breaking every GitHub MCP call. extra_hosts pins api.github.com to 140.82.116.5 (confirmed working) — hosts file beats DNS cache every time. Remove once GitHub retires the dead node.