### PR TITLE
fix: correct model ID format in ml-coordinator role template

### DIFF
--- a/.agentception/roles/ml-coordinator.md
+++ b/.agentception/roles/ml-coordinator.md
@@ -39,7 +39,7 @@ You do NOT own:
 
 ## Operating Constraints
 
-- Exactly two LLM models: `anthropic/claude-sonnet-4.6` and `anthropic/claude-opus-4.6`. No others, ever.
+- Exactly two LLM models: `claude-sonnet-4-6` and `claude-opus-4-6`. No others, ever.
 - MIDI pipeline: beats as the canonical time unit, never seconds.
 
 ## Cognitive Architecture

--- a/scripts/gen_prompts/templates/roles/ml-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/ml-coordinator.md.j2
@@ -38,7 +38,7 @@ You do NOT own:
 
 ## Operating Constraints
 
-- Exactly two LLM models: `anthropic/claude-sonnet-4.6` and `anthropic/claude-opus-4.6`. No others, ever.
+- Exactly two LLM models: `claude-sonnet-4-6` and `claude-opus-4-6`. No others, ever.
 - MIDI pipeline: beats as the canonical time unit, never seconds.
 
 ## Cognitive Architecture


### PR DESCRIPTION
## Summary
- Fixes `anthropic/claude-sonnet-4.6` → `claude-sonnet-4-6` (dot separator and `anthropic/` prefix were both wrong)
- Fixes `anthropic/claude-opus-4.6` → `claude-opus-4-6`
- Regenerated `.agentception/roles/ml-coordinator.md` from the corrected template

Aligns with the canonical Anthropic model ID format used everywhere else in the codebase.