### PR TITLE
feat: add ac://runs/{run_id}/task resource handler

### DIFF
--- a/agentception/mcp/resources.py
+++ b/agentception/mcp/resources.py
@@ -422,6 +422,27 @@ def _get_role(uri: str, slug: str) -> dict[str, object]:
     return {"ok": True, "slug": slug, "content": content}
 
 
+async def _handle_run_task(uri: str, run_id: str) -> ACResourceResult:
+    """Return the task_description field for a run as a text resource."""
+    from sqlalchemy import select
+
+    from agentception.db.engine import get_session
+    from agentception.db.models import ACAgentRun
+
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun).where(ACAgentRun.id == run_id)
+            )
+            row = result.scalar_one_or_none()
+        if row is None:
+            return _not_found(uri)
+        return _content(uri, {"run_id": run_id, "task_description": row.task_description})
+    except Exception as exc:
+        logger.error("❌ _handle_run_task %r: %s", run_id, exc, exc_info=True)
+        return _content(uri, {"error": str(exc)})
+
+
 def _content(uri: str, data: dict[str, object]) -> ACResourceResult:
     """Wrap a result dict into a single-item ACResourceResult."""
     return ACResourceResult(
@@ -531,6 +552,9 @@ async def _dispatch(
 
             if sub == "context" and len(path_parts) == 2:
                 return _content(uri, await query_run_context(run_id))
+
+            if sub == "task" and len(path_parts) == 2:
+                return await _handle_run_task(uri, run_id)
 
             if sub == "events" and len(path_parts) == 2:
                 after_id_vals = query.get("after_id", [])

--- a/agentception/tests/test_mcp_resources.py
+++ b/agentception/tests/test_mcp_resources.py
@@ -726,6 +726,59 @@ async def test_read_resource_plan_figures_unknown_role() -> None:
 
 
 # ---------------------------------------------------------------------------
+# ac://runs/{run_id}/task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_run_task_resource_returns_task_description() -> None:
+    """ac://runs/{run_id}/task returns task_description when the run exists."""
+    from unittest.mock import MagicMock
+
+    mock_row = MagicMock()
+    mock_row.task_description = "Implement the foo feature"
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_row
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("agentception.db.engine.get_session", return_value=mock_ctx):
+        result = await read_resource("ac://runs/issue-42/task")
+
+    payload = _content(result)
+    assert payload["run_id"] == "issue-42"
+    assert payload["task_description"] == "Implement the foo feature"
+
+
+@pytest.mark.anyio
+async def test_run_task_resource_returns_not_found_when_run_missing() -> None:
+    """ac://runs/{run_id}/task returns a not-found payload when the run does not exist."""
+    from unittest.mock import MagicMock
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("agentception.db.engine.get_session", return_value=mock_ctx):
+        result = await read_resource("ac://runs/issue-999/task")
+
+    payload = _content(result)
+    assert "error" in payload
+
+
+# ---------------------------------------------------------------------------
 # URI edge cases
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #449

Adds a new MCP resource handler for `ac://runs/{run_id}/task` that returns the `task_description` field for a given run. Returns a not-found payload when the run does not exist. Covered by two new tests: `test_run_task_resource_returns_task_description` and `test_run_task_resource_returns_not_found_when_run_missing`.