### PR TITLE
feat: planner — Qdrant-first file discovery + shortest-path cognitive framing

### DIFF
--- a/agentception/services/planner.py
+++ b/agentception/services/planner.py
@@ -2,23 +2,25 @@ from __future__ import annotations
 
 """Planner service — converts a GitHub issue into an immutable ExecutionPlan.
 
-The planner makes a single structured LLM call.  It receives the issue body
-and the contents of every file it needs to touch, then outputs a JSON
-``ExecutionPlan`` describing the minimal set of atomic file operations
-required to implement the issue.
+Pipeline
+--------
+1. **Discovery** — Qdrant semantic search against the main ``code`` collection
+   surfaces the most relevant files.  Any file paths explicitly named in the
+   issue body (seed paths) are merged in and prioritised.
 
-The plan is intentionally minimal:
+2. **Full file reads** — each discovered file is read in full from the
+   worktree.  Chunks from Qdrant are only used for discovery; the planner
+   always receives complete file content so it can emit verbatim
+   ``old_string`` / ``after`` anchors that match the real file byte-for-byte.
 
-- One operation per discrete file edit.
-- No validators, docstrings, or additional tests unless the issue explicitly
-  requests them.
-- Parameters are exact: ``old_string`` / ``after`` must match the verbatim
-  text in the pre-loaded file content so the executor can call the tool
-  without reading the file first.
+3. **Plan generation** — a single LLM call receives the issue text plus all
+   file contents and returns a JSON ``ExecutionPlan``.  The system prompt
+   instils a shortest-path / minimal-change mental model so the planner emits
+   only what the issue explicitly requests.
 
 Separation of concerns
-----------------------
-Planner  → creative reasoning about the codebase (reads files, infers context)
+-----------------------
+Planner  → creative reasoning (reads files, infers context, generates plan)
 Executor → mechanical determinism (applies plan, no codebase access)
 """
 
@@ -27,32 +29,66 @@ import logging
 from pathlib import Path
 
 from agentception.models import ExecutionPlan, PlanOperation
+from agentception.services.code_indexer import search_codebase
 from agentception.services.llm import call_anthropic
 
 logger = logging.getLogger(__name__)
 
-# Maximum characters of file content injected into the planner prompt per file.
-_FILE_CHAR_LIMIT: int = 12_000
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Maximum characters of file content injected per file.  25 000 chars ≈ 1 000
+# lines — enough for every file in this codebase in full without truncation.
+_FILE_CHAR_LIMIT: int = 25_000
+
+# Maximum files to inject into the planner prompt.  Qdrant results beyond
+# this cap are discarded to keep the prompt within a sane token budget.
+_MAX_FILES: int = 6
+
+# Number of Qdrant results to request for file discovery.  Fetching slightly
+# more than _MAX_FILES lets us filter out non-existent files and still fill
+# the cap.
+_DISCOVERY_SEARCH_RESULTS: int = 10
 
 # Hard cap on operations in one plan — prevents planner over-engineering.
 _MAX_OPERATIONS: int = 20
 
-_PLANNER_SYSTEM_PROMPT = """\
-You are a minimal-change planning agent. Your only job is to produce the
-smallest possible set of atomic file operations that implement the given
-GitHub issue — nothing more.
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
 
-Rules:
+_PLANNER_SYSTEM_PROMPT = """\
+You are a minimal-change planning agent.
+
+## Mental model — shortest path
+
+You find the shortest path from the current codebase state to the
+spec-compliant state described by the issue, and then you stop.
+
+Every operation you emit must be provably required by the issue. An
+operation you cannot derive directly from the issue text is not on the
+shortest path and must be omitted. You do not improve surrounding code. You
+do not add what is not asked. Before emitting each operation, ask yourself:
+if I remove this operation, does the plan still satisfy the issue? If yes,
+remove it. The measure of a correct plan is its minimality.
+
+## Rules
+
 - Implement ONLY what the issue explicitly requests.
 - Do not add validators, docstrings, or extra tests unless the issue says so.
 - Do not create new files unless the issue says to create them.
