### PR TITLE
fix: replace float timeout with httpx.Timeout to prevent indefinite LLM hangs

### DIFF
--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -47,7 +47,14 @@ _ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
 _MODEL = "claude-sonnet-4-6"
 _OPUS_MODEL = "claude-opus-4-6"
 _ANTHROPIC_VERSION = "2023-06-01"
-_DEFAULT_TIMEOUT = 120.0
+# Per-phase timeouts for Anthropic API calls.
+# connect/write: generous but bounded — API should accept the request quickly.
+# read: capped at 90s.  Streaming responses reset the read timer on every
+#   chunk, so a single float timeout never fires during a slow generation.
+#   Using httpx.Timeout(read=90) enforces a hard ceiling on the time between
+#   received bytes — if Anthropic stops sending for 90s the call raises
+#   TimeoutException and the loop retries, rather than hanging indefinitely.
+_DEFAULT_TIMEOUT = httpx.Timeout(connect=10.0, read=90.0, write=30.0, pool=10.0)
 _MAX_RETRIES = 2
 # Minimum seconds to wait after a 429 before retrying.  Anthropic's rolling
 # TPM window does not clear in 2–4s, so the standard exponential backoff used


### PR DESCRIPTION
## Problem

A scalar `timeout=120.0` on the httpx client only guards against total request time for non-streaming calls. Anthropic streaming responses reset the read timer on every received chunk — if the API stalls mid-stream (sending no data for minutes), the 120s clock never reaches zero and the agent hangs indefinitely with no recovery.

Observed: executor for issue-585 hung for 4+ minutes waiting for an Anthropic response after a grep tool call returned. The 120s timeout never fired.

## Fix

Replace `timeout=120.0` with `httpx.Timeout(connect=10.0, read=90.0, write=30.0, pool=10.0)`. The `read=90` value caps the time between received bytes — a stalled stream raises `TimeoutException` after 90s of silence, which the existing retry logic handles normally.

## Test plan
- [x] `mypy agentception/` — 0 errors (241 files)
- [x] `pytest agentception/tests/test_agent_loop.py` — 48 passed