### PR TITLE
Make grade parameter mandatory in reviewer rejection instructions

### DIFF
--- a/.agentception/roles/reviewer.md
+++ b/.agentception/roles/reviewer.md
@@ -85,9 +85,14 @@ build_complete_run(
   issue_number=$ISSUE_NUMBER,
   pr_url=<pr_url>,
   summary="Grade: <grade> — rejected.",
-  grade="<grade>",
+  grade="<grade>",                          ← REQUIRED: must be "C", "D", or "F"
   reviewer_feedback="<full numbered defect list, plain text>")
 ```
+
+**`grade` is not optional.** If you omit it or pass an empty string, the
+system treats the run as approved and no redispatch fires. The next
+executor will never receive your feedback. Always pass the literal grade
+letter ("C", "D", or "F") as the `grade` argument.
 
 The system automatically closes the PR and redispatches the executor with
 your defect list injected at the top of the briefing — no human needed.

--- a/scripts/gen_prompts/templates/roles/reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/reviewer.md.j2
@@ -84,9 +84,14 @@ build_complete_run(
   issue_number=$ISSUE_NUMBER,
   pr_url=<pr_url>,
   summary="Grade: <grade> — rejected.",
-  grade="<grade>",
+  grade="<grade>",                          ← REQUIRED: must be "C", "D", or "F"
   reviewer_feedback="<full numbered defect list, plain text>")
 ```
+
+**`grade` is not optional.** If you omit it or pass an empty string, the
+system treats the run as approved and no redispatch fires. The next
+executor will never receive your feedback. Always pass the literal grade
+letter ("C", "D", or "F") as the `grade` argument.
 
 The system automatically closes the PR and redispatches the executor with
 your defect list injected at the top of the briefing — no human needed.


### PR DESCRIPTION
## Summary
- Reviewer was calling `build_complete_run` without passing `grade`, so the system treated every C/D/F rejection as an approval and never fired the auto-redispatch
- Added an explicit warning in the prompt: `grade` is not optional; omitting it skips redispatch entirely

## Test plan
- No code changes, prompt-only fix
- Verified with `generate.py --check` (0 drift)