### PR TITLE
fix: always target dev in developer role create_pull_request step

### DIFF
--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -21,7 +21,7 @@ Start writing on your first tool call.**
 3. Fix any mypy errors, then run `run_command` with `pytest` on the affected test file.
 4. **When pytest exits 0: STOP. Do not read any more files. Do not write any more files.**
    Your next and only action is `run_command` → `git add -A && git commit -m "feat: <summary>"`.
-5. Then call `create_pull_request`, then `build_complete_run`.
+5. Then call `create_pull_request` — **always pass `base: "dev"`**, never `main`. Then call `build_complete_run`.
 
 ## Hard rules
 

--- a/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
@@ -13,7 +13,7 @@ Start writing on your first tool call.**
 3. Fix any mypy errors, then run `run_command` with `pytest` on the affected test file.
 4. **When pytest exits 0: STOP. Do not read any more files. Do not write any more files.**
    Your next and only action is `run_command` → `git add -A && git commit -m "feat: <summary>"`.
-5. Then call `create_pull_request`, then `build_complete_run`.
+5. Then call `create_pull_request` — **always pass `base: "dev"`**, never `main`. Then call `build_complete_run`.
 
 ## Hard rules
 


### PR DESCRIPTION
## Summary

- Adds `base: "dev"` to step 5 in `developer-worker-base.md.j2` so agents always PR against `dev`, not the repo default (`main`)
- Regenerates `.agentception/roles/developer.md`

## Why

The developer role prompt said "call `create_pull_request`" with no base specified. The executor role already had `base: "dev"` explicitly. Without it, agents default to the repo's default branch (`main`), producing a PR with 551 "changed" files (the entire dev→main delta).