### PR TITLE
fix(reaper): use release_worktree (dir only) — never delete branches

### DIFF
--- a/agentception/services/worktree_reaper.py
+++ b/agentception/services/worktree_reaper.py
@@ -1,59 +1,66 @@
 from __future__ import annotations
 
-"""Worktree reaper — removes orphaned agent worktrees without agent cooperation.
+"""Worktree reaper — removes orphaned agent worktree directories.
 
 ``teardown_agent_worktree`` in ``services/teardown.py`` is called by agents
-when they finish normally (via ``build_report_done``).  Agents that crash or
-are killed never reach that call, leaving their worktrees on disk indefinitely.
+when they finish normally (via ``build_complete_run``).  Agents that crash or
+are killed never reach that call, leaving their worktree directories on disk
+indefinitely.
 
 This module provides ``reap_stale_worktrees()``, which is called:
 - Once at application startup (catches orphans from the previous session).
 - Every 15 minutes by a background asyncio task (catches orphans from the
   current session).
 
-The reaper delegates all actual cleanup to the existing
-``teardown_agent_worktree()`` function — it adds no new git logic.
+**Important:** the reaper calls ``release_worktree`` (remove directory + prune
+refs only), NOT ``teardown_agent_worktree`` (which also deletes remote and
+local git branches).  Deleting the remote branch of a run that still has an
+open PR would cause GitHub to auto-close that PR — a side effect the reaper
+must never trigger.  Branch deletion is the responsibility of the merge/close
+workflow, not the disk-space cleanup pass.
 """
 
 import logging
 from pathlib import Path
 
+from agentception.config import settings
 from agentception.db.queries import get_terminal_runs_with_worktrees
-from agentception.services.teardown import teardown_agent_worktree
+from agentception.services.teardown import release_worktree
 
 logger = logging.getLogger(__name__)
 
 
 async def reap_stale_worktrees() -> int:
-    """Remove worktrees for all terminal runs whose directories still exist.
+    """Remove worktree directories for terminal runs that left them on disk.
 
-    Queries the DB for runs with status ``done`` or ``stale`` that still have
-    a ``worktree_path`` set, then tears down any whose directories are present
-    on disk.  Each teardown delegates to ``teardown_agent_worktree``, which
-    handles git worktree removal, branch deletion, and ref pruning — and
-    swallows all errors so a single bad worktree never blocks the sweep.
+    Queries the DB for runs with a terminal status (completed, failed,
+    cancelled, stopped) that still have a ``worktree_path`` set, then releases
+    any whose directories are present on disk.  Uses ``release_worktree``
+    (directory removal + ref pruning only) — **never** deletes git branches,
+    so open PRs are not closed as a side effect.
 
     Returns:
-        The number of worktrees reaped in this pass.
+        The number of worktree directories released in this pass.
     """
     runs = await get_terminal_runs_with_worktrees()
     if not runs:
         logger.debug("ℹ️  worktree reaper: no terminal runs with live worktrees")
         return 0
 
+    repo_dir = str(settings.repo_dir)
     reaped = 0
     for run in runs:
         worktree_path = run["worktree_path"]
         if not Path(worktree_path).exists():
             continue
         logger.info(
-            "⚠️  worktree reaper: stale worktree found for run %r at %s — tearing down",
+            "⚠️  worktree reaper: releasing stale worktree dir for run %r at %s",
             run["id"],
             worktree_path,
         )
-        await teardown_agent_worktree(run["id"])
+        await release_worktree(worktree_path=worktree_path, repo_dir=repo_dir)
         reaped += 1
 
     if reaped:
-        logger.info("✅ worktree reaper: reaped %d stale worktree(s)", reaped)
+        logger.info("✅ worktree reaper: released %d stale worktree dir(s)", reaped)
     return reaped

