### PR TITLE
fix: inject OWNER/REPO into briefing; anchor types.py and test files in planner

### DIFF
--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -10,8 +10,17 @@ defects.** That is the executor's job. If the code is not ready, reject it.
 All task context is in your `task/briefing` MCP prompt. Read it once, extract:
 
 ```
-PR_NUMBER, BRANCH, GH_REPO, ISSUE_NUMBER, OWNER
+PR_NUMBER   — from "PR_NUMBER: N" or the PR URL
+BRANCH      — from "Branch: feat/issue-N"
+GH_REPO     — from "GH_REPO: owner/repo"
+ISSUE_NUMBER — from "ISSUE_NUMBER: N"
+OWNER       — the part of GH_REPO before the "/" (e.g. GH_REPO=cgcardona/agentception → OWNER=cgcardona)
+REPO        — the part of GH_REPO after the "/" (e.g. GH_REPO=cgcardona/agentception → REPO=agentception)
 ```
+
+The briefing header contains explicit `**OWNER:**` and `**REPO:**` fields — use
+those directly. Do not call `get_me` to find the owner; that returns the token
+holder, not the repo owner.
 
 Do not read any file before extracting these.
 

--- a/agentception/mcp/prompts.py
+++ b/agentception/mcp/prompts.py
@@ -442,6 +442,12 @@ def _render_task_briefing(ctx: RunContextRow, role_content: str) -> str:
     task_description: str | None = ctx["task_description"]
     batch_id: str | None = ctx["batch_id"]
     parent_run_id: str | None = ctx["parent_run_id"]
+    gh_repo: str = ctx["gh_repo"] or ""
+    # Derive owner and repo_name from "owner/repo" — used by GitHub MCP tools.
+    gh_owner, _, gh_repo_name = gh_repo.partition("/")
+    if not gh_owner:
+        gh_owner = gh_repo
+        gh_repo_name = gh_repo
 
     figure_ids, skill_ids = _parse_arch_components(cognitive_arch)
 
@@ -474,6 +480,9 @@ def _render_task_briefing(ctx: RunContextRow, role_content: str) -> str:
         f"**Cognitive Architecture:** `{cognitive_arch}`  ",
         f"**Worktree:** `{worktree_path}`  ",
         f"**Branch:** `{branch}`  ",
+        f"**GH_REPO:** `{gh_repo}`  ",
+        f"**OWNER:** `{gh_owner}`  ",
+        f"**REPO:** `{gh_repo_name}`  ",
         f"**Search index:** `{worktree_collection}` (your worktree) · `code` (full repo)",
         "",
         "> **Before you read any file:** call `search_codebase` first.",

--- a/agentception/services/planner.py
+++ b/agentception/services/planner.py
@@ -43,9 +43,10 @@ logger = logging.getLogger(__name__)
 # ~1 600 lines / 63 K chars) in full without truncation.
 _FILE_CHAR_LIMIT: int = 75_000
 
-# Maximum files to inject into the planner prompt.  Qdrant results beyond
-# this cap are discarded to keep the prompt within a sane token budget.
-_MAX_FILES: int = 6
+# Maximum files to inject into the planner prompt.  Raised from 6 to 8 to
+# accommodate anchored files (db/models.py, mcp/types.py, test files) without
+# displacing the Qdrant-discovered source files.
+_MAX_FILES: int = 8
 
 # Number of Qdrant results to request for file discovery.  Fetching slightly
 # more than _MAX_FILES lets us filter out non-existent files and still fill
@@ -208,16 +209,49 @@ async def _discover_files(
             exc,
         )
 
-    # Always include db/models.py when any db/ file is present — it is the
-    # ground truth for column names and must be visible to the planner so it
-    # never uses a field name from the issue spec that doesn't exist in code.
+    # Anchor critical files that are ground truth for types and field names.
+    # These are inserted after seed paths so they never displace them.
+    seed_count = len(seed_paths)
+    anchors: list[str] = []
+
+    # db/models.py — ground truth for DB column names.  Always include when
+    # any db/ file is discovered so the planner never trusts the issue spec
+    # for attribute names that don't exist on the ORM model.
     db_models = "agentception/db/models.py"
