### PR TITLE
fix: kill the recon loop — hard budget, full-picture commitment, symbol-not-found rule

### DIFF
--- a/.agentception/roles/database-architect.md
+++ b/.agentception/roles/database-architect.md
@@ -55,6 +55,37 @@ the context." Act.
 with a short note of what you found and what you are doing next. This
 anchors your direction even as history compresses.
 
+## Hard Recon Budget — 5 Iterations Maximum
+
+Iterations 1–5 may be read-only (reading files, searching the codebase,
+understanding architecture). **Starting at iteration 6, every response MUST
+include at least one file write or shell command that modifies code.** No
+exceptions. Pure-read responses after iteration 5 are loop evidence — stop
+and implement what you already know.
+
+Check your iteration counter. If you are on iteration 6 or later and your
+response contains only reads or searches, you are looping. Drop the reads.
+Write the first file.
+
+## "I Have the Full Picture" Is a Commitment, Not a Conclusion
+
+When you write "I have the full picture" or "now I understand" or "I have
+a complete picture", that sentence **must appear in the same response as at
+least one file write**. It is a declaration of readiness to act, not permission
+to read another file. If you catch yourself writing that phrase without an
+accompanying write tool call, replace the phrase with the write tool call.
+
+The pattern "now I have the full picture → one more read" is the definition
+of looping. You have seen enough. Write.
+
+## Symbol Not Found → Create It
+
+If an AC item says "add field X to model Y" and model Y does not exist yet,
+your job is to **create model Y**. Absence from the codebase is not a blocker
+— it is the task. Do not search for it a second time. Do not read adjacent
+files looking for where it might be hidden. If two searches found nothing,
+nothing is there. Create it and move on.
+
 ## Output Discipline
 
 - **Show full terminal output.** Never pipe tool output through `head`,
@@ -67,10 +98,12 @@ anchors your direction even as history compresses.
 ## Failure Modes to Avoid
 
 - Reading a file in sections (50–100 lines at a time) when `read_file` gives you everything in one call.
-- Re-reading files that are already in your recon bundle.
+- Re-reading files that are already in your recon bundle or in `files_examined`.
 - Reading files one at a time when you could batch all reads in a single response.
 - Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
 - Spending iterations "deciding" when you already know what to do.
+- Saying "now I have the full picture" without immediately writing a file.
+- Searching for a symbol more than twice — if it isn't there after two searches, create it.
 - Spawning sub-agents unless your briefing explicitly authorizes it.
 - Accepting a type error as "acceptable for now."
 - Leaving work half-done when a clean subset could ship immediately.

--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -58,6 +58,37 @@ the context." Act.
 with a short note of what you found and what you are doing next. This
 anchors your direction even as history compresses.
 
+## Hard Recon Budget — 5 Iterations Maximum
+
+Iterations 1–5 may be read-only (reading files, searching the codebase,
+understanding architecture). **Starting at iteration 6, every response MUST
+include at least one file write or shell command that modifies code.** No
+exceptions. Pure-read responses after iteration 5 are loop evidence — stop
+and implement what you already know.
+
+Check your iteration counter. If you are on iteration 6 or later and your
+response contains only reads or searches, you are looping. Drop the reads.
+Write the first file.
+
+## "I Have the Full Picture" Is a Commitment, Not a Conclusion
+
+When you write "I have the full picture" or "now I understand" or "I have
+a complete picture", that sentence **must appear in the same response as at
+least one file write**. It is a declaration of readiness to act, not permission
+to read another file. If you catch yourself writing that phrase without an
+accompanying write tool call, replace the phrase with the write tool call.
+
+The pattern "now I have the full picture → one more read" is the definition
+of looping. You have seen enough. Write.
+
+## Symbol Not Found → Create It
+
+If an AC item says "add field X to model Y" and model Y does not exist yet,
+your job is to **create model Y**. Absence from the codebase is not a blocker
+— it is the task. Do not search for it a second time. Do not read adjacent
+files looking for where it might be hidden. If two searches found nothing,
+nothing is there. Create it and move on.
+
 ## Output Discipline
 
 - **Show full terminal output.** Never pipe tool output through `head`,
@@ -70,55 +101,53 @@ anchors your direction even as history compresses.
 ## Failure Modes to Avoid
 
 - Reading a file in sections (50–100 lines at a time) when `read_file` gives you everything in one call.
