### PR TITLE
docs: clarify Docker restart vs rebuild in .cursorrules and AGENTS.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -92,7 +92,9 @@ The enforcement protocol:
 ## Execution
 
 - **Docker-first:** Never run Python on the host. `docker compose exec agentception <cmd>`.
-- **Dev bind mounts are active.** `docker-compose.override.yml` bind-mounts `agentception/`, `tests/`, `scripts/`, and `pyproject.toml` into the container. Host file edits are **instantly visible** inside the container — no rebuild needed for code changes. Only rebuild (`docker compose build agentception && docker compose up -d`) when you change `requirements.txt`, `Dockerfile`, or `entrypoint.sh`.
+- **Dev bind mounts are active.** `docker-compose.override.yml` bind-mounts `agentception/`, `tests/`, `scripts/`, and `pyproject.toml` into the container. Host file edits are **instantly visible on disk** inside the container — but **uvicorn auto-reload is intentionally disabled** (auto-reload would kill in-flight agent runs on every file save). This means:
+  - **Python source change** → `docker compose restart agentception` (no rebuild — the bind mount already delivered the new file; restart makes uvicorn load it).
+  - **`requirements.txt`, `Dockerfile`, or `entrypoint.sh` change** → `docker compose build agentception && docker compose up -d agentception` (full image rebuild required — these files are baked into the image layer, not bind-mounted).
 - **Verification order: mypy → tests → docs.** Always run mypy first. Fix type errors before running tests so you only need one test pass.
 - **Mypy:** `docker compose exec agentception mypy agentception/ tests/` — must be clean before any commit.
 - **Typing ceiling:** `python tools/typing_audit.py --dirs agentception/ tests/ --max-any 0`. Zero `Any` is the hard ceiling — never raise it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,7 +361,9 @@ There is no third option. A codebase with known broken tests that everyone steps
 
 **Run locally before opening a PR — in this exact order.** CI does not run on feature → dev PRs; this checklist is the gate.
 
-> **Dev bind mounts are active.** Your host file edits are instantly visible inside the container — do NOT rebuild for code changes. Only rebuild when `requirements.txt`, `Dockerfile`, or `entrypoint.sh` change.
+> **Dev bind mounts are active.** `docker-compose.override.yml` bind-mounts `agentception/`, `tests/`, `scripts/`, and `pyproject.toml` into the container. Host file edits are **instantly visible on disk** inside the container — but **uvicorn auto-reload is intentionally disabled** (auto-reload would kill in-flight agent runs on every file save). This means:
+> - **Python source change** → `docker compose restart agentception` (no rebuild — the bind mount already delivered the new file; restart makes uvicorn load it).
+> - **`requirements.txt`, `Dockerfile`, or `entrypoint.sh` change** → `docker compose build agentception && docker compose up -d agentception` (full image rebuild required — these files are baked into the image layer, not bind-mounted).
 
 0. [ ] Confirm you are on a feature branch or inside a worktree — **never on `dev` or `main`**
 1. [ ] `docker compose exec agentception mypy agentception/ tests/` — clean, zero errors


### PR DESCRIPTION
## Problem

Both `.cursorrules` and `AGENTS.md` said:

> _"no rebuild needed for code changes"_

This is half-true and therefore misleading. Bind mounts make source files instantly visible on disk — but **uvicorn auto-reload is disabled** (it would kill in-flight agent runs on every file save). The old wording implied no action was needed after a Python change, silently omitting the required `docker compose restart`.

## Fix

Both files now explicitly distinguish two cases:

| Change | Action |
|--------|--------|
| Python source (`.py`, `.j2`, `.yaml`, …) | `docker compose restart agentception` — no rebuild, bind mount already delivered the file |
| `requirements.txt` / `Dockerfile` / `entrypoint.sh` | `docker compose build agentception && docker compose up -d agentception` — full image rebuild |