### PR TITLE
feat: auto-redispatch executor on reviewer rejection (retry loop)

### DIFF
--- a/.agentception/roles/executor.md
+++ b/.agentception/roles/executor.md
@@ -64,8 +64,24 @@ Re-run pytest once to confirm. Do not read files between fix attempts.
 
 ### Step 3 — Acceptance criteria check
 
-Read the issue acceptance criteria from your briefing. For each item, confirm
-it is satisfied. If any item is not met, implement it in one write call.
+Read every AC item from your briefing **one by one**. For each item:
+- If it names a specific file, verify that file was modified or created.
+- If it describes behaviour, verify the code implements it.
+- If it is not satisfied, implement it now in one write call.
+
+**Do not call `build_complete_run` if even one AC item is unmet.** A
+partial PR will be rejected by the reviewer and you will be redispatched
+with the defect list — costing extra compute for both of us.
+
+Also watch for these common code smells before submitting:
+- Using `dir()` to test whether a local variable exists — initialize it
+  before the `try` block instead.
+- Bare `except Exception` without re-raising.
+- Inline SQL strings instead of SQLAlchemy expressions.
+
+If your briefing contains a **Reviewer Rejection** section at the top,
+those defects are the highest-priority items. Address every one of them
+before touching anything else.
 
 ### Step 4 — Commit, push, PR
 

