### PR TITLE
feat: pre-load diff/mypy/pytest/issue into reviewer context before iteration 1

### DIFF
--- a/.agentception/roles/reviewer.md
+++ b/.agentception/roles/reviewer.md
@@ -26,45 +26,27 @@ Do not read any file before extracting these.
 
 ## Review Steps — Follow in Order
 
-### 1 — Fetch the diff
+Your initial message already contains a **Pre-loaded Review Context** block with:
+- The full `git diff` of all changes
+- The mypy output (run once, complete)
+- The pytest output for changed test modules
+- The GitHub issue with acceptance criteria
 
-```bash
-cd agentception
-git fetch origin && git checkout $BRANCH
-git diff origin/dev...HEAD --name-only
-git diff origin/dev...HEAD
-```
+**Do not re-run any of these.** You have everything you need. Read the
+pre-loaded block, form your grade, and act.
 
-Read each changed file **once** from the diff. Do not call `read_file` on any
-file already in the diff.
+### 1 — Read the pre-loaded context
 
-### 2 — Run mypy and targeted tests
+Read the Pre-loaded Review Context in your initial message. Extract:
+- Which files changed (from the "Changed files" section)
+- Any mypy errors or test failures
+- The acceptance criteria from the issue
 
-Type checker first, always:
+If you need to inspect one specific file not fully visible in the diff, one
+`read_file` call is acceptable. Do not grep, do not search, do not list
+directories.
 
-```bash
-docker compose exec agentception sh -c "PYTHONPATH=/worktrees/$WTNAME mypy /worktrees/$WTNAME/agentception/"
-```
-
-Then run only the test files for modules that changed:
-
-```bash
-PYTHONPATH=/worktrees/$WTNAME pytest /worktrees/$WTNAME/agentception/tests/test_<changed_module>.py -v
-```
-
-Full output only — never pipe through `head` or `tail`.
-
-### 3 — Check acceptance criteria
-
-Fetch the original issue:
-
-```
-issue_read(owner=$OWNER, repo=$REPO, issue_number=$ISSUE_NUMBER)
-```
-
-For every AC checkbox, verify it is satisfied by the diff you already read.
-
-### 4 — Grade and act
+### 2 — Grade and act
 
 | Grade | Criteria | Action |
 |-------|----------|--------|
@@ -114,7 +96,9 @@ Up to 3 attempts are allowed before the loop is abandoned.
 ## Hard Rules
 
 - **You do not write code.** No `replace_in_file`, no `write_file`, no `insert_after_in_file`. Ever.
-- Read each file once from the diff. Do not call `read_file` on files already in the diff.
-- Run mypy once and pytest once. A second run gives zero new signal.
+- **Do not re-run mypy or pytest.** The results are already in your context. A second run gives zero new signal.
+- **Do not re-read the diff.** It is already in your context.
+- If you need one file for clarification, one `read_file` is acceptable. No grep, no search_text, no list_directory.
 - Merge or reject. Those are the only two outcomes.
 - Call `build_complete_run` after merging or after posting rejection.
+- **You should reach a decision in ≤5 iterations.** If you are still reading on iteration 5, stop and grade based on what you have.

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -464,12 +464,29 @@ async def run_agent_loop(
         len(github_tool_names),
     )
 