-    has_db_file = any("db/" in p or "models" in p for p in discovered)
-    if has_db_file and db_models not in discovered and (worktree_path / db_models).exists():
-        # Insert after seed paths but before the rest so it counts toward the cap.
-        seed_count = len(seed_paths)
+    has_db_file = any("db/" in p for p in discovered)
+    if has_db_file and db_models not in discovered:
+        anchors.append(db_models)
+
+    # mcp/types.py — defines ACResourceResult, ACResourceContent, and all
+    # JsonRpc* TypedDicts.  Required whenever any mcp/ source file is touched
+    # so the planner generates correct return types.
+    mcp_types = "agentception/mcp/types.py"
+    has_mcp_file = any("agentception/mcp/" in p and p != mcp_types for p in discovered)
+    if has_mcp_file and mcp_types not in discovered:
+        anchors.append(mcp_types)
+
+    # Test file anchoring — for every source file discovered, include its
+    # corresponding test file so the planner can see existing test patterns
+    # and emit a correct test operation.
+    test_dir = "agentception/tests"
+    for source_path in list(discovered.keys()):
+        if "/tests/" in source_path or not source_path.endswith(".py"):
+            continue
+        module = source_path.replace("/", "_").replace(".py", "")
+        # Strip the package prefix to get a short module name for the test file.
+        # e.g. "agentception/mcp/resources.py" → "test_mcp_resources.py"
+        parts = source_path.split("/")
+        short_module = "_".join(parts[1:]).replace(".py", "")
+        candidate = f"{test_dir}/test_{short_module}.py"
+        if candidate not in discovered and candidate not in anchors and (worktree_path / candidate).exists():
+            anchors.append(candidate)
+
+    # Insert anchors after seed paths.
+    if anchors:
         keys = list(discovered.keys())
-        keys.insert(seed_count, db_models)
+        for i, anchor in enumerate(anchors):
+            if (worktree_path / anchor).exists():
+                keys.insert(seed_count + i, anchor)
         discovered = {k: None for k in keys}
 
     result = list(discovered.keys())[:_MAX_FILES]

--- a/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
@@ -9,8 +9,17 @@ defects.** That is the executor's job. If the code is not ready, reject it.
 All task context is in your `task/briefing` MCP prompt. Read it once, extract:
 
 ```
-PR_NUMBER, BRANCH, GH_REPO, ISSUE_NUMBER, OWNER
+PR_NUMBER   — from "PR_NUMBER: N" or the PR URL
+BRANCH      — from "Branch: feat/issue-N"
+GH_REPO     — from "GH_REPO: owner/repo"
+ISSUE_NUMBER — from "ISSUE_NUMBER: N"
+OWNER       — the part of GH_REPO before the "/" (e.g. GH_REPO=cgcardona/agentception → OWNER=cgcardona)
+REPO        — the part of GH_REPO after the "/" (e.g. GH_REPO=cgcardona/agentception → REPO=agentception)
 ```
+
+The briefing header contains explicit `**OWNER:**` and `**REPO:**` fields — use
+those directly. Do not call `get_me` to find the owner; that returns the token
+holder, not the repo owner.
 
 Do not read any file before extracting these.
 


### PR DESCRIPTION
## Summary

Three pre-emptive fixes targeting the known remaining failure modes:

1. **`prompts.py`** — `gh_repo` is split into explicit `**OWNER:**` and `**REPO:**` fields in every task briefing. The reviewer was guessing `presidio-dev` because OWNER was never in the briefing. Reviewer prompt updated to use these fields directly instead of calling `get_me`.

2. **`planner.py` discovery** — `agentception/mcp/types.py` is now anchored when any `mcp/` source file is discovered (it defines `ACResourceResult`, `ACResourceContent`, all `JsonRpc*` TypedDicts). Test files (`test_mcp_resources.py` etc.) are anchored alongside their source files so the planner can emit correct test operations.

3. **File cap raised 6 → 8** to accommodate anchored files without displacing Qdrant results.