### PR TITLE
fix: force planner JSON output via assistant turn prefill

### DIFF
--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -305,6 +305,7 @@ async def call_anthropic(
     system_prompt: str | None = None,
     temperature: float = 0.2,
     max_tokens: int = 4096,
+    prefill: str | None = None,
 ) -> str:
     """Call Claude via the Anthropic API and return the full text response.
 
@@ -313,20 +314,31 @@ async def call_anthropic(
         system_prompt: Optional system-turn message.
         temperature: Sampling temperature (0.0--1.0).
         max_tokens: Maximum tokens in the completion.
+        prefill: Optional assistant-turn prefix inserted before the model's
+            response.  When set, the model is forced to *continue* from this
+            string rather than choosing its own opening.  The prefill is
+            prepended to the returned text so callers receive the full string.
+            Use ``prefill='{"operations":'`` to guarantee JSON output from the
+            planner — the model cannot write prose if the assistant turn already
+            starts with a JSON object opener.
 
     Returns:
-        The raw text string of the model's response.
+        The raw text string of the model's response (prefill prepended if set).
 
     Raises:
         RuntimeError: When ``ANTHROPIC_API_KEY`` is not set.
         httpx.HTTPStatusError: On non-2xx responses after retries.
         httpx.TimeoutException: When the request exceeds ``_DEFAULT_TIMEOUT``.
     """
+    messages: list[dict[str, object]] = [{"role": "user", "content": user_prompt}]
+    if prefill:
+        messages.append({"role": "assistant", "content": prefill})
+
     payload: dict[str, object] = {
         "model": _MODEL,
         "max_tokens": max_tokens,
         "temperature": temperature,
-        "messages": [{"role": "user", "content": user_prompt}],
+        "messages": messages,
     }
     if system_prompt:
         payload["system"] = system_prompt
@@ -377,6 +389,8 @@ async def call_anthropic(
                 text_parts.append(text)
 
     result = "".join(text_parts)
+    if prefill:
+        result = prefill + result
     logger.info("✅ LLM response — %d chars", len(result))
     return result
 

--- a/agentception/services/planner.py
+++ b/agentception/services/planner.py
@@ -363,6 +363,10 @@ async def generate_execution_plan(
             user_message,
             system_prompt=_PLANNER_SYSTEM_PROMPT,
             max_tokens=16384,
+            # Force JSON output: prefilling the assistant turn with the
+            # opening of the JSON object prevents the model from writing
+            # prose reasoning before the JSON, which breaks _parse_plan_json.
+            prefill='{"operations":',
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("⚠️ planner: LLM call failed — %s", exc)


### PR DESCRIPTION
## Summary

- Adds `prefill: str | None = None` to `call_anthropic` — when set, an assistant turn ending with the prefix is inserted before the model responds, forcing it to continue from that string
- Planner passes `prefill='{"operations":'` so the model starts inside a JSON object and cannot emit prose

## Why

The planner LLM was returning prose reasoning instead of JSON. The first `{` in prose (e.g. from `{run_id}` in markdown) was picked up as the start of a JSON object, causing an immediate parse failure. With the prefill, the model resumes from an already-open JSON object and can only complete the array — prose is structurally impossible.