### PR TITLE
feat: add agent_max_iterations field to AgentCeptionSettings

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -173,6 +173,14 @@ class AgentCeptionSettings(BaseSettings):
     Must match the model — ``BAAI/bge-small-en-v1.5`` produces 384-dimensional
     vectors.  Override when switching to a different model.
     """
+    agent_max_iterations: int = 100
+    """Maximum number of turns an agent may take before the reaper kills it.
+
+    Set via ``AGENT_MAX_ITERATIONS`` env var.  Defaults to 100, which is
+    generous enough for complex tasks while still bounding runaway agents.
+    Reduce this in test environments to keep runs short; increase it only
+    when a specific task class is known to require more turns.
+    """
     database_url: str | None = None
     """Async database URL for AgentCeption's own ac_* tables.
 

--- a/agentception/tests/test_config.py
+++ b/agentception/tests/test_config.py
@@ -378,3 +378,24 @@ def test_ac_task_runner_invalid_value_raises_validation_error(
         _make_settings(tmp_path)
     # Pydantic v2 raises ValidationError with details about the invalid enum value
     assert "validation error" in str(exc_info.value).lower() or "ac_task_runner" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — agent_max_iterations field
+# ---------------------------------------------------------------------------
+
+
+def test_agent_max_iterations_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """agent_max_iterations defaults to 100 when AGENT_MAX_ITERATIONS is unset."""
+    monkeypatch.delenv("AGENT_MAX_ITERATIONS", raising=False)
+    s = _make_settings(tmp_path)
+    assert s.agent_max_iterations == 100
+
+
+def test_agent_max_iterations_env_var_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AGENT_MAX_ITERATIONS env var overrides the default value."""
+    monkeypatch.setenv("AGENT_MAX_ITERATIONS", "42")
+    s = _make_settings(tmp_path)
+    assert s.agent_max_iterations == 42


### PR DESCRIPTION
## Summary

Adds `agent_max_iterations: int = 100` to `AgentCeptionSettings` in `agentception/config.py` and a corresponding test `test_agent_max_iterations_default` in `agentception/tests/test_config.py`.

## Changes

- **`agentception/config.py`**: Added `agent_max_iterations: int = 100` field with docstring explaining its purpose (bounds runaway agents, configurable via `AGENT_MAX_ITERATIONS` env var).
- **`agentception/tests/test_config.py`**: Added `test_agent_max_iterations_default` and `test_agent_max_iterations_env_var_override` to cover the default value and env var override.

## Acceptance Criteria

- [x] `AgentCeptionSettings` has `agent_max_iterations: int = 100` — plain int, no `Field()`, no `ge=`
- [x] `test_agent_max_iterations_default` test function present and passing

Closes #501