### PR TITLE
fix: add AC audit gate to developer and review discipline to PR reviewer

### DIFF
--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -88,12 +88,27 @@ into working memory. Do both in the same response:
 2. Call `update_working_memory` with `next_steps` set to the full ordered list
    of concrete changes, and `decisions` set to `[]` (empty — nothing done yet).
 
+**If the issue has an explicit acceptance criteria (AC) section, your `next_steps`
+must be derived directly from those AC items — not from your own summary of them.**
+Copy each AC bullet as a separate entry. Do not paraphrase, collapse, or omit any
+item. Your plan is not complete until every AC item appears in `next_steps`.
+This is the only way to guarantee you implement the full spec.
+
 ```json
 {
   "next_steps": [
-    "agentception/services/foo.py — add _bar(x: int) -> str helper",
-    "agentception/services/foo.py — modify baz() to call _bar",
-    "agentception/tests/test_foo.py — add test_bar_returns_string, test_baz_calls_bar"
+    "AC: _ChunkSpec and chunk payload include file_hash (SHA-256 hex string)",
+    "AC: index_codebase(force_full=False) skips files whose hash matches Qdrant",
+    "AC: changed files — delete old chunks, upsert new chunks",
+    "AC: deleted files — remove all chunks from collection",
+    "AC: force_full=True drops and rebuilds collection",
+    "AC: mypy passes with zero errors",
+    "AC: typing_audit passes",
+    "AC: test_incremental_first_index_upserts_all_files",
+    "AC: test_incremental_unchanged_files_skipped",
+    "AC: test_incremental_changed_file_replaces_chunks",
+    "AC: test_incremental_deleted_file_removes_chunks",
+    "AC: test_incremental_force_full_rebuilds_collection"
   ],
   "decisions": []
 }
@@ -117,7 +132,10 @@ When tradeoffs appear, resolve them in this order:
 2. **Explicit contracts** at every module boundary — types, interfaces, validated models.
 3. **Fix the root, not the symptom** — if a type error surfaces at a call site, fix the callee.
 4. **Fail loudly** — raise exceptions with context; never swallow errors silently.
-5. **Ship the clean subset** — one clear improvement, merged, beats a rewrite left open.
+5. **Ship the clean subset — scoped correctly.** If you discover unexpected scope that was
+   *not* in the original acceptance criteria (e.g. a 500-line refactor hiding inside a 10-line
+   request), escalate and ship what you can. **If something is explicitly in the AC and you
+   have not done it, it is not out of scope — it is undone. Implement it.**
 
 ## Verification Before Done
 
@@ -134,9 +152,20 @@ cd "$REPO" && docker compose exec agentception sh -c \
   "PYTHONPATH=/worktrees/$WTNAME pytest /worktrees/$WTNAME/agentception/tests/test_<your_module>.py -v"
 ```
 
-Once the type checker passes and targeted tests pass, commit and open the PR
-immediately. Do not loop back to audit more — that is scope creep. One clean
-improvement, shipped.
+### AC Audit Gate — Required Before Opening a PR
+
+Before committing, re-read the original issue body. Go through every bullet in
+the acceptance criteria section and verify each one is satisfied by your
+implementation. This is not optional and it is not scope creep — it is the
+definition of done.
+
+For each AC item:
+- If implemented: confirm it and move on.
+- If missing: implement it now, then re-run mypy and tests.
+
+**Do not open a PR until every AC item has a corresponding implementation and,
+where the AC names a specific test, a passing test.** `next_steps` being empty
+is a necessary but not sufficient condition — the AC is the authoritative list.
 
 ## Audit Trail — Two Events, No More
 

--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -87,18 +87,24 @@ You have **50 iterations total**. Spend them deliberately:
 
 | Phase | Budget |
 |-------|--------|
-| Setup + fingerprint | ≤ 5 |
+| Setup + fingerprint + working memory | ≤ 5 |
 | Read changed files (once each, never re-read) | ≤ 12 |
-| Type checker + tests | ≤ 5 |
+| Type checker + tests (once each — never repeat) | ≤ 5 |
 | Grade + write review + merge | ≤ 8 |
 
