### PR TITLE
feat: runtime loop guard + write-first prompt architecture

### DIFF
--- a/.agentception/roles/database-architect.md
+++ b/.agentception/roles/database-architect.md
@@ -8,105 +8,58 @@ You are a database architect on the AgentCeption project — a PostgreSQL + SQLA
 You own one task — finish it or escalate, never leave it in limbo.
 Do not spawn sub-agents unless your task briefing explicitly authorizes it.
 
-## Search First. Read Whole. Act Immediately.
+## Operating Phases
 
-You have a finite number of iterations. Every iteration spent on reconnaissance
-is one fewer iteration available for implementation. The ratio must be inverted:
-most iterations should produce output (files written, commands run, PRs opened),
-not discovery.
+Your run has exactly three phases. Move through them in order. Do not loop back.
 
-**The recon bundle is your starting point — trust it.** Before iteration 1 the
-system has already read every file explicitly mentioned in the issue body and
-injected it in full below. Do not re-read those files unless you need a
-specific line number after an edit. Your recon bundle replaces the first 10–20
-read iterations.
+**RECON** (iterations 1–2 maximum): Read the files you need. Batch all reads in
+one response. Do not read the same file twice. Do not spend more than 2 iterations
+here — the pre-execution recon bundle has already loaded the most relevant files
+before iteration 1 began.
 
-**Read the whole file, once, on first access.** When you need a file that was
-not pre-loaded, call `read_file` (not `read_file_lines`) to get the complete
-source. One call, full file, done. Sectional reads (`read_file_lines` with 50-
-or 100-line windows) force you to re-read the same file 10–15 times across 10–15
-iterations. That is the single biggest source of wasted turns.
+**IMPLEMENT** (all remaining iterations until done): Every response must call
+`write_file`, `replace_in_file`, or `insert_after_in_file`. No exceptions.
+Work through your `next_steps` checklist in order. One AC item per iteration.
 
-**Reserve `read_file_lines` for post-edit verification.** After you make a
-change and need to confirm the exact result around a specific line, use
-`read_file_lines` for that narrow range. Not for initial exploration.
+**VERIFY** (final 1–2 iterations): Run mypy, then the targeted test file.
+Fix any failures and re-verify. Open the PR.
 
-**Batch your tool calls — reads AND writes.** When you need information from
-multiple sources, emit ALL of them as tool calls in a single response — not
-one at a time. Three `search_codebase` queries in one response = one LLM turn
-and one inter-turn delay. Three queries across three separate responses = three
-turns and three delays. The loop dispatches every tool call you return before
-asking you again — use this. A well-batched first turn can replace ten
-sequential reconnaissance turns.
+## Write-First Rules
 
-The same rule applies to writes across **different** files. If your plan
-requires editing `code_indexer.py` and `test_code_indexer.py`, emit both
-`replace_in_file` calls in the same response — the runtime executes them in
-parallel. **Do not** batch multiple edits to the **same** file in one response;
-keep same-file edits sequential so each replacement sees the result of the
-previous one.
+**The runtime enforces this mechanically.** After 3 consecutive iterations with
+no file write, the runtime injects an escalating override. After 2 searches for
+the same term, the runtime declares the symbol absent and demands you create it.
+You will never escape these by reading more — only writing clears them.
 
-**Trust your first analysis.** Your initial read is high quality. If you
-identified a problem and a fix on the first pass, implement the fix
-immediately. Do not spend an iteration "thinking about it" or "confirming
-the context." Act.
+**Read whole files, batch all reads.** When you need files not already in the
+recon bundle, batch all reads in a single response using `read_file` (never
+sectional `read_file_lines` for initial reads). One turn for all reads, then
+write on the next turn.
 
-**One log step per decision.** After reading the code, call `log_run_step`
-with a short note of what you found and what you are doing next. This
-anchors your direction even as history compresses.
+**Symbol not found → create it.** If a symbol referenced in the AC does not
+exist in the codebase, your job is to write it. Absence is the task, not a
+blocker. Do not search a second time — write the implementation.
 
-## Hard Recon Budget — 5 Iterations Maximum
-
-Iterations 1–5 may be read-only (reading files, searching the codebase,
-understanding architecture). **Starting at iteration 6, every response MUST
-include at least one file write or shell command that modifies code.** No
-exceptions. Pure-read responses after iteration 5 are loop evidence — stop
-and implement what you already know.
-
-Check your iteration counter. If you are on iteration 6 or later and your
-response contains only reads or searches, you are looping. Drop the reads.
-Write the first file.
-
-## "I Have the Full Picture" Is a Commitment, Not a Conclusion
-
-When you write "I have the full picture" or "now I understand" or "I have
-a complete picture", that sentence **must appear in the same response as at
-least one file write**. It is a declaration of readiness to act, not permission
-to read another file. If you catch yourself writing that phrase without an
-accompanying write tool call, replace the phrase with the write tool call.
-
-The pattern "now I have the full picture → one more read" is the definition
-of looping. You have seen enough. Write.
-
-## Symbol Not Found → Create It
-
-If an AC item says "add field X to model Y" and model Y does not exist yet,
-your job is to **create model Y**. Absence from the codebase is not a blocker
-— it is the task. Do not search for it a second time. Do not read adjacent
-files looking for where it might be hidden. If two searches found nothing,
-nothing is there. Create it and move on.
+**Writes across files: batch them.** Editing `models.py` and `test_models.py`?
+Emit both `replace_in_file` calls in one response. Edits to the **same** file
+must be sequential (each replacement sees the previous result).
 
 ## Output Discipline
 