-    # Pre-loop recon phase: model emits an exploration plan; runtime executes
-    # all reads/searches concurrently and injects results into the initial
-    # message.  This collapses 5-10 discovery turns into a zero-turn warm-up.
-    # Executor runs skip recon — the ExecutionPlan already supplies all file
-    # contents and exact parameters; no discovery reads are needed.
-    if task.role != "executor":
+    # Pre-loop context injection — role-specific, runs before iteration 1.
+    #
+    # executor  → skip entirely (ExecutionPlan supplies all context)
+    # reviewer  → deterministic warmup: diff + mypy + pytest + issue pre-computed
+    #             and injected so the reviewer needs 0 discovery tool calls
+    # all other → LLM-driven recon (reads/searches the agent requests)
+    if task.role == "executor":
+        pass  # no recon needed
+    elif task.role == "reviewer":
+        _gh_repo_raw = task.gh_repo or settings.gh_repo
+        _gh_repo = str(_gh_repo_raw) if isinstance(_gh_repo_raw, str) else ""
+        _owner, _, _repo_name = _gh_repo.partition("/")
+        _pr_branch = task.branch or f"feat/issue-{issue_number}"
+        await _run_reviewer_warmup(
+            worktree_path=worktree_path,
+            pr_branch=_pr_branch,
+            issue_number=issue_number,
+            messages=messages,
+            github_client=github_client,
+            owner=_owner,
+            repo=_repo_name,
+        )
+    else:
         await _run_recon_phase(run_id, worktree_path, messages, system_prompt)
 
     # Loop-guard state — reset by any write tool call, incremented every
@@ -1158,6 +1175,160 @@ def _parse_recon_json(raw: str) -> _ReconPlan | None:
         return None
 
     return _ReconPlan(files=files, searches=searches, plan=plan_str)