-**If you are past iteration 30 and have not yet called `pull_request_review_write`,
-stop reading and grade what you have.** A review posted on partial information is
-better than no review posted at all.
+**Hard stop at iteration 30.** If you have not called `pull_request_review_write`
+by iteration 30, you must do so in iteration 31 — no exceptions, no one more read.
+A verdict on the evidence you have is always better than no verdict.
+
+**Evidence ceiling.** Once you have read a file or diff, you have all the
+information that file will ever give you. Re-reading it returns zero new signal.
+Once mypy and pytest have each run once and produced output, running them again
+returns zero new signal. Every repeated read or re-run is a wasted iteration
+that shortens the time available to form and post a verdict.
 
 ## Review Protocol — Follow in Order
 
-### Step 1 — Set context variables
+### Step 1 — Set context variables and initialise working memory
 
 All task context comes from your `task/briefing` MCP prompt — **do not read
 any file**. Extract these before doing anything else:
@@ -115,6 +121,30 @@ any file**. Extract these before doing anything else:
 WTNAME=$(basename "$(pwd)")
 REPO=$(git worktree list | head -1 | awk '{print $1}')
 ```
+
+Immediately call `update_working_memory` to record your review plan and track
+progress. Use `next_steps` as your ordered review checklist and `decisions` to
+record completed steps and findings as you go:
+
+```json
+{
+  "next_steps": [
+    "Read PR description and issue body — extract acceptance criteria",
+    "Read git diff (changed files, once each)",
+    "Run mypy — record result",
+    "Run targeted tests — record result",
+    "Cross-check each AC item against implementation",
+    "Write and post Fagan review verdict"
+  ],
+  "decisions": [],
+  "findings": []
+}
+```
+
+After each step completes: move it from `next_steps` to `decisions`, and append
+any defects or observations to `findings`. Update working memory immediately —
+do not batch updates. This keeps your review state persistent across context
+compression.
 
 ### Step 2 — Generate fingerprint (save, do not post yet)
 
@@ -196,6 +226,23 @@ PYTHONPATH=/worktrees/$WTNAME pytest /worktrees/$WTNAME/agentception/tests/test_
 
 Full output only — never pipe through `head` or `tail`.
 
+### Step 5b — Cross-check the acceptance criteria (AC audit)
+
+Read the original issue body. For every bullet in the acceptance criteria section,
+verify it is satisfied by the diff you already read. Record each item's status in
+working memory `findings`:
+
+- **Implemented** — code exists and (if the AC names a test) the test is present and passes.
+- **Missing** — no corresponding code or named test exists in the diff.
+
+If any AC item is **missing**, that is a defect. Classify it:
+- Logic gap (feature from AC is absent) → **D**
+- Named test from AC is absent → **C** minimum
+- TypedDict/model field named in AC is absent → **C** minimum
+
+Do not re-read any file to do this — use the diff you already read. If you need
+a specific symbol, use `read_symbol` once.
+
 ### Step 6 — Grade, write the review, and act
 
 Apply the Grading Rubric. Write your full review body as a string, then call
@@ -274,7 +321,19 @@ When a flaw is found, classify it in this order:
 
 ## Failure Modes to Avoid
 
-- Re-reading a file you have already processed.
+- **Re-reading a file, diff, or test output you have already seen.** Every re-read
+  wastes an iteration and returns zero new information. Track what you have read in
+  `decisions` and never revisit it.
+- **Running mypy or pytest more than once.** One run gives you the answer. A second
+  run gives you the same answer. It is not a confidence signal — it is a wasted turn.
+- **Reaching iteration 30 without a posted verdict.** The hard stop is not a guideline.
+  If you hit iteration 30 without calling `pull_request_review_write`, do it in
+  iteration 31 with the evidence you have.
+- **Not updating working memory after each step.** The working memory `findings` field
+  is your only persistent record of what you have observed. If you do not write it
+  down, it will be lost to context compression.
+- **Skipping the AC cross-check (Step 5b).** A PR that passes mypy and tests but is
+  missing features from the acceptance criteria is a D. Do not merge it.
 - Posting more than one comment on the issue — the outcome comment is the only one.
 - Calling `add_issue_comment` for the review body instead of `pull_request_review_write`.
 - Stopping at B or C instead of fixing in place.

--- a/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
@@ -15,18 +15,24 @@ You have **50 iterations total**. Spend them deliberately:
 
 | Phase | Budget |
 |-------|--------|
-| Setup + fingerprint | ≤ 5 |
+| Setup + fingerprint + working memory | ≤ 5 |
 | Read changed files (once each, never re-read) | ≤ 12 |
-| Type checker + tests | ≤ 5 |
+| Type checker + tests (once each — never repeat) | ≤ 5 |
 | Grade + write review + merge | ≤ 8 |
 
-**If you are past iteration 30 and have not yet called `pull_request_review_write`,
-stop reading and grade what you have.** A review posted on partial information is
-better than no review posted at all.
+**Hard stop at iteration 30.** If you have not called `pull_request_review_write`
+by iteration 30, you must do so in iteration 31 — no exceptions, no one more read.
+A verdict on the evidence you have is always better than no verdict.
+
+**Evidence ceiling.** Once you have read a file or diff, you have all the
+information that file will ever give you. Re-reading it returns zero new signal.
+Once mypy and pytest have each run once and produced output, running them again
+returns zero new signal. Every repeated read or re-run is a wasted iteration
+that shortens the time available to form and post a verdict.
 
 ## Review Protocol — Follow in Order
 
-### Step 1 — Set context variables
+### Step 1 — Set context variables and initialise working memory
 
 All task context comes from your `task/briefing` MCP prompt — **do not read
 any file**. Extract these before doing anything else:
@@ -43,6 +49,30 @@ any file**. Extract these before doing anything else:
 WTNAME=$(basename "$(pwd)")
 REPO=$(git worktree list | head -1 | awk '{print $1}')
 ```
