### PR TITLE
fix: use full unfiltered transcript list for role-filter UI population

### DIFF
--- a/agentception/routes/ui/transcripts.py
+++ b/agentception/routes/ui/transcripts.py
@@ -41,6 +41,7 @@ async def transcripts_browser(request: Request) -> HTMLResponse:
         if tr_root is not None:
             transcripts_dir_str = str(tr_root)
             all_transcripts = await index_transcripts(tr_root)
+            _all_transcripts_for_roles = all_transcripts
 
             # Server-side filter pass
             for t in all_transcripts:
@@ -63,10 +64,9 @@ async def transcripts_browser(request: Request) -> HTMLResponse:
         error = str(exc)
 
     # Collect unique roles from the full unfiltered index for the filter UI
-    # (re-use transcripts if no filters active, otherwise do a second pass cheaply)
     all_roles: list[str] = []
     seen_roles: set[str] = set()
-    for t in transcripts:
+    for t in (_all_transcripts_for_roles if '_all_transcripts_for_roles' in dir() else transcripts):
         r = str(t.get("role") or "unknown")
         if r not in seen_roles:
             seen_roles.add(r)


### PR DESCRIPTION
Closes #37

## What changed

`agentception/routes/ui/transcripts.py` — role-filter bug fix:

- When server-side filters are active, `all_transcripts` (the full unfiltered list) is now captured into `_all_transcripts_for_roles` immediately after indexing.
- The role-collection loop now iterates over `_all_transcripts_for_roles` when available, falling back to `transcripts` when no filters are active.

This ensures the role filter UI always shows **all** available roles, not just the roles present in the currently-filtered result set — which was the bug: applying a role filter would collapse the filter dropdown to only the selected role, making it impossible to switch to a different role without clearing the filter first.