### PR TITLE
fix: role-filter bug and CSS/JS separation on transcript pages

### DIFF
--- a/agentception/routes/ui/transcripts.py
+++ b/agentception/routes/ui/transcripts.py
@@ -63,10 +63,9 @@ async def transcripts_browser(request: Request) -> HTMLResponse:
         error = str(exc)
 
     # Collect unique roles from the full unfiltered index for the filter UI
-    # (re-use transcripts if no filters active, otherwise do a second pass cheaply)
     all_roles: list[str] = []
     seen_roles: set[str] = set()
-    for t in transcripts:
+    for t in (all_transcripts if tr_root is not None else []):
         r = str(t.get("role") or "unknown")
         if r not in seen_roles:
             seen_roles.add(r)

--- a/agentception/static/scss/pages/_transcripts.scss
+++ b/agentception/static/scss/pages/_transcripts.scss
@@ -28,18 +28,6 @@
   flex-shrink: 0;
 }
 
-/* ── Scrollbar ────────────────────────────────────────────────── */
-
-::-webkit-scrollbar { width: 6px; height: 6px; }
-::-webkit-scrollbar-track { background: var(--bg-void); }
-::-webkit-scrollbar-thumb {
-  background: var(--border-default);
-  border-radius: var(--radius-full);
-}
-::-webkit-scrollbar-thumb:hover {
-  background: var(--border-strong);
-}
-
 /* ── Media queries ────────────────────────────────────────────── */
 
 @media (max-width: 900px) {
@@ -81,31 +69,6 @@
   font-family: var(--font-mono);
   font-size: 0.8125rem;
 }
-
-/* ── Page header row (title + filter buttons) ─────────────────── */
-.page-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 1.25rem;
-  gap: 1rem;
-}
-
-.page-title {
-  font-size: 1.125rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  letter-spacing: -0.02em;
-  margin: 0;
-}
-
-.page-subtitle {
-  font-size: 0.8125rem;
-  color: var(--text-muted);
-  margin: 0.2rem 0 0;
-}
-
-.page-subtitle a { color: var(--accent-bright); }
 
 .filter-group {
   display: flex;


### PR DESCRIPTION
Closes #37

- **Role-filter bug**: `all_roles` was built from the already-filtered `transcripts` list, so selecting a role filter would collapse the filter UI to only that one role. Fixed by iterating over `all_transcripts` (the full unfiltered index) when `tr_root` is set.
- **CSS cleanup**: Removed duplicate scrollbar and page-header/title/subtitle rules from `_transcripts.scss` that were already defined in the shared base stylesheet, eliminating specificity conflicts.