### PR TITLE
fix: gitignore .agentception/memory.json runtime artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,8 @@ package-lock.json
 
 # Agent ephemeral briefing files — never committed
 # Runtime role-version ledger — written by the app server on every role commit.
-# This is runtime state, not source code. Tracking it causes dev to appear dirty
-# after every agent run. The DB is the canonical state store; this file is a
-# local cache for the running container.
+# These are runtime state, not source code. Tracking them causes dev to appear
+# dirty after every agent run. The DB is the canonical state store; these files
+# are local caches for the running container / active worktree.
 .agentception/role-versions.json
+.agentception/memory.json


### PR DESCRIPTION
Adds `.agentception/memory.json` to `.gitignore` so agent working memory is never committed as part of a feature PR. Same pattern as the existing `.agentception/role-versions.json` exclusion.