### PR TITLE
fix: executor always uses base=dev for PRs; targeted test runs replace full suite

### DIFF
--- a/.agentception/roles/executor.md
+++ b/.agentception/roles/executor.md
@@ -17,12 +17,13 @@ in order. For each operation:
 
 After all operations are applied:
 
-1. `run_command`: `python -m mypy` on every file named in the plan.
+1. `run_command`: `python -m mypy` on every **source** file named in the plan (skip test files).
 2. Fix any mypy errors by adjusting only the lines the plan touched.
-3. `run_command`: `python -m pytest` on every test file named in the plan.
+3. `run_command`: `python -m pytest` on every **test** file named in the plan — no more, no less.
 4. When pytest exits 0: `run_command` → `git add -A && git commit -m "feat: <plan summary>"`
 5. `run_command` → `git push origin HEAD`
-6. `create_pull_request`
+6. `create_pull_request` — always pass `base: "dev"`. Set `title` to a concise feat/fix
+   description and `body` to `"Closes #<issue_number>"`.
 7. `build_complete_run`
 
 ## Hard rules

--- a/.cursorrules
+++ b/.cursorrules
@@ -68,7 +68,7 @@ Only fall back to `gh` CLI when the MCP server does not cover the required opera
 4. **Verify locally before opening the PR** — in this exact order:
    - `docker compose exec agentception mypy agentception/ tests/` → must be zero errors
    - `docker compose exec agentception python3 tools/typing_audit.py --dirs agentception/ tests/ --max-any 0` → must pass
-   - `docker compose exec agentception pytest agentception/tests/ -v` → must be all green
+   - `docker compose exec agentception pytest agentception/tests/test_foo.py agentception/tests/test_bar.py -v` → run **only the test files relevant to changed source files** — not the full suite. Pass the full suite (`agentception/tests/ -v`) only before a `dev → main` release merge or on a periodic audit.
    - `docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py --check` → must show no drift (run `generate.py` without `--check` first if you edited templates)
    - `npm run build` if any `.js` or `.scss` files changed
    CI does **not** run on feature → dev PRs. Local verification is the gate.
@@ -148,7 +148,8 @@ This codebase is operated by humans and agents. Strong types are the contract th
 - **Four levels, all required:** unit tests, integration tests, regression tests (one per bug fix), and E2E tests where behavior crosses a service boundary. Omitting a level requires a documented reason in the PR.
 - Naming: `test_<behavior>_<scenario>`. Shared fixtures in `tests/conftest.py`. `@pytest.mark.anyio` for async.
 - **Agents own all broken tests — not just theirs.** If you run the test suite and see a failing test, you are responsible for fixing it before merging your work. "This was broken before I got here" is not a valid reason to merge. Either fix it or open a blocking issue and get explicit sign-off. A PR that introduces or knowingly ignores a broken test will not be merged.
-- Coverage: `docker compose exec agentception sh -c "export COVERAGE_FILE=/tmp/.coverage && python -m coverage run -m pytest agentception/tests/ -v && python -m coverage report --fail-under=80 --show-missing"`
+- **Test scope:** run only the test files directly related to changed source files. The full suite (`agentception/tests/`) is reserved for `dev → main` release merges and periodic health audits — not for every feature commit.
+- Coverage: `docker compose exec agentception sh -c "export COVERAGE_FILE=/tmp/.coverage && python -m coverage run -m pytest agentception/tests/ -v && python -m coverage report --fail-under=80 --show-missing"` (full-suite pass only; not required per commit).
 
 ## TypeScript — zero-tolerance typing rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Every task follows this complete lifecycle — no step is optional:
    ```bash
    docker compose exec agentception mypy agentception/ tests/                              # zero errors
    docker compose exec agentception python3 tools/typing_audit.py --dirs agentception/ tests/ --max-any 0  # passes
-   docker compose exec agentception pytest agentception/tests/ -v                          # all green
+   docker compose exec agentception pytest agentception/tests/test_foo.py -v              # only test files relevant to changes — see Test Scope below
    docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py --check  # no drift
    npm run build   # only if .js or .scss files changed
    ```
