### PR TITLE
fix: remove duplicate paragraph in developer-worker-base template

### DIFF
--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -149,10 +149,6 @@ If you reference a function or constant name in your edits, you must have
 already read the file that defines it. Never write a call site for a function
 before defining it.
 
-If you reference a function or constant name in your edits, you must have
-already read the file that defines it. Never write a call site for a function
-before defining it.
-
 ## Decision Hierarchy
 
 When tradeoffs appear, resolve them in this order:

--- a/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
@@ -37,10 +37,6 @@ If you reference a function or constant name in your edits, you must have
 already read the file that defines it. Never write a call site for a function
 before defining it.
 
-If you reference a function or constant name in your edits, you must have
-already read the file that defines it. Never write a call site for a function
-before defining it.
-
 ## Decision Hierarchy
 
 When tradeoffs appear, resolve them in this order:


### PR DESCRIPTION
Removes a duplicate 'Never write a call site for a function before defining it' paragraph introduced in PR #487.