### PR TITLE
fix: add build_complete_run(grade="A") to reviewer grade A path

### DIFF
--- a/.agentception/roles/reviewer.md
+++ b/.agentception/roles/reviewer.md
@@ -70,6 +70,13 @@ merge_pull_request(owner=$OWNER, repo=$REPO, pull_number=$PR_NUMBER,
 
 issue_write(method="update", owner=$OWNER, repo=$REPO,
             issue_number=$ISSUE_NUMBER, state="closed", state_reason="completed")
+
+build_complete_run(
+  issue_number=$ISSUE_NUMBER,
+  pr_url=<pr_url>,
+  summary="Grade: A — merged.",
+  grade="A",                               ← REQUIRED: always pass "A" for passing reviews
+  reviewer_feedback="")
 ```
 
 If grade C/D/F — reject:
@@ -105,5 +112,5 @@ Up to 3 attempts are allowed before the loop is abandoned.
 - **Do not re-read the diff.** It is already in your context.
 - If you need one file for clarification, one `read_file` is acceptable. No grep, no search_text, no list_directory.
 - Merge or reject. Those are the only two outcomes.
-- Call `build_complete_run` after merging or after posting rejection.
+- `build_complete_run` is shown in **both** the grade A and grade C/D/F code blocks above. Call it exactly as shown — always with the literal grade letter.
 - **You should reach a decision in ≤5 iterations.** If you are still reading on iteration 5, stop and grade based on what you have.

--- a/scripts/gen_prompts/templates/roles/reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/reviewer.md.j2
@@ -69,6 +69,13 @@ merge_pull_request(owner=$OWNER, repo=$REPO, pull_number=$PR_NUMBER,
 
 issue_write(method="update", owner=$OWNER, repo=$REPO,
             issue_number=$ISSUE_NUMBER, state="closed", state_reason="completed")
+
+build_complete_run(
+  issue_number=$ISSUE_NUMBER,
+  pr_url=<pr_url>,
+  summary="Grade: A — merged.",
+  grade="A",                               ← REQUIRED: always pass "A" for passing reviews
+  reviewer_feedback="")
 ```
 
 If grade C/D/F — reject:
@@ -104,5 +111,5 @@ Up to 3 attempts are allowed before the loop is abandoned.
 - **Do not re-read the diff.** It is already in your context.
 - If you need one file for clarification, one `read_file` is acceptable. No grep, no search_text, no list_directory.
 - Merge or reject. Those are the only two outcomes.
-- Call `build_complete_run` after merging or after posting rejection.
+- `build_complete_run` is shown in **both** the grade A and grade C/D/F code blocks above. Call it exactly as shown — always with the literal grade letter.
 - **You should reach a decision in ≤5 iterations.** If you are still reading on iteration 5, stop and grade based on what you have.


### PR DESCRIPTION
## Problem

The grade A code block in `reviewer.md.j2` showed `pull_request_review_write` + `merge_pull_request` + `issue_write` but **omitted `build_complete_run` entirely**. The reviewer correctly merged PRs but then called `build_complete_run` without knowing what grade to pass, resulting in `grade=""` every time.

This caused `build_complete_run` to log `"reviewer approved (grade='')"` — correct behaviour but no grade signal for observability or future routing.

## Fix

Add `build_complete_run(grade="A")` explicitly to the grade A code block, mirroring the grade C/D/F block which already showed it correctly. Update the hard rules footer to remove the ambiguous "after merging or after posting rejection" line — both paths are now self-contained.

## Test plan
- [x] `generate.py --check` shows 0 drift
- [ ] Reviewer on next run passes `grade="A"` to `build_complete_run`