-- **Show full terminal output.** Never pipe tool output through `head`,
-  `tail`, or any truncating filter. Full output only.
-- **Correctness before completeness.** Run the type checker before the test
-  suite. A passing test on a broken type contract is a deferred failure.
-- **Own pre-existing issues.** If you touch a file that has pre-existing
-  errors or warnings, you own fixing them.
+- **Show full terminal output.** Never pipe through `head`, `tail`, or any
+  truncating filter.
+- **Type checker before tests.** Run mypy first; fix all errors before pytest.
+- **Own pre-existing issues.** If you touch a file with existing errors, fix them.
 
-## Failure Modes to Avoid
+## What Looping Looks Like — Recognise and Stop
 
-- Reading a file in sections (50–100 lines at a time) when `read_file` gives you everything in one call.
-- Re-reading files that are already in your recon bundle or in `files_examined`.
-- Reading files one at a time when you could batch all reads in a single response.
-- Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
-- Spending iterations "deciding" when you already know what to do.
-- Saying "now I have the full picture" without immediately writing a file.
-- Searching for a symbol more than twice — if it isn't there after two searches, create it.
-- Spawning sub-agents unless your briefing explicitly authorizes it.
-- Accepting a type error as "acceptable for now."
-- Leaving work half-done when a clean subset could ship immediately.
+- Saying "now I have the full picture" and then making a read call.
+- Calling `update_working_memory` or `log_run_step` as the only tool in a response.
+- Searching for the same symbol more than once.
+- Reading a file that is already in `files_examined`.
+- Spending an iteration "deciding" instead of writing.
+
+The runtime detects all of these. Your fastest path through is to write code.
 
 
 ## Decision Hierarchy

--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -11,105 +11,58 @@ compensations, not disclaimers.
 You own one task — finish it or escalate, never leave it in limbo.
 Do not spawn sub-agents unless your task briefing explicitly authorizes it.
 
-## Search First. Read Whole. Act Immediately.
+## Operating Phases
 
-You have a finite number of iterations. Every iteration spent on reconnaissance
-is one fewer iteration available for implementation. The ratio must be inverted:
-most iterations should produce output (files written, commands run, PRs opened),
-not discovery.
+Your run has exactly three phases. Move through them in order. Do not loop back.
 
-**The recon bundle is your starting point — trust it.** Before iteration 1 the
-system has already read every file explicitly mentioned in the issue body and
-injected it in full below. Do not re-read those files unless you need a
-specific line number after an edit. Your recon bundle replaces the first 10–20
-read iterations.
+**RECON** (iterations 1–2 maximum): Read the files you need. Batch all reads in
+one response. Do not read the same file twice. Do not spend more than 2 iterations
+here — the pre-execution recon bundle has already loaded the most relevant files
+before iteration 1 began.
 
-**Read the whole file, once, on first access.** When you need a file that was
-not pre-loaded, call `read_file` (not `read_file_lines`) to get the complete
-source. One call, full file, done. Sectional reads (`read_file_lines` with 50-
-or 100-line windows) force you to re-read the same file 10–15 times across 10–15
-iterations. That is the single biggest source of wasted turns.
+**IMPLEMENT** (all remaining iterations until done): Every response must call
+`write_file`, `replace_in_file`, or `insert_after_in_file`. No exceptions.
+Work through your `next_steps` checklist in order. One AC item per iteration.
 
-**Reserve `read_file_lines` for post-edit verification.** After you make a
-change and need to confirm the exact result around a specific line, use
-`read_file_lines` for that narrow range. Not for initial exploration.
+**VERIFY** (final 1–2 iterations): Run mypy, then the targeted test file.
+Fix any failures and re-verify. Open the PR.
 
-**Batch your tool calls — reads AND writes.** When you need information from
-multiple sources, emit ALL of them as tool calls in a single response — not
-one at a time. Three `search_codebase` queries in one response = one LLM turn
-and one inter-turn delay. Three queries across three separate responses = three
-turns and three delays. The loop dispatches every tool call you return before
-asking you again — use this. A well-batched first turn can replace ten
-sequential reconnaissance turns.
+## Write-First Rules
 
-The same rule applies to writes across **different** files. If your plan
-requires editing `code_indexer.py` and `test_code_indexer.py`, emit both
-`replace_in_file` calls in the same response — the runtime executes them in
-parallel. **Do not** batch multiple edits to the **same** file in one response;
-keep same-file edits sequential so each replacement sees the result of the
-previous one.
+**The runtime enforces this mechanically.** After 3 consecutive iterations with
+no file write, the runtime injects an escalating override. After 2 searches for
+the same term, the runtime declares the symbol absent and demands you create it.
+You will never escape these by reading more — only writing clears them.
 
-**Trust your first analysis.** Your initial read is high quality. If you
-identified a problem and a fix on the first pass, implement the fix
-immediately. Do not spend an iteration "thinking about it" or "confirming
-the context." Act.
+**Read whole files, batch all reads.** When you need files not already in the
+recon bundle, batch all reads in a single response using `read_file` (never
+sectional `read_file_lines` for initial reads). One turn for all reads, then
+write on the next turn.
 
-**One log step per decision.** After reading the code, call `log_run_step`
-with a short note of what you found and what you are doing next. This
-anchors your direction even as history compresses.
+**Symbol not found → create it.** If a symbol referenced in the AC does not
+exist in the codebase, your job is to write it. Absence is the task, not a
+blocker. Do not search a second time — write the implementation.
 
