### PR TITLE
Replace _SERVER_INFO dict with _ServerInfo TypedDict

### DIFF
--- a/.agentception/memory.json
+++ b/.agentception/memory.json
@@ -1,25 +1,22 @@
 {
-  "plan": "Add SHA-256 hash-based incremental indexing to code_indexer.py:\n1. Add `files_skipped` field to IndexStats TypedDict\n2. Add `_compute_file_hash(path)` helper that returns SHA-256 hex digest\n3. Add `_fetch_indexed_hashes(client, collection)` async helper that queries Qdrant for existing file hashes\n4. Modify `index_codebase` to: fetch existing hashes, skip files whose hash matches, store file_hash in point payloads, return files_skipped count\n5. Update tests: add files_skipped to existing test assertions, add new tests for skip behavior and hash storage",
+  "plan": "Read the issue, define _ServerInfo TypedDict with keys 'name' and 'version', replace the _SERVER_INFO dict literal annotation with the typed instance, verify mypy passes.",
   "files_examined": [
-    "agentception/services/code_indexer.py",
-    "docs/reference/type-contracts.md",
-    "agentception/mcp/types.py",
-    "agentception/tests/test_code_indexer.py",
-    "agentception/tests/test_system_api.py"
+    "agentception/workflow/linking.py",
+    "agentception/static/scss/app.scss",
+    "agentception/workflow/invariants.py",
+    "scripts/gen_prompts/generate.py",
+    "agentception/mcp/server.py"
   ],
   "findings": {
-    "agentception/services/code_indexer.py": "[Type signatures]\nclass IndexStats(TypedDict): \"\"\"Result returned by :func:`index_codebase`.\"\"\"\nclass SearchMatch(TypedDict): \"\"\"A single result from :func:`search_codebase`.\"\"\"\ndef _get_model() -> object: \"\"\"Return the cached TextEmbedding model, initialising it on first call.\"\"\" global _cached_model\ndef _reset_model() -> None: \"\"\"Clear the cached model \u2014 used by tests to inject a mock.\"\"\" global _cached_model\ndef _embed_sync(texts: list[str]) -> list[list[float]]: \"\"\"Embed *texts* synchronously (runs in a thread pool via asyncio.to_thread).\"\"\" from fastembed import T\u2026\nasync def _embed(texts: list[str]) -> list[list[float]]: \"\"\"Async wrapper around :func:`_embed_sync` using the thread pool.\"\"\" return await asyncio.to_thread(_e\u2026\ndef _compute_bm25_vector(text: str, vocab_size: int = 10000) -> dict[int, float]: \"\"\"Compute a BM25-style sparse vector for *text*.\ndef _should_index(path: Path) -> bool: \"\"\"Return True when *path* is a text file we want to embed.\"\"\" if path.suffix not in _TEXT_EXTENSIONS:\ndef _walk_files(repo_path: Path) -> list[Path]: \"\"\"Return all indexable source files under *repo_path*, sorted.\"\"\" results: list[Path] = []\nclass _ChunkSpec(TypedDict): \"\"\"Internal: a raw chunk before embedding.\"\"\"\ndef _chunk_file_ast(path: Path, repo_root: Path) -> list[_ChunkSpec]: \"\"\"Split a Python file into chunks by top-level symbols (classes, functions).\ndef _chunk_file_char( path: Path, repo_root: Path, raw: str | None = None, rel: str | None = None ) -> list[_ChunkSpec]:\ndef _chunk_file(path: Path, repo_root: Path) -> list[_ChunkSpec]: \"\"\"Split *path* into chunks using the appropriate strategy.\nasync def _ensure_collection(client: \"AsyncQdrantClient\", collection: str) -> None: \"\"\"Create or migrate the Qdrant collection for hybrid dense+sparse search.\nasync def index_codebase( repo_path: Path | None = None, *,\nasync def search_codebase( query: str, n_results: int = 5,",
-    "agentception/tests/test_code_indexer.py": "[Existing tests \u2014 do not duplicate]\ntest_should_index_accepts_python_files\ntest_should_index_rejects_unknown_extension\ntest_should_index_rejects_large_file\ntest_walk_files_skips_git_and_pycache\ntest_walk_files_includes_multiple_extensions\ntest_chunk_file_produces_at_least_one_chunk\ntest_chunk_file_relative_path\ntest_chunk_file_large_file_produces_multiple_chunks\ntest_chunk_file_ids_are_deterministic\ntest_chunk_file_ids_are_unique_within_file\ntest_chunk_file_missing_file_returns_empty\ntest_chunk_file_ast_extracts_functions\ntest_chunk_file_ast_extracts_classes\ntest_chunk_file_ast_includes_decorators\ntest_chunk_file_ast_preserves_async_functions\ntest_chunk_file_ast_falls_back_on_syntax_error\ntest_chunk_file_ast_falls_back_when_no_symbols\ntest_chunk_file_ast_chunk_ids_use_symbol_names\ntest_chunk_file_non_python_uses_character_chunking\ntest_index_codebase_returns_stats\ntest_index_codebase_error_returns_ok_false\ntest_search_codebase_returns_matches\ntest_search_codebase_empty_when_no_results\ntest_search_codebase_returns_empty_on_qdrant_error\ntest_search_codebase_skips_malformed_payloads\ntest_hybrid_search\ntest_chunk_file_ast_symbol_field_populated\ntest_chunk_file_char_symbol_field_empty\ntest_ensure_collection_no_payload_indexes_config_kwarg\ntest_ensure_collection_migrates_legacy_single_vector_schema\ntest_index_codebase_writes_symbol_to_payload"
+    "agentception/workflow/linking.py": "[Type signatures]\nclass CandidateLink(TypedDict): \"\"\"One candidate PR\u2194Issue link produced by the linker.\"\"\"\nclass PRRow(TypedDict): \"\"\"Minimal PR fields needed for link discovery.\"\"\"\nclass RunRow(TypedDict): \"\"\"Minimal run fields needed for the run_pr_number signal.\"\"\"\ndef discover_links_for_pr( pr: PRRow, repo: str,\nclass BestPR(TypedDict): \"\"\"The canonical PR associated with an issue after link resolution.\"\"\"\nclass PRInfo(TypedDict): \"\"\"Minimal PR metadata for best-PR selection.\"\"\"\ndef best_pr_for_issue( issue_number: int, links: list[CandidateLink],\ndef sort_key(link: CandidateLink) -> tuple[int, int, int]: pr_num = link[\"pr_number\"] info = pr_info.get(pr_num)",
+    "agentception/workflow/invariants.py": "[Type signatures]\nclass InvariantContext(TypedDict): \"\"\"Data snapshot passed to the invariant checker.\"\"\"\nclass WorkflowSnapshot(TypedDict): \"\"\"Minimal workflow state fields for invariant checking.\"\"\"\ndef check_invariants(ctx: InvariantContext) -> list[str]: \"\"\"Run all invariant checks and return a list of alert strings.\ndef _inv_pr_link_1(ctx: InvariantContext) -> list[str]: \"\"\"INV-PR-LINK-1: Every PR with ``Closes #N`` must have a link row.\"\"\" alerts: list[str] = []\ndef _inv_run_pr_1(ctx: InvariantContext) -> list[str]: \"\"\"INV-RUN-PR-1: Runs with pr_number must have a matching PR row or warning.\"\"\" alerts: list[str] = []\ndef _inv_lane_1(ctx: InvariantContext) -> list[str]: \"\"\"INV-LANE-1: pr_open/reviewing lanes must have an open best-PR.\"\"\" alerts: list[str] = []\ndef _inv_base_1(ctx: InvariantContext) -> list[str]: \"\"\"INV-BASE-1: PRs targeting non-dev base branches.\"\"\" alerts: list[str] = []"
   },
   "decisions": [],
   "next_steps": [
-    "code_indexer.py \u2014 add files_skipped to IndexStats TypedDict",
-    "code_indexer.py \u2014 add _compute_file_hash(path: Path) -> str helper",
-    "code_indexer.py \u2014 add _fetch_indexed_hashes(client, collection) async helper that scrolls Qdrant for file+hash payloads",
-    "code_indexer.py \u2014 modify index_codebase to use incremental logic: fetch hashes, skip unchanged files, store file_hash in payload, return files_skipped",
-    "test_code_indexer.py \u2014 update existing test assertions to include files_skipped field",
-    "test_code_indexer.py \u2014 add test_index_codebase_skips_unchanged_files and test_index_codebase_rehashes_changed_files tests",
-    "Run mypy and pytest to verify",
-    "Claim issue, commit, open PR"
+    "Claim issue and post fingerprint comment",
+    "Define _ServerInfo TypedDict in agentception/mcp/server.py with fields: name: str, version: str",
+    "Replace _SERVER_INFO: dict[str, object] = {...} with _SERVER_INFO: _ServerInfo = _ServerInfo(name='agentception', version='0.1.1')",
+    "Run mypy to verify zero errors",
+    "Commit and push, open PR with fingerprint"
   ]
 }

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -34,7 +34,7 @@ Boundary constraint: zero imports from external packages.
 
 import json
 import logging
