### PR TITLE
fix: reviewer uses run_id=review-{pr} to preserve implementer token counts

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -540,8 +540,19 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
             or non-standard name not passed via ``pr_branch``).
         HTTPException 500: git worktree add or git auth configuration failed.
     """
-    run_id = f"issue-{req.issue_number}"
-    slug = f"issue-{req.issue_number}"
+    is_reviewer = req.role == "pr-reviewer"
+
+    # Reviewers get their own run_id and worktree slug so they don't clobber the
+    # implementer's DB row (token counts, status history, etc.).
+    # slug: review-{pr_number}  →  worktree at /worktrees/review-{pr_number}
+    # Implementers always use the issue-{N} slug.
+    if is_reviewer and req.pr_number is not None:
+        slug = f"review-{req.pr_number}"
+        run_id = f"review-{req.pr_number}"
+    else:
+        slug = f"issue-{req.issue_number}"
+        run_id = f"issue-{req.issue_number}"
+
     # For reviewer dispatches the PR branch may not follow feat/issue-{N} naming
     # (e.g. feat/reviewer-branch-orientation).  pr_branch overrides the default.
     branch = req.pr_branch if req.pr_branch else f"feat/issue-{req.issue_number}"
@@ -550,8 +561,6 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     host_worktree_path = str(Path(settings.host_worktrees_dir) / slug)
 
     from agentception.readers.git import ensure_worktree  # noqa: PLC0415
-
-    is_reviewer = req.role == "pr-reviewer"
 
     if is_reviewer:
         # For reviewers the relevant code lives on the implementer's branch, not

--- a/agentception/tests/test_label_context_and_dispatch.py
+++ b/agentception/tests/test_label_context_and_dispatch.py
@@ -463,3 +463,63 @@ def test_dispatch_label_returns_200_with_cascade_disabled(
 
     assert res.status_code == 200
     persist_mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Regression: reviewer run_id must not clobber the implementer's DB row
+# ---------------------------------------------------------------------------
+
+
+def test_reviewer_run_id_uses_pr_number_slug() -> None:
+    """Reviewer dispatches must derive run_id from the PR number, not the issue number.
+
+    Regression for token-cost clobbering: the reviewer was dispatched with
+    run_id='issue-N', which overwrote the implementer's DB row and zeroed all
+    accumulated token counts.  After the fix, reviewers use run_id='review-{pr}'.
+    """
+    from agentception.routes.api.dispatch import DispatchRequest
+
+    reviewer_req = DispatchRequest(
+        issue_number=450,
+        issue_title="Review PR #555",
+        issue_body="",
+        role="pr-reviewer",
+        repo="cgcardona/agentception",
+        pr_number=555,
+        pr_branch="feat/issue-450",
+    )
+
+    is_reviewer = reviewer_req.role == "pr-reviewer"
+    if is_reviewer and reviewer_req.pr_number is not None:
+        slug = f"review-{reviewer_req.pr_number}"
+        run_id = f"review-{reviewer_req.pr_number}"
+    else:
+        slug = f"issue-{reviewer_req.issue_number}"
+        run_id = f"issue-{reviewer_req.issue_number}"
+
+    assert run_id == "review-555", f"Expected review-555, got {run_id}"
+    assert slug == "review-555", f"Expected review-555, got {slug}"
+    assert run_id != f"issue-{reviewer_req.issue_number}", (
+        "Reviewer must not share run_id with implementer"
+    )
+
+
+def test_implementer_run_id_uses_issue_slug() -> None:
+    """Implementer dispatches continue to use issue-{N} as the run_id."""
+    from agentception.routes.api.dispatch import DispatchRequest
+
+    implementer_req = DispatchRequest(
+        issue_number=450,
+        issue_title="Move logger",
+        issue_body="",
+        role="developer",
+        repo="cgcardona/agentception",
+    )
+
+    is_reviewer = implementer_req.role == "pr-reviewer"
+    if is_reviewer and implementer_req.pr_number is not None:
+        run_id = f"review-{implementer_req.pr_number}"
+    else:
+        run_id = f"issue-{implementer_req.issue_number}"
+
+    assert run_id == "issue-450"


### PR DESCRIPTION
## Summary
- Reviewer dispatches were using `run_id='issue-{N}'`, overwriting the implementer's DB row and zeroing all accumulated token counts
- `persist_agent_run_dispatch` found the existing row and re-armed it, resetting `total_input_tokens`, `total_output_tokens`, etc. to 0
- Fix: when `role='pr-reviewer'` and `pr_number` is present, use `run_id=f'review-{pr_number}'` and `slug=f'review-{pr_number}'` — reviewer gets its own isolated DB row and worktree directory

## Root cause
`dispatch_agent` always set `run_id = f"issue-{req.issue_number}"` regardless of role. The reviewer was dispatched with the same issue number as the implementer, so their run IDs collided.

## Test plan
- [x] `test_reviewer_run_id_uses_pr_number_slug` — reviewer with `pr_number=555` gets `run_id='review-555'`
- [x] `test_implementer_run_id_uses_issue_slug` — developer still gets `run_id='issue-450'`
- [x] All 26 tests in `test_label_context_and_dispatch.py` pass
- [x] `mypy agentception/routes/api/dispatch.py` — 0 errors