+
+Immediately call `update_working_memory` to record your review plan and track
+progress. Use `next_steps` as your ordered review checklist and `decisions` to
+record completed steps and findings as you go:
+
+```json
+{
+  "next_steps": [
+    "Read PR description and issue body — extract acceptance criteria",
+    "Read git diff (changed files, once each)",
+    "Run mypy — record result",
+    "Run targeted tests — record result",
+    "Cross-check each AC item against implementation",
+    "Write and post Fagan review verdict"
+  ],
+  "decisions": [],
+  "findings": []
+}
+```
+
+After each step completes: move it from `next_steps` to `decisions`, and append
+any defects or observations to `findings`. Update working memory immediately —
+do not batch updates. This keeps your review state persistent across context
+compression.
 
 ### Step 2 — Generate fingerprint (save, do not post yet)
 
@@ -86,6 +116,23 @@ PYTHONPATH=/worktrees/$WTNAME pytest /worktrees/$WTNAME/{{ active_test_dir }}/te
 ```
 
 Full output only — never pipe through `head` or `tail`.
+
+### Step 5b — Cross-check the acceptance criteria (AC audit)
+
+Read the original issue body. For every bullet in the acceptance criteria section,
+verify it is satisfied by the diff you already read. Record each item's status in
+working memory `findings`:
+
+- **Implemented** — code exists and (if the AC names a test) the test is present and passes.
+- **Missing** — no corresponding code or named test exists in the diff.
+
+If any AC item is **missing**, that is a defect. Classify it:
+- Logic gap (feature from AC is absent) → **D**
+- Named test from AC is absent → **C** minimum
+- TypedDict/model field named in AC is absent → **C** minimum
+
+Do not re-read any file to do this — use the diff you already read. If you need
+a specific symbol, use `read_symbol` once.
 
 ### Step 6 — Grade, write the review, and act
 
@@ -165,7 +212,19 @@ When a flaw is found, classify it in this order:
 
 ## Failure Modes to Avoid
 
-- Re-reading a file you have already processed.
+- **Re-reading a file, diff, or test output you have already seen.** Every re-read
+  wastes an iteration and returns zero new information. Track what you have read in
+  `decisions` and never revisit it.
+- **Running mypy or pytest more than once.** One run gives you the answer. A second
+  run gives you the same answer. It is not a confidence signal — it is a wasted turn.
+- **Reaching iteration 30 without a posted verdict.** The hard stop is not a guideline.
+  If you hit iteration 30 without calling `pull_request_review_write`, do it in
+  iteration 31 with the evidence you have.
+- **Not updating working memory after each step.** The working memory `findings` field
+  is your only persistent record of what you have observed. If you do not write it
+  down, it will be lost to context compression.
+- **Skipping the AC cross-check (Step 5b).** A PR that passes mypy and tests but is
+  missing features from the acceptance criteria is a D. Do not merge it.
 - Posting more than one comment on the issue — the outcome comment is the only one.
 - Calling `add_issue_comment` for the review body instead of `pull_request_review_write`.
 - Stopping at B or C instead of fixing in place.

--- a/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
@@ -9,12 +9,27 @@ into working memory. Do both in the same response:
 2. Call `update_working_memory` with `next_steps` set to the full ordered list
    of concrete changes, and `decisions` set to `[]` (empty — nothing done yet).
 
+**If the issue has an explicit acceptance criteria (AC) section, your `next_steps`
+must be derived directly from those AC items — not from your own summary of them.**
+Copy each AC bullet as a separate entry. Do not paraphrase, collapse, or omit any
+item. Your plan is not complete until every AC item appears in `next_steps`.
+This is the only way to guarantee you implement the full spec.
+
 ```json
 {
   "next_steps": [
-    "agentception/services/foo.py — add _bar(x: int) -> str helper",
-    "agentception/services/foo.py — modify baz() to call _bar",
-    "agentception/tests/test_foo.py — add test_bar_returns_string, test_baz_calls_bar"
+    "AC: _ChunkSpec and chunk payload include file_hash (SHA-256 hex string)",
+    "AC: index_codebase(force_full=False) skips files whose hash matches Qdrant",
+    "AC: changed files — delete old chunks, upsert new chunks",
+    "AC: deleted files — remove all chunks from collection",
+    "AC: force_full=True drops and rebuilds collection",
+    "AC: mypy passes with zero errors",
+    "AC: typing_audit passes",
+    "AC: test_incremental_first_index_upserts_all_files",
+    "AC: test_incremental_unchanged_files_skipped",
+    "AC: test_incremental_changed_file_replaces_chunks",
+    "AC: test_incremental_deleted_file_removes_chunks",
+    "AC: test_incremental_force_full_rebuilds_collection"
   ],
   "decisions": []
 }