-from typing import cast
+from typing import TypedDict, cast
 
 from agentception.mcp.build_commands import (
     build_block_run,
@@ -95,11 +95,18 @@ from agentception.mcp.types import (
 
 logger = logging.getLogger(__name__)
 
+class _ServerInfo(TypedDict):
+    """Server identity advertised in the ``initialize`` response."""
+
+    name: str
+    version: str
+
+
 #: MCP protocol version this server implements.
 _MCP_PROTOCOL_VERSION = "2024-11-05"
 
 #: Server identity advertised in the ``initialize`` response.
-_SERVER_INFO: dict[str, object] = {"name": "agentception", "version": "0.1.1"}
+_SERVER_INFO: _ServerInfo = _ServerInfo(name="agentception", version="0.1.1")
 
 # ---------------------------------------------------------------------------
 # Tool registry


### PR DESCRIPTION
## Summary

Replaces the loosely-typed `_SERVER_INFO: dict[str, object]` literal in `agentception/mcp/server.py` with a proper `_ServerInfo` TypedDict, making the server identity contract explicit and mypy-verifiable.

### Changes

- **`agentception/mcp/server.py`**
  - Added `_ServerInfo(TypedDict)` with `name: str` and `version: str` fields
  - Changed `_SERVER_INFO: dict[str, object] = {"name": ..., "version": ...}` to `_SERVER_INFO: _ServerInfo = _ServerInfo(name="agentception", version="0.1.1")`
  - Added `TypedDict` to the `typing` import

### Verification

```
mypy agentception/ → Success: no issues found in 225 source files
```

Closes #442

<details>
<summary>🤖 Agent Fingerprint</summary>

| | |
|---|---|
| **Role** | `developer` |
| **Architecture** | `guido_van_rossum:python` |
| **Session** | `eng-20260310T185312Z-0000` |
| **Batch** | `issue-442-20260310T185011Z-0451` |
| **Claimed at** | `2026-03-10T18:53:12Z` |

</details>