### PR TITLE
fix: replace Bearer extraHeader with askpass helper for git auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get update && apt-get install -y gh \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install the GitHub askpass helper and configure system-wide git auth.
+#
+# Git's git-receive-pack (push) and git-upload-pack (fetch/clone) endpoints
+# only accept HTTP Basic auth — Bearer tokens are rejected with 401. The askpass
+# helper supplies "x-access-token" / $GITHUB_TOKEN so git generates a valid
+# Basic auth header without any token ever touching remote.origin.url or a
+# per-worktree git config file (which risks GitHub secret scanning revocation).
+#
+# --system writes to /etc/gitconfig (baked into the image layer), so it applies
+# regardless of which $HOME the container runs with. GIT_TERMINAL_PROMPT=0
+# prevents git from falling back to an interactive TTY prompt when credentials
+# are missing — agents run non-interactively and must fail fast instead.
+COPY scripts/github-askpass /usr/local/bin/github-askpass
+RUN chmod +x /usr/local/bin/github-askpass \
+    && git config --system core.askPass /usr/local/bin/github-askpass \
+    && git config --system GIT_TERMINAL_PROMPT 0
+
 # Install the GitHub MCP server binary — provides the agent loop with typed
 # GitHub tools (get_issue, list_issues, add_issue_comment, create_pull_request,
 # merge_pull_request, etc.) via the MCP stdio protocol.

--- a/agentception/services/run_factory.py
+++ b/agentception/services/run_factory.py
@@ -7,7 +7,11 @@ tool catches ``RunCreationError`` and returns a structured error dict.
 This module also owns the shared worktree utilities (``_configure_worktree_auth``,
 ``_index_worktree``, ``_WORKTREE_COLLECTION_PREFIX``) that are imported by
 ``spawn_child.py`` so every worktree — whether spawned via coordinator MCP tool
-or via the official dispatch pipeline — gets auth and Qdrant indexing.
+or via the official dispatch pipeline — gets worktree isolation and Qdrant indexing.
+
+Git push authentication is handled by the container-wide askpass helper baked
+into the image (``/usr/local/bin/github-askpass``).  No token is ever written
+to any git config file.
 """
 
 from __future__ import annotations
@@ -138,10 +142,9 @@ async def _create_worktree(
 ) -> None:
     """Create a git worktree at *worktree_path* branching off *base_ref*.
 
-    After creation the worktree's remote URL is rewritten to embed the
-    ``GITHUB_TOKEN`` so that ``git push`` works inside the container without
-    a separate credential helper.  The token lives only in the worktree's
-    local git config — it is not committed.
+    After creation ``_configure_worktree_auth`` enables ``extensions.worktreeConfig``
+    for config isolation.  Authentication for ``git push`` is handled automatically
+    by the container-wide askpass helper (``/usr/local/bin/github-askpass``).
     """
     worktree_path.parent.mkdir(parents=True, exist_ok=True)
     proc = await asyncio.create_subprocess_exec(
@@ -192,26 +195,26 @@ async def _index_worktree(worktree_path: Path, run_id: str) -> None:
 
 
 async def _configure_worktree_auth(worktree_path: Path, run_id: str) -> None:
-    """Configure git auth for the worktree using http.extraHeader.
+    """Enable per-worktree git config isolation for the newly created worktree.
 
-    Uses ``git config --worktree http.https://github.com/.extraHeader`` to
-    inject the GITHUB_TOKEN as a Bearer authorization header.  This writes
-    only to the worktree-specific config file
-    (``.git/worktrees/<name>/config.worktree``) and never touches
-    ``remote.origin.url`` or the shared ``.git/config``.
+    Git push authentication is handled entirely by the container-wide askpass
+    helper (``/usr/local/bin/github-askpass``, configured via
+    ``git config --system core.askPass`` in the Dockerfile).  The helper
+    returns ``x-access-token`` / ``$GITHUB_TOKEN`` as Basic credentials, which
+    is the only auth scheme that GitHub's git-receive-pack endpoint accepts.
+    Bearer tokens (``Authorization: Bearer …``) are rejected by the git
+    protocol even though they work for the REST API.
 
-    The old approach of embedding the token in the remote URL wrote to the
-    shared ``.git/config`` (git worktrees share one config), polluting the
-    main repo's remote URL and potentially triggering GitHub secret scanning
-    which auto-revokes exposed tokens.
+    This function's only remaining job is to enable ``extensions.worktreeConfig``
+    so that future worktree-specific git config keys (e.g. user.email overrides
+    or per-agent fetch refspecs) can be written to the isolated
+    ``.git/worktrees/<name>/config.worktree`` file rather than the shared
+    ``.git/config``.  This prevents any per-worktree setting from leaking into
+    the main repo config.
+
+    Tokens must never appear in ``remote.origin.url`` — GitHub's secret
+    scanning auto-revokes any PAT it detects in a pushed config blob.
     """