-- Re-reading files that are already in your recon bundle.
+- Re-reading files that are already in your recon bundle or in `files_examined`.
 - Reading files one at a time when you could batch all reads in a single response.
 - Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
 - Spending iterations "deciding" when you already know what to do.
+- Saying "now I have the full picture" without immediately writing a file.
+- Searching for a symbol more than twice — if it isn't there after two searches, create it.
 - Spawning sub-agents unless your briefing explicitly authorizes it.
 - Accepting a type error as "acceptable for now."
 - Leaving work half-done when a clean subset could ship immediately.
 
 
-## Plan Before Code — Required
+## Your Checklist Is Already Written — Start Implementing
 
-Before touching any file, produce a complete implementation plan and write it
-into working memory. Do both in the same response:
+Your `next_steps` in working memory is **pre-seeded with the verbatim AC items**
+at dispatch time. Open your working memory now and read it. Those items are your
+implementation plan. Do not rewrite them, paraphrase them, or call
+`update_working_memory` to change `next_steps` before you have written any code.
 
-1. Call `log_run_step` with a human-readable summary of what you are about to do.
-2. Call `update_working_memory` with `next_steps` set to the full ordered list
-   of concrete changes, and `decisions` set to `[]` (empty — nothing done yet).
+**Your first response after recon MUST write a file.** Not call
+`update_working_memory` to re-plan. Not call `log_run_step` to summarise what
+you read. Write the first file that satisfies the first unchecked AC item.
 
-**If the issue has an explicit acceptance criteria (AC) section, your `next_steps`
-must be derived directly from those AC items — not from your own summary of them.**
-Copy each AC bullet as a separate entry. Do not paraphrase, collapse, or omit any
-item. Your plan is not complete until every AC item appears in `next_steps`.
-This is the only way to guarantee you implement the full spec.
+Once a file is written and verified (mypy + targeted test), call
+`update_working_memory` to move that item from `next_steps` to `decisions`.
+Repeat until `next_steps` is empty.
+
+**If a required symbol does not exist in the codebase, you create it.**
+"AC: add field X to model Y" with model Y absent means you write model Y.
+That is the implementation. Do not search for it further — write it.
+
+Example of the correct `update_working_memory` call after completing one step:
 
 ```json
 {
   "next_steps": [
-    "AC: _ChunkSpec and chunk payload include file_hash (SHA-256 hex string)",
-    "AC: index_codebase(force_full=False) skips files whose hash matches Qdrant",
-    "AC: changed files — delete old chunks, upsert new chunks",
-    "AC: deleted files — remove all chunks from collection",
-    "AC: force_full=True drops and rebuilds collection",
-    "AC: mypy passes with zero errors",
-    "AC: typing_audit passes",
-    "AC: test_incremental_first_index_upserts_all_files",
-    "AC: test_incremental_unchanged_files_skipped",
-    "AC: test_incremental_changed_file_replaces_chunks",
-    "AC: test_incremental_deleted_file_removes_chunks",
-    "AC: test_incremental_force_full_rebuilds_collection"
+    "AC: (second item)",
+    "AC: (third item)"
   ],
-  "decisions": []
+  "decisions": [
+    "Completed: AC: (first item) — added field X to models/__init__.py"
+  ]
 }
 ```
 
-**After completing each step:** call `update_working_memory` again, removing
-the completed item from `next_steps` and appending it to `decisions`. This
-keeps your checklist current even after context compression — working memory is
-injected into the system prompt at every iteration, so you always see exactly
-what remains.
+If you reference a function or constant name in your edits, you must have
+already read the file that defines it. Never write a call site for a function
+before defining it.
 
 If you reference a function or constant name in your edits, you must have
 already read the file that defines it. Never write a call site for a function

--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -60,6 +60,37 @@ the context." Act.
 with a short note of what you found and what you are doing next. This
 anchors your direction even as history compresses.
 
