### PR TITLE
feat: add agent_max_iterations field to AgentCeptionSettings

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -109,6 +109,7 @@ class AgentCeptionSettings(BaseSettings):
     """
     gh_repo: str = "cgcardona/agentception"
     poll_interval_seconds: int = 30
+    agent_max_iterations: int = 100
     github_cache_seconds: int = 60
     ac_api_key: str = ""
     """Shared secret for authenticating requests to the ``/api/*`` routes.

--- a/agentception/tests/test_config.py
+++ b/agentception/tests/test_config.py
@@ -378,3 +378,10 @@ def test_ac_task_runner_invalid_value_raises_validation_error(
         _make_settings(tmp_path)
     # Pydantic v2 raises ValidationError with details about the invalid enum value
     assert "validation error" in str(exc_info.value).lower() or "ac_task_runner" in str(exc_info.value).lower()
+
+
+def test_agent_max_iterations_default() -> None:
+    """agent_max_iterations defaults to 100."""
+    s = AgentCeptionSettings()
+    assert s.agent_max_iterations == 100
+


### PR DESCRIPTION
## Summary

Adds `agent_max_iterations: int = 100` to `AgentCeptionSettings` in `agentception/config.py`.

## Changes

- **`agentception/config.py`**: Added `agent_max_iterations: int = 100` as a plain int field (no `Field()`, no `ge=`) immediately after `poll_interval_seconds`.
- **`agentception/tests/test_config.py`**: Added `test_agent_max_iterations_default` verifying the field defaults to 100.

## Acceptance Criteria

- [x] `AgentCeptionSettings` has `agent_max_iterations: int = 100` — plain int, no Field, no ge=, no docstring
- [x] Exactly ONE new test function in test_config.py: `test_agent_max_iterations_default`
