### PR TITLE
fix: auto-correct planner path errors and broaden seed path extraction

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -125,8 +125,11 @@ _AC_CHECKBOX_RE = re.compile(r"^-\s+\[[ xX]\]\s+(.+)$")
 _SECTION_HEADER_RE = re.compile(r"^#{1,3}\s+")
 # Matches the acceptance criteria section header (case-insensitive)
 _AC_HEADER_RE = re.compile(r"^#{1,3}\s+acceptance criteria", re.IGNORECASE)
-# Matches file paths with at least one slash, e.g. agentception/db/models.py
-_AC_FILE_PATH_RE = re.compile(r"`([a-zA-Z0-9_./-]+\.[a-zA-Z]+)`")
+# Matches backtick-quoted file paths, e.g. `agentception/db/models.py`
+_AC_FILE_PATH_RE = re.compile(r"`([a-zA-Z0-9_./-]+\.[a-zA-Z0-9]+)`")
+# Matches plain (unquoted) relative file paths, e.g. agentception/mcp/__init__.py
+# Requires at least one slash so bare words like "foo.py" are not matched.
+_PLAIN_FILE_PATH_RE = re.compile(r"\b([a-zA-Z0-9_.][a-zA-Z0-9_./]*(?:/[a-zA-Z0-9_.]+)+\.[a-zA-Z0-9]+)\b")
 
 # Max lines to inject per file.  Beyond this, the tail is truncated with a
 # notice — the agent can always read_file_lines for deeper context if needed.
@@ -164,21 +167,26 @@ def _extract_ac_items(issue_body: str) -> list[str]:
 
 
 def _extract_ac_file_paths(issue_body: str) -> list[str]:
-    """Return unique file paths (with at least one slash) mentioned in AC items.
+    """Return unique file paths (with at least one slash) mentioned in the issue body.
 
-    Scans every backtick-quoted token in the issue body for tokens that look
-    like relative file paths (contain ``/`` and an extension).  Deduplicates
-    and sorts so the order is deterministic across runs.
+    Scans both backtick-quoted tokens and plain unquoted text for tokens that
+    look like relative file paths (contain ``/`` and have a file extension).
+    Deduplicates and sorts so the order is deterministic across runs.
 
-    Examples of matches:
+    Examples of matches (backtick-quoted or plain):
         ``agentception/db/models.py``
-        ``agentception/alembic/versions/0009_add_contract_hash.py``
-        ``agentception/README.md``
+        agentception/mcp/__init__.py
+        ``.cursor/mcp.json``
     """
     paths: set[str] = set()
     for match in _AC_FILE_PATH_RE.finditer(issue_body):
         candidate = match.group(1)
         if "/" in candidate:
+            paths.add(candidate)
+    for match in _PLAIN_FILE_PATH_RE.finditer(issue_body):
+        candidate = match.group(1)
+        # Exclude URLs and other non-path patterns.
+        if not candidate.startswith(("http", "www")):
             paths.add(candidate)
     return sorted(paths)
 

--- a/agentception/services/planner.py
+++ b/agentception/services/planner.py
@@ -340,6 +340,37 @@ async def generate_execution_plan(
         logger.warning("⚠️ planner: could not parse ExecutionPlan from LLM response")
         return None
 
+    # Validate and auto-correct operation file paths.  The LLM sometimes
+    # generates paths with a spurious leading component (e.g.
+    # ``agentception/.cursor/mcp.json`` instead of ``.cursor/mcp.json``).
+    # For read/modify operations we can fix this by stripping leading
+    # components until the file is found; write_file creates new files so
+    # there is nothing to validate against.
+    for op in plan.operations:
+        if op.tool in ("replace_in_file", "insert_after_in_file"):
+            if not (worktree_path / op.file).exists():
+                parts = Path(op.file).parts
+                corrected: str | None = None
+                for i in range(1, len(parts)):
+                    candidate = str(Path(*parts[i:]))
+                    if (worktree_path / candidate).exists():
+                        corrected = candidate
+                        break
+                if corrected is not None:
+                    logger.warning(
+                        "⚠️ planner: corrected path %r → %r for run_id=%s",
+                        op.file,
+                        corrected,
+                        run_id,
+                    )
+                    op.file = corrected
+                else:
+                    logger.warning(
+                        "⚠️ planner: path not found in worktree: %r (run_id=%s) — executor will fail",
+                        op.file,
+                        run_id,
+                    )
+
     logger.info(
         "✅ planner: generated plan for run_id=%s — %d operation(s): %s",
         run_id,


### PR DESCRIPTION
Two root causes fixed:

**1. Planner path correction** — after plan generation, validate each `replace_in_file` / `insert_after_in_file` path against the worktree. If a path like `agentception/.cursor/mcp.json` doesn't exist, strip leading components until the real path (`.cursor/mcp.json`) is found. The executor no longer receives a bad path.

**2. Broader seed extraction** — `_extract_ac_file_paths` previously only matched backtick-quoted file paths. Issue bodies often mention files in plain text (e.g. `agentception/mcp/__init__.py` without backticks), causing the planner to miss them as seeds and fall back to the developer role. A second regex now matches unquoted file paths with at least one slash.