-    import os  # noqa: PLC0415
-
-    token = os.environ.get("GITHUB_TOKEN", "")
-    if not token:
-        logger.warning("⚠️ GITHUB_TOKEN not set — git push will require manual auth in worktrees")
-        return
-
     # Enable per-worktree config in the shared .git/config (idempotent).
     # Required for --worktree flag to write to the worktree-specific file
     # rather than the shared config.
@@ -221,27 +224,15 @@ async def _configure_worktree_auth(worktree_path: Path, run_id: str) -> None:
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    await ext_proc.communicate()
-
-    # Write the Authorization header into the worktree-specific config only.
-    # Scoped to github.com so it never leaks to other hosts.
-    hdr_proc = await asyncio.create_subprocess_exec(
-        "git", "config", "--worktree",
-        "http.https://github.com/.extraHeader",
-        f"Authorization: Bearer {token}",
-        cwd=str(worktree_path),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    _, hdr_err = await hdr_proc.communicate()
-    if hdr_proc.returncode != 0:
+    _, ext_err = await ext_proc.communicate()
+    if ext_proc.returncode != 0:
         logger.warning(
-            "⚠️ _configure_worktree_auth — could not set extraHeader for run_id=%s: %s",
-            run_id, hdr_err.decode().strip(),
+            "⚠️ _configure_worktree_auth — could not enable worktreeConfig for run_id=%s: %s",
+            run_id, ext_err.decode().strip(),
         )
         return
 
-    logger.info("✅ worktree auth configured via extraHeader — run_id=%s", run_id)
+    logger.info("✅ worktree auth configured (askpass + worktreeConfig) — run_id=%s", run_id)
 
 
 async def _insert_run(

--- a/agentception/tests/test_run_factory.py
+++ b/agentception/tests/test_run_factory.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -18,80 +17,81 @@ def _make_proc(returncode: int = 0, stderr: bytes = b"") -> AsyncMock:
 
 
 @pytest.mark.anyio
-async def test_configure_worktree_auth_sets_extraheader_not_remote_url() -> None:
-    """Happy path: token present → extensions.worktreeConfig enabled, extraHeader written.
+async def test_configure_worktree_auth_enables_worktree_config() -> None:
+    """Happy path: exactly one git config call enables extensions.worktreeConfig.
 
-    Critically, remote.origin.url must never be touched — that was the old
-    behaviour that polluted the shared .git/config and caused token revocation.
+    Auth is handled by the container-wide askpass helper (baked into the image
+    via ``git config --system core.askPass``).  _configure_worktree_auth must
+    not set any Authorization header or touch remote.origin.url — both risks
+    triggering GitHub secret scanning and PAT revocation.
     """
     from agentception.services.run_factory import _configure_worktree_auth
 
     ext_proc = _make_proc()
-    hdr_proc = _make_proc()
-
     call_args: list[tuple[object, ...]] = []
 
     async def fake_exec(*args: object, **_kwargs: object) -> AsyncMock:
         call_args.append(args)
-        if "extensions.worktreeConfig" in args:
-            return ext_proc
-        return hdr_proc
+        return ext_proc
 
-    with (
-        patch("agentception.services.run_factory.asyncio.create_subprocess_exec", side_effect=fake_exec),
-        patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_testtoken123"}, clear=False),
-    ):
+    with patch("agentception.services.run_factory.asyncio.create_subprocess_exec", side_effect=fake_exec):
         await _configure_worktree_auth(Path("/worktrees/issue-99"), "issue-99")
 
-    # Must have made exactly two git config calls.
-    assert len(call_args) == 2
+    # Must have made exactly one git config call.
+    assert len(call_args) == 1
 
-    # First call: enable extensions.worktreeConfig.
+    # That call must enable extensions.worktreeConfig only.
     assert call_args[0] == ("git", "config", "--local", "extensions.worktreeConfig", "true")
 
-    # Second call: set extraHeader — NOT remote set-url.
-    assert call_args[1] == (
-        "git", "config", "--worktree",
-        "http.https://github.com/.extraHeader",
-        "Authorization: Bearer ghp_testtoken123",
-    )
-
-    # Sanity-check: remote.origin.url was never touched.
+    # Sanity-check: no token-related calls were made.
     for args in call_args:
-        assert "set-url" not in args, "remote.origin.url must not be modified"
+        assert "extraHeader" not in args, "Bearer extraHeader must not be set — git protocol needs Basic auth"
+        assert "set-url" not in args, "remote.origin.url must never be modified"
+        assert "Bearer" not in args, "Bearer tokens are rejected by GitHub's git protocol"
 
 
 @pytest.mark.anyio
-async def test_configure_worktree_auth_no_token_skips_git_calls() -> None:
-    """No GITHUB_TOKEN → warning logged, no git subprocess spawned."""
+async def test_configure_worktree_auth_worktree_config_failure_logs_warning() -> None:
+    """extensions.worktreeConfig git config fails → warning logged, no exception raised."""
     from agentception.services.run_factory import _configure_worktree_auth
 
-    with (
-        patch("agentception.services.run_factory.asyncio.create_subprocess_exec") as mock_exec,
-        patch.dict("os.environ", {}, clear=False),
-        patch("os.environ.get", return_value=""),
-    ):
-        await _configure_worktree_auth(Path("/worktrees/issue-99"), "issue-99")
-
-    mock_exec.assert_not_called()
-
-
-@pytest.mark.anyio
-async def test_configure_worktree_auth_extraheader_failure_logs_warning() -> None:
-    """extraHeader git config fails → warning logged, no exception raised."""
-    from agentception.services.run_factory import _configure_worktree_auth
-
-    ext_proc = _make_proc(returncode=0)
-    hdr_proc = _make_proc(returncode=1, stderr=b"error: not in a git repo")
+    ext_proc = _make_proc(returncode=1, stderr=b"error: not in a git repo")
 
     async def fake_exec(*args: object, **_kwargs: object) -> AsyncMock:
-        if "extensions.worktreeConfig" in args:
-            return ext_proc
-        return hdr_proc
+        return ext_proc
+
+    with patch("agentception.services.run_factory.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        # Must not raise — failure is logged as a warning only.
+        await _configure_worktree_auth(Path("/worktrees/issue-99"), "issue-99")
+
+
+@pytest.mark.anyio
+async def test_configure_worktree_auth_no_bearer_header_ever_set() -> None:
+    """Regression: Bearer extraHeader must never appear regardless of token presence.
+
+    GitHub's git-receive-pack endpoint only accepts Basic auth.  The old
+    implementation set Authorization: Bearer which caused all pushes to fail
+    with HTTP 401 even when the token was valid for the REST API.
+    """
+    from agentception.services.run_factory import _configure_worktree_auth
+
+    ext_proc = _make_proc()
+    all_args: list[tuple[object, ...]] = []
+
+    async def fake_exec(*args: object, **_kwargs: object) -> AsyncMock:
+        all_args.append(args)
+        return ext_proc
 
     with (
         patch("agentception.services.run_factory.asyncio.create_subprocess_exec", side_effect=fake_exec),
         patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_testtoken123"}, clear=False),
     ):
-        # Must not raise — failure is logged as a warning only.
         await _configure_worktree_auth(Path("/worktrees/issue-99"), "issue-99")
+
+    # No git call should ever include a Bearer token or Authorization header.
+    for args in all_args:
+        flat = " ".join(str(a) for a in args)
+        assert "Bearer" not in flat
+        assert "Authorization" not in flat
+        assert "extraHeader" not in flat
+        assert "ghp_testtoken123" not in flat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
       # gh CLI reads GITHUB_TOKEN when the keychain (macOS) is unavailable inside Docker.
       # Set GITHUB_TOKEN in .env to a PAT with repo+issues scope.
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      # Prevent git from falling back to an interactive TTY prompt when credentials
+      # are missing. Agents run non-interactively; fail fast is always correct here.
+      GIT_TERMINAL_PROMPT: "0"
     volumes:
       # Mount cursor dir at same absolute path so worktree paths resolve correctly.
       - ${HOME}/.cursor:${HOME}/.cursor
@@ -42,12 +45,15 @@ services:
       # git worktrees created inside the container are immediately visible to Cursor
       # agents running on the host at the same absolute path.
       - ${HOME}/.agentception/worktrees/agentception:/worktrees
-    # api.github.com has a dead node (140.82.116.6) in DNS rotation that refuses
-    # all connections. Docker's embedded DNS caches whichever node it gets first,
-    # causing intermittent GitHub MCP failures. Pin to the working node until
-    # GitHub removes the dead node from rotation. Remove this entry once resolved.
-    extra_hosts:
-      - "api.github.com:140.82.116.5"
+    # Use Cloudflare DNS instead of Docker's embedded resolver.
+    # Docker's embedded DNS caches whichever node it gets first, and GitHub
+    # occasionally has dead nodes in rotation (e.g. 140.82.116.6) that refuse
+    # all connections. 1.1.1.1 performs its own health-aware routing and avoids
+    # returning dead nodes. This also prevents hardcoded IPs from going stale
+    # as GitHub updates its infrastructure.
+    dns:
+      - "1.1.1.1"
+      - "8.8.8.8"
     networks:
       - agentception-net
     command: >

--- a/scripts/github-askpass
+++ b/scripts/github-askpass
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Git askpass helper for GitHub token authentication.
+#
+# Git's git-receive-pack (push) and git-upload-pack (fetch/clone) endpoints
+# only accept HTTP Basic auth — not Bearer tokens. This script is called by
+# git when it needs credentials for an HTTPS remote; it returns the PAT as
+# the password with "x-access-token" as the username, which GitHub accepts
+# for all git protocol operations.
+#
+# Set via: git config --system core.askPass /usr/local/bin/github-askpass
+# Ensure:  GIT_TERMINAL_PROMPT=0 (prevents git from falling back to a TTY)
+case "$1" in
+  Username*) echo "x-access-token" ;;
+  Password*) echo "$GITHUB_TOKEN" ;;
+esac


### PR DESCRIPTION
## Summary

- **Root cause:** `_configure_worktree_auth` set `Authorization: Bearer $GITHUB_TOKEN` via `http.extraHeader`. Git's auth precedence puts `extraHeader` above everything (URL credentials, credential helpers, askpass). GitHub's git-receive-pack endpoint **only accepts Basic auth** — Bearer is rejected with HTTP 401 at the git protocol layer even when the token is valid for the REST API. This is why every agent push failed with `remote: invalid credentials` while `curl` to the same endpoint with Basic auth returned 200.
- **Fix:** Bake a `github-askpass` shell script into the Docker image, configured system-wide via `git config --system core.askPass`. Git calls it for username/password and generates a valid Basic auth header automatically. No token ever touches a git config file.
- **Cleanup:** Remove hardcoded `extra_hosts` IP pin (stale as GitHub rotates infrastructure); replace with `dns: [1.1.1.1, 8.8.8.8]`. Add `GIT_TERMINAL_PROMPT=0` to prevent git from blocking on a TTY prompt in non-interactive containers.

## Test plan

- [x] `mypy` clean (0 errors)
- [x] 1714 tests pass
- [x] New tests assert: no `Bearer`, no `Authorization`, no `extraHeader` ever set by `_configure_worktree_auth`
- [ ] After container rebuild: verify `git push` succeeds from a new agent worktree