### PR TITLE
fix: upgrade LLM models from claude-*-4-5 to claude-*-4-6

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -6,7 +6,7 @@ AgentCeption — multi-agent orchestration system for AI-powered development wor
 
 - **Entry points:** `GET /` (Build dashboard), MCP tools (Cursor/Claude). Same engine, same pipeline.
 - **Stack:** Python 3.12, FastAPI, Jinja2, HTMX, Alpine.js, TypeScript (piecemeal — convert every `.ts` file you touch), SCSS, Pydantic v2, SQLAlchemy (async), Alembic. Fully async.
-- **Models:** `claude-sonnet-4-5-20250929` and `claude-opus-4-5-20250929` via Anthropic direct API. No others.
+- **Models:** `claude-sonnet-4-6` and `claude-opus-4-6` via Anthropic direct API. No others.
 - **Version:** Single source of truth in `pyproject.toml`.
 
 ## Agent scope

--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 All three public entry points target the Anthropic Messages API directly
 (https://api.anthropic.com/v1/messages).  Prompt caching (cache_control:
 ephemeral on the system prompt) is active; confirmed working on
-claude-sonnet-4-5-20250929, giving ~90% input-token discount on turns 2-N.
+claude-sonnet-4-6, giving ~90% input-token discount on turns 2-N.
 
 Three public entry points:
 
@@ -44,8 +44,8 @@ from agentception.config import settings
 logger = logging.getLogger(__name__)
 
 _ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
-_MODEL = "claude-sonnet-4-5-20250929"
-_OPUS_MODEL = "claude-opus-4-5-20250929"
+_MODEL = "claude-sonnet-4-6"
+_OPUS_MODEL = "claude-opus-4-6"
 _ANTHROPIC_VERSION = "2023-06-01"
 _DEFAULT_TIMEOUT = 120.0
 _MAX_RETRIES = 2


### PR DESCRIPTION
## Summary
- Bumps `_MODEL` from `claude-sonnet-4-5-20250929` to `claude-sonnet-4-6` and `_OPUS_MODEL` from `claude-opus-4-5-20250929` to `claude-opus-4-6`
- Prompt caching confirmed working on 4.6 via direct curl test (turn 1: `cache_creation=2187`, turn 2: `cache_read=2187`)
- Pricing is identical between 4.5 and 4.6 — no cost regression
- All 1711 tests pass

## Test plan
- [x] `mypy` clean on `llm.py`
- [x] Full test suite: 1711 passed, 0 failed
- [x] Cache write/read confirmed via curl against `api.anthropic.com`