--- a/.agentception/roles/pr-reviewer.md
+++ b/.agentception/roles/pr-reviewer.md
@@ -90,7 +90,7 @@ issue_write(method="update", owner=$OWNER, repo=$REPO,
             issue_number=$ISSUE_NUMBER, state="closed", state_reason="completed")
 ```
 
-If grade B/C/D/F — reject:
+If grade C/D/F — reject:
 
 ```
 pull_request_review_write(
@@ -98,9 +98,18 @@ pull_request_review_write(
   method="create_and_submit",
   event="REQUEST_CHANGES",
   body="Grade: <grade> — <specific defect: what failed and why>")
+
+build_complete_run(
+  issue_number=$ISSUE_NUMBER,
+  pr_url=<pr_url>,
+  summary="Grade: <grade> — rejected.",
+  grade="<grade>",
+  reviewer_feedback="<full numbered defect list, plain text>")
 ```
 
-Then call `build_complete_run`.
+The system automatically closes the PR and redispatches the executor with
+your defect list injected at the top of the briefing — no human needed.
+Up to 3 attempts are allowed before the loop is abandoned.
 
 ## Hard Rules
 

--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -2604,6 +2604,25 @@ async def get_agent_run_role(run_id: str) -> str | None:
         return None
 
 
+async def get_agent_run_task_description(run_id: str) -> str | None:
+    """Return the task_description for a single agent run, or None if not found.
+
+    Used by auto_redispatch to count prior reviewer-rejection sections injected
+    into the task description — the rejection count determines the attempt number
+    without requiring an extra DB column.
+    """
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun.task_description).where(ACAgentRun.id == run_id)
+            )
+            row = result.one_or_none()
+        return row[0] if row is not None else None
+    except Exception as exc:
+        logger.warning("⚠️  get_agent_run_task_description DB query failed (non-fatal): %s", exc)
+        return None
+
+
 class TerminalRunRow(TypedDict):
     """Minimal run fields needed by the worktree reaper."""
 

--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -37,6 +37,7 @@ from agentception.db.persist import (
 from agentception.config import settings
 from agentception.db.queries import get_agent_run_role, get_agent_run_teardown
 
+from agentception.services.auto_redispatch import auto_redispatch_after_rejection
 from agentception.services.auto_reviewer import auto_dispatch_reviewer
 from agentception.services.spawn_child import ScopeType, SpawnChildError, Tier, spawn_child
 from agentception.services.teardown import release_worktree, teardown_agent_worktree
@@ -189,6 +190,8 @@ async def build_complete_run(
     pr_url: str,
     summary: str = "",
     agent_run_id: str | None = None,
+    grade: str = "",
+    reviewer_feedback: str = "",
 ) -> dict[str, object]:
     """Record that the agent has finished work and transition to completed.
 
@@ -199,11 +202,20 @@ async def build_complete_run(
     Was: part of ``build_report_done``.  Teardown is now a separate explicit
     command so orchestration layers can control when cleanup happens.
 
+    When called by a pr-reviewer with a failing grade (C/D/F), a new developer
+    run is automatically dispatched with the reviewer's feedback injected into
+    the briefing — up to 3 attempts before the loop is abandoned.
+
     Args:
         issue_number: GitHub issue number the agent worked on.
-        pr_url: Full URL of the opened pull request.
+        pr_url: Full URL of the opened (or rejected) pull request.
         summary: Optional one-sentence description of what was done.
         agent_run_id: Run ID used to transition the run state.
+        grade: Grade assigned by the pr-reviewer (e.g. "A", "B", "C", "D", "F").
+            Empty string when called by a non-reviewer agent.
+        reviewer_feedback: Full defect list from the pr-reviewer.  Injected
+            verbatim into the re-dispatched developer briefing.  Empty string
+            when called by a non-reviewer agent.
 
     Returns:
         ``{"ok": True, "event": "done", "status": "completed"}``
@@ -229,16 +241,39 @@ async def build_complete_run(
         issue_number, pr_url, agent_run_id,
     )
 
-    # Auto-dispatch a pr-reviewer for completed implementer runs only.
-    # Skip when the completing run is itself a pr-reviewer to prevent an
-    # infinite reviewer → reviewer → … dispatch loop.
+    # Reviewer path: grade determines whether to merge (handled by reviewer) or
+    # redispatch a corrected developer run.
     caller_role = await get_agent_run_role(agent_run_id) if agent_run_id else None
     if caller_role == "pr-reviewer":
-        logger.info(
-            "ℹ️ build_complete_run: skipping auto-reviewer (caller is pr-reviewer) run_id=%r",
-            agent_run_id,
-        )
+        _FAILING_GRADES: frozenset[str] = frozenset({"C", "D", "F"})
+        normalised_grade = grade.strip().upper()
+        if normalised_grade in _FAILING_GRADES:
+            logger.info(
+                "ℹ️ build_complete_run: reviewer rejected (grade=%r) — "
+                "scheduling auto-redispatch for issue #%d run_id=%r",
+                grade,
+                issue_number,
+                agent_run_id,
+            )
+            asyncio.create_task(
+                auto_redispatch_after_rejection(
+                    issue_number=issue_number,
+                    pr_url=pr_url,
+                    reviewer_feedback=reviewer_feedback,
+                    grade=normalised_grade,
+                ),
+                name=f"auto-redispatch-{issue_number}",
+            )
+        else:
+            # Grade A or B: reviewer already merged — nothing else to do.
+            logger.info(
+                "ℹ️ build_complete_run: reviewer approved (grade=%r) — "
+                "no redispatch needed run_id=%r",
+                grade,
+                agent_run_id,
+            )
     else:
+        # Non-reviewer (implementer) completed: release worktree and dispatch reviewer.
         # Release the executor's worktree before dispatching the reviewer.
         # Git forbids the same branch in two worktrees simultaneously; if the
         # executor's worktree still holds the branch the reviewer dispatch will

--- a/agentception/services/auto_redispatch.py
+++ b/agentception/services/auto_redispatch.py
@@ -1,0 +1,198 @@
+"""Auto-redispatch a developer run after a reviewer rejection.
+
+When the pr-reviewer calls build_complete_run with a failing grade (C/D/F),
+this service:
+
+1. Closes the rejected PR.
+2. Fetches the original issue details from GitHub.
+3. Builds an enhanced issue body injecting the reviewer's defect list at the top.
+4. Redispatches a developer run with the enriched briefing so the executor
+   sees the full defect list before writing a single line of code.
+
+Maximum 3 attempts. After the third rejection the run is abandoned and an
+error is logged — no further redispatch occurs.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+
+import httpx
+
+from agentception.config import settings
+from agentception.db.queries import get_agent_run_task_description
+from agentception.readers.github import close_pr, get_issue
+
+logger = logging.getLogger(__name__)
+
+_PR_URL_RE = re.compile(r"/pull/(\d+)")
+_SERVICE_URL = "http://localhost:10003/api/dispatch/issue"
+
+# Seconds to wait before redispatching — gives GitHub time to process
+# the PR close before the new worktree fetch starts.
+_REDISPATCH_DELAY_SECS: float = 3.0
+
+# Maximum number of reviewer-rejected attempts before giving up.
+_MAX_ATTEMPTS: int = 3
+
+# Marker string embedded in enhanced issue bodies so we can count retries.
+_REJECTION_MARKER = "## Reviewer Rejection — Attempt"
+
+
+def _count_prior_rejections(task_description: str | None) -> int:
+    """Count existing rejection sections already injected into the task description."""
+    if not task_description:
+        return 0
+    return task_description.count(_REJECTION_MARKER)
+
+
+def _build_enhanced_body(
+    original_body: str,
+    reviewer_feedback: str,
+    grade: str,
+    attempt: int,
+) -> str:
+    """Prepend a rejection section to the original issue body.
+
+    The rejection section is always prepended so the executor sees it
+    before reading the rest of the spec — highest-priority context first.
+    """
+    feedback_section = (
+        f"{_REJECTION_MARKER} {attempt} (Grade: {grade})\n\n"
+        f"The previous implementation was **rejected**. Every defect listed "
+        f"below **must** be resolved before calling `build_complete_run`.\n\n"
+        f"{reviewer_feedback}\n\n"
+        f"---\n\n"
+    )
+    return feedback_section + original_body
+
+
+async def auto_redispatch_after_rejection(
+    issue_number: int,
+    pr_url: str,
+    reviewer_feedback: str,
+    grade: str,
+) -> None:
+    """Close a rejected PR and redispatch the developer for a new attempt.
+
+    Called as a fire-and-forget background task from build_complete_run when
+    the pr-reviewer signals a failing grade.  Never raises — all errors are
+    logged at ERROR level and swallowed so the reviewer's completed state is
+    not disturbed.
+
+    Args:
+        issue_number: GitHub issue number the implementer worked on.
+        pr_url: Full URL of the rejected pull request.
+        reviewer_feedback: Full defect list from the reviewer (plain text).
+        grade: Single letter grade from the reviewer (e.g. "C", "D", "F").
+    """
+    run_id = f"issue-{issue_number}"
+
+    # Determine attempt number from the current task_description in the DB.
+    # Each prior rejection prepends a _REJECTION_MARKER section; counting them
+    # gives us the number of prior attempts without any extra DB columns.
+    task_desc = await get_agent_run_task_description(run_id)
+    prior_count = _count_prior_rejections(task_desc)
+    attempt = prior_count + 1
+
+    if attempt > _MAX_ATTEMPTS:
+        logger.error(
+            "❌ auto_redispatch: max attempts (%d) reached for issue #%d — "
+            "no further redispatch. Last grade: %s",
+            _MAX_ATTEMPTS,
+            issue_number,
+            grade,
+        )
+        return
+
+    pr_match = _PR_URL_RE.search(pr_url)
+    if not pr_match:
+        logger.error(
+            "❌ auto_redispatch: cannot parse PR number from %r — abandoning issue #%d",
+            pr_url,
+            issue_number,
+        )
+        return
+    pr_number = int(pr_match.group(1))
+
+    await asyncio.sleep(_REDISPATCH_DELAY_SECS)
+
+    # Close the rejected PR so the branch can be recreated clean.
+    try:
+        await close_pr(
+            pr_number,
+            comment=(
+                f"**Grade {grade} — Attempt {attempt} rejected.** "
+                f"Closing for rework. Defects:\n\n{reviewer_feedback}"
+            ),
+        )
+        logger.info(
+            "✅ auto_redispatch: closed PR #%d for issue #%d (attempt %d, grade %s)",
+            pr_number,
+            issue_number,
+            attempt,
+            grade,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "❌ auto_redispatch: failed to close PR #%d — %s (continuing)",
+            pr_number,
+            exc,
+        )
+
+    # Fetch the original issue from GitHub for title + body.
+    try:
+        issue = await get_issue(issue_number)
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "❌ auto_redispatch: failed to fetch issue #%d — %s",
+            issue_number,
+            exc,
+        )
+        return
+
+    issue_title = str(issue.get("title") or f"Issue #{issue_number}")
+    original_body = str(issue.get("body") or "")
+    enhanced_body = _build_enhanced_body(original_body, reviewer_feedback, grade, attempt)
+
+    payload: dict[str, object] = {
+        "issue_number": issue_number,
+        "issue_title": issue_title,
+        "issue_body": enhanced_body,
+        "role": "developer",
+        "repo": settings.gh_repo,
+    }
+    headers = {
+        "X-API-Key": settings.ac_api_key,
+        "Content-Type": "application/json",
+    }
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                _SERVICE_URL,
+                json=payload,
+                headers=headers,
+                timeout=30.0,
+            )
+            resp.raise_for_status()
+        logger.info(
+            "✅ auto_redispatch: developer dispatched for issue #%d (attempt %d/%d)",
+            issue_number,
+            attempt,
+            _MAX_ATTEMPTS,
+        )
+    except httpx.HTTPStatusError as exc:
+        logger.error(
+            "❌ auto_redispatch: dispatch returned %d for issue #%d — %s",
+            exc.response.status_code,
+            issue_number,
+            exc.response.text[:200],
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.error(
+            "❌ auto_redispatch: failed to dispatch for issue #%d — %s",
+            issue_number,
+            exc,
+        )

--- a/agentception/tests/test_auto_redispatch.py
+++ b/agentception/tests/test_auto_redispatch.py
@@ -1,0 +1,309 @@
+"""Tests for agentception/services/auto_redispatch.py.
+
+Covers:
+- _count_prior_rejections: zero, one, multiple rejections in task_description
+- _build_enhanced_body: correct structure and ordering
+- auto_redispatch_after_rejection:
+    - max attempts guard
+    - bad PR URL guard
+    - happy path: closes PR, fetches issue, dispatches developer
+    - close_pr failure is non-fatal (continues to dispatch)
+    - dispatch HTTP error is logged and swallowed
+
+Run targeted:
+    pytest agentception/tests/test_auto_redispatch.py -v
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from agentception.services.auto_redispatch import (
+    _REJECTION_MARKER,
+    _build_enhanced_body,
+    _count_prior_rejections,
+    auto_redispatch_after_rejection,
+)
+
+
+# ---------------------------------------------------------------------------
+# _count_prior_rejections
+# ---------------------------------------------------------------------------
+
+
+def test_count_prior_rejections_none() -> None:
+    """Returns 0 when task_description is None."""
+    assert _count_prior_rejections(None) == 0
+
+
+def test_count_prior_rejections_empty() -> None:
+    """Returns 0 when task_description is an empty string."""
+    assert _count_prior_rejections("") == 0
+
+
+def test_count_prior_rejections_no_markers() -> None:
+    """Returns 0 when no rejection markers are present."""
+    assert _count_prior_rejections("normal issue body without rejections") == 0
+
+
+def test_count_prior_rejections_one() -> None:
+    """Returns 1 when exactly one rejection marker is present."""
+    body = f"{_REJECTION_MARKER} 1 (Grade: C)\n\nsome feedback\n\n---\n\noriginal"
+    assert _count_prior_rejections(body) == 1
+
+
+def test_count_prior_rejections_two() -> None:
+    """Returns 2 when two rejection markers are present (second attempt)."""
+    body = (
+        f"{_REJECTION_MARKER} 2 (Grade: C)\n\nfeedback2\n\n---\n\n"
+        f"{_REJECTION_MARKER} 1 (Grade: D)\n\nfeedback1\n\n---\n\noriginal"
+    )
+    assert _count_prior_rejections(body) == 2
+
+
+# ---------------------------------------------------------------------------
+# _build_enhanced_body
+# ---------------------------------------------------------------------------
+
+
+def test_build_enhanced_body_prepends_rejection_section() -> None:
+    """Rejection section must appear before the original body."""
+    result = _build_enhanced_body(
+        original_body="## Original spec",
+        reviewer_feedback="1. Missing test\n2. dir() smell",
+        grade="C",
+        attempt=1,
+    )
+    rejection_pos = result.find(_REJECTION_MARKER)
+    original_pos = result.find("## Original spec")
+    assert rejection_pos < original_pos
+
+
+def test_build_enhanced_body_contains_grade_and_attempt() -> None:
+    """Output must include the grade and attempt number."""
+    result = _build_enhanced_body(
+        original_body="body",
+        reviewer_feedback="defect",
+        grade="D",
+        attempt=2,
+    )
+    assert "Grade: D" in result
+    assert "Attempt 2" in result
+
+
+def test_build_enhanced_body_contains_feedback() -> None:
+    """Reviewer feedback must appear verbatim in the output."""
+    feedback = "1. Missing SCSS move\n2. No regression test"
+    result = _build_enhanced_body("body", feedback, "C", 1)
+    assert feedback in result
+
+
+def test_build_enhanced_body_original_body_preserved() -> None:
+    """Original issue body must appear intact in the output."""
+    original = "## Objective\nDo the thing.\n\n## AC\n- [ ] item"
+    result = _build_enhanced_body(original, "defect", "C", 1)
+    assert original in result
+
+
+# ---------------------------------------------------------------------------
+# auto_redispatch_after_rejection
+# ---------------------------------------------------------------------------
+
+_ISSUE_NUMBER = 37
+_PR_URL = "https://github.com/cgcardona/agentception/pull/569"
+_GRADE = "C"
+_FEEDBACK = "1. dir() smell\n2. SCSS not moved\n3. No regression test"
+
+
+@pytest.mark.anyio
+async def test_auto_redispatch_max_attempts_guard() -> None:
+    """No dispatch or PR-close occurs when max attempts is reached."""
+    with (
+        patch(
+            "agentception.services.auto_redispatch.get_agent_run_task_description",
+            new_callable=AsyncMock,
+            # 3 prior rejections → attempt 4 → over the limit
+            return_value=(
+                f"{_REJECTION_MARKER} 1\n"
+                f"{_REJECTION_MARKER} 2\n"
+                f"{_REJECTION_MARKER} 3\n"
+            ),
+        ),
+        patch(
+            "agentception.services.auto_redispatch.close_pr",
+            new_callable=AsyncMock,
+        ) as mock_close,
+        patch(
+            "agentception.services.auto_redispatch.get_issue",
+            new_callable=AsyncMock,
+        ) as mock_get_issue,
+    ):
+        await auto_redispatch_after_rejection(
+            issue_number=_ISSUE_NUMBER,
+            pr_url=_PR_URL,
+            reviewer_feedback=_FEEDBACK,
+            grade=_GRADE,
+        )
+    mock_close.assert_not_called()
+    mock_get_issue.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_auto_redispatch_bad_pr_url_guard() -> None:
+    """No dispatch occurs when the PR URL cannot be parsed."""
+    with (
+        patch(
+            "agentception.services.auto_redispatch.get_agent_run_task_description",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "agentception.services.auto_redispatch.close_pr",
+            new_callable=AsyncMock,
+        ) as mock_close,
+        patch("agentception.services.auto_redispatch.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await auto_redispatch_after_rejection(
+            issue_number=_ISSUE_NUMBER,
+            pr_url="https://github.com/cgcardona/agentception/issues/37",  # not a pull URL
+            reviewer_feedback=_FEEDBACK,
+            grade=_GRADE,
+        )
+    mock_close.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_auto_redispatch_happy_path() -> None:
+    """Closes PR, fetches issue, dispatches developer on the happy path."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with (
+        patch(
+            "agentception.services.auto_redispatch.get_agent_run_task_description",
+            new_callable=AsyncMock,
+            return_value=None,  # first attempt
+        ),
+        patch(
+            "agentception.services.auto_redispatch.close_pr",
+            new_callable=AsyncMock,
+        ) as mock_close,
+        patch(
+            "agentception.services.auto_redispatch.get_issue",
+            new_callable=AsyncMock,
+            return_value={"title": "Fix transcripts", "body": "## Original"},
+        ) as mock_get_issue,
+        patch("agentception.services.auto_redispatch.asyncio.sleep", new_callable=AsyncMock),
+        patch("agentception.services.auto_redispatch.settings") as mock_settings,
+        patch("agentception.services.auto_redispatch.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_settings.gh_repo = "cgcardona/agentception"
+        mock_settings.ac_api_key = "test-key"
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await auto_redispatch_after_rejection(
+            issue_number=_ISSUE_NUMBER,
+            pr_url=_PR_URL,
+            reviewer_feedback=_FEEDBACK,
+            grade=_GRADE,
+        )
+
+    mock_close.assert_called_once_with(569, comment=mock_close.call_args[1]["comment"])
+    mock_get_issue.assert_called_once_with(_ISSUE_NUMBER)
+    mock_client.post.assert_called_once()
+    payload = mock_client.post.call_args[1]["json"]
+    assert payload["role"] == "developer"
+    assert payload["issue_number"] == _ISSUE_NUMBER
+    assert _REJECTION_MARKER in payload["issue_body"]
+    assert _FEEDBACK in payload["issue_body"]
+
+
+@pytest.mark.anyio
+async def test_auto_redispatch_close_pr_failure_is_nonfatal() -> None:
+    """A close_pr failure must not prevent the developer dispatch."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with (
+        patch(
+            "agentception.services.auto_redispatch.get_agent_run_task_description",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "agentception.services.auto_redispatch.close_pr",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("GitHub unavailable"),
+        ),
+        patch(
+            "agentception.services.auto_redispatch.get_issue",
+            new_callable=AsyncMock,
+            return_value={"title": "Fix", "body": "body"},
+        ),
+        patch("agentception.services.auto_redispatch.asyncio.sleep", new_callable=AsyncMock),
+        patch("agentception.services.auto_redispatch.settings") as mock_settings,
+        patch("agentception.services.auto_redispatch.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_settings.gh_repo = "cgcardona/agentception"
+        mock_settings.ac_api_key = "test-key"
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await auto_redispatch_after_rejection(
+            issue_number=_ISSUE_NUMBER,
+            pr_url=_PR_URL,
+            reviewer_feedback=_FEEDBACK,
+            grade=_GRADE,
+        )
+
+    # Dispatch must still have been called despite close_pr raising.
+    mock_client.post.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_auto_redispatch_http_error_is_swallowed() -> None:
+    """An HTTP error from the dispatch endpoint must be logged, not raised."""
+    with (
+        patch(
+            "agentception.services.auto_redispatch.get_agent_run_task_description",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("agentception.services.auto_redispatch.close_pr", new_callable=AsyncMock),
+        patch(
+            "agentception.services.auto_redispatch.get_issue",
+            new_callable=AsyncMock,
+            return_value={"title": "Fix", "body": "body"},
+        ),
+        patch("agentception.services.auto_redispatch.asyncio.sleep", new_callable=AsyncMock),
+        patch("agentception.services.auto_redispatch.settings") as mock_settings,
+        patch("agentception.services.auto_redispatch.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_settings.gh_repo = "cgcardona/agentception"
+        mock_settings.ac_api_key = "test-key"
+
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_resp = MagicMock(spec=httpx.Response)
+        mock_resp.status_code = 500
+        mock_resp.text = "internal error"
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError("500", request=mock_request, response=mock_resp)
+        )
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        # Must not raise.
+        await auto_redispatch_after_rejection(
+            issue_number=_ISSUE_NUMBER,
+            pr_url=_PR_URL,
+            reviewer_feedback=_FEEDBACK,
+            grade=_GRADE,
+        )

--- a/scripts/gen_prompts/templates/roles/executor.md.j2
+++ b/scripts/gen_prompts/templates/roles/executor.md.j2
@@ -63,8 +63,24 @@ Re-run pytest once to confirm. Do not read files between fix attempts.
 
 ### Step 3 — Acceptance criteria check
 
-Read the issue acceptance criteria from your briefing. For each item, confirm
-it is satisfied. If any item is not met, implement it in one write call.
+Read every AC item from your briefing **one by one**. For each item:
+- If it names a specific file, verify that file was modified or created.
+- If it describes behaviour, verify the code implements it.
+- If it is not satisfied, implement it now in one write call.
+
+**Do not call `build_complete_run` if even one AC item is unmet.** A
+partial PR will be rejected by the reviewer and you will be redispatched
+with the defect list — costing extra compute for both of us.
+
+Also watch for these common code smells before submitting:
+- Using `dir()` to test whether a local variable exists — initialize it
+  before the `try` block instead.
+- Bare `except Exception` without re-raising.
+- Inline SQL strings instead of SQLAlchemy expressions.
+
+If your briefing contains a **Reviewer Rejection** section at the top,
+those defects are the highest-priority items. Address every one of them
+before touching anything else.
 
 ### Step 4 — Commit, push, PR
 

--- a/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/pr-reviewer.md.j2
@@ -89,7 +89,7 @@ issue_write(method="update", owner=$OWNER, repo=$REPO,
             issue_number=$ISSUE_NUMBER, state="closed", state_reason="completed")
 ```
 
-If grade B/C/D/F — reject:
+If grade C/D/F — reject:
 
 ```
 pull_request_review_write(
@@ -97,9 +97,18 @@ pull_request_review_write(
   method="create_and_submit",
   event="REQUEST_CHANGES",
   body="Grade: <grade> — <specific defect: what failed and why>")
+
+build_complete_run(
+  issue_number=$ISSUE_NUMBER,
+  pr_url=<pr_url>,
+  summary="Grade: <grade> — rejected.",
+  grade="<grade>",
+  reviewer_feedback="<full numbered defect list, plain text>")
 ```
 
-Then call `build_complete_run`.
+The system automatically closes the PR and redispatches the executor with
+your defect list injected at the top of the briefing — no human needed.
+Up to 3 attempts are allowed before the loop is abandoned.
 
 ## Hard Rules
 


### PR DESCRIPTION
## Summary
- When the pr-reviewer rejects with grade C/D/F, the system now automatically closes the PR, prepends the full defect list to the issue briefing, and redispatches a fresh developer run — no human in the middle
- Attempt count tracked via `_REJECTION_MARKER` sections in `task_description` (no new DB columns)
- Max 3 attempts before loop is abandoned
- Executor prompt gets stronger AC-check gate and common code-smell list (`dir()` pattern, bare except)
- Reviewer prompt updated to pass `grade` + `reviewer_feedback` to `build_complete_run`
- 14 unit tests, mypy clean

## New files
- `agentception/services/auto_redispatch.py`
- `agentception/tests/test_auto_redispatch.py`

## Modified
- `agentception/mcp/build_commands.py` — `build_complete_run` gains `grade` + `reviewer_feedback` params
- `agentception/db/queries.py` — `get_agent_run_task_description`
- `scripts/gen_prompts/templates/roles/pr-reviewer.md.j2`
- `scripts/gen_prompts/templates/roles/executor.md.j2`