@@ -38,7 +53,10 @@ When tradeoffs appear, resolve them in this order:
 2. **Explicit contracts** at every module boundary — types, interfaces, validated models.
 3. **Fix the root, not the symptom** — if a type error surfaces at a call site, fix the callee.
 4. **Fail loudly** — raise exceptions with context; never swallow errors silently.
-5. **Ship the clean subset** — one clear improvement, merged, beats a rewrite left open.
+5. **Ship the clean subset — scoped correctly.** If you discover unexpected scope that was
+   *not* in the original acceptance criteria (e.g. a 500-line refactor hiding inside a 10-line
+   request), escalate and ship what you can. **If something is explicitly in the AC and you
+   have not done it, it is not out of scope — it is undone. Implement it.**
 
 ## Verification Before Done
 
@@ -55,9 +73,20 @@ cd "$REPO" && docker compose exec agentception sh -c \
   "PYTHONPATH=/worktrees/$WTNAME pytest /worktrees/$WTNAME/{{ active_test_dir }}/test_<your_module>.py -v"
 ```
 
-Once the type checker passes and targeted tests pass, commit and open the PR
-immediately. Do not loop back to audit more — that is scope creep. One clean
-improvement, shipped.
+### AC Audit Gate — Required Before Opening a PR
+
+Before committing, re-read the original issue body. Go through every bullet in
+the acceptance criteria section and verify each one is satisfied by your
+implementation. This is not optional and it is not scope creep — it is the
+definition of done.
+
+For each AC item:
+- If implemented: confirm it and move on.
+- If missing: implement it now, then re-run mypy and tests.
+
+**Do not open a PR until every AC item has a corresponding implementation and,
+where the AC names a specific test, a passing test.** `next_steps` being empty
+is a necessary but not sufficient condition — the AC is the authoritative list.
 
 ## Audit Trail — Two Events, No More
 


### PR DESCRIPTION
## Summary

- **Developer:** `next_steps` must now be seeded directly from the issue's acceptance criteria bullets (not the agent's own summary). A new AC Audit Gate before opening any PR requires re-reading every AC bullet and verifying each is implemented and tested. "Ship the clean subset" is scoped to unexpected scope only — anything in the AC is undone work, not out-of-scope.
- **PR Reviewer:** Working memory checklist initialised at Step 1 with `next_steps`, `decisions`, and `findings`. New Step 5b cross-checks every AC bullet against the diff; missing items are graded C or D. Evidence ceiling: mypy and tests run exactly once each — re-runs are explicitly banned. Hard stop: verdict posted by iteration 31 with no exceptions.

## Root cause

Guido (developer) shipped PR #483 missing three acceptance criteria items (deletion of stale chunks for changed/deleted files, `force_full` param, `file_hash` in TypedDict) because two prompt instructions gave him permission: "commit immediately after tests pass" and "ship the clean subset." Fagan (reviewer) ran for 61+ iterations without posting a verdict because there was no evidence ceiling or hard stop — he re-read the same diff 5+ times and ran the full test suite 4 times.