### PR TITLE
fix: add additionalProperties=false to structured outputs schema

### DIFF
--- a/agentception/services/planner.py
+++ b/agentception/services/planner.py
@@ -83,10 +83,12 @@ _EXECUTION_PLAN_SCHEMA: dict[str, object] = {
                     "content": {"type": "string"},
                 },
                 "required": ["tool", "file"],
+                "additionalProperties": False,
             },
         },
     },
     "required": ["operations"],
+    "additionalProperties": False,
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Anthropic's structured-outputs beta requires `additionalProperties: false` on every object node in the schema (root + array items). Without it the API returns a 400 `invalid_request_error`.

Diagnosed by sending a raw curl request directly to the Anthropic API and reading the exact error message before touching the application code.