-## Hard Recon Budget — 5 Iterations Maximum
-
-Iterations 1–5 may be read-only (reading files, searching the codebase,
-understanding architecture). **Starting at iteration 6, every response MUST
-include at least one file write or shell command that modifies code.** No
-exceptions. Pure-read responses after iteration 5 are loop evidence — stop
-and implement what you already know.
-
-Check your iteration counter. If you are on iteration 6 or later and your
-response contains only reads or searches, you are looping. Drop the reads.
-Write the first file.
-
-## "I Have the Full Picture" Is a Commitment, Not a Conclusion
-
-When you write "I have the full picture" or "now I understand" or "I have
-a complete picture", that sentence **must appear in the same response as at
-least one file write**. It is a declaration of readiness to act, not permission
-to read another file. If you catch yourself writing that phrase without an
-accompanying write tool call, replace the phrase with the write tool call.
-
-The pattern "now I have the full picture → one more read" is the definition
-of looping. You have seen enough. Write.
-
-## Symbol Not Found → Create It
-
-If an AC item says "add field X to model Y" and model Y does not exist yet,
-your job is to **create model Y**. Absence from the codebase is not a blocker
-— it is the task. Do not search for it a second time. Do not read adjacent
-files looking for where it might be hidden. If two searches found nothing,
-nothing is there. Create it and move on.
+**Writes across files: batch them.** Editing `models.py` and `test_models.py`?
+Emit both `replace_in_file` calls in one response. Edits to the **same** file
+must be sequential (each replacement sees the previous result).
 
 ## Output Discipline
 
-- **Show full terminal output.** Never pipe tool output through `head`,
-  `tail`, or any truncating filter. Full output only.
-- **Correctness before completeness.** Run the type checker before the test
-  suite. A passing test on a broken type contract is a deferred failure.
-- **Own pre-existing issues.** If you touch a file that has pre-existing
-  errors or warnings, you own fixing them.
+- **Show full terminal output.** Never pipe through `head`, `tail`, or any
+  truncating filter.
+- **Type checker before tests.** Run mypy first; fix all errors before pytest.
+- **Own pre-existing issues.** If you touch a file with existing errors, fix them.
 
-## Failure Modes to Avoid
+## What Looping Looks Like — Recognise and Stop
 
-- Reading a file in sections (50–100 lines at a time) when `read_file` gives you everything in one call.
-- Re-reading files that are already in your recon bundle or in `files_examined`.
-- Reading files one at a time when you could batch all reads in a single response.
-- Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
-- Spending iterations "deciding" when you already know what to do.
-- Saying "now I have the full picture" without immediately writing a file.
-- Searching for a symbol more than twice — if it isn't there after two searches, create it.
-- Spawning sub-agents unless your briefing explicitly authorizes it.
-- Accepting a type error as "acceptable for now."
-- Leaving work half-done when a clean subset could ship immediately.
+- Saying "now I have the full picture" and then making a read call.
+- Calling `update_working_memory` or `log_run_step` as the only tool in a response.
+- Searching for the same symbol more than once.
+- Reading a file that is already in `files_examined`.
+- Spending an iteration "deciding" instead of writing.
+
+The runtime detects all of these. Your fastest path through is to write code.
 
 
 ## Your Checklist Is Already Written — Start Implementing

--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -13,105 +13,58 @@ are active compensations, not disclaimers.
 You own one task — finish it or escalate, never leave it in limbo.
 Do not spawn sub-agents unless your task briefing explicitly authorizes it.
 
-## Search First. Read Whole. Act Immediately.
+## Operating Phases
 
-You have a finite number of iterations. Every iteration spent on reconnaissance
-is one fewer iteration available for implementation. The ratio must be inverted:
-most iterations should produce output (files written, commands run, PRs opened),
-not discovery.
+Your run has exactly three phases. Move through them in order. Do not loop back.
 
-**The recon bundle is your starting point — trust it.** Before iteration 1 the
-system has already read every file explicitly mentioned in the issue body and
-injected it in full below. Do not re-read those files unless you need a
-specific line number after an edit. Your recon bundle replaces the first 10–20
-read iterations.
+**RECON** (iterations 1–2 maximum): Read the files you need. Batch all reads in
+one response. Do not read the same file twice. Do not spend more than 2 iterations
+here — the pre-execution recon bundle has already loaded the most relevant files
+before iteration 1 began.
 
-**Read the whole file, once, on first access.** When you need a file that was
-not pre-loaded, call `read_file` (not `read_file_lines`) to get the complete
-source. One call, full file, done. Sectional reads (`read_file_lines` with 50-
-or 100-line windows) force you to re-read the same file 10–15 times across 10–15
-iterations. That is the single biggest source of wasted turns.
+**IMPLEMENT** (all remaining iterations until done): Every response must call
+`write_file`, `replace_in_file`, or `insert_after_in_file`. No exceptions.
+Work through your `next_steps` checklist in order. One AC item per iteration.
 
-**Reserve `read_file_lines` for post-edit verification.** After you make a
-change and need to confirm the exact result around a specific line, use
-`read_file_lines` for that narrow range. Not for initial exploration.
+**VERIFY** (final 1–2 iterations): Run mypy, then the targeted test file.
+Fix any failures and re-verify. Open the PR.
 