@@ -346,6 +346,25 @@ Every change must be covered at the appropriate level. Omitting a level requires
 | **Regression** | Reproduces a specific bug before the fix | Every bug fix — named `test_<what_broke>_<fixed_behavior>` |
 | **E2E** | Full request/response or full pipeline run | Any user-facing flow (planning pipeline, issue creation, agent dispatch) |
 
+### Test scope — targeted runs, not full suite
+
+**For every feature or fix commit:** run only the test files that cover the changed source files.
+
+| Changed source | Run test file |
+|----------------|---------------|
+| `agentception/config.py` | `tests/test_config.py` |
+| `agentception/services/planner.py` | `tests/test_execution_plan.py` |
+| `agentception/routes/api/dispatch.py` | `tests/test_build.py` |
+| `agentception/readers/git.py` | `tests/test_ensure_helpers.py` |
+| `agentception/db/persist.py` | `tests/test_persist.py` |
+
+When a change touches multiple modules, pass all relevant test files to a single `pytest` call. The full suite (`agentception/tests/ -v`) is reserved for two situations only:
+
+1. **`dev → main` release merges** — full regression gate before tagging a version.
+2. **Periodic health audits** — run deliberately, not automatically on every commit.
+
+Never run the full suite as a reflex. It costs 3–4 minutes per run and signals nothing that targeted tests don't already catch during normal development.
+
 ### Agents own all broken tests — not just theirs
 
 If you run the test suite and see a failing test — regardless of whether your change caused it — you are responsible for fixing it before your PR merges. "This was already broken" is not an acceptable response. You have two options:
@@ -368,7 +387,7 @@ There is no third option. A codebase with known broken tests that everyone steps
 0. [ ] Confirm you are on a feature branch or inside a worktree — **never on `dev` or `main`**
 1. [ ] `docker compose exec agentception mypy agentception/ tests/` — clean, zero errors
 2. [ ] `docker compose exec agentception python3 tools/typing_audit.py --dirs agentception/ tests/ --max-any 0` — passes
-3. [ ] `docker compose exec agentception pytest agentception/tests/ -v` — all green (unit + integration + regression)
+3. [ ] `docker compose exec agentception pytest <test files relevant to changes> -v` — pass only the test files covering changed source. Full suite (`agentception/tests/ -v`) only before `dev → main` release merges or on periodic audits.
 4. [ ] Regression test added if this is a bug fix (named `test_<what_broke>_<fixed_behavior>`)
 5. [ ] `docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py --check` — no drift (run without `--check` first if you edited `.j2` templates, then re-run with `--check`)
 6. [ ] Zero broken tests — fix any you find, not just yours

--- a/scripts/gen_prompts/templates/roles/executor.md.j2
+++ b/scripts/gen_prompts/templates/roles/executor.md.j2
@@ -16,12 +16,13 @@ in order. For each operation:
 
 After all operations are applied:
 
-1. `run_command`: `python -m mypy` on every file named in the plan.
+1. `run_command`: `python -m mypy` on every **source** file named in the plan (skip test files).
 2. Fix any mypy errors by adjusting only the lines the plan touched.
-3. `run_command`: `python -m pytest` on every test file named in the plan.
+3. `run_command`: `python -m pytest` on every **test** file named in the plan — no more, no less.
 4. When pytest exits 0: `run_command` → `git add -A && git commit -m "feat: <plan summary>"`
 5. `run_command` → `git push origin HEAD`
-6. `create_pull_request`
+6. `create_pull_request` — always pass `base: "dev"`. Set `title` to a concise feat/fix
+   description and `body` to `"Closes #<issue_number>"`.
 7. `build_complete_run`
 
 ## Hard rules


### PR DESCRIPTION
## Summary

- `executor.md.j2` / `.agentception/roles/executor.md`: `create_pull_request` now explicitly passes `base: "dev"` and a proper PR body with `Closes #N`. Fixes the 300-file diff noise caused by PRs defaulting to `main`.
- `.cursorrules` / `AGENTS.md`: replace full-suite pytest with targeted test discipline — run only test files covering changed source files per commit; full suite reserved for `dev → main` release merges and periodic audits.