### PR TITLE
feat: calibrate rate-limit pacing and token budget for Anthropic Tier 3

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -145,6 +145,17 @@ class AgentCeptionSettings(BaseSettings):
     """
     ac_task_runner: TaskRunnerChoice = TaskRunnerChoice.anthropic
     planner_enabled: bool = True
+    ac_min_turn_delay_secs: float = 1.5
+    """Minimum seconds between consecutive LLM calls in the agent loop.
+
+    Proactive pacing guard that keeps token consumption under the Anthropic
+    rate limit ceiling.  Calibrated for **Tier 3** (800K input / 160K output
+    TPM, 2K RPM): 1.5 s allows up to ~3 concurrent agents at ~1 000 output
+    tokens per turn before the output-TPM cap is reached.  Lower this further
+    if running fewer concurrent agents; raise it when running many in parallel.
+
+    Set via ``AC_MIN_TURN_DELAY_SECS`` env var.
+    """
     """Task runner backend for agent execution.
     
     Set via ``AC_TASK_RUNNER`` env var.  Valid values: ``cursor``, ``anthropic``.

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -253,31 +253,28 @@ _MAX_HISTORY_MESSAGES: int = 20
 _HISTORY_TAIL: int = 14
 
 # ---------------------------------------------------------------------------
-# Token-rate guard — keeps input token consumption under the Tier 1 limit
-# (30 000 tokens/minute).  We target 27 000 to leave a safety margin.
+# Token-rate guard — proactive pacing between consecutive LLM calls.
 # ---------------------------------------------------------------------------
 
-# Minimum seconds between consecutive LLM calls.  A proactive fixed cadence
-# beats a reactive burst-then-sleep TPM guard.  At Tier 2 limits (450K input /
-# 90K output TPM, 1K RPM) a 7s floor keeps throughput at ~8.5 turns/min, giving
-# ~10.5K average output tokens per turn of headroom — comfortably above any
-# realistic agent turn.  Input TPM is not the constraint: system-prompt cache
-# reads are excluded from the 450K limit, so uncached input per turn is only
-# new messages and tool results (~1–5K).
-_MIN_TURN_DELAY_SECS: float = 4.0
+# Minimum seconds between consecutive LLM calls.  A fixed cadence beats a
+# reactive burst-then-sleep TPM guard.  Calibrated for **Tier 3** (800K input /
+# 160K output TPM, 2K RPM): the default 1.5 s floor allows ~3 concurrent agents
+# at ~1 000 output tokens per turn before the output-TPM cap is reached.
+# Tunable via the ``AC_MIN_TURN_DELAY_SECS`` env var (see config.py).
 _last_llm_call_at: float = 0.0
 
 
 async def _enforce_turn_delay() -> None:
-    """Sleep until _MIN_TURN_DELAY_SECS has elapsed since the last LLM call completed.
+    """Sleep until settings.ac_min_turn_delay_secs has elapsed since the last LLM call.
 
     The timestamp is updated by the caller *after* call_anthropic_with_tools
     returns, so retry backoff inside the LLM call does not eat into the next
     window.  If the previous turn's tool dispatch already consumed the full
     window this returns immediately.
     """
+    min_delay = settings.ac_min_turn_delay_secs
     elapsed = time.monotonic() - _last_llm_call_at
-    wait = _MIN_TURN_DELAY_SECS - elapsed
+    wait = min_delay - elapsed
     if wait > 0.0:
         logger.info("⏳ agent_loop: inter-turn delay — sleeping %.1fs", wait)
         await asyncio.sleep(wait)

--- a/agentception/services/planner.py
+++ b/agentception/services/planner.py
@@ -327,7 +327,7 @@ async def generate_execution_plan(
         raw = await call_anthropic(
             user_message,
             system_prompt=_PLANNER_SYSTEM_PROMPT,
-            max_tokens=4096,
+            max_tokens=8192,
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("⚠️ planner: LLM call failed — %s", exc)

--- a/agentception/tests/test_config.py
+++ b/agentception/tests/test_config.py
@@ -390,3 +390,8 @@ def test_planner_enabled_default() -> None:
     s = AgentCeptionSettings()
     assert s.planner_enabled is True
 
+
+def test_ac_min_turn_delay_secs_default() -> None:
+    s = AgentCeptionSettings()
+    assert s.ac_min_turn_delay_secs == 1.5
+


### PR DESCRIPTION
Upgrades the two main pacing knobs now that the account is on Tier 3 (800K input / 160K output TPM, 2K RPM).

## Changes

- `config.py`: `ac_min_turn_delay_secs: float = 1.5` — replaces the hardcoded 4.0 s constant, now env-tunable via `AC_MIN_TURN_DELAY_SECS`
- `agent_loop.py`: `_enforce_turn_delay` reads `settings.ac_min_turn_delay_secs`; comment updated to Tier 3 numbers
- `planner.py`: `max_tokens` 4096 → 8192 — headroom for large multi-operation plans
- `test_config.py`: `test_ac_min_turn_delay_secs_default`