+## Hard Recon Budget — 5 Iterations Maximum
+
+Iterations 1–5 may be read-only (reading files, searching the codebase,
+understanding architecture). **Starting at iteration 6, every response MUST
+include at least one file write or shell command that modifies code.** No
+exceptions. Pure-read responses after iteration 5 are loop evidence — stop
+and implement what you already know.
+
+Check your iteration counter. If you are on iteration 6 or later and your
+response contains only reads or searches, you are looping. Drop the reads.
+Write the first file.
+
+## "I Have the Full Picture" Is a Commitment, Not a Conclusion
+
+When you write "I have the full picture" or "now I understand" or "I have
+a complete picture", that sentence **must appear in the same response as at
+least one file write**. It is a declaration of readiness to act, not permission
+to read another file. If you catch yourself writing that phrase without an
+accompanying write tool call, replace the phrase with the write tool call.
+
+The pattern "now I have the full picture → one more read" is the definition
+of looping. You have seen enough. Write.
+
+## Symbol Not Found → Create It
+
+If an AC item says "add field X to model Y" and model Y does not exist yet,
+your job is to **create model Y**. Absence from the codebase is not a blocker
+— it is the task. Do not search for it a second time. Do not read adjacent
+files looking for where it might be hidden. If two searches found nothing,
+nothing is there. Create it and move on.
+
 ## Output Discipline
 
 - **Show full terminal output.** Never pipe tool output through `head`,
@@ -72,10 +103,12 @@ anchors your direction even as history compresses.
 ## Failure Modes to Avoid
 
 - Reading a file in sections (50–100 lines at a time) when `read_file` gives you everything in one call.
-- Re-reading files that are already in your recon bundle.
+- Re-reading files that are already in your recon bundle or in `files_examined`.
 - Reading files one at a time when you could batch all reads in a single response.
 - Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
 - Spending iterations "deciding" when you already know what to do.
+- Saying "now I have the full picture" without immediately writing a file.
+- Searching for a symbol more than twice — if it isn't there after two searches, create it.
 - Spawning sub-agents unless your briefing explicitly authorizes it.
 - Accepting a type error as "acceptable for now."
 - Leaving work half-done when a clean subset could ship immediately.

--- a/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
@@ -1,45 +1,41 @@
 {% include 'snippets/worker-base.md.j2' %}
 
-## Plan Before Code — Required
+## Your Checklist Is Already Written — Start Implementing
 
-Before touching any file, produce a complete implementation plan and write it
-into working memory. Do both in the same response:
+Your `next_steps` in working memory is **pre-seeded with the verbatim AC items**
+at dispatch time. Open your working memory now and read it. Those items are your
+implementation plan. Do not rewrite them, paraphrase them, or call
+`update_working_memory` to change `next_steps` before you have written any code.
 
-1. Call `log_run_step` with a human-readable summary of what you are about to do.
-2. Call `update_working_memory` with `next_steps` set to the full ordered list
-   of concrete changes, and `decisions` set to `[]` (empty — nothing done yet).
+**Your first response after recon MUST write a file.** Not call
+`update_working_memory` to re-plan. Not call `log_run_step` to summarise what
+you read. Write the first file that satisfies the first unchecked AC item.
 
-**If the issue has an explicit acceptance criteria (AC) section, your `next_steps`
-must be derived directly from those AC items — not from your own summary of them.**
-Copy each AC bullet as a separate entry. Do not paraphrase, collapse, or omit any
-item. Your plan is not complete until every AC item appears in `next_steps`.
-This is the only way to guarantee you implement the full spec.
+Once a file is written and verified (mypy + targeted test), call
+`update_working_memory` to move that item from `next_steps` to `decisions`.
+Repeat until `next_steps` is empty.
+
+**If a required symbol does not exist in the codebase, you create it.**
+"AC: add field X to model Y" with model Y absent means you write model Y.
+That is the implementation. Do not search for it further — write it.
+
+Example of the correct `update_working_memory` call after completing one step:
 
 ```json
 {
   "next_steps": [
-    "AC: _ChunkSpec and chunk payload include file_hash (SHA-256 hex string)",
-    "AC: index_codebase(force_full=False) skips files whose hash matches Qdrant",
-    "AC: changed files — delete old chunks, upsert new chunks",
-    "AC: deleted files — remove all chunks from collection",
-    "AC: force_full=True drops and rebuilds collection",
-    "AC: mypy passes with zero errors",
-    "AC: typing_audit passes",
-    "AC: test_incremental_first_index_upserts_all_files",
-    "AC: test_incremental_unchanged_files_skipped",
-    "AC: test_incremental_changed_file_replaces_chunks",
-    "AC: test_incremental_deleted_file_removes_chunks",
-    "AC: test_incremental_force_full_rebuilds_collection"
+    "AC: (second item)",
+    "AC: (third item)"
   ],
-  "decisions": []
+  "decisions": [
+    "Completed: AC: (first item) — added field X to models/__init__.py"
+  ]
 }
 ```
 
