### PR TITLE
feat: restrict autoApprove in mcp.json to safe read-only tools

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -9,7 +9,20 @@
         "agentception",
         "python", "-m", "agentception.mcp.stdio_server"
       ],
-      "autoApprove": ["*"]
+      "autoApprove": [
+        "ping",
+        "resources/list",
+        "resources/templates/list",
+        "resources/read",
+        "prompts/list",
+        "prompts/get",
+        "log_run_step",
+        "log_run_blocker",
+        "log_run_decision",
+        "log_run_message",
+        "log_run_error",
+        "query_run_status"
+      ]
     }
   }
 }


### PR DESCRIPTION
Closes #448