-- Do not improve surrounding code.
-- Each operation maps to one tool call. Parameters must be exact — the
-  executor cannot read files, so every string you emit must match the
-  file content verbatim.
+- Do not improve or refactor surrounding code.
+- Each operation maps to one tool call. Parameters must be verbatim — the
+  executor cannot read files, so every string you emit must appear exactly
+  in the pre-loaded file content below.
+- old_string must be unique within the file so the replacement is
+  unambiguous.
 
-Output ONLY a JSON object with this exact schema (no markdown fences, no
-surrounding text):
+## Output format
+
+Output ONLY a JSON object with this exact schema — no markdown fences, no
+surrounding text, no explanation:
 
 {
   "operations": [
@@ -76,13 +112,67 @@ surrounding text):
   ]
 }
 
-Use "replace_in_file" for edits to existing files (preferred — most precise).
-Use "insert_after_in_file" when you need to append after a known anchor line.
-Use "write_file" only when creating a brand-new file.
-
-old_string for replace_in_file must be unique in the file and must appear
-verbatim in the pre-loaded file content below.
+Prefer replace_in_file for edits to existing files — it is the most
+precise operation and easiest for the executor to apply correctly.
+Use insert_after_in_file when appending after a known anchor line.
+Use write_file only when creating a brand-new file.
 """
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+async def _discover_files(
+    query: str,
+    seed_paths: list[str],
+    worktree_path: Path,
+    run_id: str,
+) -> list[str]:
+    """Return the ordered list of files the planner should read.
+
+    Strategy
+    --------
+    1. Start with *seed_paths* — files explicitly named in the issue body or
+       supplied by the caller.  These are always included and kept in front.
+    2. Run a semantic search against the main Qdrant ``code`` collection to
+       find additional relevant files.  The worktree is freshly created from
+       ``origin/dev``, so the main collection's content is identical.
+    3. Filter search results to files that actually exist in the worktree (a
+       file mentioned by Qdrant but absent on disk would cause a read error).
+    4. Return the union of seed paths and discovered paths, seed paths first,
+       capped at ``_MAX_FILES``.
+
+    Qdrant unavailability is treated as a non-fatal warning — the planner
+    falls back to seed paths only, which is still better than nothing.
+    """
+    # Use a dict to preserve insertion order while deduplicating.
+    discovered: dict[str, None] = {p: None for p in seed_paths}
+
+    try:
+        matches = await search_codebase(query, n_results=_DISCOVERY_SEARCH_RESULTS)
+        for match in matches:
+            file_path = match["file"]
+            # Only include files that exist in the worktree — Qdrant may
+            # reference paths from a slightly different repo state.
+            if (worktree_path / file_path).exists():
+                discovered[file_path] = None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "⚠️ planner: Qdrant discovery failed for run_id=%s — %s (seed paths only)",
+            run_id,
+            exc,
+        )
+
+    result = list(discovered.keys())[:_MAX_FILES]
+    logger.info(
+        "✅ planner: discovered %d file(s) for run_id=%s: %s",
+        len(result),
+        run_id,
+        result,
+    )
+    return result
 
 
 def _build_planner_prompt(
@@ -98,10 +188,12 @@ def _build_planner_prompt(
         parts.append("## Pre-loaded file contents\n")
         for rel_path, content in file_contents.items():
             truncated = content[:_FILE_CHAR_LIMIT]
-            suffix = f"\n... (truncated at {_FILE_CHAR_LIMIT} chars)" if len(content) > _FILE_CHAR_LIMIT else ""
-            parts.append(
-                f"### {rel_path}\n\n```\n{truncated}{suffix}\n```"
+            suffix = (
+                f"\n... (truncated at {_FILE_CHAR_LIMIT} chars)"
+                if len(content) > _FILE_CHAR_LIMIT
+                else ""
             )
+            parts.append(f"### {rel_path}\n\n```\n{truncated}{suffix}\n```")
 
     return "\n\n".join(parts)
 
@@ -109,9 +201,10 @@ def _build_planner_prompt(
 def _parse_plan_json(raw: str, run_id: str, issue_number: int) -> ExecutionPlan | None:
     """Parse the LLM response into an ExecutionPlan.
 
