### PR TITLE
fix: force planner JSON via user-message cue (revert unsupported prefill)

### DIFF
--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -305,7 +305,7 @@ async def call_anthropic(
     system_prompt: str | None = None,
     temperature: float = 0.2,
     max_tokens: int = 4096,
-    prefill: str | None = None,
+
 ) -> str:
     """Call Claude via the Anthropic API and return the full text response.
 
@@ -314,31 +314,20 @@ async def call_anthropic(
         system_prompt: Optional system-turn message.
         temperature: Sampling temperature (0.0--1.0).
         max_tokens: Maximum tokens in the completion.
-        prefill: Optional assistant-turn prefix inserted before the model's
-            response.  When set, the model is forced to *continue* from this
-            string rather than choosing its own opening.  The prefill is
-            prepended to the returned text so callers receive the full string.
-            Use ``prefill='{"operations":'`` to guarantee JSON output from the
-            planner — the model cannot write prose if the assistant turn already
-            starts with a JSON object opener.
 
     Returns:
-        The raw text string of the model's response (prefill prepended if set).
+        The raw text string of the model's response.
 
     Raises:
         RuntimeError: When ``ANTHROPIC_API_KEY`` is not set.
         httpx.HTTPStatusError: On non-2xx responses after retries.
         httpx.TimeoutException: When the request exceeds ``_DEFAULT_TIMEOUT``.
     """
-    messages: list[dict[str, object]] = [{"role": "user", "content": user_prompt}]
-    if prefill:
-        messages.append({"role": "assistant", "content": prefill})
-
     payload: dict[str, object] = {
         "model": _MODEL,
         "max_tokens": max_tokens,
         "temperature": temperature,
-        "messages": messages,
+        "messages": [{"role": "user", "content": user_prompt}],
     }
     if system_prompt:
         payload["system"] = system_prompt
@@ -389,8 +378,6 @@ async def call_anthropic(
                 text_parts.append(text)
 
     result = "".join(text_parts)
-    if prefill:
-        result = prefill + result
     logger.info("✅ LLM response — %d chars", len(result))
     return result
 

--- a/agentception/services/planner.py
+++ b/agentception/services/planner.py
@@ -358,15 +358,21 @@ async def generate_execution_plan(
         len(file_contents),
     )
 
+    # Append a hard JSON-output cue to the user message.  This is more
+    # reliable than system-prompt instructions alone: placing the partial
+    # JSON structure immediately before the model's response window makes
+    # it structurally difficult to emit prose first.
+    forced_message = (
+        user_message
+        + '\n\n---\nOutput the ExecutionPlan JSON now. '
+        'Begin your response immediately with {"operations": ['
+    )
+
     try:
         raw = await call_anthropic(
-            user_message,
+            forced_message,
             system_prompt=_PLANNER_SYSTEM_PROMPT,
             max_tokens=16384,
-            # Force JSON output: prefilling the assistant turn with the
-            # opening of the JSON object prevents the model from writing
-            # prose reasoning before the JSON, which breaks _parse_plan_json.
-            prefill='{"operations":',
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("⚠️ planner: LLM call failed — %s", exc)


### PR DESCRIPTION
## Summary

- Reverts the `prefill` parameter added to `call_anthropic` — `claude-sonnet-4-6` returns 400 "This model does not support assistant message prefill"
- Instead appends a hard structural cue at the end of the planner user message: `Begin your response immediately with {"operations": [` — making it structurally awkward to open with prose

## Why

The planner was producing prose reasoning instead of JSON. Assistant prefilling was the cleanest solution but is unsupported by this model. The user-message cue achieves the same effect without requiring API support.