### PR TITLE
feat: enable Qdrant worktree indexing for all roles and re-index after writes

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -866,15 +866,14 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     asyncio.create_task(run_agent_loop(run_id), name=f"agent-loop-{run_id}")
 
     # Index the worktree in the background so agents can search it via
-    # search_codebase.  Skipped for executor dispatches: the planner already
-    # indexed the same worktree moments ago, and the executor operates from an
-    # immutable plan — it never calls search_codebase.  Re-embedding 4 600+
-    # chunks is the primary cause of per-dispatch OOM spikes.
-    if effective_role != "executor":
-        asyncio.create_task(
-            _index_worktree(Path(worktree_path), run_id),
-            name=f"index-worktree-{run_id}",
-        )
+    # search_codebase.  Every role gets a per-run worktree collection so that
+    # search_codebase scoped to "worktree-<run_id>" reflects the agent's own
+    # edits, not just origin/dev.  The incremental indexer only re-hashes
+    # changed files, so the cost after the initial build is minimal.
+    asyncio.create_task(
+        _index_worktree(Path(worktree_path), run_id),
+        name=f"index-worktree-{run_id}",
+    )
 
     logger.info("✅ dispatch: agent loop fired for run_id=%s", run_id)
 

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -54,7 +54,7 @@ from agentception.services.llm import (
     call_anthropic,
     call_anthropic_with_tools,
 )
-from agentception.services.code_indexer import search_codebase
+from agentception.services.code_indexer import index_codebase, search_codebase
 from agentception.services.github_mcp_client import GitHubMCPClient
 from agentception.tools.definitions import (
     FILE_TOOL_DEFS,
@@ -726,6 +726,20 @@ async def run_agent_loop(
                         files_written[fp] = files_written.get(fp, 0) + 1
                 except (json.JSONDecodeError, AttributeError):
                     pass
+
+            # Re-index the worktree after any write so that subsequent
+            # search_codebase calls targeting "worktree-<run_id>" reflect the
+            # agent's own edits.  Incremental mode: only changed files are
+            # re-embedded — cost is proportional to what was written.
+            if tool_names_this_iter & _WRITE_TOOL_NAMES:
+                _worktree_collection = f"worktree-{run_id}"
+                asyncio.create_task(
+                    index_codebase(
+                        worktree_path,
+                        collection=_worktree_collection,
+                    ),
+                    name=f"reindex-{run_id}-iter-{iteration}",
+                )
 
             # Accumulate search queries for symbol-absence detection.
             for tc in response["tool_calls"]:
@@ -1422,14 +1436,28 @@ async def _run_recon_phase(
             return None
 
     async def _search_one(query: str) -> list[dict[str, object]]:
+        # Prefer the worktree-scoped collection so results include any files
+        # the agent has already written.  Fall back to the main "code"
+        # collection if the worktree collection doesn't exist yet (indexing
+        # runs in the background and may not have finished).
+        _wt_collection = f"worktree-{run_id}"
         try:
-            results = await search_codebase(query, 5)
+            results = await search_codebase(query, 5, collection=_wt_collection)
+            if not results:
+                results = await search_codebase(query, 5)
             return [
                 {"file": m["file"], "chunk": m["chunk"][:800], "score": m["score"]}
                 for m in results
             ]
         except Exception:  # noqa: BLE001
-            return []
+            try:
+                results = await search_codebase(query, 5)
+                return [
+                    {"file": m["file"], "chunk": m["chunk"][:800], "score": m["score"]}
+                    for m in results
+                ]
+            except Exception:  # noqa: BLE001
+                return []
 
     file_tasks = [_read_one(f) for f in plan.files]
     search_tasks = [_search_one(q) for q in plan.searches]


### PR DESCRIPTION
## Summary

- Remove executor exclusion from worktree indexing — every role now gets a per-run `worktree-<run_id>` Qdrant collection
- Trigger incremental `index_codebase` after every write tool call so the collection stays current as the agent edits files
- Pre-recon `_search_one` now targets the worktree collection first, falling back to main `"code"` if background indexing hasn't finished

## Motivation

Executors were excluded from worktree Qdrant indexing, meaning `search_codebase` always hit `origin/dev` and never saw the agent's own edits. This forced agents to do 60-80 read iterations to navigate large files instead of using semantic search. The three changes together mean:
1. Every agent (including executors) gets a private collection scoped to their run
2. Writes are immediately reflected in search results after the async re-index completes
3. Pre-recon searches return worktree-aware results from iteration 1

## Test plan
- [x] `mypy agentception/` — 0 errors (241 files)
- [x] `pytest agentception/tests/test_agent_loop.py agentception/tests/test_code_indexer.py` — 92 passed