-    Strips markdown fences if present, then extracts the first valid JSON object
-    using ``JSONDecoder.raw_decode`` so trailing text (explanations, notes) never
-    causes a parse error.  Returns None on any parse or validation error.
+    Strips markdown fences if present, then extracts the first valid JSON
+    object using ``JSONDecoder.raw_decode`` so trailing text (explanations,
+    notes) never causes a parse error.  Returns ``None`` on any parse or
+    validation error.
     """
     text = raw.strip()
 
@@ -165,6 +258,11 @@ def _parse_plan_json(raw: str, run_id: str, issue_number: int) -> ExecutionPlan 
         return None
 
 
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
 async def generate_execution_plan(
     run_id: str,
     issue_number: int,
@@ -175,9 +273,16 @@ async def generate_execution_plan(
 ) -> ExecutionPlan | None:
     """Call the LLM once to produce a minimal ExecutionPlan for *run_id*.
 
-    Reads each file in *file_paths* from the worktree and injects the contents
-    into the planner prompt so the LLM can emit verbatim ``old_string`` /
-    ``after`` values that the executor can use without reading files.
+    Three-phase pipeline:
+
+    1. **Discovery** — ``_discover_files`` merges *file_paths* (explicit seeds
+       from the issue body) with Qdrant semantic search results to build the
+       final list of files to read.
+    2. **Full file reads** — each discovered file is read in full from the
+       worktree so the LLM can emit verbatim ``old_string`` / ``after`` values
+       that the executor can apply without ever reading the file itself.
+    3. **Plan generation** — a single ``call_anthropic`` call returns a JSON
+       ``ExecutionPlan`` which is validated and returned.
 
     Args:
         run_id: Agent run identifier (e.g. ``"issue-501"``).
