### PR TITLE
docs: fix wrong run context URI and add seven missing arch resources to mcp.md catalogue

### DIFF
--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -145,7 +145,7 @@ AgentCeption exposes all three MCP endpoint types:
 | `ac://runs/{run_id}` | Metadata for one run |
 | `ac://runs/{run_id}/children` | Child runs spawned by this run |
 | `ac://runs/{run_id}/events` | Structured event log; append `?after_id=N` to paginate |
-| `ac://runs/{run_id}/task` | Raw `ac://runs/{run_id}/context` TOML text |
+| `ac://runs/{run_id}/context` | Raw task context TOML text for one run |
 | `ac://batches/{batch_id}/tree` | All runs in a batch |
 | `ac://system/dispatcher` | Dispatcher counters and active batch_id |
 | `ac://system/health` | DB reachability and per-status counts |
@@ -153,6 +153,12 @@ AgentCeption exposes all three MCP endpoint types:
 | `ac://plan/schema` | PlanSpec JSON Schema |
 | `ac://plan/labels` | GitHub label catalogue |
 | `ac://plan/figures/{role}` | Cognitive-arch figures for a role slug |
+| `ac://arch/figures` | All cognitive architecture figures |
+| `ac://arch/archetypes` | All cognitive architecture archetypes |
+| `ac://arch/figures/{figure_id}` | One cognitive architecture figure by ID |
+| `ac://arch/archetypes/{archetype_id}` | One cognitive architecture archetype by ID |
+| `ac://arch/skills/{skill_id}` | One skill domain by ID |
+| `ac://arch/atoms/{atom_id}` | One cognitive atom dimension by ID |
 | `ac://roles/list` | All available role slugs |
 | `ac://roles/{slug}` | Full role definition Markdown for a slug |
 


### PR DESCRIPTION
Closes #451

### Changes

- **Fix:** `ac://runs/{run_id}/task` → `ac://runs/{run_id}/context` (the URI was wrong; description updated to "Raw task context TOML text for one run")
- **Add:** `ac://arch/figures` — All cognitive architecture figures
- **Add:** `ac://arch/archetypes` — All cognitive architecture archetypes
- **Add:** `ac://arch/figures/{figure_id}` — One cognitive architecture figure by ID
- **Add:** `ac://arch/archetypes/{archetype_id}` — One cognitive architecture archetype by ID
- **Add:** `ac://arch/skills/{skill_id}` — One skill domain by ID
- **Add:** `ac://arch/atoms/{atom_id}` — One cognitive atom dimension by ID

Pure documentation change — no Python source files modified, no mypy or test impact.