### PR TITLE
Fix orphan sweep killing reviewer runs before first LLM iteration

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -863,9 +863,21 @@ async def _upsert_agent_runs(
         # lifecycle, not by the GitHub polling loop.  Exclude them from the
         # orphan sweep so the polling tick never flips an in-progress adhoc
         # run to "failed" just because it isn't backed by a GitHub issue.
-        if orphan.id not in live_ids and orphan.issue_number is not None:
+        #
+        # Reviewer runs are also excluded: unlike executor runs (where
+        # pr_number is set only after the PR is opened and the run is done),
+        # reviewer runs have pr_number set AT DISPATCH TIME because the PR
+        # already exists.  Applying the pr_number → completed heuristic to a
+        # reviewer would kill it immediately after creation.  Reviewer
+        # lifecycle is always driven by build_complete_run, never by poller
+        # inference.
+        if (
+            orphan.id not in live_ids
+            and orphan.issue_number is not None
+            and orphan.role != "reviewer"
+        ):
             if orphan.pr_number is not None:
-                # Engineer completed — PR exists but the agent is done working.
+                # Executor completed — PR exists but the agent is done working.
                 # "done" puts the card in the "PR Open" lane (any status with
                 # pr_number except "reviewing"), which is correct: the PR is
                 # open awaiting human or reviewer-agent action, not being

--- a/agentception/tests/test_persist_reviewer_orphan_guard.py
+++ b/agentception/tests/test_persist_reviewer_orphan_guard.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+"""Regression test for the reviewer orphan-sweep guard in db/persist.py.
+
+Bug: reviewer runs have pr_number set AT DISPATCH TIME (the PR already
+exists before the reviewer starts).  The orphan sweep's heuristic
+  "implementing + pr_number + not in live_ids → completed"
+was designed for executor runs where pr_number is written only after the
+executor finishes and opens the PR.  Applying it to a reviewer would
+kill the run immediately after creation — before the first LLM call.
+
+Fix: _upsert_agent_runs() now skips the orphan sweep for runs whose
+role is "reviewer".  Reviewer lifecycle is always driven by
+build_complete_run, never by poller inference.
+
+Run:
+    docker compose exec agentception pytest \
+        agentception/tests/test_persist_reviewer_orphan_guard.py -v
+"""
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agentception.db.models import ACAgentRun
+from agentception.models import AgentNode, AgentStatus
+
+_UTC = datetime.timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_reviewer_run(role: str = "reviewer") -> ACAgentRun:
+    """Return a minimal ACAgentRun in implementing state with a pr_number set."""
+    return ACAgentRun(
+        id="review-576",
+        role=role,
+        status="implementing",
+        issue_number=575,
+        pr_number=576,
+        branch="feat/issue-575",
+        worktree_path="/worktrees/review-576",
+        spawned_at=datetime.datetime.now(_UTC),
+    )
+
+
+def _make_session(existing_run: ACAgentRun) -> MagicMock:
+    """Return a mock AsyncSession wired for _upsert_agent_runs.
+
+    _upsert_agent_runs performs three sequential execute() calls:
+      1. Per-agent row lookup (scalar_one_or_none)
+      2. Orphan sweep (scalars().all())
+      3. Pending-launch TTL sweep (scalars().all())
+    """
+    lookup = MagicMock()
+    lookup.scalar_one_or_none.return_value = existing_run
+
+    orphan_result = MagicMock()
+    orphan_result.scalars.return_value.all.return_value = [existing_run]
+
+    ttl_result = MagicMock()
+    ttl_result.scalars.return_value.all.return_value = []
+
+    session = MagicMock(spec=AsyncSession)
+    session.execute = AsyncMock(side_effect=[lookup, orphan_result, ttl_result])
+    session.add = MagicMock()
+    return session
+
+
+def _make_session_no_agents(existing_run: ACAgentRun) -> MagicMock:
+    """Session for the empty-agents-list case (no per-agent lookup)."""
+    orphan_result = MagicMock()
+    orphan_result.scalars.return_value.all.return_value = [existing_run]
+
+    ttl_result = MagicMock()
+    ttl_result.scalars.return_value.all.return_value = []
+
+    session = MagicMock(spec=AsyncSession)
+    session.execute = AsyncMock(side_effect=[orphan_result, ttl_result])
+    session.add = MagicMock()
+    return session
+
+
+def _make_agent_node() -> AgentNode:
+    return AgentNode(
+        id="review-576",
+        role="reviewer",
+        status=AgentStatus.IMPLEMENTING,
+        issue_number=575,
+        pr_number=576,
+        branch="feat/issue-575",
+        worktree_path="/worktrees/review-576",
+        cognitive_arch="michael_fagan:python",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_reviewer_not_orphaned_when_missing_from_live_ids() -> None:
+    """Orphan sweep must NOT mark a reviewer run as completed.
+
+    Scenario: the poller runs a tick where the reviewer is not in the
+    agents list (live_ids is empty).  Before the fix the sweep would see
+    role=reviewer + pr_number + not_in_live_ids and set status="completed",
+    killing the run before its first LLM iteration.
+    """
+    from agentception.db.persist import _upsert_agent_runs  # noqa: PLC0415
+
+    reviewer_run = _make_reviewer_run(role="reviewer")
+    session = _make_session_no_agents(reviewer_run)
+
+    await _upsert_agent_runs(session, agents=[])
+
+    assert reviewer_run.status == "implementing", (
+        f"Reviewer run was orphaned: status={reviewer_run.status!r}. "
+        "The orphan sweep must skip reviewer runs regardless of pr_number."
+    )
+
+
+@pytest.mark.anyio
+async def test_executor_still_orphaned_when_missing_from_live_ids() -> None:
+    """Orphan sweep must still mark a non-reviewer run as completed.
+
+    The reviewer exclusion must not accidentally protect executor/developer
+    runs — their orphan → completed transition must still work.
+    """
+    from agentception.db.persist import _upsert_agent_runs  # noqa: PLC0415
+
+    executor_run = _make_reviewer_run(role="developer")
+    session = _make_session_no_agents(executor_run)
+
+    await _upsert_agent_runs(session, agents=[])
+
+    assert executor_run.status == "completed", (
+        f"Executor run was NOT orphaned: status={executor_run.status!r}. "
+        "Orphan sweep must still complete non-reviewer runs with a pr_number."
+    )
+
+
+@pytest.mark.anyio
+async def test_reviewer_in_live_ids_not_completed() -> None:
+    """When the reviewer IS in live_ids its status must not become completed."""
+    from agentception.db.persist import _upsert_agent_runs  # noqa: PLC0415
+
+    reviewer_run = _make_reviewer_run(role="reviewer")
+    node = _make_agent_node()
+    session = _make_session(reviewer_run)
+
+    await _upsert_agent_runs(session, agents=[node])
+
+    assert reviewer_run.status != "completed", (
+        "Reviewer run must not be completed when present in live_ids."
+    )


### PR DESCRIPTION
## Summary
- Reviewer runs have `pr_number` set at dispatch time, unlike executor runs where it's set only after opening the PR
- The orphan sweep's `implementing + pr_number + not in live_ids → completed` heuristic was designed for executors — applying it to reviewers killed them within 0.5s of creation, before the warmup finished
- Fix: skip the orphan sweep for `role == "reviewer"` runs; their lifecycle is always driven by `build_complete_run`

## Test plan
- 3 new regression tests: reviewer excluded, executor still orphaned, reviewer-in-live-ids untouched
- All 3 green