@@ -185,22 +290,30 @@ async def generate_execution_plan(
         issue_title: Issue title string.
         issue_body: Raw Markdown issue body.
         worktree_path: Absolute path to the git worktree on disk.
-        file_paths: Relative paths of files the planner should read.
+        file_paths: Seed paths — files explicitly named in the issue body.
+            These are always included and prioritised over Qdrant results.
 
     Returns:
-        A validated :class:`ExecutionPlan`, or ``None`` if the planner call
-        or parsing fails.  Callers should fall back to the developer role
-        when ``None`` is returned.
+        A validated :class:`ExecutionPlan`, or ``None`` if any phase fails.
+        Callers should fall back to the developer role when ``None`` is
+        returned.
     """
-    # Read file contents from the worktree.
+    # Phase 1: File discovery.
+    discovery_query = f"{issue_title}\n\n{issue_body[:600]}"
+    all_file_paths = await _discover_files(
+        discovery_query, file_paths, worktree_path, run_id
+    )
+
+    # Phase 2: Full file reads from the worktree.
     file_contents: dict[str, str] = {}
-    for rel in file_paths:
+    for rel in all_file_paths:
         full = worktree_path / rel
         try:
             file_contents[rel] = full.read_text(encoding="utf-8", errors="replace")
         except OSError as exc:
             logger.warning("⚠️ planner: could not read %s — %s", rel, exc)
 
+    # Phase 3: Plan generation.
     user_message = _build_planner_prompt(issue_title, issue_body, file_contents)
 
     logger.info(

--- a/agentception/tests/test_execution_plan.py
+++ b/agentception/tests/test_execution_plan.py
@@ -19,6 +19,7 @@ import pytest
 from agentception.models import ExecutionPlan, PlanOperation
 from agentception.services.planner import (
     _build_planner_prompt,
+    _discover_files,
     _parse_plan_json,
     generate_execution_plan,
 )
@@ -291,9 +292,15 @@ async def test_generate_execution_plan_returns_plan_on_success(
         }
     )
 
-    with patch(
-        "agentception.services.planner.call_anthropic",
-        new=AsyncMock(return_value=llm_response),
+    with (
+        patch(
+            "agentception.services.planner.call_anthropic",
+            new=AsyncMock(return_value=llm_response),
+        ),
+        patch(
+            "agentception.services.planner.search_codebase",
+            new=AsyncMock(return_value=[]),
+        ),
     ):
         plan = await generate_execution_plan(
             run_id="issue-501",
@@ -314,9 +321,15 @@ async def test_generate_execution_plan_returns_none_on_llm_failure(
     tmp_path: Path,
 ) -> None:
     """generate_execution_plan returns None when the LLM call raises."""
-    with patch(
-        "agentception.services.planner.call_anthropic",
-        new=AsyncMock(side_effect=RuntimeError("API unavailable")),
+    with (
+        patch(
+            "agentception.services.planner.call_anthropic",
+            new=AsyncMock(side_effect=RuntimeError("API unavailable")),
+        ),
+        patch(
+            "agentception.services.planner.search_codebase",
+            new=AsyncMock(return_value=[]),
+        ),
     ):
         plan = await generate_execution_plan(
             run_id="issue-501",
@@ -335,9 +348,15 @@ async def test_generate_execution_plan_returns_none_on_bad_json(
     tmp_path: Path,
 ) -> None:
     """generate_execution_plan returns None when the LLM returns unparseable JSON."""
-    with patch(
-        "agentception.services.planner.call_anthropic",
-        new=AsyncMock(return_value="not json at all"),
+    with (
+        patch(
+            "agentception.services.planner.call_anthropic",
+            new=AsyncMock(return_value="not json at all"),
+        ),
+        patch(
+            "agentception.services.planner.search_codebase",
+            new=AsyncMock(return_value=[]),
+        ),
     ):
         plan = await generate_execution_plan(
             run_id="issue-501",
@@ -349,3 +368,135 @@ async def test_generate_execution_plan_returns_none_on_bad_json(
         )
 
     assert plan is None
+
+
+# ---------------------------------------------------------------------------
+# _discover_files — file discovery phase
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_discover_files_seeds_always_included(tmp_path: Path) -> None:
+    """Seed paths are always included even when Qdrant returns nothing."""
+    seed = tmp_path / "agentception" / "config.py"
+    seed.parent.mkdir(parents=True)
+    seed.write_text("x")
+
+    with patch(
+        "agentception.services.planner.search_codebase",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await _discover_files(
+            "add field",
+            ["agentception/config.py"],
+            tmp_path,
+            "test-run",
+        )
+
+    assert "agentception/config.py" in result
+
+
+@pytest.mark.anyio
+async def test_discover_files_qdrant_results_merged(tmp_path: Path) -> None:
+    """Qdrant results for files that exist in the worktree are included."""
+    (tmp_path / "agentception").mkdir(parents=True)
+    (tmp_path / "agentception" / "config.py").write_text("x")
+    (tmp_path / "agentception" / "poller.py").write_text("y")
+
+    qdrant_match = {"file": "agentception/poller.py", "chunk": "...", "score": 0.9, "start_line": 1, "end_line": 5}
+
+    with patch(
+        "agentception.services.planner.search_codebase",
+        new=AsyncMock(return_value=[qdrant_match]),
+    ):
+        result = await _discover_files(
+            "add field",
+            ["agentception/config.py"],
+            tmp_path,
+            "test-run",
+        )
+
+    assert "agentception/config.py" in result
+    assert "agentception/poller.py" in result
+
+
+@pytest.mark.anyio
+async def test_discover_files_nonexistent_qdrant_result_excluded(tmp_path: Path) -> None:
+    """Qdrant results referencing files absent from the worktree are filtered out."""
+    qdrant_match = {"file": "some/phantom/file.py", "chunk": "...", "score": 0.9, "start_line": 1, "end_line": 5}
+
+    with patch(
+        "agentception.services.planner.search_codebase",
+        new=AsyncMock(return_value=[qdrant_match]),
+    ):
+        result = await _discover_files("query", [], tmp_path, "test-run")
+
+    assert "some/phantom/file.py" not in result
+
+
+@pytest.mark.anyio
+async def test_discover_files_qdrant_failure_falls_back_to_seeds(tmp_path: Path) -> None:
+    """When Qdrant raises, _discover_files returns seed paths only — no crash."""
+    seed = tmp_path / "agentception" / "config.py"
+    seed.parent.mkdir(parents=True)
+    seed.write_text("x")
+
+    with patch(
+        "agentception.services.planner.search_codebase",
+        new=AsyncMock(side_effect=RuntimeError("qdrant down")),
+    ):
+        result = await _discover_files(
+            "query",
+            ["agentception/config.py"],
+            tmp_path,
+            "test-run",
+        )
+
+    assert result == ["agentception/config.py"]
+
+
+@pytest.mark.anyio
+async def test_discover_files_capped_at_max_files(tmp_path: Path) -> None:
+    """Total discovered files are capped at _MAX_FILES."""
+    from agentception.services.planner import _MAX_FILES
+
+    # Create 10 files in tmp worktree
+    (tmp_path / "agentception").mkdir(parents=True)
+    qdrant_results = []
+    for i in range(10):
+        fname = f"agentception/file{i}.py"
+        (tmp_path / fname).write_text("x")
+        qdrant_results.append(
+            {"file": fname, "chunk": "...", "score": 0.9, "start_line": 1, "end_line": 5}
+        )
+
+    with patch(
+        "agentception.services.planner.search_codebase",
+        new=AsyncMock(return_value=qdrant_results),
+    ):
+        result = await _discover_files("query", [], tmp_path, "test-run")
+
+    assert len(result) <= _MAX_FILES
+
+
+@pytest.mark.anyio
+async def test_discover_files_seeds_prioritised_over_qdrant(tmp_path: Path) -> None:
+    """Seed paths appear before Qdrant-discovered paths in the result."""
+    (tmp_path / "agentception").mkdir(parents=True)
+    (tmp_path / "agentception" / "seed.py").write_text("x")
+    (tmp_path / "agentception" / "qdrant.py").write_text("y")
+
+    qdrant_match = {"file": "agentception/qdrant.py", "chunk": "...", "score": 0.9, "start_line": 1, "end_line": 5}
+
+    with patch(
+        "agentception.services.planner.search_codebase",
+        new=AsyncMock(return_value=[qdrant_match]),
+    ):
+        result = await _discover_files(
+            "query",
+            ["agentception/seed.py"],
+            tmp_path,
+            "test-run",
+        )
+
+    assert result.index("agentception/seed.py") < result.index("agentception/qdrant.py")


### PR DESCRIPTION
## Problem

The planner was relying on regex-extracted file paths from the issue body. For prescriptive test issues (like 501) that contained verbatim `old_string` values this worked by accident. For any real-world issue the planner would call the LLM with no file content, forcing it to invent `old_string` values from training data — values that would not match the actual codebase, causing every executor `replace_in_file` call to fail.

## What changed

### Three-phase pipeline

```
generate_execution_plan()
    │
    ├── Phase 1: _discover_files()
    │       search_codebase(issue query, n=10)  ← Qdrant main 'code' collection
    │       merge with seed paths from issue body (seeds prioritised)
    │       filter to files that exist in worktree
    │       cap at _MAX_FILES=6
    │
    ├── Phase 2: Full file reads
    │       read each discovered file in full (up to 25 000 chars each)
    │
    └── Phase 3: call_anthropic(issue + full files) → ExecutionPlan
```

### Cognitive framing

Added a shortest-path paragraph to the system prompt: *"Before emitting each operation, ask yourself: if I remove this operation, does the plan still satisfy the issue? If yes, remove it."* This instils the Dijkstra minimal-edge invariant without importing Dijkstra's perfectionist quality bar.

### Resilience

- Qdrant unavailability is non-fatal — falls back to seed paths only.
- Files mentioned in Qdrant but absent from the worktree are silently filtered.
- File char limit raised 12 000 → 25 000 so most files are read in full.

## Tests

6 new unit tests covering all `_discover_files` paths:
- Seeds always included
- Qdrant results merged
- Phantom files (absent from worktree) filtered out
- Qdrant failure fallback to seeds
- File cap at `_MAX_FILES`
- Seeds appear before Qdrant results

`mypy` 228 files · 0 errors. `pytest` 1770 passed · 0 failed.