### PR TITLE
fix: remove post-write Qdrant re-index that caused 3-4 min agent freezes

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -54,7 +54,7 @@ from agentception.services.llm import (
     call_anthropic,
     call_anthropic_with_tools,
 )
-from agentception.services.code_indexer import index_codebase, search_codebase
+from agentception.services.code_indexer import search_codebase
 from agentception.services.github_mcp_client import GitHubMCPClient
 from agentception.tools.definitions import (
     FILE_TOOL_DEFS,
@@ -730,20 +730,6 @@ async def run_agent_loop(
                         files_written[fp] = files_written.get(fp, 0) + 1
                 except (json.JSONDecodeError, AttributeError):
                     pass
-
-            # Re-index the worktree after any write so that subsequent
-            # search_codebase calls targeting "worktree-<run_id>" reflect the
-            # agent's own edits.  Incremental mode: only changed files are
-            # re-embedded — cost is proportional to what was written.
-            if tool_names_this_iter & _WRITE_TOOL_NAMES:
-                _worktree_collection = f"worktree-{run_id}"
-                asyncio.create_task(
-                    index_codebase(
-                        worktree_path,
-                        collection=_worktree_collection,
-                    ),
-                    name=f"reindex-{run_id}-iter-{iteration}",
-                )
 
             # Accumulate search queries for symbol-absence detection.
             for tc in response["tool_calls"]:


### PR DESCRIPTION
## Problem

PR #580 added `asyncio.create_task(index_codebase(...))` after every write tool call. This re-embedded the entire worktree (524 files / 4,008 chunks) after each write because:

1. The initial worktree index fires concurrently at dispatch and hasn't stored hashes yet
2. The incremental mode therefore found nothing to skip and re-embedded everything from scratch
3. FastEmbed running in `asyncio.to_thread` saturated the CPU for **3–4 minutes per write**
4. This stalled the agent loop, making runs appear frozen mid-iteration

Observed: executor for issue-585 hung for 3m43s between iterations — exactly the time the re-index took to complete.

## Fix

Remove the post-write re-index entirely. The initial worktree index (fired once at dispatch) is sufficient. Real-time re-indexing needs debouncing + scoped single-file indexing before it can be safe.

## Test plan
- [x] `mypy agentception/` — 0 errors (241 files)
- [x] `pytest agentception/tests/test_agent_loop.py` — 48 passed