### PR TITLE
fix: prevent pr-reviewer from re-dispatching another reviewer

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -2587,6 +2587,23 @@ async def get_agent_run_teardown(run_id: str) -> AgentRunTeardownRow | None:
         return None
 
 
+async def get_agent_run_role(run_id: str) -> str | None:
+    """Return the role of a single agent run, or None if not found / on error.
+
+    Intentionally lightweight — fetches only the role column.
+    """
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun.role).where(ACAgentRun.id == run_id)
+            )
+            row = result.one_or_none()
+        return row[0] if row is not None else None
+    except Exception as exc:
+        logger.warning("⚠️  get_agent_run_role DB query failed (non-fatal): %s", exc)
+        return None
+
+
 class TerminalRunRow(TypedDict):
     """Minimal run fields needed by the worktree reaper."""
 

--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -34,7 +34,7 @@ from agentception.db.persist import (
     resume_agent_run,
     stop_agent_run,
 )
-
+from agentception.db.queries import get_agent_run_role
 
 from agentception.services.auto_reviewer import auto_dispatch_reviewer
 from agentception.services.spawn_child import ScopeType, SpawnChildError, Tier, spawn_child
@@ -228,12 +228,21 @@ async def build_complete_run(
         issue_number, pr_url, agent_run_id,
     )
 
-    # Auto-dispatch a pr-reviewer for every completed implementer run.
-    # Fire-and-forget: reviewer failure never affects the implementer's result.
-    asyncio.create_task(
-        auto_dispatch_reviewer(issue_number=issue_number, pr_url=pr_url),
-        name=f"auto-reviewer-{issue_number}",
-    )
+    # Auto-dispatch a pr-reviewer for completed implementer runs only.
+    # Skip when the completing run is itself a pr-reviewer to prevent an
+    # infinite reviewer → reviewer → … dispatch loop.
+    caller_role = await get_agent_run_role(agent_run_id) if agent_run_id else None
+    if caller_role == "pr-reviewer":
+        logger.info(
+            "ℹ️ build_complete_run: skipping auto-reviewer (caller is pr-reviewer) run_id=%r",
+            agent_run_id,
+        )
+    else:
+        # Fire-and-forget: reviewer failure never affects the implementer's result.
+        asyncio.create_task(
+            auto_dispatch_reviewer(issue_number=issue_number, pr_url=pr_url),
+            name=f"auto-reviewer-{issue_number}",
+        )
 
     return {"ok": True, "event": "done", "status": "completed"}
 

--- a/agentception/tests/test_mcp_build_commands_pr3.py
+++ b/agentception/tests/test_mcp_build_commands_pr3.py
@@ -328,3 +328,87 @@ async def test_claim_stop_resume_flow() -> None:
         )
 
     assert json.loads(resume_result["content"][0]["text"])["status"] == "implementing"
+
+
+# ---------------------------------------------------------------------------
+# Regression: pr-reviewer must not trigger a second reviewer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_reviewer_does_not_redispatch_reviewer() -> None:
+    """When a pr-reviewer calls build_complete_run, no auto-reviewer is dispatched.
+
+    Regression for the infinite reviewer loop: reviewer merges PR → calls
+    build_complete_run → auto_dispatch_reviewer → second reviewer → …
+    """
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="pr-reviewer",
+        ) as mock_role,
+        patch(
+            "agentception.mcp.build_commands.auto_dispatch_reviewer",
+            new_callable=AsyncMock,
+        ) as mock_dispatch,
+        patch("asyncio.create_task"),
+    ):
+        result = await call_tool_async(
+            "build_complete_run",
+            {
+                "issue_number": 449,
+                "pr_url": "https://github.com/owner/repo/pull/553",
+                "agent_run_id": "issue-449",
+            },
+        )
+
+    assert json.loads(result["content"][0]["text"])["ok"] is True
+    mock_role.assert_awaited_once_with("issue-449")
+    mock_dispatch.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_implementer_does_redispatch_reviewer() -> None:
+    """When a developer calls build_complete_run, reviewer IS dispatched."""
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="developer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.auto_dispatch_reviewer",
+            new_callable=AsyncMock,
+        ),
+        patch("asyncio.create_task") as mock_create_task,
+    ):
+        result = await call_tool_async(
+            "build_complete_run",
+            {
+                "issue_number": 42,
+                "pr_url": "https://github.com/owner/repo/pull/100",
+                "agent_run_id": "issue-42",
+            },
+        )
+
+    assert json.loads(result["content"][0]["text"])["ok"] is True
+    mock_create_task.assert_called_once()


### PR DESCRIPTION
## Summary
- `build_complete_run` now looks up the caller's role before firing `auto_dispatch_reviewer`
- If the completing run is itself a `pr-reviewer`, the dispatch is skipped — breaking the infinite reviewer → reviewer loop observed after PR #553 merged
- Added `get_agent_run_role()` lightweight query (role column only, no messages) to `db/queries.py`
- Two regression tests: reviewer skips auto-dispatch, developer triggers it

## Root cause
The reviewer called `build_complete_run` with the PR URL after merging. `auto_dispatch_reviewer` was always called regardless of the caller's role, which spun up a second reviewer on an already-merged PR.

## Test plan
- [x] `test_build_complete_run_reviewer_does_not_redispatch_reviewer` — reviewer role → `auto_dispatch_reviewer` not called
- [x] `test_build_complete_run_implementer_does_redispatch_reviewer` — developer role → `create_task` called
- [x] All 21 tests in `test_mcp_build_commands_pr3.py` pass
- [x] `mypy agentception/` — 0 errors