### PR TITLE
fix(planner): use write_file for AC-named test files, not append to nearest existing

### DIFF
--- a/.agentception/roles/planner.md
+++ b/.agentception/roles/planner.md
@@ -15,6 +15,10 @@ Rules:
   tests.** If the issue says "test_foo_bar must pass", your plan must include
   an operation that writes or updates that test. A plan without tests when AC
   requires them is incomplete.
+- **When the issue names a specific new test file** (e.g. "Add
+  `agentception/tests/test_foo.py`"), use `write_file` to create that exact
+  file. Never add tests to a differently-named existing file when the AC names
+  a specific new file. The file path in the plan must match the AC exactly.
 - Prefer `replace_in_file` for edits to existing files — it is the most
   precise and easiest for the executor to apply correctly.
 - `old_string` must appear verbatim in the pre-loaded file and must be unique.

--- a/scripts/gen_prompts/templates/roles/planner.md.j2
+++ b/scripts/gen_prompts/templates/roles/planner.md.j2
@@ -14,6 +14,10 @@ Rules:
   tests.** If the issue says "test_foo_bar must pass", your plan must include
   an operation that writes or updates that test. A plan without tests when AC
   requires them is incomplete.
+- **When the issue names a specific new test file** (e.g. "Add
+  `agentception/tests/test_foo.py`"), use `write_file` to create that exact
+  file. Never add tests to a differently-named existing file when the AC names
+  a specific new file. The file path in the plan must match the AC exactly.
 - Prefer `replace_in_file` for edits to existing files — it is the most
   precise and easiest for the executor to apply correctly.
 - `old_string` must appear verbatim in the pre-loaded file and must be unique.


### PR DESCRIPTION
## Summary
- The planner was appending tests to the nearest existing test file found by Qdrant instead of creating the exact file named in the issue AC
- Root cause of the Grade C rejection on #263: tests landed in `test_label_context_and_dispatch.py` instead of the AC-required `test_dispatch_regenerate.py`
- New rule: when the issue AC names a specific new test file, use `write_file` to create exactly that file — never add to a differently-named existing file

## Test plan
- No automated tests for planner prompt changes
- Verified `generate.py --check` shows 0 drift
- Template and generated output committed together