### PR TITLE
fix: GIT_TERMINAL_PROMPT is an env var not a git config key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # are missing — agents run non-interactively and must fail fast instead.
 COPY scripts/github-askpass /usr/local/bin/github-askpass
 RUN chmod +x /usr/local/bin/github-askpass \
-    && git config --system core.askPass /usr/local/bin/github-askpass \
-    && git config --system GIT_TERMINAL_PROMPT 0
+    && git config --system core.askPass /usr/local/bin/github-askpass
 
 # Install the GitHub MCP server binary — provides the agent loop with typed
 # GitHub tools (get_issue, list_issues, add_issue_comment, create_pull_request,


### PR DESCRIPTION
GIT_TERMINAL_PROMPT is not a git config setting — it's an environment variable. Passing it to `git config --system` fails the Docker build with "key does not contain a section". It's already correctly set in `docker-compose.yml` as an environment variable.