-**Batch your tool calls — reads AND writes.** When you need information from
-multiple sources, emit ALL of them as tool calls in a single response — not
-one at a time. Three `search_codebase` queries in one response = one LLM turn
-and one inter-turn delay. Three queries across three separate responses = three
-turns and three delays. The loop dispatches every tool call you return before
-asking you again — use this. A well-batched first turn can replace ten
-sequential reconnaissance turns.
+## Write-First Rules
 
-The same rule applies to writes across **different** files. If your plan
-requires editing `code_indexer.py` and `test_code_indexer.py`, emit both
-`replace_in_file` calls in the same response — the runtime executes them in
-parallel. **Do not** batch multiple edits to the **same** file in one response;
-keep same-file edits sequential so each replacement sees the result of the
-previous one.
+**The runtime enforces this mechanically.** After 3 consecutive iterations with
+no file write, the runtime injects an escalating override. After 2 searches for
+the same term, the runtime declares the symbol absent and demands you create it.
+You will never escape these by reading more — only writing clears them.
 
-**Trust your first analysis.** Your initial read is high quality. If you
-identified a problem and a fix on the first pass, implement the fix
-immediately. Do not spend an iteration "thinking about it" or "confirming
-the context." Act.
+**Read whole files, batch all reads.** When you need files not already in the
+recon bundle, batch all reads in a single response using `read_file` (never
+sectional `read_file_lines` for initial reads). One turn for all reads, then
+write on the next turn.
 
-**One log step per decision.** After reading the code, call `log_run_step`
-with a short note of what you found and what you are doing next. This
-anchors your direction even as history compresses.
+**Symbol not found → create it.** If a symbol referenced in the AC does not
+exist in the codebase, your job is to write it. Absence is the task, not a
+blocker. Do not search a second time — write the implementation.
 
-## Hard Recon Budget — 5 Iterations Maximum
-
-Iterations 1–5 may be read-only (reading files, searching the codebase,
-understanding architecture). **Starting at iteration 6, every response MUST
-include at least one file write or shell command that modifies code.** No
-exceptions. Pure-read responses after iteration 5 are loop evidence — stop
-and implement what you already know.
-
-Check your iteration counter. If you are on iteration 6 or later and your
-response contains only reads or searches, you are looping. Drop the reads.
-Write the first file.
-
-## "I Have the Full Picture" Is a Commitment, Not a Conclusion
-
-When you write "I have the full picture" or "now I understand" or "I have
-a complete picture", that sentence **must appear in the same response as at
-least one file write**. It is a declaration of readiness to act, not permission
-to read another file. If you catch yourself writing that phrase without an
-accompanying write tool call, replace the phrase with the write tool call.
-
-The pattern "now I have the full picture → one more read" is the definition
-of looping. You have seen enough. Write.
-
-## Symbol Not Found → Create It
-
-If an AC item says "add field X to model Y" and model Y does not exist yet,
-your job is to **create model Y**. Absence from the codebase is not a blocker
-— it is the task. Do not search for it a second time. Do not read adjacent
-files looking for where it might be hidden. If two searches found nothing,
-nothing is there. Create it and move on.
+**Writes across files: batch them.** Editing `models.py` and `test_models.py`?
+Emit both `replace_in_file` calls in one response. Edits to the **same** file
+must be sequential (each replacement sees the previous result).
 
 ## Output Discipline
 
-- **Show full terminal output.** Never pipe tool output through `head`,
-  `tail`, or any truncating filter. Full output only.
-- **Correctness before completeness.** Run the type checker before the test
-  suite. A passing test on a broken type contract is a deferred failure.
-- **Own pre-existing issues.** If you touch a file that has pre-existing
-  errors or warnings, you own fixing them.
+- **Show full terminal output.** Never pipe through `head`, `tail`, or any
+  truncating filter.
+- **Type checker before tests.** Run mypy first; fix all errors before pytest.
+- **Own pre-existing issues.** If you touch a file with existing errors, fix them.
 
-## Failure Modes to Avoid
+## What Looping Looks Like — Recognise and Stop
 
-- Reading a file in sections (50–100 lines at a time) when `read_file` gives you everything in one call.
-- Re-reading files that are already in your recon bundle or in `files_examined`.
-- Reading files one at a time when you could batch all reads in a single response.
-- Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
-- Spending iterations "deciding" when you already know what to do.
-- Saying "now I have the full picture" without immediately writing a file.
-- Searching for a symbol more than twice — if it isn't there after two searches, create it.
-- Spawning sub-agents unless your briefing explicitly authorizes it.
-- Accepting a type error as "acceptable for now."
-- Leaving work half-done when a clean subset could ship immediately.
+- Saying "now I have the full picture" and then making a read call.
+- Calling `update_working_memory` or `log_run_step` as the only tool in a response.
+- Searching for the same symbol more than once.
+- Reading a file that is already in `files_examined`.
+- Spending an iteration "deciding" instead of writing.
+
+The runtime detects all of these. Your fastest path through is to write code.
 
 
 ## Iteration Budget — Hard Ceiling

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -100,6 +100,61 @@ if str(_RESOLVE_ARCH_DIR) not in sys.path:
 # Hard cap on conversation turns.  Each iteration is one LLM call.
 _DEFAULT_MAX_ITERATIONS = 100
 
