### PR TITLE
fix: guard insert_after_in_file against bare class/def headers

### DIFF
--- a/agentception/tests/test_file_tools.py
+++ b/agentception/tests/test_file_tools.py
@@ -390,3 +390,59 @@ class TestInsertAfterInFile:
         text = p.read_text(encoding="utf-8")
         assert "def baz" in text
         assert text.index("def baz") < text.index("def bar")
+
+    # ------------------------------------------------------------------
+    # Regression: inserting after a bare class/def header must be refused
+    # because it detaches the body from its header (SyntaxError).
+    # ------------------------------------------------------------------
+
+    def test_insert_after_class_header_with_indented_body_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """Anchor ends on `class Foo:` whose body follows — must be rejected."""
+        code = (
+            "class Foo:\n"
+            "    def method(self) -> None:\n"
+            "        pass\n"
+        )
+        p = tmp_path / "cls.py"
+        p.write_text(code, encoding="utf-8")
+        result = insert_after_in_file(p, "class Foo:", "\nclass Bar:\n    pass\n")
+        assert result["ok"] is False
+        assert "SyntaxError" in str(result["error"])
+        # File must be untouched.
+        assert p.read_text(encoding="utf-8") == code
+
+    def test_insert_after_def_header_with_indented_body_is_refused(
+        self, tmp_path: Path
+    ) -> None:
+        """Anchor ends on `def foo():` whose body follows — must be rejected."""
+        code = "def foo():\n    return 1\n"
+        p = tmp_path / "fn.py"
+        p.write_text(code, encoding="utf-8")
+        result = insert_after_in_file(p, "def foo():", "\ndef bar():\n    pass\n")
+        assert result["ok"] is False
+        assert "SyntaxError" in str(result["error"])
+        assert p.read_text(encoding="utf-8") == code
+
+    def test_insert_after_class_header_no_body_after_is_allowed(
+        self, tmp_path: Path
+    ) -> None:
+        """Anchor ends on `class Foo:` but nothing indented follows — safe to insert."""
+        code = "class Foo:\n    pass\n"
+        p = tmp_path / "ok.py"
+        p.write_text(code, encoding="utf-8")
+        # Anchor includes the whole class so the next line is not indented.
+        result = insert_after_in_file(p, "class Foo:\n    pass\n", "\nclass Bar:\n    pass\n")
+        assert result["ok"] is True
+
+    def test_insert_after_class_def_line_safe_when_next_line_not_indented(
+        self, tmp_path: Path
+    ) -> None:
+        """Header ends with ':' but next non-blank line is at column 0 — allowed."""
+        code = "class Foo: pass\nclass Bar: pass\n"
+        p = tmp_path / "oneliner.py"
+        p.write_text(code, encoding="utf-8")
+        # "class Foo: pass" ends with "pass", not ":", so guard should not fire.
+        result = insert_after_in_file(p, "class Foo: pass\n", "\n# comment\n")
+        assert result["ok"] is True

--- a/agentception/tools/file_tools.py
+++ b/agentception/tools/file_tools.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import ast as _ast
 import logging
+import re as _re
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -282,6 +283,34 @@ def insert_after_in_file(
         }
 
     insert_pos = original.index(anchor) + len(anchor)
+
+    # Guard: refuse to insert immediately after a bare class/function definition
+    # header.  A header line ends with ":" and the following non-blank line is
+    # indented — inserting between them detaches the body from its header and
+    # produces a SyntaxError.  The caller must use an anchor that ends inside
+    # the body (e.g. the last method's closing line) rather than on the header.
+    _CLASS_DEF_RE = _re.compile(r"^\s*(class|def)\s+\w+")
+    anchor_end_line = original[:insert_pos].rpartition("\n")[2]
+    stripped_header = anchor_end_line.rstrip()
+    if stripped_header.endswith(":") and _CLASS_DEF_RE.match(stripped_header):
+        for _line in original[insert_pos:].splitlines():
+            if not _line.strip():
+                continue  # skip blank lines
+            if _line[0] in (" ", "\t"):
+                return {
+                    "ok": False,
+                    "error": (
+                        "insert_after_in_file: anchor ends on a class/function "
+                        "definition header whose body immediately follows. "
+                        "Inserting here would detach the body from its header "
+                        "and produce a SyntaxError. "
+                        "Use an anchor that ends inside the body — for example, "
+                        "the last line of the final method — so the new content "
+                        "is appended after the complete class/function."
+                    ),
+                }
+            break  # next non-blank line is not indented — safe to insert
+
     updated = original[:insert_pos] + new_content + original[insert_pos:]
 
     try:


### PR DESCRIPTION
## Summary
- Adds a safety guard in `insert_after_in_file` that detects when the anchor ends on a bare `class`/`def` header line whose body immediately follows
- Returns a structured error directing the agent to pick an anchor inside the body instead, preventing the SyntaxError that caused the agent loop in issue #585
- Four regression tests added covering class header rejection, def header rejection, safe multiline anchors, and one-liner class forms

## Test plan
- [ ] `docker compose exec agentception pytest agentception/tests/test_file_tools.py -v` — all 46 tests green
- [ ] `docker compose exec agentception mypy agentception/tools/file_tools.py agentception/tests/test_file_tools.py` — zero errors