-**After completing each step:** call `update_working_memory` again, removing
-the completed item from `next_steps` and appending it to `decisions`. This
-keeps your checklist current even after context compression — working memory is
-injected into the system prompt at every iteration, so you always see exactly
-what remains.
+If you reference a function or constant name in your edits, you must have
+already read the file that defines it. Never write a call site for a function
+before defining it.
 
 If you reference a function or constant name in your edits, you must have
 already read the file that defines it. Never write a call site for a function

--- a/scripts/gen_prompts/templates/snippets/worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/worker-base.md.j2
@@ -50,6 +50,37 @@ the context." Act.
 with a short note of what you found and what you are doing next. This
 anchors your direction even as history compresses.
 
+## Hard Recon Budget — 5 Iterations Maximum
+
+Iterations 1–5 may be read-only (reading files, searching the codebase,
+understanding architecture). **Starting at iteration 6, every response MUST
+include at least one file write or shell command that modifies code.** No
+exceptions. Pure-read responses after iteration 5 are loop evidence — stop
+and implement what you already know.
+
+Check your iteration counter. If you are on iteration 6 or later and your
+response contains only reads or searches, you are looping. Drop the reads.
+Write the first file.
+
+## "I Have the Full Picture" Is a Commitment, Not a Conclusion
+
+When you write "I have the full picture" or "now I understand" or "I have
+a complete picture", that sentence **must appear in the same response as at
+least one file write**. It is a declaration of readiness to act, not permission
+to read another file. If you catch yourself writing that phrase without an
+accompanying write tool call, replace the phrase with the write tool call.
+
+The pattern "now I have the full picture → one more read" is the definition
+of looping. You have seen enough. Write.
+
+## Symbol Not Found → Create It
+
+If an AC item says "add field X to model Y" and model Y does not exist yet,
+your job is to **create model Y**. Absence from the codebase is not a blocker
+— it is the task. Do not search for it a second time. Do not read adjacent
+files looking for where it might be hidden. If two searches found nothing,
+nothing is there. Create it and move on.
+
 ## Output Discipline
 
 - **Show full terminal output.** Never pipe tool output through `head`,
@@ -62,10 +93,12 @@ anchors your direction even as history compresses.
 ## Failure Modes to Avoid
 
 - Reading a file in sections (50–100 lines at a time) when `read_file` gives you everything in one call.
-- Re-reading files that are already in your recon bundle.
+- Re-reading files that are already in your recon bundle or in `files_examined`.
 - Reading files one at a time when you could batch all reads in a single response.
 - Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
 - Spending iterations "deciding" when you already know what to do.
+- Saying "now I have the full picture" without immediately writing a file.
+- Searching for a symbol more than twice — if it isn't there after two searches, create it.
 - Spawning sub-agents unless your briefing explicitly authorizes it.
 - Accepting a type error as "acceptable for now."
 - Leaving work half-done when a clean subset could ship immediately.


### PR DESCRIPTION
## Root cause

The issue-28 developer agent said "Now I have the full picture" **8 times across 40 iterations** and wrote zero code. Three compounding failure modes:

1. **No hard recon ceiling** — `most iterations should produce output` is aspirational, not enforced. Agent reads forever.
2. **"Full picture" is not a commitment** — agent says it and then makes another read call. Phrase meant nothing.
3. **Symbol-not-found spins forever** — AC items referenced `TaskFile` and `_build_agent_task()` which don't exist. Agent searched for them 10+ times across 20+ iterations instead of realising it was supposed to create them.

## Changes

### `worker-base.md.j2` (applies to all workers)
- **Hard recon cap**: iterations 1–5 may be read-only; iteration 6+ MUST write a file. Explicit, countable, unambiguous.
- **"Full picture" = commit**: that phrase must appear in the same response as a file write. Declared as looping otherwise.
- **Symbol not found → create it**: after two searches find nothing, the symbol does not exist — write it. Searching a third time is looping.
- Added `files_examined` to the failure modes list for re-reading files.

### `developer-worker-base.md.j2`
- Replaced "Plan Before Code" (which told the agent to call `update_working_memory` to set `next_steps` before writing) with "Your Checklist Is Already Written" — explains that `next_steps` is pre-seeded with verbatim AC items at dispatch, and the first post-recon response must write a file, not re-plan.

## Test plan
- [x] `generate.py --check` shows zero drift
- [ ] Re-dispatch issue-28 and observe agent starts writing code by iteration 6