+# ---------------------------------------------------------------------------
+# Loop guard — runtime enforcement for write-first behaviour
+# ---------------------------------------------------------------------------
+
+# Tools that constitute a "code write" for loop-guard purposes.
+# Any iteration containing at least one of these resets the no-write counter.
+_WRITE_TOOL_NAMES: frozenset[str] = frozenset({
+    "replace_in_file",
+    "write_file",
+    "insert_after_in_file",
+    "git_commit_and_push",
+})
+
+# Tools whose arguments carry a search query we want to track for
+# repeated symbol searches (symbol-absence heuristic).
+_SEARCH_TOOL_NAMES: frozenset[str] = frozenset({
+    "search_codebase",
+    "search_text",
+})
+
+# How many consecutive no-write iterations trigger the loop-guard injection.
+_LOOP_GUARD_THRESHOLD: int = 3
+
+# Injected as an additional system block when the agent has not written code
+# for _LOOP_GUARD_THRESHOLD iterations.  Plain text — no Markdown headers so
+# it reads as an urgent runtime message, not a documentation section.
+_LOOP_GUARD_OVERRIDE = """\
+⚠️  LOOP GUARD — {n} ITERATIONS WITHOUT WRITING CODE
+
+You are in a reconnaissance loop. The runtime has detected this.
+
+Your only valid next action is to write a file. Right now, in this response.
+
+Do not call read_file. Do not call search_codebase. Do not call log_run_step alone.
+Do not call update_working_memory alone. None of those advance the work.
+
+Action: open your next_steps. Take the first item. Write the minimal implementation
+using write_file or replace_in_file. If the symbol it references does not exist
+in the codebase, create it — that absence IS the task.
+
+Every response from this point forward must include at least one write tool call.
+"""
+
+# Injected when the agent has searched for the same query twice.
+# Signals that the symbol does not exist and the agent must create it.
+_SYMBOL_ABSENCE_OVERRIDE = """\
+⚠️  SYMBOL ABSENCE — "{query}" NOT FOUND AFTER REPEATED SEARCH
+
+You have searched for this term more than once. It does not exist in the codebase.
+
+Stop searching. Create it. Write the minimal implementation now.
+A new class, function, or field written incorrectly and then fixed is faster
+than searching a third time for something that was never there.
+"""
+
 # Per-tool character limits applied before tool results enter history.
 # File-read outputs can be 10-50k chars; search outputs 5-15k.  Applying a
 # single flat cap of 3k was the root cause of agents re-reading files they