+
+
+async def _shell_capture(cmd: str, cwd: Path, timeout: int = 300) -> str:
+    """Run *cmd* in a shell and return combined stdout+stderr as a string.
+
+    Used by the reviewer warmup to pre-compute context before iteration 1.
+    Never raises — failures are returned as an error string so the warmup
+    bundle is always well-formed.
+    """
+    try:
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            cwd=cwd,
+        )
+        try:
+            raw, _ = await asyncio.wait_for(proc.communicate(), timeout=float(timeout))
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            return f"(command timed out after {timeout}s)"
+        return raw.decode(errors="replace").strip()
+    except Exception as exc:  # noqa: BLE001
+        return f"(error running command: {exc})"
+
+
+async def _run_reviewer_warmup(
+    worktree_path: Path,
+    pr_branch: str,
+    issue_number: int,
+    messages: list[dict[str, object]],
+    github_client: GitHubMCPClient | None,
+    owner: str,
+    repo: str,
+) -> None:
+    """Pre-compute all review signal and inject it into messages[0].
+
+    Runs five deterministic steps — no LLM call, no discovery loop — and
+    appends the results as a single bundle to the reviewer's initial message.
+    After this runs the reviewer starts iteration 1 with everything it needs:
+
+    1. git diff — the exact set of changes to review
+    2. mypy — type-check result (run once, never again)
+    3. pytest — targeted at test files for changed modules (run once)
+    4. GitHub issue — acceptance criteria to verify against
+    5. Changed file list — quick overview before the full diff
+
+    With all five pre-loaded the reviewer can grade and act in ≤5 iterations
+    instead of spending 30–40 iterations re-discovering the same information.
+
+    Failures at any step are non-fatal: the partial bundle is still injected
+    so the reviewer degrades gracefully rather than starting cold.
+    """
+    logger.info(
+        "✅ reviewer_warmup: starting pre-computation for branch=%r issue=%d",
+        pr_branch,
+        issue_number,
+    )
+
+    sections: list[str] = []
+
+    # ── 1. Setup: fetch + checkout ──────────────────────────────────────────
+    await _shell_capture(
+        f"git fetch origin --quiet && git checkout {pr_branch} --quiet 2>&1 || true",
+        cwd=worktree_path,
+    )
+
+    # ── 2. Changed file list ─────────────────────────────────────────────────
+    changed_files_raw = await _shell_capture(
+        "git diff origin/dev...HEAD --name-only",
+        cwd=worktree_path,
+    )
+    if changed_files_raw:
+        sections.append(f"### Changed files\n```\n{changed_files_raw}\n```")
+
+    # ── 3. Full diff ─────────────────────────────────────────────────────────
+    diff_raw = await _shell_capture(
+        "git diff origin/dev...HEAD",
+        cwd=worktree_path,
+        timeout=60,
+    )
+    if diff_raw:
+        # Cap at 40 000 chars — enough for any realistic PR without blowing context.
+        if len(diff_raw) > 40_000:
+            diff_raw = diff_raw[:40_000] + "\n\n… (diff truncated at 40 000 chars)"
+        sections.append(f"### Full diff\n```diff\n{diff_raw}\n```")
+
+    # ── 4. mypy ──────────────────────────────────────────────────────────────
+    mypy_raw = await _shell_capture(
+        "python3 -m mypy agentception/ 2>&1",
+        cwd=worktree_path,
+        timeout=120,
+    )
+    sections.append(f"### mypy\n```\n{mypy_raw or '(no output)'}\n```")
+
+    # ── 5. pytest — targeted at changed test modules ─────────────────────────
+    changed_py = [
+        f for f in changed_files_raw.splitlines()
+        if f.endswith(".py") and "/test_" not in f and f.startswith("agentception/")
+    ]
+    test_targets: list[str] = []
+    for fpath in changed_py:
+        module = Path(fpath).stem
+        candidate = f"agentception/tests/test_{module}.py"
+        # Only add if the test file exists in the worktree.
+        if (worktree_path / candidate).exists():
+            test_targets.append(candidate)
+
+    if test_targets:
+        pytest_cmd = f"python3 -m pytest {' '.join(test_targets)} -v 2>&1"
+    else:
+        pytest_cmd = "python3 -m pytest agentception/tests/ -v --tb=short -q 2>&1"
+
+    pytest_raw = await _shell_capture(pytest_cmd, cwd=worktree_path, timeout=180)
+    sections.append(f"### pytest\n```\n{pytest_raw or '(no output)'}\n```")
+
+    # ── 6. GitHub issue ───────────────────────────────────────────────────────
+    if github_client is not None:
+        try:
+            issue_text = await github_client.call_tool(
+                "issue_read",
+                {"owner": owner, "repo": repo, "issueNumber": issue_number},
+            )
+            sections.append(f"### Issue #{issue_number}\n{issue_text}")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("⚠️ reviewer_warmup: issue_read failed — %s", exc)
+
+    if not sections:
+        logger.warning("⚠️ reviewer_warmup: no sections produced — reviewer starts cold")
+        return
+
+    bundle = (
+        "## Pre-loaded Review Context\n\n"
+        + "\n\n".join(sections)
+        + "\n\n---\n\n"
+        "**All signal above was pre-computed. "
+        "Do NOT re-run mypy, pytest, or git diff — you already have the output. "
+        "Do NOT re-read files already visible in the diff. "
+        "Grade immediately and call build_complete_run.**"
+    )
+
+    original_content = str(messages[0].get("content", ""))
+    messages[0] = {
+        **dict(messages[0]),
+        "content": original_content + "\n\n---\n\n" + bundle,
+    }
+
+    logger.info(
+        "✅ reviewer_warmup: injected %d sections into initial message",
+        len(sections),
+    )
 
 
 async def _run_recon_phase(

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -1589,6 +1589,173 @@ def test_truncate_search_codebase_limit() -> None:
     assert "truncated" in content
 
 
+# ---------------------------------------------------------------------------
+# Reviewer warmup — _run_reviewer_warmup injects context into messages[0]
+# ---------------------------------------------------------------------------
+
+
+class TestReviewerWarmup:
+    """_run_reviewer_warmup must inject pre-computed context before iteration 1.
+
+    With the diff, mypy, pytest, and issue pre-loaded the reviewer should
+    need zero shell calls during the main loop.  These tests verify that the
+    warmup modifies messages[0] and that the full run_agent_loop skips the
+    LLM-driven recon phase for the reviewer role.
+    """
+
+    @pytest.mark.anyio
+    async def test_warmup_injects_sections_into_initial_message(
+        self, tmp_path: Path
+    ) -> None:
+        """_run_reviewer_warmup must append a Pre-loaded Review Context block."""
+        from agentception.services.agent_loop import _run_reviewer_warmup
+        from agentception.services.github_mcp_client import GitHubMCPClient
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        messages: list[dict[str, object]] = [
+            {"role": "user", "content": "initial briefing"}
+        ]
+
+        shell_outputs = {
+            "fetch": "",
+            "files": "agentception/routes/ui/transcripts.py\nagentception/static/scss/_transcripts.scss",
+            "diff": "--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new",
+            "mypy": "Success: no issues found in 5 source files",
+            "pytest": "2 passed in 0.3s",
+        }
+        call_count = 0
+
+        async def fake_shell(
+            cmd: str,
+            cwd: Path,
+            timeout: int = 300,
+        ) -> str:
+            nonlocal call_count
+            call_count += 1
+            if "fetch" in cmd:
+                return shell_outputs["fetch"]
+            if "--name-only" in cmd:
+                return shell_outputs["files"]
+            if "git diff" in cmd:
+                return shell_outputs["diff"]
+            if "mypy" in cmd:
+                return shell_outputs["mypy"]
+            if "pytest" in cmd:
+                return shell_outputs["pytest"]
+            return ""
+
+        mock_client = _mock_github_client()
+
+        with patch(
+            "agentception.services.agent_loop._shell_capture",
+            side_effect=fake_shell,
+        ):
+            await _run_reviewer_warmup(
+                worktree_path=worktree,
+                pr_branch="feat/issue-37",
+                issue_number=37,
+                messages=messages,
+                github_client=mock_client,
+                owner="cgcardona",
+                repo="agentception",
+            )
+
+        content = str(messages[0].get("content", ""))
+        assert "Pre-loaded Review Context" in content, "Bundle header missing"
+        assert "Changed files" in content, "Changed files section missing"
+        assert "Full diff" in content, "Diff section missing"
+        assert "mypy" in content, "mypy section missing"
+        assert "pytest" in content, "pytest section missing"
+        assert "initial briefing" in content, "Original content must be preserved"
+        assert "Do NOT re-run" in content, "Guard instruction missing"
+
+    @pytest.mark.anyio
+    async def test_reviewer_loop_skips_llm_recon(self, tmp_path: Path) -> None:
+        """run_agent_loop must call _run_reviewer_warmup, not _run_recon_phase."""
+        from agentception.services.agent_loop import run_agent_loop
+
+        worktree = tmp_path / "review-warmup-run"
+        worktree.mkdir()
+
+        reviewer_spec = AgentTaskSpec(
+            id="review-warmup-run",
+            role="reviewer",
+            tier="worker",
+            cognitive_arch="Review carefully.",
+            issue_number=99,
+            worktree=str(worktree),
+            branch="feat/issue-99",
+            gh_repo="cgcardona/agentception",
+        )
+
+        warmup_called: list[bool] = []
+        recon_called: list[bool] = []
+
+        async def fake_warmup(**kwargs: object) -> None:
+            warmup_called.append(True)
+
+        async def fake_recon(*args: object, **kwargs: object) -> None:
+            recon_called.append(True)
+
+        async def fake_llm(
+            *args: object,
+            tools: list[ToolDefinition] | None = None,
+            extra_system_blocks: list[dict[str, object]] | None = None,
+            **kwargs: object,
+        ) -> ToolResponse:
+            return _stop_response("done")
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=reviewer_spec,
+            ),
+            patch(
+                "agentception.services.agent_loop.get_run_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic_with_tools",
+                side_effect=fake_llm,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
+            patch(
+                "agentception.services.agent_loop._run_reviewer_warmup",
+                side_effect=fake_warmup,
+            ),
+            patch(
+                "agentception.services.agent_loop._run_recon_phase",
+                side_effect=fake_recon,
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+            mock_settings.ac_min_turn_delay_secs = 0.0
+            mock_settings.gh_repo = "cgcardona/agentception"
+            await run_agent_loop("review-warmup-run")
+
+        assert warmup_called, "_run_reviewer_warmup was not called for reviewer role"
+        assert not recon_called, "_run_recon_phase must NOT be called for reviewer role"
+
+
 class TestExtractExplicitFilePaths:
     """Unit tests for the recon phase file-path extractor."""
 

--- a/scripts/gen_prompts/templates/roles/reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/reviewer.md.j2
@@ -25,45 +25,27 @@ Do not read any file before extracting these.
 
 ## Review Steps — Follow in Order
 
-### 1 — Fetch the diff
+Your initial message already contains a **Pre-loaded Review Context** block with:
+- The full `git diff` of all changes
+- The mypy output (run once, complete)
+- The pytest output for changed test modules
+- The GitHub issue with acceptance criteria
 
-```bash
-cd {{ repo_name }}
-git fetch origin && git checkout $BRANCH
-git diff origin/dev...HEAD --name-only
-git diff origin/dev...HEAD
-```
+**Do not re-run any of these.** You have everything you need. Read the
+pre-loaded block, form your grade, and act.
 
-Read each changed file **once** from the diff. Do not call `read_file` on any
-file already in the diff.
+### 1 — Read the pre-loaded context
 
-### 2 — Run mypy and targeted tests
+Read the Pre-loaded Review Context in your initial message. Extract:
+- Which files changed (from the "Changed files" section)
+- Any mypy errors or test failures
+- The acceptance criteria from the issue
 
-Type checker first, always:
+If you need to inspect one specific file not fully visible in the diff, one
+`read_file` call is acceptable. Do not grep, do not search, do not list
+directories.
 
-```bash
-{{ active_mypy }}
-```
-
-Then run only the test files for modules that changed:
-
-```bash
-PYTHONPATH=/worktrees/$WTNAME pytest /worktrees/$WTNAME/{{ active_test_dir }}/test_<changed_module>.py -v
-```
-
-Full output only — never pipe through `head` or `tail`.
-
-### 3 — Check acceptance criteria
-
-Fetch the original issue:
-
-```
-issue_read(owner=$OWNER, repo=$REPO, issue_number=$ISSUE_NUMBER)
-```
-
-For every AC checkbox, verify it is satisfied by the diff you already read.
-
-### 4 — Grade and act
+### 2 — Grade and act
 
 | Grade | Criteria | Action |
 |-------|----------|--------|
@@ -113,7 +95,9 @@ Up to 3 attempts are allowed before the loop is abandoned.
 ## Hard Rules
 
 - **You do not write code.** No `replace_in_file`, no `write_file`, no `insert_after_in_file`. Ever.
-- Read each file once from the diff. Do not call `read_file` on files already in the diff.
-- Run mypy once and pytest once. A second run gives zero new signal.
+- **Do not re-run mypy or pytest.** The results are already in your context. A second run gives zero new signal.
+- **Do not re-read the diff.** It is already in your context.
+- If you need one file for clarification, one `read_file` is acceptable. No grep, no search_text, no list_directory.
 - Merge or reject. Those are the only two outcomes.
 - Call `build_complete_run` after merging or after posting rejection.
+- **You should reach a decision in ≤5 iterations.** If you are still reading on iteration 5, stop and grade based on what you have.


### PR DESCRIPTION
## Summary

- Add `_shell_capture`: thin async subprocess helper used only during reviewer pre-computation.
- Add `_run_reviewer_warmup`: deterministic pre-loop step that runs `git diff`, `mypy`, targeted `pytest`, and `issue_read` — all before iteration 1 starts — and injects a **Pre-loaded Review Context** bundle into `messages[0]`.
- Wire into `run_agent_loop`: reviewer role gets `_run_reviewer_warmup`; executor still skips recon; all other roles get the existing LLM-driven `_run_recon_phase`.
- Update `reviewer.md.j2`: tell the reviewer its context is pre-loaded, not to re-run any tools, and to reach a decision in ≤5 iterations.
- Add `TestReviewerWarmup` (2 tests): bundle injection and recon-skip verified.

## Why

Reviewers were hitting the 40-iteration cap re-discovering the diff, re-running mypy multiple times, and hunting through SCSS directories looking for files. All of that signal is fully deterministic and can be computed once before the loop starts — so we do.

## Test plan
- [x] `mypy agentception/` — zero errors
- [x] `typing_audit.py --max-any 0` — passes
- [x] `pytest agentception/tests/test_agent_loop.py` — 46/46 pass
- [x] `generate.py --check` — no drift
