### PR TITLE
feat: add AC_PLANNER_ENABLED config flag to allow disabling the planner

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -144,6 +144,7 @@ class AgentCeptionSettings(BaseSettings):
     tools are unavailable in the agent loop.
     """
     ac_task_runner: TaskRunnerChoice = TaskRunnerChoice.anthropic
+    planner_enabled: bool = True
     """Task runner backend for agent execution.
     
     Set via ``AC_TASK_RUNNER`` env var.  Valid values: ``cursor``, ``anthropic``.

--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -672,7 +672,7 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     # On planner failure: fall back to the developer role (original behaviour).
     # ---------------------------------------------------------------------------
     effective_role = req.role
-    if req.role == "developer" and task_description and req.issue_body:
+    if req.role == "developer" and task_description and req.issue_body and settings.planner_enabled:
         ac_file_paths_for_planner = _extract_ac_file_paths(req.issue_body)
         execution_plan = await generate_execution_plan(
             run_id=run_id,

--- a/agentception/tests/test_config.py
+++ b/agentception/tests/test_config.py
@@ -385,3 +385,8 @@ def test_agent_max_iterations_default() -> None:
     s = AgentCeptionSettings()
     assert s.agent_max_iterations == 100
 
+
+def test_planner_enabled_default() -> None:
+    s = AgentCeptionSettings()
+    assert s.planner_enabled is True
+


### PR DESCRIPTION
Generated by the planner/executor pipeline for issue #515.

## Changes

- `agentception/config.py`: +1 — `planner_enabled: bool = True`
- `agentception/routes/api/dispatch.py`: 1 line changed — gates the planner block on `settings.planner_enabled`
- `agentception/tests/test_config.py`: +4 — one test `test_planner_enabled_default`

Total: 3 files changed, 7 insertions, 1 deletion.