--- a/agentception/tests/test_worktree_reaper.py
+++ b/agentception/tests/test_worktree_reaper.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+"""Tests for the worktree reaper.
+
+Critical invariant: the reaper must call release_worktree (dir removal only),
+never teardown_agent_worktree (which deletes remote branches and closes open PRs).
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_reaper_calls_release_not_teardown(tmp_path: Path) -> None:
+    """Reaper calls release_worktree, never teardown_agent_worktree.
+
+    Regression for the bug where reap_stale_worktrees called teardown_agent_worktree,
+    which deleted the remote branch and caused GitHub to auto-close open PRs.
+    """
+    fake_worktree = tmp_path / "issue-99"
+    fake_worktree.mkdir()
+
+    with (
+        patch(
+            "agentception.services.worktree_reaper.get_terminal_runs_with_worktrees",
+            new_callable=AsyncMock,
+            return_value=[{"id": "issue-99", "worktree_path": str(fake_worktree), "branch": "feat/issue-99"}],
+        ),
+        patch(
+            "agentception.services.worktree_reaper.release_worktree",
+            new_callable=AsyncMock,
+        ) as mock_release,
+        patch(
+            "agentception.services.worktree_reaper.settings",
+            new_callable=MagicMock,
+            repo_dir="/app",
+        ),
+    ):
+        from agentception.services.worktree_reaper import reap_stale_worktrees
+
+        count = await reap_stale_worktrees()
+
+    assert count == 1
+    mock_release.assert_awaited_once_with(
+        worktree_path=str(fake_worktree),
+        repo_dir="/app",
+    )
+
+
+@pytest.mark.anyio
+async def test_reaper_skips_missing_dirs(tmp_path: Path) -> None:
+    """Reaper skips runs whose worktree directory no longer exists on disk."""
+    absent = str(tmp_path / "issue-100")  # directory not created
+
+    with (
+        patch(
+            "agentception.services.worktree_reaper.get_terminal_runs_with_worktrees",
+            new_callable=AsyncMock,
+            return_value=[{"id": "issue-100", "worktree_path": absent, "branch": "feat/issue-100"}],
+        ),
+        patch(
+            "agentception.services.worktree_reaper.release_worktree",
+            new_callable=AsyncMock,
+        ) as mock_release,
+        patch(
+            "agentception.services.worktree_reaper.settings",
+            new_callable=MagicMock,
+            repo_dir="/app",
+        ),
+    ):
+        from agentception.services.worktree_reaper import reap_stale_worktrees
+
+        count = await reap_stale_worktrees()
+
+    assert count == 0
+    mock_release.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_reaper_returns_zero_when_no_terminal_runs() -> None:
+    """Reaper returns 0 and does nothing when there are no terminal runs."""
+    with (
+        patch(
+            "agentception.services.worktree_reaper.get_terminal_runs_with_worktrees",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.services.worktree_reaper.release_worktree",
+            new_callable=AsyncMock,
+        ) as mock_release,
+        patch(
+            "agentception.services.worktree_reaper.settings",
+            new_callable=MagicMock,
+            repo_dir="/app",
+        ),
+    ):
+        from agentception.services.worktree_reaper import reap_stale_worktrees
+
+        count = await reap_stale_worktrees()
+
+    assert count == 0
+    mock_release.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_reaper_counts_multiple_released_dirs(tmp_path: Path) -> None:
+    """Reaper processes all stale worktrees and returns correct count."""
+    dir_a = tmp_path / "issue-1"
+    dir_b = tmp_path / "issue-2"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    absent = str(tmp_path / "issue-3")  # not on disk — must be skipped
+
+    runs = [
+        {"id": "issue-1", "worktree_path": str(dir_a), "branch": "feat/issue-1"},
+        {"id": "issue-2", "worktree_path": str(dir_b), "branch": "feat/issue-2"},
+        {"id": "issue-3", "worktree_path": absent, "branch": "feat/issue-3"},
+    ]
+
+    with (
+        patch(
+            "agentception.services.worktree_reaper.get_terminal_runs_with_worktrees",
+            new_callable=AsyncMock,
+            return_value=runs,
+        ),
+        patch(
+            "agentception.services.worktree_reaper.release_worktree",
+            new_callable=AsyncMock,
+        ) as mock_release,
+        patch(
+            "agentception.services.worktree_reaper.settings",
+            new_callable=MagicMock,
+            repo_dir="/app",
+        ),
+    ):
+        from agentception.services.worktree_reaper import reap_stale_worktrees
+
+        count = await reap_stale_worktrees()
+
+    assert count == 2
+    assert mock_release.await_count == 2


### PR DESCRIPTION
## Root cause

The `reap_stale_worktrees` loop was calling `teardown_agent_worktree`, which does three things:
1. Remove the worktree directory
2. `git push origin --delete <branch>` — delete the **remote** branch
3. `git branch -D <branch>` — delete the local branch

Step 2 is the killer. When an agent completes and creates a PR, there is a window where:
- The run status is `completed` (terminal)
- The worktree directory still exists on disk
- The open PR depends on the remote branch

If the reaper fires in that window, it deletes the remote branch, and **GitHub automatically closes any open PR whose head branch is deleted**.

## Fix

Switch the reaper to call `release_worktree` (directory removal + ref pruning only). Branch deletion is now exclusively the responsibility of the explicit `teardown_agent_worktree` path — called intentionally after a PR is merged or a run is abandoned.

## Tests

Added `test_worktree_reaper.py` with 4 tests, including a regression test that asserts the reaper calls `release_worktree` and never `teardown_agent_worktree`.