### PR TITLE
fix: persist_agent_run_dispatch re-arm always updates role column

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -1010,6 +1010,7 @@ async def persist_agent_run_dispatch(
                     run_id, existing.status,
                 )
                 existing.status = "pending_launch"
+                existing.role = role  # always update — role may change (e.g. developer → executor)
                 existing.spawn_mode = spawn_mode_json
                 # Reset spawned_at so the pending_launch TTL sweep (15 min window)
                 # does not immediately re-fail a re-dispatched run whose original


### PR DESCRIPTION
When a run already exists in DB and is re-armed to `pending_launch`, the `role` field was never updated — so a developer → executor promotion from the planner was silently lost. This meant re-dispatched runs always fell back to the old role.

One-line fix: `existing.role = role` in the re-arm path.