### PR TITLE
fix(dispatch): release executor worktree before dispatching reviewer

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -34,11 +34,12 @@ from agentception.db.persist import (
     resume_agent_run,
     stop_agent_run,
 )
-from agentception.db.queries import get_agent_run_role
+from agentception.config import settings
+from agentception.db.queries import get_agent_run_role, get_agent_run_teardown
 
 from agentception.services.auto_reviewer import auto_dispatch_reviewer
 from agentception.services.spawn_child import ScopeType, SpawnChildError, Tier, spawn_child
-from agentception.services.teardown import teardown_agent_worktree
+from agentception.services.teardown import release_worktree, teardown_agent_worktree
 
 logger = logging.getLogger(__name__)
 
@@ -238,6 +239,21 @@ async def build_complete_run(
             agent_run_id,
         )
     else:
+        # Release the executor's worktree before dispatching the reviewer.
+        # Git forbids the same branch in two worktrees simultaneously; if the
+        # executor's worktree still holds the branch the reviewer dispatch will
+        # fail with "already used by worktree at …".  We only remove the
+        # worktree directory and prune refs — branches are left intact because
+        # the open PR still references the remote branch.
+        if agent_run_id:
+            teardown_info = await get_agent_run_teardown(agent_run_id)
+            wt_path = teardown_info.get("worktree_path") if teardown_info else None
+            if wt_path is not None:
+                await release_worktree(
+                    worktree_path=wt_path,
+                    repo_dir=str(settings.repo_dir),
+                )
+
         # Fire-and-forget: reviewer failure never affects the implementer's result.
         asyncio.create_task(
             auto_dispatch_reviewer(issue_number=issue_number, pr_url=pr_url),

--- a/agentception/services/teardown.py
+++ b/agentception/services/teardown.py
@@ -21,6 +21,43 @@ from agentception.services.run_factory import _WORKTREE_COLLECTION_PREFIX
 logger = logging.getLogger(__name__)
 
 
+async def release_worktree(worktree_path: str, repo_dir: str) -> None:
+    """Remove the worktree directory and prune stale refs — branches untouched.
+
+    Used by :func:`build_complete_run` immediately before dispatching the PR
+    reviewer.  The reviewer needs to check out the same branch in its own
+    worktree; git forbids two worktrees sharing a branch, so the executor's
+    worktree must be released first.  Branches are intentionally **not** deleted
+    here because the open PR still references the remote branch.
+
+    Safe to call even if the worktree dir no longer exists (idempotent).
+    """
+    repo = repo_dir
+    if Path(worktree_path).exists():
+        rm_proc = await asyncio.create_subprocess_exec(
+            "git", "-C", repo, "worktree", "remove", "--force", worktree_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await rm_proc.communicate()
+        if rm_proc.returncode == 0:
+            logger.info("✅ release_worktree: removed %s", worktree_path)
+        else:
+            logger.warning(
+                "⚠️  release_worktree: worktree remove failed: %s",
+                stderr.decode().strip(),
+            )
+    else:
+        logger.info("ℹ️  release_worktree: %s already gone — skipping", worktree_path)
+
+    prune_proc = await asyncio.create_subprocess_exec(
+        "git", "-C", repo, "worktree", "prune",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await prune_proc.communicate()
+
+
 async def teardown_agent_worktree(run_id: str) -> None:
     """Remove the worktree, prune refs, and delete the branch for a finished agent.
 

--- a/agentception/tests/test_mcp_build_commands_pr3.py
+++ b/agentception/tests/test_mcp_build_commands_pr3.py
@@ -396,6 +396,11 @@ async def test_build_complete_run_implementer_does_redispatch_reviewer() -> None
             return_value="developer",
         ),
         patch(
+            "agentception.mcp.build_commands.get_agent_run_teardown",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
             "agentception.mcp.build_commands.auto_dispatch_reviewer",
             new_callable=AsyncMock,
         ),
@@ -412,3 +417,59 @@ async def test_build_complete_run_implementer_does_redispatch_reviewer() -> None
 
     assert json.loads(result["content"][0]["text"])["ok"] is True
     mock_create_task.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_releases_worktree_before_reviewer() -> None:
+    """Executor worktree is released before the reviewer is dispatched.
+
+    Regression for the "branch already used by worktree" failure: if the
+    executor's worktree still holds feat/issue-N when the reviewer tries to
+    create its own worktree for the same branch, git rejects the second
+    worktree with a fatal error.  build_complete_run must call
+    release_worktree (remove dir + prune refs) first.
+    """
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="developer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_teardown",
+            new_callable=AsyncMock,
+            return_value={"worktree_path": "/worktrees/issue-99", "branch": "feat/issue-99"},
+        ),
+        patch(
+            "agentception.mcp.build_commands.release_worktree",
+            new_callable=AsyncMock,
+        ) as mock_release,
+        patch(
+            "agentception.mcp.build_commands.auto_dispatch_reviewer",
+            new_callable=AsyncMock,
+        ),
+        patch("asyncio.create_task"),
+    ):
+        result = await call_tool_async(
+            "build_complete_run",
+            {
+                "issue_number": 99,
+                "pr_url": "https://github.com/owner/repo/pull/200",
+                "agent_run_id": "issue-99",
+            },
+        )
+
+    assert json.loads(result["content"][0]["text"])["ok"] is True
+    mock_release.assert_awaited_once_with(
+        worktree_path="/worktrees/issue-99",
+        repo_dir=str(__import__("agentception.config", fromlist=["settings"]).settings.repo_dir),
+    )


### PR DESCRIPTION
## Summary
- Adds `release_worktree()` to `teardown.py` — removes the worktree dir and prunes refs without deleting branches (the open PR still references the remote branch)
- Calls it in `build_complete_run` before dispatching the reviewer, so `feat/issue-N` is no longer locked when the reviewer's `ensure_worktree` runs
- Regression test: `test_build_complete_run_releases_worktree_before_reviewer`

## Root cause
Git forbids the same branch in two worktrees simultaneously. When `build_complete_run` auto-dispatched the reviewer, the executor's worktree at `/worktrees/issue-N` still held `feat/issue-N`, causing the reviewer dispatch to fail with `fatal: 'feat/issue-N' is already used by worktree at '/worktrees/issue-N'`.

Closes #560