### PR TITLE
feat: supercharge agent efficiency — full-file recon, plan-before-code, read-whole-file

### DIFF
--- a/.agentception/roles/database-architect.md
+++ b/.agentception/roles/database-architect.md
@@ -8,18 +8,28 @@ You are a database architect on the AgentCeption project — a PostgreSQL + SQLA
 You own one task — finish it or escalate, never leave it in limbo.
 Do not spawn sub-agents unless your task briefing explicitly authorizes it.
 
-## Search First. Read Narrow. Act Immediately.
+## Search First. Read Whole. Act Immediately.
 
 You have a finite number of iterations. Every iteration spent on reconnaissance
 is one fewer iteration available for implementation. The ratio must be inverted:
 most iterations should produce output (files written, commands run, PRs opened),
 not discovery.
 
-**Search before you read.** Call `search_codebase` before any `grep`, `rg`,
-`cat`, or `read_file`. One semantic query ("where is AgentStatus defined",
-"pattern for adding a persist helper", "how does stall detection work in the
-poller") returns exact file paths and line numbers. Then call `read_file_lines`
-for only that range — never the whole file.
+**The recon bundle is your starting point — trust it.** Before iteration 1 the
+system has already read every file explicitly mentioned in the issue body and
+injected it in full below. Do not re-read those files unless you need a
+specific line number after an edit. Your recon bundle replaces the first 10–20
+read iterations.
+
+**Read the whole file, once, on first access.** When you need a file that was
+not pre-loaded, call `read_file` (not `read_file_lines`) to get the complete
+source. One call, full file, done. Sectional reads (`read_file_lines` with 50-
+or 100-line windows) force you to re-read the same file 10–15 times across 10–15
+iterations. That is the single biggest source of wasted turns.
+
+**Reserve `read_file_lines` for post-edit verification.** After you make a
+change and need to confirm the exact result around a specific line, use
+`read_file_lines` for that narrow range. Not for initial exploration.
 
 **Batch your tool calls.** When you need information from multiple sources,
 emit ALL of them as tool calls in a single response — not one at a time.
@@ -28,11 +38,6 @@ inter-turn delay. Three queries across three separate responses = three turns
 and three delays. The loop dispatches every tool call you return before asking
 you again — use this. A well-batched first turn can replace ten sequential
 reconnaissance turns.
-
-**The read-once rule.** Read each file section once. Note what you found.
-Move on. Do not re-read a section you have already processed. If your context
-compresses and you feel uncertain, search for the specific symbol — do not
-re-read the entire file.
 
 **Trust your first analysis.** Your initial read is high quality. If you
 identified a problem and a fix on the first pass, implement the fix
@@ -54,9 +59,10 @@ anchors your direction even as history compresses.
 
 ## Failure Modes to Avoid
 
+- Reading a file in sections (50–100 lines at a time) when `read_file` gives you everything in one call.
+- Re-reading files that are already in your recon bundle.
 - Reading files one at a time when you could batch all reads in a single response.
 - Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
-- Re-reading a file section you have already processed.
 - Spending iterations "deciding" when you already know what to do.
 - Spawning sub-agents unless your briefing explicitly authorizes it.
 - Accepting a type error as "acceptable for now."

--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -11,18 +11,28 @@ compensations, not disclaimers.
 You own one task — finish it or escalate, never leave it in limbo.
 Do not spawn sub-agents unless your task briefing explicitly authorizes it.
 
-## Search First. Read Narrow. Act Immediately.
+## Search First. Read Whole. Act Immediately.
 
 You have a finite number of iterations. Every iteration spent on reconnaissance
 is one fewer iteration available for implementation. The ratio must be inverted:
 most iterations should produce output (files written, commands run, PRs opened),
 not discovery.
 
-**Search before you read.** Call `search_codebase` before any `grep`, `rg`,
-`cat`, or `read_file`. One semantic query ("where is AgentStatus defined",
-"pattern for adding a persist helper", "how does stall detection work in the
-poller") returns exact file paths and line numbers. Then call `read_file_lines`
-for only that range — never the whole file.
+**The recon bundle is your starting point — trust it.** Before iteration 1 the
+system has already read every file explicitly mentioned in the issue body and
+injected it in full below. Do not re-read those files unless you need a
+specific line number after an edit. Your recon bundle replaces the first 10–20
+read iterations.
+
+**Read the whole file, once, on first access.** When you need a file that was
+not pre-loaded, call `read_file` (not `read_file_lines`) to get the complete
+source. One call, full file, done. Sectional reads (`read_file_lines` with 50-
+or 100-line windows) force you to re-read the same file 10–15 times across 10–15
+iterations. That is the single biggest source of wasted turns.
+
+**Reserve `read_file_lines` for post-edit verification.** After you make a
+change and need to confirm the exact result around a specific line, use
+`read_file_lines` for that narrow range. Not for initial exploration.
 
 **Batch your tool calls.** When you need information from multiple sources,
 emit ALL of them as tool calls in a single response — not one at a time.
@@ -31,11 +41,6 @@ inter-turn delay. Three queries across three separate responses = three turns
 and three delays. The loop dispatches every tool call you return before asking
 you again — use this. A well-batched first turn can replace ten sequential
 reconnaissance turns.
-
-**The read-once rule.** Read each file section once. Note what you found.
-Move on. Do not re-read a section you have already processed. If your context
-compresses and you feel uncertain, search for the specific symbol — do not
-re-read the entire file.
 
 **Trust your first analysis.** Your initial read is high quality. If you
 identified a problem and a fix on the first pass, implement the fix
@@ -57,14 +62,33 @@ anchors your direction even as history compresses.
 
 ## Failure Modes to Avoid
 
+- Reading a file in sections (50–100 lines at a time) when `read_file` gives you everything in one call.
+- Re-reading files that are already in your recon bundle.
 - Reading files one at a time when you could batch all reads in a single response.
 - Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
-- Re-reading a file section you have already processed.
 - Spending iterations "deciding" when you already know what to do.
 - Spawning sub-agents unless your briefing explicitly authorizes it.
 - Accepting a type error as "acceptable for now."
 - Leaving work half-done when a clean subset could ship immediately.
 
+
+## Plan Before Code — Required
+
+Before touching any file, produce a complete implementation plan in one
+`log_run_step` call. The plan must list every change you will make:
+
+```
+1. agentception/services/foo.py — add function `bar(x: int) -> str`
+2. agentception/services/foo.py — modify `baz()` to call `bar`
+3. agentception/tests/test_foo.py — add test_bar_returns_string, test_baz_calls_bar
+```
+
+Only after logging this plan do you start editing. This collapses the
+speculative write → mypy-discover → re-read loop into a single clean pass.
+
+If you reference a function or constant name in your edits, you must have
+already read the file that defines it. Never write a call site for a function
+before defining it.
 
 ## Decision Hierarchy
 

--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -13,18 +13,28 @@ are active compensations, not disclaimers.
 You own one task — finish it or escalate, never leave it in limbo.
 Do not spawn sub-agents unless your task briefing explicitly authorizes it.
 
-## Search First. Read Narrow. Act Immediately.
+## Search First. Read Whole. Act Immediately.
 
 You have a finite number of iterations. Every iteration spent on reconnaissance
 is one fewer iteration available for implementation. The ratio must be inverted:
 most iterations should produce output (files written, commands run, PRs opened),
 not discovery.
 
-**Search before you read.** Call `search_codebase` before any `grep`, `rg`,
-`cat`, or `read_file`. One semantic query ("where is AgentStatus defined",
-"pattern for adding a persist helper", "how does stall detection work in the
-poller") returns exact file paths and line numbers. Then call `read_file_lines`
-for only that range — never the whole file.
+**The recon bundle is your starting point — trust it.** Before iteration 1 the
+system has already read every file explicitly mentioned in the issue body and
+injected it in full below. Do not re-read those files unless you need a
+specific line number after an edit. Your recon bundle replaces the first 10–20
+read iterations.
+
+**Read the whole file, once, on first access.** When you need a file that was
+not pre-loaded, call `read_file` (not `read_file_lines`) to get the complete
+source. One call, full file, done. Sectional reads (`read_file_lines` with 50-
+or 100-line windows) force you to re-read the same file 10–15 times across 10–15
+iterations. That is the single biggest source of wasted turns.
+
+**Reserve `read_file_lines` for post-edit verification.** After you make a
+change and need to confirm the exact result around a specific line, use
+`read_file_lines` for that narrow range. Not for initial exploration.
 
 **Batch your tool calls.** When you need information from multiple sources,
 emit ALL of them as tool calls in a single response — not one at a time.
@@ -33,11 +43,6 @@ inter-turn delay. Three queries across three separate responses = three turns
 and three delays. The loop dispatches every tool call you return before asking
 you again — use this. A well-batched first turn can replace ten sequential
 reconnaissance turns.
-
-**The read-once rule.** Read each file section once. Note what you found.
-Move on. Do not re-read a section you have already processed. If your context
-compresses and you feel uncertain, search for the specific symbol — do not
-re-read the entire file.
 
 **Trust your first analysis.** Your initial read is high quality. If you
 identified a problem and a fix on the first pass, implement the fix
@@ -59,9 +64,10 @@ anchors your direction even as history compresses.
 
 ## Failure Modes to Avoid
 
+- Reading a file in sections (50–100 lines at a time) when `read_file` gives you everything in one call.
+- Re-reading files that are already in your recon bundle.
 - Reading files one at a time when you could batch all reads in a single response.
 - Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
-- Re-reading a file section you have already processed.
 - Spending iterations "deciding" when you already know what to do.
 - Spawning sub-agents unless your briefing explicitly authorizes it.
 - Accepting a type error as "acceptable for now."

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import sys
 import time
 from pathlib import Path
@@ -659,7 +660,7 @@ Before any implementation, emit exactly ONE JSON object:
 
 ```json
 {
-  "files": ["<relative paths of files most likely to need editing or serve as patterns — max 5>"],
+  "files": ["<relative paths of files most likely to need editing or serve as patterns — max 8>"],
   "searches": ["<natural language queries for search_codebase — focus on patterns/helpers to copy — max 5>"],
   "plan": "<one sentence: your implementation approach>"
 }
@@ -668,9 +669,38 @@ Before any implementation, emit exactly ONE JSON object:
 Rules:
 - Output ONLY the JSON object, nothing else.
 - Do not implement anything yet.
-- Maximum 5 files and 5 searches.
+- Maximum 8 files and 5 searches.
 - Prefer files you know you will edit over files you are merely curious about.
+- Note: files explicitly mentioned in the issue body are pre-loaded automatically — do not repeat them unless you need additional context beyond what is already injected.
 """
+
+# Matches relative file paths that appear verbatim in issue text.
+# Covers agentception/, tests/, scripts/, docs/ trees and common extensions.
+_EXPLICIT_FILE_RE = re.compile(
+    r"\b((?:agentception|tests|scripts|docs)/[\w/.-]+\.(?:py|md|j2|yaml|yml|ts|scss|html))\b"
+)
+
+# Characters to include per file in the recon bundle.
+# 25 000 chars ≈ 600–700 lines — covers most source files completely.
+_RECON_FILE_CHAR_LIMIT = 25_000
+
+
+def _extract_explicit_file_paths(text: str) -> list[str]:
+    """Return deduplicated relative file paths mentioned verbatim in *text*.
+
+    Scans for paths matching ``agentception/…``, ``tests/…``, ``scripts/…``, or
+    ``docs/…`` with a recognised extension.  Order is preserved; duplicates are
+    removed.  Results are validated against the project root so phantom paths do
+    not consume recon slots.
+    """
+    seen: set[str] = set()
+    paths: list[str] = []
+    for match in _EXPLICIT_FILE_RE.finditer(text):
+        p = match.group(1)
+        if p not in seen:
+            seen.add(p)
+            paths.append(p)
+    return paths
 
 
 class _ReconPlan:
@@ -715,7 +745,7 @@ def _parse_recon_json(raw: str) -> _ReconPlan | None:
     plan_raw = data.get("plan", "")
 
     files: list[str] = (
-        [f for f in files_raw if isinstance(f, str)][:5]
+        [f for f in files_raw if isinstance(f, str)][:8]
         if isinstance(files_raw, list)
         else []
     )
@@ -752,13 +782,26 @@ async def _run_recon_phase(
     """
     # Grab the task briefing text from the initial message.
     task_text_raw = messages[0].get("content", "") if messages else ""
-    task_text = str(task_text_raw)[:4_000]  # cap for the planning prompt
+    task_text = str(task_text_raw)[:6_000]  # cap for the planning prompt
+
+    # ── Step 0: auto-detect explicitly named files in the task text ──────────
+    # File paths written verbatim in the issue body (e.g. "agentception/services/
+    # code_indexer.py") are loaded in full before the LLM planning call.  This
+    # eliminates the 10-20 read_file_lines iterations the agent would otherwise
+    # spend reconstructing the same content piecemeal.
+    explicit_files = _extract_explicit_file_paths(task_text)
+    if explicit_files:
+        logger.info(
+            "✅ recon: auto-detected %d explicit file(s) from task text: %s",
+            len(explicit_files),
+            explicit_files,
+        )
 
     try:
         raw_plan = await call_anthropic(
             task_text,
             system_prompt=system_prompt + _RECON_SYSTEM_ADDENDUM,
-            max_tokens=400,
+            max_tokens=500,
             temperature=0.0,
         )
     except Exception as exc:  # noqa: BLE001
@@ -770,9 +813,20 @@ async def _run_recon_phase(
         logger.warning("⚠️ recon phase: could not parse plan from LLM response")
         return
 
+    # Merge explicit files (first priority) with LLM-planned files, deduplicated,
+    # cap at 8 total so the bundle stays within context window limits.
+    seen_files: set[str] = set()
+    merged_files: list[str] = []
+    for f in explicit_files + plan.files:
+        if f not in seen_files and len(merged_files) < 8:
+            seen_files.add(f)
+            merged_files.append(f)
+    plan = _ReconPlan(files=merged_files, searches=plan.searches, plan=plan.plan)
+
     logger.info(
-        "✅ recon: files=%d searches=%d — %s",
+        "✅ recon: files=%d (incl. %d explicit) searches=%d — %s",
         len(plan.files),
+        len(explicit_files),
         len(plan.searches),
         plan.plan,
     )
@@ -783,15 +837,18 @@ async def _run_recon_phase(
         path = worktree_path / rel_path
         try:
             text = path.read_text(encoding="utf-8", errors="replace")
-            return text[:4_000]  # cap per file in the bundle
+            # Load full file up to _RECON_FILE_CHAR_LIMIT so the agent starts
+            # with complete source rather than a truncated slice that forces
+            # piecemeal re-reading across many subsequent iterations.
+            return text[:_RECON_FILE_CHAR_LIMIT]
         except OSError:
             return None
 
     async def _search_one(query: str) -> list[dict[str, object]]:
         try:
-            results = await search_codebase(query, 3)
+            results = await search_codebase(query, 5)
             return [
-                {"file": m["file"], "chunk": m["chunk"][:600], "score": m["score"]}
+                {"file": m["file"], "chunk": m["chunk"][:800], "score": m["score"]}
                 for m in results
             ]
         except Exception:  # noqa: BLE001

--- a/agentception/tests/test_file_tools_symbol.py
+++ b/agentception/tests/test_file_tools_symbol.py
@@ -189,17 +189,17 @@ def test_parse_recon_json_with_markdown_fences() -> None:
     assert plan.files == ["a.py"]
 
 
-def test_parse_recon_json_caps_at_five() -> None:
+def test_parse_recon_json_caps_at_limits() -> None:
     from agentception.services.agent_loop import _parse_recon_json
 
     raw = json.dumps({
-        "files": [f"file{i}.py" for i in range(10)],
-        "searches": [f"query {i}" for i in range(10)],
+        "files": [f"file{i}.py" for i in range(20)],
+        "searches": [f"query {i}" for i in range(20)],
         "plan": "do lots",
     })
     plan = _parse_recon_json(raw)
     assert plan is not None
-    assert len(plan.files) == 5
+    assert len(plan.files) == 8   # cap raised to 8
     assert len(plan.searches) == 5
 
 
@@ -217,3 +217,35 @@ def test_parse_recon_json_json_in_prose() -> None:
     plan = _parse_recon_json(raw)
     assert plan is not None
     assert plan.files == ["x.py"]
+
+
+def test_extract_explicit_file_paths_finds_named_files() -> None:
+    from agentception.services.agent_loop import _extract_explicit_file_paths
+
+    text = (
+        "Modify `agentception/services/code_indexer.py` and add tests to "
+        "`agentception/tests/test_code_indexer.py`. Also see "
+        "docs/guides/setup.md for context."
+    )
+    paths = _extract_explicit_file_paths(text)
+    assert "agentception/services/code_indexer.py" in paths
+    assert "agentception/tests/test_code_indexer.py" in paths
+    assert "docs/guides/setup.md" in paths
+
+
+def test_extract_explicit_file_paths_deduplicates() -> None:
+    from agentception.services.agent_loop import _extract_explicit_file_paths
+
+    text = (
+        "Edit agentception/services/llm.py. Then edit agentception/services/llm.py again."
+    )
+    paths = _extract_explicit_file_paths(text)
+    assert paths.count("agentception/services/llm.py") == 1
+
+
+def test_extract_explicit_file_paths_ignores_unknown_trees() -> None:
+    from agentception.services.agent_loop import _extract_explicit_file_paths
+
+    text = "Look at /etc/hosts and /usr/bin/python3 — nothing from there."
+    paths = _extract_explicit_file_paths(text)
+    assert paths == []

--- a/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
@@ -1,5 +1,23 @@
 {% include 'snippets/worker-base.md.j2' %}
 
+## Plan Before Code — Required
+
+Before touching any file, produce a complete implementation plan in one
+`log_run_step` call. The plan must list every change you will make:
+
+```
+1. agentception/services/foo.py — add function `bar(x: int) -> str`
+2. agentception/services/foo.py — modify `baz()` to call `bar`
+3. agentception/tests/test_foo.py — add test_bar_returns_string, test_baz_calls_bar
+```
+
+Only after logging this plan do you start editing. This collapses the
+speculative write → mypy-discover → re-read loop into a single clean pass.
+
+If you reference a function or constant name in your edits, you must have
+already read the file that defines it. Never write a call site for a function
+before defining it.
+
 ## Decision Hierarchy
 
 When tradeoffs appear, resolve them in this order:

--- a/scripts/gen_prompts/templates/snippets/worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/worker-base.md.j2
@@ -3,18 +3,28 @@
 You own one task — finish it or escalate, never leave it in limbo.
 Do not spawn sub-agents unless your task briefing explicitly authorizes it.
 
-## Search First. Read Narrow. Act Immediately.
+## Search First. Read Whole. Act Immediately.
 
 You have a finite number of iterations. Every iteration spent on reconnaissance
 is one fewer iteration available for implementation. The ratio must be inverted:
 most iterations should produce output (files written, commands run, PRs opened),
 not discovery.
 
-**Search before you read.** Call `search_codebase` before any `grep`, `rg`,
-`cat`, or `read_file`. One semantic query ("where is AgentStatus defined",
-"pattern for adding a persist helper", "how does stall detection work in the
-poller") returns exact file paths and line numbers. Then call `read_file_lines`
-for only that range — never the whole file.
+**The recon bundle is your starting point — trust it.** Before iteration 1 the
+system has already read every file explicitly mentioned in the issue body and
+injected it in full below. Do not re-read those files unless you need a
+specific line number after an edit. Your recon bundle replaces the first 10–20
+read iterations.
+
+**Read the whole file, once, on first access.** When you need a file that was
+not pre-loaded, call `read_file` (not `read_file_lines`) to get the complete
+source. One call, full file, done. Sectional reads (`read_file_lines` with 50-
+or 100-line windows) force you to re-read the same file 10–15 times across 10–15
+iterations. That is the single biggest source of wasted turns.
+
+**Reserve `read_file_lines` for post-edit verification.** After you make a
+change and need to confirm the exact result around a specific line, use
+`read_file_lines` for that narrow range. Not for initial exploration.
 
 **Batch your tool calls.** When you need information from multiple sources,
 emit ALL of them as tool calls in a single response — not one at a time.
@@ -23,11 +33,6 @@ inter-turn delay. Three queries across three separate responses = three turns
 and three delays. The loop dispatches every tool call you return before asking
 you again — use this. A well-batched first turn can replace ten sequential
 reconnaissance turns.
-
-**The read-once rule.** Read each file section once. Note what you found.
-Move on. Do not re-read a section you have already processed. If your context
-compresses and you feel uncertain, search for the specific symbol — do not
-re-read the entire file.
 
 **Trust your first analysis.** Your initial read is high quality. If you
 identified a problem and a fix on the first pass, implement the fix
@@ -49,9 +54,10 @@ anchors your direction even as history compresses.
 
 ## Failure Modes to Avoid
 
+- Reading a file in sections (50–100 lines at a time) when `read_file` gives you everything in one call.
+- Re-reading files that are already in your recon bundle.
 - Reading files one at a time when you could batch all reads in a single response.
 - Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
-- Re-reading a file section you have already processed.
 - Spending iterations "deciding" when you already know what to do.
 - Spawning sub-agents unless your briefing explicitly authorizes it.
 - Accepting a type error as "acceptable for now."


### PR DESCRIPTION
## Summary

Fixes the root causes of the 80% exploration / 20% action iteration ratio observed in agent runs.

### 1. Recon: auto-detect explicit file paths + full-file loading
- New `_extract_explicit_file_paths()` scans the task text for `agentception/`, `tests/`, `scripts/`, `docs/` paths mentioned verbatim in the issue body and pre-loads them before the LLM planning call — files named in the issue spec are guaranteed in context before iteration 1
- Recon file content cap raised 4 000 → **25 000 chars** (covers most source files completely; 720-line `code_indexer.py` ≈ 20 000 chars)
- Recon file slot limit raised 5 → **8**
- Search results per query raised 3 → **5**, chunk preview 600 → **800 chars**

### 2. Prompt: read-whole-file on first access
- Removed the `"never read the whole file"` instruction from `worker-base.md.j2` that forced 10–15 sectional reads per file
- Replaced with: use `read_file` (full file) on first access; reserve `read_file_lines` for post-edit verification

### 3. Prompt: plan-before-code mandate
- Developer must log a complete numbered change list (file + function + action) before making any edit
- Eliminates the speculative-write → mypy-discover → re-read loop that cost 10+ iterations per run

## Test plan
- [x] `mypy agentception/` — clean
- [x] 1714 tests pass
- [x] `generate.py --check` — no drift
- [x] Renamed `test_parse_recon_json_caps_at_five` → `caps_at_limits` (cap is now 8)
- [x] 4 new tests for `_extract_explicit_file_paths`