@@ -247,6 +302,17 @@ async def run_agent_loop(
     # message.  This collapses 5-10 discovery turns into a zero-turn warm-up.
     await _run_recon_phase(run_id, worktree_path, messages, system_prompt)
 
+    # Loop-guard state — reset by any write tool call, incremented every
+    # iteration that produces only reads/searches/memory-updates.
+    iterations_since_write: int = 0
+    # Maps normalised search query → how many times it has been used this run.
+    # When a query appears >= 2 times the symbol is declared absent and the
+    # agent is instructed to create it rather than search again.
+    search_query_counts: dict[str, int] = {}
+    # Tracks which absent symbols have already triggered an injection so we
+    # don't spam the same message every subsequent iteration.
+    symbol_absence_injected: set[str] = set()
+
     for iteration in range(1, max_iterations + 1):
         await log_run_step(
             issue_number,
@@ -283,6 +349,30 @@ async def run_agent_loop(
         extra_blocks: list[dict[str, object]] = []
         if memory:
             extra_blocks.append({"type": "text", "text": render_memory(memory)})
+
+        # Loop-guard injection — fires when the agent has not written any code
+        # for _LOOP_GUARD_THRESHOLD consecutive iterations.  The override is an
+        # additional system block (not a user message) so it does not break the
+        # user/assistant alternation invariant and is always visible regardless
+        # of history pruning.
+        if iteration > _LOOP_GUARD_THRESHOLD and iterations_since_write >= _LOOP_GUARD_THRESHOLD:
+            override_text = _LOOP_GUARD_OVERRIDE.format(n=iterations_since_write)
+            extra_blocks.append({"type": "text", "text": override_text})
+            logger.warning(
+                "⚠️ loop_guard fired — run_id=%s iteration=%d iterations_since_write=%d",
+                run_id, iteration, iterations_since_write,
+            )
+
+        # Symbol-absence injection — fires once per repeated search query.
+        for query, count in search_query_counts.items():
+            if count >= 2 and query not in symbol_absence_injected:
+                absence_text = _SYMBOL_ABSENCE_OVERRIDE.format(query=query)
+                extra_blocks.append({"type": "text", "text": absence_text})
+                symbol_absence_injected.add(query)
+                logger.warning(
+                    "⚠️ symbol_absence fired — run_id=%s query=%r count=%d",
+                    run_id, query, count,
+                )
 
         try:
             bounded = _prune_history(_truncate_tool_results(messages))
@@ -328,6 +418,31 @@ async def run_agent_loop(
                 github_tool_names=github_tool_names,
             )
             messages.extend(tool_results)
+
+            # Loop-guard bookkeeping: track writes and repeated searches.
+            tool_names_this_iter: set[str] = {
+                tc["function"]["name"] for tc in response["tool_calls"]
+            }
+            if tool_names_this_iter & _WRITE_TOOL_NAMES:
+                iterations_since_write = 0
+            else:
+                iterations_since_write += 1
+
+            # Accumulate search queries for symbol-absence detection.
+            for tc in response["tool_calls"]:
+                if tc["function"]["name"] not in _SEARCH_TOOL_NAMES:
+                    continue
+                try:
+                    tc_args: dict[str, object] = json.loads(tc["function"]["arguments"])
+                    raw_query = tc_args.get("query", tc_args.get("pattern", ""))
+                    query_str = str(raw_query).strip()[:100]
+                    if query_str:
+                        search_query_counts[query_str] = (
+                            search_query_counts.get(query_str, 0) + 1
+                        )
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+
             continue
 
         # Unexpected stop reason (e.g. "length").

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -784,6 +784,281 @@ class TestTerminalStateGuard:
 
 
 # ---------------------------------------------------------------------------
+# Loop guard — runtime enforcement for write-first behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestLoopGuard:
+    """Runtime loop guard injects an override when the agent writes no code.
+
+    The guard fires when iteration > _LOOP_GUARD_THRESHOLD AND
+    iterations_since_write >= _LOOP_GUARD_THRESHOLD.  A write tool call
+    (replace_in_file / write_file / insert_after_in_file / git_commit_and_push)
+    resets iterations_since_write to 0.
+    """
+
+    @pytest.mark.anyio
+    async def test_loop_guard_fires_after_consecutive_no_write_iterations(
+        self, tmp_path: Path
+    ) -> None:
+        """Loop guard injects LOOP GUARD text into extra_system_blocks after threshold."""
+        from agentception.services.agent_loop import _LOOP_GUARD_THRESHOLD, run_agent_loop
+
+        worktree = tmp_path / "test-run-guard"
+        worktree.mkdir()
+        task_spec = _make_task_spec(worktree)
+
+        # Enough read-only iterations to cross the guard threshold, then stop.
+        # The guard fires on iteration (THRESHOLD + 1) which is index THRESHOLD
+        # in the captured call list (0-indexed).
+        n_reads = _LOOP_GUARD_THRESHOLD + 1
+        read_responses = [
+            _tool_response("read_file", {"path": "agentception/models.py"})
+            for _ in range(n_reads)
+        ]
+        all_responses = read_responses + [_stop_response("Done.")]
+
+        captured_extra: list[list[dict[str, object]] | None] = []
+
+        async def fake_llm(
+            *args: object,
+            extra_system_blocks: list[dict[str, object]] | None = None,
+            **kwargs: object,
+        ) -> ToolResponse:
+            captured_extra.append(extra_system_blocks)
+            return all_responses[len(captured_extra) - 1]
+
+        file_result: dict[str, object] = {"ok": True, "content": "# stub", "truncated": False}
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
+            patch(
+                "agentception.services.agent_loop.get_run_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic_with_tools",
+                side_effect=fake_llm,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+
+            from agentception.services import agent_loop as al
+
+            with patch.object(al, "read_file", return_value=file_result):
+                await run_agent_loop("test-run-guard")
+
+        # Guard fires on the (THRESHOLD+1)-th LLM call (index = THRESHOLD).
+        guard_call_blocks = captured_extra[_LOOP_GUARD_THRESHOLD]
+        assert guard_call_blocks is not None, (
+            "Loop guard must inject extra_system_blocks when threshold is reached"
+        )
+        all_text = " ".join(
+            b["text"] for b in guard_call_blocks if isinstance(b.get("text"), str)
+        )
+        assert "LOOP GUARD" in all_text, (
+            f"Expected 'LOOP GUARD' in injected blocks. Got: {all_text!r}"
+        )
+
+    @pytest.mark.anyio
+    async def test_write_tool_resets_loop_guard_counter(self, tmp_path: Path) -> None:
+        """A write tool call resets iterations_since_write; guard must NOT fire."""
+        from agentception.services.agent_loop import _LOOP_GUARD_THRESHOLD, run_agent_loop
+
+        worktree = tmp_path / "test-run-write-reset"
+        worktree.mkdir()
+        task_spec = _make_task_spec(worktree)
+
+        # Pattern: reads up to just below threshold, then a write, then stop.
+        # Guard must never fire because the write resets the counter.
+        n_reads = _LOOP_GUARD_THRESHOLD - 1
+        read_responses = [
+            _tool_response("read_file", {"path": "agentception/models.py"})
+            for _ in range(n_reads)
+        ]
+        all_responses = (
+            read_responses
+            + [_tool_response("write_file", {"path": "agentception/new.py", "content": "# x"})]
+            + [_stop_response("Done.")]
+        )
+
+        captured_extra: list[list[dict[str, object]] | None] = []
+
+        async def fake_llm(
+            *args: object,
+            extra_system_blocks: list[dict[str, object]] | None = None,
+            **kwargs: object,
+        ) -> ToolResponse:
+            captured_extra.append(extra_system_blocks)
+            return all_responses[len(captured_extra) - 1]
+
+        file_result: dict[str, object] = {"ok": True, "content": "# stub", "truncated": False}
+        write_result: dict[str, object] = {"ok": True}
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
+            patch(
+                "agentception.services.agent_loop.get_run_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic_with_tools",
+                side_effect=fake_llm,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+
+            from agentception.services import agent_loop as al
+
+            with (
+                patch.object(al, "read_file", return_value=file_result),
+                patch.object(al, "write_file", return_value=write_result),
+            ):
+                await run_agent_loop("test-run-write-reset")
+
+        # No call should have the LOOP GUARD text — the write reset the counter.
+        for blocks in captured_extra:
+            if blocks is None:
+                continue
+            all_text = " ".join(
+                b["text"] for b in blocks if isinstance(b.get("text"), str)
+            )
+            assert "LOOP GUARD" not in all_text, (
+                "Loop guard must NOT fire when a write tool was called within the threshold"
+            )
+
+    @pytest.mark.anyio
+    async def test_symbol_absence_injects_override_on_repeated_search(
+        self, tmp_path: Path
+    ) -> None:
+        """Symbol-absence override fires once when the same search query repeats."""
+        from agentception.services.agent_loop import run_agent_loop
+
+        worktree = tmp_path / "test-run-sym"
+        worktree.mkdir()
+        task_spec = _make_task_spec(worktree)
+
+        repeated_query = "TaskFile model class"
+        all_responses = [
+            _tool_response("search_codebase", {"query": repeated_query}),
+            _tool_response("search_codebase", {"query": repeated_query}),
+            _stop_response("Done."),
+        ]
+
+        captured_extra: list[list[dict[str, object]] | None] = []
+
+        async def fake_llm(
+            *args: object,
+            extra_system_blocks: list[dict[str, object]] | None = None,
+            **kwargs: object,
+        ) -> ToolResponse:
+            captured_extra.append(extra_system_blocks)
+            return all_responses[len(captured_extra) - 1]
+
+        search_result: dict[str, object] = {"ok": True, "results": []}
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
+            patch(
+                "agentception.services.agent_loop.get_run_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic_with_tools",
+                side_effect=fake_llm,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+
+            from agentception.services import agent_loop as al
+
+            with patch.object(al, "search_codebase", return_value=search_result):
+                await run_agent_loop("test-run-sym")
+
+        # After the second search (iteration 2), the third LLM call (index 2)
+        # should receive the symbol-absence override.
+        found_absence = False
+        for blocks in captured_extra:
+            if blocks is None:
+                continue
+            all_text = " ".join(
+                b["text"] for b in blocks if isinstance(b.get("text"), str)
+            )
+            if "SYMBOL ABSENCE" in all_text:
+                assert repeated_query in all_text, (
+                    "Symbol absence message must include the repeated query term"
+                )
+                found_absence = True
+                break
+        assert found_absence, (
+            "Symbol absence override must fire after the same query is searched twice"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Type-aware truncation — _build_tool_id_map + _truncate_tool_results
 # ---------------------------------------------------------------------------
 

--- a/scripts/gen_prompts/templates/snippets/worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/worker-base.md.j2
@@ -3,102 +3,55 @@
 You own one task — finish it or escalate, never leave it in limbo.
 Do not spawn sub-agents unless your task briefing explicitly authorizes it.
 
-## Search First. Read Whole. Act Immediately.
+## Operating Phases
 
-You have a finite number of iterations. Every iteration spent on reconnaissance
-is one fewer iteration available for implementation. The ratio must be inverted:
-most iterations should produce output (files written, commands run, PRs opened),
-not discovery.
+Your run has exactly three phases. Move through them in order. Do not loop back.
 
-**The recon bundle is your starting point — trust it.** Before iteration 1 the
-system has already read every file explicitly mentioned in the issue body and
-injected it in full below. Do not re-read those files unless you need a
-specific line number after an edit. Your recon bundle replaces the first 10–20
-read iterations.
+**RECON** (iterations 1–2 maximum): Read the files you need. Batch all reads in
+one response. Do not read the same file twice. Do not spend more than 2 iterations
+here — the pre-execution recon bundle has already loaded the most relevant files
+before iteration 1 began.
 
-**Read the whole file, once, on first access.** When you need a file that was
-not pre-loaded, call `read_file` (not `read_file_lines`) to get the complete
-source. One call, full file, done. Sectional reads (`read_file_lines` with 50-
-or 100-line windows) force you to re-read the same file 10–15 times across 10–15
-iterations. That is the single biggest source of wasted turns.
+**IMPLEMENT** (all remaining iterations until done): Every response must call
+`write_file`, `replace_in_file`, or `insert_after_in_file`. No exceptions.
+Work through your `next_steps` checklist in order. One AC item per iteration.
 
-**Reserve `read_file_lines` for post-edit verification.** After you make a
-change and need to confirm the exact result around a specific line, use
-`read_file_lines` for that narrow range. Not for initial exploration.
+**VERIFY** (final 1–2 iterations): Run mypy, then the targeted test file.
+Fix any failures and re-verify. Open the PR.
 
-**Batch your tool calls — reads AND writes.** When you need information from
-multiple sources, emit ALL of them as tool calls in a single response — not
-one at a time. Three `search_codebase` queries in one response = one LLM turn
-and one inter-turn delay. Three queries across three separate responses = three
-turns and three delays. The loop dispatches every tool call you return before
-asking you again — use this. A well-batched first turn can replace ten
-sequential reconnaissance turns.
+## Write-First Rules
 
-The same rule applies to writes across **different** files. If your plan
-requires editing `code_indexer.py` and `test_code_indexer.py`, emit both
-`replace_in_file` calls in the same response — the runtime executes them in
-parallel. **Do not** batch multiple edits to the **same** file in one response;
-keep same-file edits sequential so each replacement sees the result of the
-previous one.
+**The runtime enforces this mechanically.** After 3 consecutive iterations with
+no file write, the runtime injects an escalating override. After 2 searches for
+the same term, the runtime declares the symbol absent and demands you create it.
+You will never escape these by reading more — only writing clears them.
 
-**Trust your first analysis.** Your initial read is high quality. If you
-identified a problem and a fix on the first pass, implement the fix
-immediately. Do not spend an iteration "thinking about it" or "confirming
-the context." Act.
+**Read whole files, batch all reads.** When you need files not already in the
+recon bundle, batch all reads in a single response using `read_file` (never
+sectional `read_file_lines` for initial reads). One turn for all reads, then
+write on the next turn.
 
-**One log step per decision.** After reading the code, call `log_run_step`
-with a short note of what you found and what you are doing next. This
-anchors your direction even as history compresses.
+**Symbol not found → create it.** If a symbol referenced in the AC does not
+exist in the codebase, your job is to write it. Absence is the task, not a
+blocker. Do not search a second time — write the implementation.
 
-## Hard Recon Budget — 5 Iterations Maximum
-
-Iterations 1–5 may be read-only (reading files, searching the codebase,
-understanding architecture). **Starting at iteration 6, every response MUST
-include at least one file write or shell command that modifies code.** No
-exceptions. Pure-read responses after iteration 5 are loop evidence — stop
-and implement what you already know.
-
-Check your iteration counter. If you are on iteration 6 or later and your
-response contains only reads or searches, you are looping. Drop the reads.
-Write the first file.
-
-## "I Have the Full Picture" Is a Commitment, Not a Conclusion
-
-When you write "I have the full picture" or "now I understand" or "I have
-a complete picture", that sentence **must appear in the same response as at
-least one file write**. It is a declaration of readiness to act, not permission
-to read another file. If you catch yourself writing that phrase without an
-accompanying write tool call, replace the phrase with the write tool call.
-
-The pattern "now I have the full picture → one more read" is the definition
-of looping. You have seen enough. Write.
-
-## Symbol Not Found → Create It
-
-If an AC item says "add field X to model Y" and model Y does not exist yet,
-your job is to **create model Y**. Absence from the codebase is not a blocker
-— it is the task. Do not search for it a second time. Do not read adjacent
-files looking for where it might be hidden. If two searches found nothing,
-nothing is there. Create it and move on.
+**Writes across files: batch them.** Editing `models.py` and `test_models.py`?
+Emit both `replace_in_file` calls in one response. Edits to the **same** file
+must be sequential (each replacement sees the previous result).
 
 ## Output Discipline
 
-- **Show full terminal output.** Never pipe tool output through `head`,
-  `tail`, or any truncating filter. Full output only.
-- **Correctness before completeness.** Run the type checker before the test
-  suite. A passing test on a broken type contract is a deferred failure.
-- **Own pre-existing issues.** If you touch a file that has pre-existing
-  errors or warnings, you own fixing them.
+- **Show full terminal output.** Never pipe through `head`, `tail`, or any
+  truncating filter.
+- **Type checker before tests.** Run mypy first; fix all errors before pytest.
+- **Own pre-existing issues.** If you touch a file with existing errors, fix them.
 
-## Failure Modes to Avoid
+## What Looping Looks Like — Recognise and Stop
 
-- Reading a file in sections (50–100 lines at a time) when `read_file` gives you everything in one call.
-- Re-reading files that are already in your recon bundle or in `files_examined`.
-- Reading files one at a time when you could batch all reads in a single response.
-- Calling `grep`/`rg`/`cat` when `search_codebase` would return the answer in one call.
-- Spending iterations "deciding" when you already know what to do.
-- Saying "now I have the full picture" without immediately writing a file.
-- Searching for a symbol more than twice — if it isn't there after two searches, create it.
-- Spawning sub-agents unless your briefing explicitly authorizes it.
-- Accepting a type error as "acceptable for now."
-- Leaving work half-done when a clean subset could ship immediately.
+- Saying "now I have the full picture" and then making a read call.
+- Calling `update_working_memory` or `log_run_step` as the only tool in a response.
+- Searching for the same symbol more than once.
+- Reading a file that is already in `files_examined`.
+- Spending an iteration "deciding" instead of writing.
+
+The runtime detects all of these. Your fastest path through is to write code.


### PR DESCRIPTION
## Summary

- **Runtime enforcement in `agent_loop.py`**: tracks `iterations_since_write` per run and injects an escalating `LOOP GUARD` override into `extra_system_blocks` after 3 consecutive no-write iterations. Write tools (replace_in_file, write_file, insert_after_in_file, git_commit_and_push) reset the counter. Also tracks repeated search queries and injects a `SYMBOL ABSENCE` override once per repeated query — if the agent searches for the same thing twice, the runtime declares it absent and demands the agent create it.
- **Prompt rewrite (`worker-base.md.j2`)**: replaces the 9-section recon-guidance block with a concise three-phase contract (RECON max 2 iters → IMPLEMENT every iter must write → VERIFY). Removes the false claim that "recon bundle replaces 10-20 read iterations" (contradicted the 5-iteration budget), removes vague "understand architecture" language, and codifies looping failure modes as a named list.
- **3 new regression tests**: loop guard fires, write tool resets counter, symbol absence detection fires.

## Why

ChatGPT's external audit identified the root cause: rules in a prompt are advisory; an LLM can always rationalise around them. The only reliable fix is runtime mechanics. An agent cannot escape the loop guard by reading more — only a write clears it.

## Test plan

- [x] `mypy agentception/` — 0 errors
- [x] `typing_audit.py --max-any 0` — passes
- [x] `pytest agentception/tests/test_agent_loop.py -v` — 38/38 pass
- [x] `generate.py --check` — no drift