### PR TITLE
feat: overhaul Qdrant search quality — all three tiers

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -171,19 +171,31 @@ class AgentCeptionSettings(BaseSettings):
     """
     qdrant_collection: str = "code"
     """Name of the Qdrant collection used for codebase vectors."""
-    embed_model: str = "BAAI/bge-small-en-v1.5"
+    embed_model: str = "jinaai/jina-embeddings-v2-base-code"
     """FastEmbed model name for generating code chunk embeddings.
 
-    ``BAAI/bge-small-en-v1.5`` produces 384-dimensional vectors and is
-    fast enough to index a mid-sized codebase in seconds on CPU.  The model
-    is downloaded from HuggingFace Hub on first use and cached in
+    ``jinaai/jina-embeddings-v2-base-code`` is a code-specific 768-dimensional
+    model trained on English and 30 programming languages with an 8 192-token
+    context window.  It substantially outperforms general-purpose text models
+    (e.g. ``BAAI/bge-small-en-v1.5``) on code retrieval tasks because it
+    understands identifier names, type signatures, and code patterns.  The model
+    is downloaded from HuggingFace Hub on first use (~640 MB) and cached in
     ``FASTEMBED_CACHE_DIR`` (default ``/tmp/fastembed_cache``).
     """
-    embed_model_dim: int = 384
+    embed_model_dim: int = 768
     """Vector dimension produced by ``embed_model``.
 
-    Must match the model — ``BAAI/bge-small-en-v1.5`` produces 384-dimensional
-    vectors.  Override when switching to a different model.
+    Must match the model — ``jinaai/jina-embeddings-v2-base-code`` produces
+    768-dimensional vectors.  Override when switching to a different model.
+    """
+    rerank_model: str = "BAAI/bge-reranker-base"
+    """FastEmbed cross-encoder model used to rerank hybrid search results.
+
+    After dense+sparse retrieval, a cross-encoder scores each candidate chunk
+    jointly with the query text and re-orders the list for precision.
+    ``BAAI/bge-reranker-base`` (~280 MB) provides a strong relevance signal
+    with acceptable CPU latency (~50 ms for 10 candidates).  Set to an empty
+    string to disable reranking.
     """
     database_url: str | None = None
     """Async database URL for AgentCeption's own ac_* tables.

--- a/agentception/services/code_indexer.py
+++ b/agentception/services/code_indexer.py
@@ -6,25 +6,47 @@ in Qdrant.  The agent then searches with natural language instead of regex.
 
 Chunking Strategy
 -----------------
-Python files are chunked by top-level symbols (classes, functions, async
-functions) using AST parsing. Each symbol becomes a single chunk, including
-its decorators, docstring, and full body. This produces semantically coherent
-chunks that preserve complete definitions.
+Python files are chunked at the symbol level using AST parsing:
 
-Non-Python files use overlapping character-level chunks for compatibility.
+- **Top-level functions** become individual chunks.
+- **Top-level classes** are split into a *class header* chunk (class
+  definition, docstring, class-level attributes) and one *method chunk* per
+  method/async-method in the class body.  This ensures precise retrieval of
+  individual methods even in large classes — searching for
+  ``teardown_worktree`` returns exactly that method, not the full
+  ``WorktreeManager`` class.
+
+TypeScript / JavaScript files are chunked by function and class boundaries
+via tree-sitter AST parsing.  All other files use overlapping character-level
+chunks for compatibility.
+
+Chunk Text Enrichment
+---------------------
+Before embedding, every chunk's raw source text is prefixed with its file
+path and symbol name::
+
+    # agentception/readers/worktrees.py
+    # def ensure_worktree
+    <raw source>
+
+This anchors the dense embedding to the file's location and symbol identity
+so that queries like "create a git worktree" score highest for
+``readers/worktrees.py :: ensure_worktree`` rather than for callers of that
+function in other files.
 
 Hybrid Search
 -------------
-Search combines dense semantic vectors (FastEmbed ``BAAI/bge-small-en-v1.5``)
-with sparse BM25 vectors produced by FastEmbed's ``Qdrant/bm25`` model.  The
-sparse model computes proper corpus-aware IDF (pre-trained on a large text
-corpus) instead of the old hash-based toy implementation that had a 10k-slot
-vocabulary, ~40–50% token-collision rate, and no IDF weighting.
+Search combines dense semantic vectors (``jinaai/jina-embeddings-v2-base-code``
+— a code-specific 768-dimension model with 8 192-token context window) with
+sparse BM25 vectors produced by FastEmbed's ``Qdrant/bm25`` model.  The
+sparse model computes proper corpus-aware IDF instead of a hash-based toy.
 
-Results from both retrieval methods are fused using Reciprocal Rank Fusion
-(RRF) with k=60.  This ensures exact keyword matches (e.g. class names, rare
-identifiers) rank highly while preserving semantic similarity for natural
-language queries.
+Results are fused server-side by Qdrant using Reciprocal Rank Fusion (RRF)
+via the native ``prefetch + Fusion.RRF`` API — a single round-trip rather
+than two sequential queries plus manual Python fusion.
+
+After fusion, a cross-encoder reranker (``BAAI/bge-reranker-base``) scores
+each candidate jointly against the query and re-orders the list for precision.
 
 Incremental Indexing
 --------------------
@@ -34,26 +56,25 @@ hash differs from the stored value (new, changed, or deleted) incur Qdrant
 writes.  Unchanged files are skipped entirely — zero Qdrant calls.  Pass
 ``force_full=True`` to drop and rebuild the collection from scratch.
 
-A ``_bm25_version`` field is stored in every chunk payload.  When the BM25
-implementation changes (e.g. upgrading from the old hash-based vectors to
-``Qdrant/bm25``), the stored version is compared with ``_BM25_VERSION`` at
+An ``_index_version`` field is stored in every chunk payload.  When the
+indexing pipeline changes (chunking strategy, embedding model, BM25
+implementation), the stored version is compared with ``_INDEX_VERSION`` at
 the start of ``index_codebase``.  A mismatch triggers an automatic forced
-full rebuild so the new sparse vectors replace the old ones in one pass.
+full rebuild.
 
 Public API
 ----------
 ``index_codebase(repo_path, force_full=False)``
-    Walk every readable source file in *repo_path*, chunk appropriately
-    (AST for Python, character-level for others), embed with
-    :data:`~agentception.config.settings.embed_model` (default
-    ``BAAI/bge-small-en-v1.5``), compute BM25 sparse vectors via
-    ``Qdrant/bm25``, and upsert both to the Qdrant collection configured in
+    Walk every readable source file in *repo_path*, chunk appropriately,
+    enrich chunk text with file path + symbol prefix, embed with the
+    code-specific FastEmbed model, compute BM25 sparse vectors, and upsert
+    to the Qdrant collection configured in
     :data:`~agentception.config.settings.qdrant_collection`.
     Incremental by default — only changed/new/deleted files are processed.
 
 ``search_codebase(query, n_results)``
-    Run hybrid search combining dense (FastEmbed) and sparse (BM25)
-    vectors, fuse results with RRF, and return the top *n_results* code chunks.
+    Run hybrid search (dense + sparse via Qdrant native RRF), then rerank
+    with a cross-encoder.  Returns the top *n_results* code chunks.
 
 Both functions accept optional overrides for ``qdrant_url`` and
 ``collection`` so tests can inject isolated instances without touching the
@@ -123,18 +144,22 @@ class SearchMatch(TypedDict):
     end_line: int
 
 
-# ── BM25 version sentinel ─────────────────────────────────────────────────────
-# Stored in every chunk payload so index_codebase can detect when the sparse
-# vectorizer has changed and trigger an automatic full rebuild.
+# ── Index pipeline version sentinel ───────────────────────────────────────────
+# Stored in every chunk payload under the key ``_index_version``.  Bump this
+# string whenever the indexing pipeline changes in a way that invalidates
+# existing vectors (new chunking strategy, new embedding model, new BM25
+# implementation, chunk text enrichment format, etc.).  A mismatch between
+# the stored value and _INDEX_VERSION triggers an automatic forced full rebuild.
 
-_BM25_VERSION = "qdrant-bm25-v2"
+_INDEX_VERSION = "v5"
 
 
 # ── Module-level embedding model caches ───────────────────────────────────────
 # Lazily initialised on first use so tests can monkey-patch before loading.
 
-_cached_model: object = None   # TextEmbedding instance after first load
-_bm25_model: object = None     # SparseTextEmbedding instance after first load
+_cached_model: object = None    # TextEmbedding instance after first load
+_bm25_model: object = None      # SparseTextEmbedding instance after first load
+_rerank_model: object = None    # TextCrossEncoder instance after first load
 
 
 def _get_model() -> object:
@@ -171,8 +196,51 @@ def _reset_bm25_model() -> None:
     _bm25_model = None
 
 
+def _get_rerank_model() -> object:
+    """Return the cached TextCrossEncoder reranker, initialising it on first call."""
+    global _rerank_model
+    if _rerank_model is None:
+        from fastembed.rerank.cross_encoder import TextCrossEncoder  # noqa: PLC0415
+
+        logger.info(
+            "✅ code_indexer — loading reranker model: %s", settings.rerank_model
+        )
+        _rerank_model = TextCrossEncoder(settings.rerank_model)
+    return _rerank_model
+
+
+def _reset_rerank_model() -> None:
+    """Clear the cached reranker — used by tests to inject a mock."""
+    global _rerank_model
+    _rerank_model = None
+
+
+def _rerank_sync(query: str, documents: list[str]) -> list[float]:
+    """Return cross-encoder relevance scores for *documents* given *query*.
+
+    Runs synchronously — call via :func:`asyncio.to_thread` from async code.
+    Scores are in the same order as *documents*.
+    """
+    from fastembed.rerank.cross_encoder import TextCrossEncoder  # noqa: PLC0415
+
+    model = _get_rerank_model()
+    if not isinstance(model, TextCrossEncoder):
+        raise TypeError(f"Expected TextCrossEncoder, got {type(model)}")
+    return [float(s) for s in model.rerank(query, documents)]
+
+
+async def _rerank(query: str, documents: list[str]) -> list[float]:
+    """Async wrapper around :func:`_rerank_sync` using the thread pool."""
+    return await asyncio.to_thread(_rerank_sync, query, documents)
+
+
 def _embed_sync(texts: list[str]) -> list[list[float]]:
-    """Embed *texts* synchronously (runs in a thread pool via asyncio.to_thread)."""
+    """Embed *texts* synchronously (runs in a thread pool via asyncio.to_thread).
+
+    Uses ``jinaai/jina-embeddings-v2-base-code`` (768 dims, 8 192-token context)
+    which is trained on code and substantially outperforms general English models
+    for code retrieval tasks.
+    """
     from fastembed import TextEmbedding  # noqa: PLC0415
 
     model = _get_model()
@@ -268,11 +336,18 @@ class _ChunkSpec(TypedDict):
 
 
 def _chunk_file_ast(path: Path, repo_root: Path) -> list[_ChunkSpec]:
-    """Split a Python file into chunks by top-level symbols (classes, functions).
+    """Split a Python file into symbol-level chunks using AST parsing.
 
-    Each top-level class or function becomes a single chunk, including its
-    decorators, docstring, and full body. This produces semantically coherent
-    chunks that preserve complete definitions.
+    **Top-level functions** each become a single chunk.
+
+    **Top-level classes** are split into:
+    - A *class header* chunk: the class definition, docstring, and any
+      class-level attributes up to the first method body.  This preserves
+      class-level context (``__slots__``, class variables, type annotations)
+      without duplicating all method bodies.
+    - One *method chunk* per ``FunctionDef`` / ``AsyncFunctionDef`` in the
+      class body, labelled ``"class Foo > def bar"``.  This enables precise
+      retrieval of individual methods even in large classes.
 
     Falls back to character-based chunking if AST parsing fails.
     """
@@ -285,51 +360,88 @@ def _chunk_file_ast(path: Path, repo_root: Path) -> list[_ChunkSpec]:
 
     rel = str(path.relative_to(repo_root))
 
-    # Try to parse as Python AST.
     try:
         tree = ast.parse(raw, filename=str(path))
     except SyntaxError:
-        # Fall back to character chunking for malformed Python.
         return _chunk_file_char(path, repo_root, raw, rel)
 
     chunks: list[_ChunkSpec] = []
     lines = raw.splitlines(keepends=True)
 
-    for idx, node in enumerate(tree.body):
-        # Only chunk top-level classes and functions.
-        if not isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-
-        # Extract the full source for this node, including decorators.
-        start_line = node.lineno
-        end_line = node.end_lineno or start_line
-
-        # Include decorators if present.
+    def _node_start(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) -> int:
+        """Return the first line of *node* including any decorators (1-indexed)."""
         if node.decorator_list:
-            first_decorator = node.decorator_list[0]
-            start_line = first_decorator.lineno
+            return node.decorator_list[0].lineno
+        return node.lineno
 
-        # Extract text from the original source (1-indexed lines).
-        text = "".join(lines[start_line - 1 : end_line])
+    def _node_end(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) -> int:
+        """Return the last line of *node* (1-indexed)."""
+        return node.end_lineno if node.end_lineno is not None else node.lineno
 
-        # Generate deterministic chunk ID.
-        raw_hash = hashlib.md5(f"{rel}:{node.name}".encode()).hexdigest()
+    def _make_chunk(key: str, symbol: str, start: int, end: int) -> _ChunkSpec:
+        text = "".join(lines[start - 1 : end])
+        raw_hash = hashlib.md5(f"{rel}:{key}".encode()).hexdigest()
         chunk_id = int(raw_hash, 16) % (2**62)
-
-        kind = "class" if isinstance(node, ast.ClassDef) else "def"
-        chunks.append(
-            _ChunkSpec(
-                chunk_id=chunk_id,
-                file=rel,
-                text=text,
-                start_line=start_line,
-                end_line=end_line,
-                symbol=f"{kind} {node.name}",
-                file_hash="",  # stamped by index_codebase after hashing the file
-            )
+        return _ChunkSpec(
+            chunk_id=chunk_id,
+            file=rel,
+            text=text,
+            start_line=start,
+            end_line=end,
+            symbol=symbol,
+            file_hash="",
         )
 
-    # If no top-level symbols found, fall back to character chunking.
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            kind = "def" if isinstance(node, ast.FunctionDef) else "async def"
+            chunks.append(_make_chunk(
+                key=node.name,
+                symbol=f"{kind} {node.name}",
+                start=_node_start(node),
+                end=_node_end(node),
+            ))
+
+        elif isinstance(node, ast.ClassDef):
+            class_start = _node_start(node)
+            class_end = _node_end(node)
+
+            methods = [
+                child for child in node.body
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+            ]
+
+            if methods:
+                # Class header: from class decorator/definition up to just
+                # before the first method body (exclusive).
+                first_m_start = _node_start(methods[0])
+                header_end = first_m_start - 1
+                header_text = "".join(lines[class_start - 1 : header_end]).rstrip()
+                if header_text:
+                    chunks.append(_make_chunk(
+                        key=f"{node.name}:header",
+                        symbol=f"class {node.name}",
+                        start=class_start,
+                        end=header_end,
+                    ))
+
+                for method in methods:
+                    m_kind = "def" if isinstance(method, ast.FunctionDef) else "async def"
+                    chunks.append(_make_chunk(
+                        key=f"{node.name}.{method.name}",
+                        symbol=f"class {node.name} > {m_kind} {method.name}",
+                        start=_node_start(method),
+                        end=_node_end(method),
+                    ))
+            else:
+                # No methods (e.g. NamedTuple, pure-data class): emit whole class.
+                chunks.append(_make_chunk(
+                    key=node.name,
+                    symbol=f"class {node.name}",
+                    start=class_start,
+                    end=class_end,
+                ))
+
     if not chunks:
         return _chunk_file_char(path, repo_root, raw, rel)
 
@@ -411,22 +523,22 @@ def _compute_file_hash(path: Path) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _bm25_version_is_current(payload: dict[str, object]) -> bool:
-    """Return True when *payload* contains the current :data:`_BM25_VERSION`.
+def _index_version_is_current(payload: dict[str, object]) -> bool:
+    """Return True when *payload* contains the current :data:`_INDEX_VERSION`.
 
-    Extracted from :func:`_needs_bm25_rebuild` so the version check logic
+    Extracted from :func:`_needs_index_rebuild` so the version check logic
     can be tested without a live Qdrant client or async context.
     """
-    return payload.get("_bm25_version") == _BM25_VERSION
+    return payload.get("_index_version") == _INDEX_VERSION
 
 
-async def _needs_bm25_rebuild(client: "AsyncQdrantClient", collection: str) -> bool:
-    """Return True when the stored BM25 version does not match :data:`_BM25_VERSION`.
+async def _needs_index_rebuild(client: "AsyncQdrantClient", collection: str) -> bool:
+    """Return True when the stored index version does not match :data:`_INDEX_VERSION`.
 
-    Fetches a single point from *collection* and checks its ``_bm25_version``
-    payload field via :func:`_bm25_version_is_current`.  If the field is absent
+    Fetches a single point from *collection* and checks its ``_index_version``
+    payload field via :func:`_index_version_is_current`.  If the field is absent
     (pre-upgrade points) or holds an older version string, a full forced rebuild
-    is required to replace the stale sparse vectors.  Returns ``False`` when the
+    is required to replace the stale vectors.  Returns ``False`` when the
     collection is empty or when Qdrant is unreachable — neither case requires a
     rebuild.
     """
@@ -441,7 +553,7 @@ async def _needs_bm25_rebuild(client: "AsyncQdrantClient", collection: str) -> b
         points, _ = result
         if not points:
             return False
-        return not _bm25_version_is_current(points[0].payload or {})
+        return not _index_version_is_current(points[0].payload or {})
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "⚠️ code_indexer — could not check BM25 version (skipping rebuild check): %s",
@@ -578,6 +690,23 @@ async def _delete_chunks_by_file(
     )
 
 
+async def _ensure_payload_index(client: "AsyncQdrantClient", collection: str) -> None:
+    """Create a keyword payload index on the ``file`` field if not present.
+
+    This index lets callers filter search results by file path server-side
+    (e.g. restrict to ``agentception/services/``) without pulling irrelevant
+    chunks into Python.  Qdrant silently ignores the call when the index
+    already exists, so this is safe to call on every index run.
+    """
+    from qdrant_client.models import PayloadSchemaType  # noqa: PLC0415
+
+    await client.create_payload_index(
+        collection_name=collection,
+        field_name="file",
+        field_schema=PayloadSchemaType.KEYWORD,
+    )
+
+
 # ── Public API ────────────────────────────────────────────────────────────────
 
 
@@ -646,17 +775,22 @@ async def index_codebase(
 
             await _ensure_collection(client, coll)
 
-            # Detect BM25 implementation change — auto-trigger full rebuild.
-            # Sparse vectors from the old hash-based implementation are
-            # incompatible with Qdrant/bm25 (different index ranges).
-            if not force_full and await _needs_bm25_rebuild(client, coll):
+            # Detect index pipeline changes — auto-trigger full rebuild.
+            # Any change to chunking strategy, embedding model, BM25
+            # implementation, or chunk text enrichment format requires a
+            # clean rebuild so all vectors are consistent.
+            if not force_full and await _needs_index_rebuild(client, coll):
                 logger.info(
-                    "✅ code_indexer — BM25 version mismatch; triggering full rebuild "
-                    "to replace stale sparse vectors with Qdrant/bm25"
+                    "✅ code_indexer — index version mismatch (want %s); "
+                    "triggering full rebuild",
+                    _INDEX_VERSION,
                 )
                 await client.delete_collection(coll)
                 await _ensure_collection(client, coll)
                 force_full = True
+
+            # Ensure file-path keyword index for filtered search.
+            await _ensure_payload_index(client, coll)
 
             # Incremental: build file→hash map from Qdrant.
             # Empty when force_full since the collection was just dropped.
@@ -709,9 +843,20 @@ async def index_codebase(
 
             for batch_start in range(0, len(all_chunks), _UPSERT_BATCH):
                 batch = all_chunks[batch_start : batch_start + _UPSERT_BATCH]
-                texts = [c["text"] for c in batch]
-                dense_vectors = await _embed(texts)
-                sparse_vectors = await _compute_bm25_vectors(texts)
+
+                # Enrich each chunk with its file path and symbol name before
+                # embedding.  Prepending this metadata anchors the dense vector
+                # to the chunk's location and identity, so "create a worktree"
+                # scores highest for the *implementation* in worktrees.py rather
+                # than callers or tests that reference the same function name.
+                embed_texts = [
+                    f"# {c['file']}\n# {c['symbol']}\n{c['text']}"
+                    if c["symbol"]
+                    else f"# {c['file']}\n{c['text']}"
+                    for c in batch
+                ]
+                dense_vectors = await _embed(embed_texts)
+                sparse_vectors = await _compute_bm25_vectors(embed_texts)
 
                 points = [
                     PointStruct(
@@ -730,7 +875,7 @@ async def index_codebase(
                             "end_line": chunk["end_line"],
                             "symbol": chunk["symbol"],
                             "file_hash": chunk["file_hash"],
-                            "_bm25_version": _BM25_VERSION,
+                            "_index_version": _INDEX_VERSION,
                         },
                     )
                     for chunk, dense_vec, sparse_vec in zip(batch, dense_vectors, sparse_vectors)
@@ -778,33 +923,50 @@ async def search_codebase(
 ) -> list[SearchMatch]:
     """Search the indexed codebase for chunks relevant to *query*.
 
-    Performs hybrid search combining dense (FastEmbed) and sparse (BM25)
-    vectors, then fuses results using Reciprocal Rank Fusion (RRF) with
-    k=60 (standard parameter).
+    Pipeline:
+    1. **Embed** the query with the same code-specific dense model used at
+       index time (``jinaai/jina-embeddings-v2-base-code``).
+    2. **Hybrid retrieval** — Qdrant fetches ``n_results * 4`` candidates by
+       running dense and sparse (BM25) searches in parallel server-side and
+       fusing them with Reciprocal Rank Fusion (RRF) in a single round-trip.
+    3. **Rerank** — a cross-encoder (``BAAI/bge-reranker-base``) scores each
+       candidate jointly against the query and re-orders the list, cutting
+       false positives that slipped through the retrieval phase.
 
     Args:
-        query: Natural-language description of what to find.
-        n_results: Maximum results to return.
+        query: Natural-language or code-level description of what to find.
+        n_results: Maximum results to return after reranking.
         qdrant_url: Override the Qdrant URL (useful in tests).
         collection: Override the collection name (useful in tests).
 
     Returns:
-        List of :class:`SearchMatch` dicts ordered by descending RRF score.
-        Returns an empty list when the collection has not been indexed yet
-        or when Qdrant is unavailable.
+        List of :class:`SearchMatch` dicts ordered by descending reranker
+        score (or RRF score when reranking is disabled).  Returns an empty
+        list when the collection has not been indexed yet or Qdrant is
+        unavailable.
     """
     from qdrant_client import AsyncQdrantClient  # noqa: PLC0415
-    from qdrant_client.models import ScoredPoint, SparseVector  # noqa: PLC0415
+    from qdrant_client.models import (  # noqa: PLC0415
+        Fusion,
+        FusionQuery,
+        Prefetch,
+        SparseVector,
+    )
 
     url = qdrant_url or settings.qdrant_url
     coll = collection or settings.qdrant_collection
 
+    # Fetch more candidates than needed so the reranker has room to reorder.
+    fetch_limit = n_results * 4
+
     try:
-        # Compute both dense and sparse query vectors.
-        dense_vectors = await _embed([query])
-        dense_query = dense_vectors[0]
-        bm25_results = await _compute_bm25_vectors([query])
-        sparse_dict = bm25_results[0]
+        # Compute query vectors (dense + sparse) concurrently.
+        dense_vecs, bm25_vecs = await asyncio.gather(
+            _embed([query]),
+            _compute_bm25_vectors([query]),
+        )
+        dense_query = dense_vecs[0]
+        sparse_dict = bm25_vecs[0]
         sparse_query = SparseVector(
             indices=list(sparse_dict.keys()),
             values=list(sparse_dict.values()),
@@ -812,72 +974,93 @@ async def search_codebase(
 
         client = AsyncQdrantClient(url=url)
         try:
-            # Run dense vector search.
-            dense_response = await client.query_points(
+            # Native Qdrant hybrid search: prefetch dense + sparse in parallel,
+            # fuse server-side with RRF — single round-trip, no Python fusion.
+            response = await client.query_points(
                 collection_name=coll,
-                query=dense_query,
-                using="dense",
-                limit=n_results * 2,  # Fetch more for fusion.
+                prefetch=[
+                    Prefetch(query=dense_query, using="dense", limit=fetch_limit),
+                    Prefetch(query=sparse_query, using="sparse", limit=fetch_limit),
+                ],
+                query=FusionQuery(fusion=Fusion.RRF),
+                limit=fetch_limit,
+                with_payload=True,
             )
-            dense_results = dense_response.points
-
-            # Run sparse vector search.
-            sparse_response = await client.query_points(
-                collection_name=coll,
-                query=sparse_query,
-                using="sparse",
-                limit=n_results * 2,  # Fetch more for fusion.
-            )
-            sparse_results = sparse_response.points
+            candidates = response.points
         finally:
             await client.close()
 
-        # Reciprocal Rank Fusion (RRF) with k=60.
-        rrf_k = 60
-        rrf_scores: dict[str, float] = {}
+        # Extract payload fields, dropping malformed points.
+        class _Candidate:
+            __slots__ = ("file", "chunk", "start_line", "end_line", "rrf_score")
 
-        # Add dense results to RRF scores.
-        for rank, point in enumerate(dense_results, start=1):
-            point_id = str(point.id)
-            rrf_scores[point_id] = rrf_scores.get(point_id, 0.0) + 1.0 / (rrf_k + rank)
+            def __init__(
+                self,
+                file: str,
+                chunk: str,
+                start_line: int,
+                end_line: int,
+                rrf_score: float,
+            ) -> None:
+                self.file = file
+                self.chunk = chunk
+                self.start_line = start_line
+                self.end_line = end_line
+                self.rrf_score = rrf_score
 
-        # Add sparse results to RRF scores.
-        for rank, point in enumerate(sparse_results, start=1):
-            point_id = str(point.id)
-            rrf_scores[point_id] = rrf_scores.get(point_id, 0.0) + 1.0 / (rrf_k + rank)
-
-        # Sort by RRF score descending and take top n_results.
-        sorted_ids = sorted(rrf_scores.keys(), key=lambda pid: rrf_scores[pid], reverse=True)[:n_results]
-
-        # Build a map of point_id -> point for payload extraction.
-        all_points: dict[str, ScoredPoint] = {str(p.id): p for p in dense_results}
-        all_points.update({str(p.id): p for p in sparse_results})
-
-        # Build final results.
-        matches: list[SearchMatch] = []
-        for point_id in sorted_ids:
-            scored_point: ScoredPoint | None = all_points.get(point_id)
-            if scored_point is None:
-                continue
-            payload = scored_point.payload or {}
+        valid: list[_Candidate] = []
+        for point in candidates:
+            payload = point.payload or {}
             file_val = payload.get("file")
             chunk_val = payload.get("chunk")
-            start_val = payload.get("start_line")
-            end_val = payload.get("end_line")
             if not isinstance(file_val, str) or not isinstance(chunk_val, str):
                 continue
-            matches.append(
-                SearchMatch(
-                    file=file_val,
-                    chunk=chunk_val,
-                    score=rrf_scores[point_id],
-                    start_line=int(start_val) if isinstance(start_val, int) else 0,
-                    end_line=int(end_val) if isinstance(end_val, int) else 0,
-                )
+            start_val = payload.get("start_line")
+            end_val = payload.get("end_line")
+            valid.append(_Candidate(
+                file=file_val,
+                chunk=chunk_val,
+                start_line=int(start_val) if isinstance(start_val, int) else 0,
+                end_line=int(end_val) if isinstance(end_val, int) else 0,
+                rrf_score=float(point.score),
+            ))
+
+        if not valid:
+            return []
+
+        # Cross-encoder reranking: score each candidate against the query and
+        # re-order by relevance.  Skip when rerank_model is empty (test override).
+        if settings.rerank_model and len(valid) > 1:
+            documents = [c.chunk for c in valid]
+            rerank_scores = await _rerank(query, documents)
+            ranked = sorted(
+                zip(valid, rerank_scores),
+                key=lambda pair: pair[1],
+                reverse=True,
             )
+            return [
+                SearchMatch(
+                    file=c.file,
+                    chunk=c.chunk,
+                    score=score,
+                    start_line=c.start_line,
+                    end_line=c.end_line,
+                )
+                for c, score in ranked[:n_results]
+            ]
+
+        # Reranking disabled: return top n_results by RRF score.
+        return [
+            SearchMatch(
+                file=c.file,
+                chunk=c.chunk,
+                score=c.rrf_score,
+                start_line=c.start_line,
+                end_line=c.end_line,
+            )
+            for c in valid[:n_results]
+        ]
 
     except Exception as exc:
         logger.warning("⚠️ code_indexer — search failed: %s", exc)
         return []
-
-    return matches

--- a/agentception/tests/test_code_indexer.py
+++ b/agentception/tests/test_code_indexer.py
@@ -15,10 +15,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from agentception.services.code_indexer import (
-    _BM25_VERSION,
+    _INDEX_VERSION,
     IndexStats,
     SearchMatch,
-    _bm25_version_is_current,
+    _index_version_is_current,
     _chunk_file,
     _compute_file_hash,
     _delete_chunks_by_file,
@@ -61,8 +61,8 @@ def _make_scored_point(
 
 
 def _fake_embed(_texts: list[str]) -> list[list[float]]:
-    """Return deterministic 384-dim zero vectors — no model download."""
-    return [[0.0] * 384 for _ in _texts]
+    """Return deterministic 768-dim zero vectors — no model download."""
+    return [[0.0] * 768 for _ in _texts]
 
 
 async def _fake_bm25(texts: list[str]) -> list[dict[int, float]]:
@@ -76,8 +76,8 @@ def _mock_bm25_vectors() -> Generator[None, None, None]:
 
     - ``_compute_bm25_vectors``: prevented from loading the Qdrant/bm25 ONNX
       model — returns trivial sparse vectors instead.
-    - ``_needs_bm25_rebuild``: always returns False so incremental tests are
-      not perturbed by missing ``_bm25_version`` fields in mock payloads.
+    - ``_needs_index_rebuild``: always returns False so incremental tests are
+      not perturbed by missing ``_index_version`` fields in mock payloads.
 
     Tests that need to exercise the rebuild path should override these patches
     locally with their own ``patch`` context managers.
@@ -89,7 +89,7 @@ def _mock_bm25_vectors() -> Generator[None, None, None]:
             side_effect=_fake_bm25,
         ),
         patch(
-            "agentception.services.code_indexer._needs_bm25_rebuild",
+            "agentception.services.code_indexer._needs_index_rebuild",
             new_callable=AsyncMock,
             return_value=False,
         ),
@@ -206,12 +206,15 @@ def test_chunk_file_ast_extracts_functions(tmp_path: Path) -> None:
     assert "def bar():" in chunks[1]["text"]
 
 
-def test_chunk_file_ast_extracts_classes(tmp_path: Path) -> None:
-    """AST chunking extracts each top-level class as a separate chunk."""
+def test_chunk_file_ast_extracts_class_with_methods_as_separate_chunks(
+    tmp_path: Path,
+) -> None:
+    """Classes with methods are split: one header chunk + one chunk per method."""
     f = tmp_path / "classes.py"
     f.write_text(
         "class Alpha:\n"
         "    '''Class docstring.'''\n"
+        "    x: int = 0\n"
         "    def method(self):\n"
         "        pass\n"
         "\n"
@@ -219,11 +222,35 @@ def test_chunk_file_ast_extracts_classes(tmp_path: Path) -> None:
         "    pass\n"
     )
     chunks = _chunk_file(f, tmp_path)
-    assert len(chunks) == 2
-    assert "class Alpha:" in chunks[0]["text"]
-    assert "Class docstring" in chunks[0]["text"]
-    assert "def method" in chunks[0]["text"]
-    assert "class Beta:" in chunks[1]["text"]
+    # Alpha → header + 1 method; Beta → whole class (no methods).
+    assert len(chunks) == 3
+
+    symbols = [c["symbol"] for c in chunks]
+    assert "class Alpha" in symbols
+    assert "class Alpha > def method" in symbols
+    assert "class Beta" in symbols
+
+    header = next(c for c in chunks if c["symbol"] == "class Alpha")
+    assert "class Alpha:" in header["text"]
+    assert "Class docstring" in header["text"]
+    assert "def method" not in header["text"]  # method is in its own chunk
+
+    method_chunk = next(c for c in chunks if c["symbol"] == "class Alpha > def method")
+    assert "def method" in method_chunk["text"]
+
+
+def test_chunk_file_ast_class_without_methods_emits_whole_class(tmp_path: Path) -> None:
+    """A class with no methods is emitted as a single chunk."""
+    f = tmp_path / "data_class.py"
+    f.write_text(
+        "class Point:\n"
+        "    x: float\n"
+        "    y: float\n"
+    )
+    chunks = _chunk_file(f, tmp_path)
+    assert len(chunks) == 1
+    assert "class Point" in chunks[0]["symbol"]
+    assert "class Point:" in chunks[0]["text"]
 
 
 def test_chunk_file_ast_includes_decorators(tmp_path: Path) -> None:
@@ -351,11 +378,13 @@ async def test_search_codebase_returns_matches() -> None:
     )
 
     mock_client = AsyncMock()
+    # Native hybrid search: single query_points call returns fused results.
     mock_client.query_points.return_value = SimpleNamespace(points=[expected_point])
 
     with (
         patch("agentception.services.code_indexer._embed", side_effect=_fake_embed),
         patch("qdrant_client.AsyncQdrantClient", return_value=mock_client),
+        # Only 1 valid candidate — reranking is skipped (requires len > 1).
     ):
         matches: list[SearchMatch] = await search_codebase("qdrant url config", n_results=3)
 
@@ -363,10 +392,7 @@ async def test_search_codebase_returns_matches() -> None:
     m = matches[0]
     assert m["file"] == "agentception/config.py"
     assert "qdrant_url" in m["chunk"]
-    # Score is now an RRF score (sum of 1/(k+rank) from dense and sparse results).
-    # Just verify it's positive and reasonable.
-    assert m["score"] > 0.0
-    assert m["score"] < 1.0
+    assert isinstance(m["score"], float)
 
 
 @pytest.mark.anyio
@@ -411,114 +437,110 @@ async def test_search_codebase_skips_malformed_payloads() -> None:
 
 
 @pytest.mark.anyio
-async def test_hybrid_search() -> None:
-    """Hybrid search combines dense and sparse results with RRF fusion.
-    
-    This test verifies:
-    1. Hybrid query returns results from both dense and sparse searches.
-    2. A keyword-heavy query (exact class name) benefits from sparse matching.
-    3. RRF fusion correctly merges results from both vectors.
+async def test_hybrid_search_uses_native_qdrant_prefetch() -> None:
+    """search_codebase issues a single prefetch+RRF query and cross-encoder reranks.
+
+    The new pipeline issues one ``query_points`` call with ``prefetch`` for
+    both dense and sparse sub-queries, delegating RRF fusion to Qdrant
+    server-side.  A cross-encoder then re-orders by relevance score.
     """
-    # Create mock points that would come from dense and sparse searches.
-    # Point 1: High sparse score (exact keyword match), lower dense score.
-    point_keyword_match = SimpleNamespace(
-        id=1,
-        version=0,
-        score=0.95,  # High sparse score
-        payload={
-            "file": "models/state.py",
-            "chunk": "class RunState(str, enum.Enum):\n    implementing = 'implementing'\n",
-            "start_line": 10,
-            "end_line": 12,
-        },
-        vector=None,
-    )
-    
-    # Point 2: High dense score (semantic match), lower sparse score.
-    point_semantic_match = SimpleNamespace(
-        id=2,
-        version=0,
-        score=0.85,  # High dense score
-        payload={
-            "file": "services/workflow.py",
-            "chunk": "def transition_to_implementing(run_id: str) -> None:\n    pass\n",
-            "start_line": 50,
-            "end_line": 52,
-        },
-        vector=None,
-    )
-    
-    # Point 3: Appears in both results (should get highest RRF score).
-    point_both_match = SimpleNamespace(
-        id=3,
-        version=0,
-        score=0.80,
+    from qdrant_client.models import FusionQuery, Prefetch
+
+    p_high = SimpleNamespace(
+        id=1, version=0, score=0.03,
         payload={
             "file": "models/run.py",
             "chunk": "class AgentRun:\n    state: RunState\n",
-            "start_line": 20,
-            "end_line": 22,
+            "start_line": 20, "end_line": 22,
+        },
+        vector=None,
+    )
+    p_mid = SimpleNamespace(
+        id=2, version=0, score=0.02,
+        payload={
+            "file": "services/workflow.py",
+            "chunk": "def transition_to_implementing(run_id: str) -> None:\n    pass\n",
+            "start_line": 50, "end_line": 52,
+        },
+        vector=None,
+    )
+    p_low = SimpleNamespace(
+        id=3, version=0, score=0.01,
+        payload={
+            "file": "models/state.py",
+            "chunk": "class RunState(str, enum.Enum):\n    implementing = 'implementing'\n",
+            "start_line": 10, "end_line": 12,
         },
         vector=None,
     )
 
     mock_client = AsyncMock()
-    
-    # Mock dense search returns points 2 and 3 (semantic matches).
-    dense_response = SimpleNamespace(points=[point_semantic_match, point_both_match])
-    
-    # Mock sparse search returns points 1 and 3 (keyword matches).
-    sparse_response = SimpleNamespace(points=[point_keyword_match, point_both_match])
-    
-    # query_points is called twice: once for dense, once for sparse.
-    # We need to return different results based on the 'using' parameter.
-    async def mock_query_points(collection_name: str, query: object, using: str, limit: int) -> object:
-        if using == "dense":
-            return dense_response
-        elif using == "sparse":
-            return sparse_response
-        else:
-            return SimpleNamespace(points=[])
-    
-    mock_client.query_points.side_effect = mock_query_points
+    mock_client.query_points.return_value = SimpleNamespace(points=[p_high, p_mid, p_low])
+
+    # Reranker reverses the order: state.py → workflow.py → run.py.
+    fake_rerank_scores = [0.1, 0.5, 0.9]
 
     with (
         patch("agentception.services.code_indexer._embed", side_effect=_fake_embed),
+        patch(
+            "agentception.services.code_indexer._rerank",
+            new_callable=AsyncMock,
+            return_value=fake_rerank_scores,
+        ),
         patch("qdrant_client.AsyncQdrantClient", return_value=mock_client),
     ):
         matches = await search_codebase("RunState", n_results=3)
 
-    # Verify results are returned.
+    # Single native Qdrant call with prefetch structure.
+    assert mock_client.query_points.call_count == 1
+    call_kwargs = mock_client.query_points.call_args.kwargs
+    assert "prefetch" in call_kwargs
+    prefetch = call_kwargs["prefetch"]
+    assert len(prefetch) == 2
+    assert all(isinstance(p, Prefetch) for p in prefetch)
+    assert isinstance(call_kwargs["query"], FusionQuery)
+
+    # Reranker re-ordered results.
     assert len(matches) == 3
-    
-    # Verify RRF fusion: point_both_match (id=3) should rank highest because
-    # it appears in both dense and sparse results, getting RRF score from both.
-    # RRF score for point 3: 1/(60+1) + 1/(60+2) ≈ 0.0164 + 0.0161 = 0.0325
-    # RRF score for point 1: 1/(60+1) ≈ 0.0164 (only in sparse, rank 1)
-    # RRF score for point 2: 1/(60+1) ≈ 0.0164 (only in dense, rank 1)
-    # Point 3 should be first.
-    assert matches[0]["file"] == "models/run.py"
-    
-    # Verify all expected files are present.
-    files = {m["file"] for m in matches}
-    assert "models/state.py" in files  # Keyword match
-    assert "services/workflow.py" in files  # Semantic match
-    assert "models/run.py" in files  # Both match
-    
-    # Verify scores are RRF scores (not raw similarity scores).
-    # All scores should be small positive floats (RRF scores are typically < 0.1).
-    for match in matches:
-        assert 0.0 < match["score"] < 1.0
-        assert isinstance(match["score"], float)
+    assert matches[0]["file"] == "models/state.py"
+    assert matches[1]["file"] == "services/workflow.py"
+    assert matches[2]["file"] == "models/run.py"
+    assert matches[0]["score"] == pytest.approx(0.9)
+
+
+@pytest.mark.anyio
+async def test_search_codebase_skips_reranking_for_single_result() -> None:
+    """Reranking is skipped when only one valid candidate is returned."""
+    point = _make_scored_point("agentception/config.py", "x = 1", score=0.5)
+    mock_client = AsyncMock()
+    mock_client.query_points.return_value = SimpleNamespace(points=[point])
+
+    rerank_called = False
+
+    async def _fake_rerank(q: str, docs: list[str]) -> list[float]:
+        nonlocal rerank_called
+        rerank_called = True
+        return [1.0] * len(docs)
+
+    with (
+        patch("agentception.services.code_indexer._embed", side_effect=_fake_embed),
+        patch("agentception.services.code_indexer._rerank", side_effect=_fake_rerank),
+        patch("qdrant_client.AsyncQdrantClient", return_value=mock_client),
+    ):
+        matches = await search_codebase("x", n_results=1)
+
+    assert not rerank_called
+    assert len(matches) == 1
 
 
 # ── payload index and symbol field tests ─────────────────────────────────────
 
 
 def test_chunk_file_ast_symbol_field_populated(tmp_path: Path) -> None:
-    """AST chunks carry a populated symbol field ('class X' or 'def f')."""
+    """AST chunks carry a populated symbol field describing each symbol."""
     f = tmp_path / "syms.py"
     f.write_text(
+        # MyModel has no methods → emitted as one whole-class chunk.
         "class MyModel:\n"
         "    pass\n"
         "\n"
@@ -526,9 +548,9 @@ def test_chunk_file_ast_symbol_field_populated(tmp_path: Path) -> None:
         "    pass\n"
     )
     chunks = _chunk_file(f, tmp_path)
-    assert len(chunks) == 2
-    assert chunks[0]["symbol"] == "class MyModel"
-    assert chunks[1]["symbol"] == "def my_handler"
+    symbols = {c["symbol"] for c in chunks}
+    assert "class MyModel" in symbols
+    assert "async def my_handler" in symbols
 
 
 def test_chunk_file_char_symbol_field_empty(tmp_path: Path) -> None:
@@ -538,6 +560,61 @@ def test_chunk_file_char_symbol_field_empty(tmp_path: Path) -> None:
     chunks = _chunk_file(f, tmp_path)
     assert len(chunks) >= 1
     assert all(c["symbol"] == "" for c in chunks)
+
+
+@pytest.mark.anyio
+async def test_index_codebase_embeds_enriched_text(tmp_path: Path) -> None:
+    """index_codebase prepends file path and symbol to each chunk before embedding.
+
+    The embedded text must start with ``# <file>`` so the dense vector is
+    anchored to the chunk's location, not just the raw source code.
+    """
+    py_file = tmp_path / "utils.py"
+    py_file.write_text("def helper():\n    return 42\n")
+
+    embedded_texts: list[str] = []
+
+    def _capture_embed(texts: list[str]) -> list[list[float]]:
+        embedded_texts.extend(texts)
+        return [[0.0] * 768 for _ in texts]
+
+    mock_client = AsyncMock()
+    mock_client.get_collections.return_value = SimpleNamespace(collections=[])
+    mock_client.scroll.return_value = ([], None)
+
+    with (
+        patch("agentception.services.code_indexer._embed", side_effect=_capture_embed),
+        patch("qdrant_client.AsyncQdrantClient", return_value=mock_client),
+    ):
+        await index_codebase(repo_path=tmp_path)
+
+    assert embedded_texts, "At least one text must have been embedded"
+    for text in embedded_texts:
+        assert text.startswith("# "), (
+            f"Embedded text must start with file path header, got: {text[:60]!r}"
+        )
+        assert "utils.py" in text
+
+
+@pytest.mark.anyio
+async def test_index_codebase_creates_payload_index(tmp_path: Path) -> None:
+    """index_codebase calls create_payload_index to enable filtered search."""
+    py_file = tmp_path / "mod.py"
+    py_file.write_text("def f(): pass\n")
+
+    mock_client = AsyncMock()
+    mock_client.get_collections.return_value = SimpleNamespace(collections=[])
+    mock_client.scroll.return_value = ([], None)
+
+    with (
+        patch("agentception.services.code_indexer._embed", side_effect=_fake_embed),
+        patch("qdrant_client.AsyncQdrantClient", return_value=mock_client),
+    ):
+        await index_codebase(repo_path=tmp_path)
+
+    mock_client.create_payload_index.assert_called_once()
+    call_kwargs = mock_client.create_payload_index.call_args.kwargs
+    assert call_kwargs["field_name"] == "file"
 
 
 @pytest.mark.anyio
@@ -965,28 +1042,29 @@ async def test_incremental_force_full_rebuilds_collection(tmp_path: Path) -> Non
     mock_client.upsert.assert_called()
 
 
-def test_bm25_version_is_current_true_when_version_matches() -> None:
-    """_bm25_version_is_current returns True when payload contains the current version."""
-    assert _bm25_version_is_current({"_bm25_version": _BM25_VERSION}) is True
+def test_index_version_is_current_true_when_version_matches() -> None:
+    """_index_version_is_current returns True when payload contains the current version."""
+    assert _index_version_is_current({"_index_version": _INDEX_VERSION}) is True
 
 
-def test_bm25_version_is_current_false_when_version_absent() -> None:
-    """_bm25_version_is_current returns False when _bm25_version field is missing."""
-    assert _bm25_version_is_current({"file": "mod.py"}) is False
+def test_index_version_is_current_false_when_version_absent() -> None:
+    """_index_version_is_current returns False when _index_version field is missing."""
+    assert _index_version_is_current({"file": "mod.py"}) is False
 
 
-def test_bm25_version_is_current_false_when_version_stale() -> None:
-    """_bm25_version_is_current returns False when payload holds an older version."""
-    assert _bm25_version_is_current({"_bm25_version": "qdrant-bm25-v1"}) is False
+def test_index_version_is_current_false_when_version_stale() -> None:
+    """_index_version_is_current returns False when payload holds an older version."""
+    assert _index_version_is_current({"_index_version": "v1"}) is False
 
 
 @pytest.mark.anyio
-async def test_bm25_version_mismatch_triggers_full_rebuild(tmp_path: Path) -> None:
-    """index_codebase drops and rebuilds the collection when _needs_bm25_rebuild returns True.
+async def test_index_version_mismatch_triggers_full_rebuild(tmp_path: Path) -> None:
+    """index_codebase drops and rebuilds the collection when _needs_index_rebuild returns True.
 
-    Regression: switching from the old hash-based BM25 to Qdrant/bm25 changes
-    the sparse vector index space.  The automatic rebuild replaces stale points
-    so hybrid search returns correct results from the first run.
+    Regression: any change to the index pipeline (embedding model, chunking
+    strategy, BM25 implementation, chunk text enrichment) changes vector
+    semantics.  The automatic rebuild replaces stale points so search returns
+    correct results from the first run after an upgrade.
     """
     py_file = tmp_path / "mod.py"
     py_file.write_text("def greet(): return 'hello'\n")
@@ -1005,10 +1083,10 @@ async def test_bm25_version_mismatch_triggers_full_rebuild(tmp_path: Path) -> No
     )
     mock_client.scroll.return_value = ([], None)
 
-    # Override autouse mock: _needs_bm25_rebuild returns True to trigger rebuild.
+    # Override autouse mock: _needs_index_rebuild returns True to trigger rebuild.
     with (
         patch(
-            "agentception.services.code_indexer._needs_bm25_rebuild",
+            "agentception.services.code_indexer._needs_index_rebuild",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -1021,13 +1099,13 @@ async def test_bm25_version_mismatch_triggers_full_rebuild(tmp_path: Path) -> No
     # Version mismatch forced a full rebuild — nothing skipped.
     assert stats["files_skipped"] == 0
     assert stats["files_indexed"] == 1
-    # Collection was dropped and recreated to replace stale sparse vectors.
+    # Collection was dropped and recreated.
     mock_client.delete_collection.assert_called()
     mock_client.create_collection.assert_called()
-    # All upserted points must carry the current BM25 version.
+    # All upserted points must carry the current index version.
     upsert_call = mock_client.upsert.call_args
     upserted_points = upsert_call.kwargs["points"]
     for point in upserted_points:
-        assert point.payload.get("_bm25_version") == _BM25_VERSION, (
-            "Every indexed chunk must carry the current _bm25_version"
+        assert point.payload.get("_index_version") == _INDEX_VERSION, (
+            "Every indexed chunk must carry the current _index_version"
         )

--- a/scripts/search_benchmark.py
+++ b/scripts/search_benchmark.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Qdrant search quality benchmark for AgentCeption.
+
+Measures MRR@5, Hit@1, Hit@3, Hit@5, and per-query latency against a
+hand-crafted evaluation set derived from this codebase.  Run this script
+before and after each search-quality improvement to quantify progress.
+
+Usage:
+    docker compose exec agentception python3 /app/scripts/search_benchmark.py
+
+Output:
+    Per-query table with hit/miss indicators and rank, plus aggregate
+    MRR@5, Hit@1, Hit@3, Hit@5, and mean latency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Query:
+    """A single evaluation query with its expected answer."""
+
+    query: str
+    expected_file: str          # substring that should appear in the top result's file path
+    expected_symbol: str | None  # function/class name that should appear in the chunk (optional)
+    description: str            # human-readable label for the result table
+
+
+EVAL_SET: list[Query] = [
+    Query(
+        query="create a git worktree from a remote branch",
+        expected_file="readers/worktrees.py",
+        expected_symbol="ensure_worktree",
+        description="ensure_worktree",
+    ),
+    Query(
+        query="delete and clean up a git worktree after an agent finishes",
+        expected_file="readers/worktrees.py",
+        expected_symbol="teardown_worktree",
+        description="teardown_worktree",
+    ),
+    Query(
+        query="hybrid dense and sparse vector search combining results with RRF",
+        expected_file="services/code_indexer.py",
+        expected_symbol="search_codebase",
+        description="search_codebase",
+    ),
+    Query(
+        query="compute BM25 sparse embedding vectors for a batch of texts",
+        expected_file="services/code_indexer.py",
+        expected_symbol="_compute_bm25_vectors",
+        description="_compute_bm25_vectors",
+    ),
+    Query(
+        query="assemble context briefing for a developer agent before dispatch",
+        expected_file="services/context_assembler.py",
+        expected_symbol="assemble_executor_context",
+        description="assemble_executor_context",
+    ),
+    Query(
+        query="find the innermost AST function or class enclosing a given line number",
+        expected_file="services/context_assembler.py",
+        expected_symbol="_ast_enclosing_scope",
+        description="_ast_enclosing_scope",
+    ),
+    Query(
+        query="stream server-sent events to the browser during an agent run",
+        expected_file="routes/api/dispatch.py",
+        expected_symbol=None,
+        description="SSE streaming in dispatch",
+    ),
+    Query(
+        query="persist an agent event record to the database",
+        expected_file="db/persist.py",
+        expected_symbol=None,
+        description="persist agent event",
+    ),
+    Query(
+        query="Pydantic Settings class for Qdrant URL and collection configuration",
+        expected_file="agentception/config.py",
+        expected_symbol="Settings",
+        description="Qdrant config in Settings",
+    ),
+    Query(
+        query="create a GitHub issue with labels and milestone via API",
+        expected_file="readers/issue_creator.py",
+        expected_symbol=None,
+        description="issue_creator",
+    ),
+    Query(
+        query="call Anthropic Claude API with streaming enabled",
+        expected_file="services/llm.py",
+        expected_symbol=None,
+        description="Anthropic LLM call",
+    ),
+    Query(
+        query="SQLAlchemy async session factory for database connections",
+        expected_file="db/base.py",
+        expected_symbol=None,
+        description="async DB session",
+    ),
+]
+
+TOP_K = 5  # Evaluate MRR and hits up to this rank.
+
+
+def _hit_rank(results: list[dict[str, object]], q: Query) -> int | None:
+    """Return the 1-based rank of the first result matching *q*, or None."""
+    for rank, r in enumerate(results[:TOP_K], start=1):
+        file_val = str(r.get("file", ""))
+        chunk_val = str(r.get("chunk", ""))
+        if q.expected_file in file_val:
+            if q.expected_symbol is None or q.expected_symbol in chunk_val:
+                return rank
+    return None
+
+
+async def run_benchmark() -> None:
+    """Execute all evaluation queries and print a formatted results table."""
+    # Late import so the script can be run before the module is on sys.path.
+    import sys
+    sys.path.insert(0, "/app")
+
+    from agentception.services.code_indexer import search_codebase
+
+    print("\n" + "=" * 72)
+    print("  AgentCeption  —  Qdrant Search Quality Benchmark")
+    print("=" * 72)
+    print(f"{'Query':<42} {'Rank':>4}  {'File hit':>8}  {'Sym hit':>7}  {'ms':>6}")
+    print("-" * 72)
+
+    reciprocal_ranks: list[float] = []
+    hit_at: dict[int, int] = {1: 0, 3: 0, 5: 0}
+    latencies: list[float] = []
+
+    for q in EVAL_SET:
+        t0 = time.perf_counter()
+        results = await search_codebase(q.query, n_results=TOP_K)
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        latencies.append(elapsed_ms)
+
+        rank = _hit_rank(results, q)
+        rr = 1.0 / rank if rank else 0.0
+        reciprocal_ranks.append(rr)
+
+        for k in (1, 3, 5):
+            if rank is not None and rank <= k:
+                hit_at[k] += 1
+
+        # Per-query output
+        rank_str = str(rank) if rank else "—"
+        file_hit = "✅" if rank is not None else "❌"
+
+        # Check symbol independently for visibility
+        sym_hit = "n/a"
+        if q.expected_symbol is not None:
+            found_sym = any(
+                q.expected_symbol in str(r.get("chunk", ""))
+                for r in results[:TOP_K]
+            )
+            sym_hit = "✅" if found_sym else "❌"
+
+        label = q.description[:41]
+        print(f"{label:<42} {rank_str:>4}  {file_hit:>8}  {sym_hit:>7}  {elapsed_ms:>5.0f}")
+
+    n = len(EVAL_SET)
+    mrr = sum(reciprocal_ranks) / n
+    mean_ms = sum(latencies) / n
+
+    print("-" * 72)
+    print(f"\n  MRR@{TOP_K}   : {mrr:.3f}")
+    print(f"  Hit@1   : {hit_at[1]}/{n}  ({100 * hit_at[1] / n:.0f}%)")
+    print(f"  Hit@3   : {hit_at[3]}/{n}  ({100 * hit_at[3] / n:.0f}%)")
+    print(f"  Hit@5   : {hit_at[5]}/{n}  ({100 * hit_at[5] / n:.0f}%)")
+    print(f"  Latency : {mean_ms:.0f} ms/query (mean)\n")
+    print("=" * 72 + "\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_benchmark())


### PR DESCRIPTION
## Summary

- **Tier 1**: Chunk text enrichment (file path + symbol prefix before embedding), method-level Python AST chunking (class header + one chunk per method), payload index on `file` field
- **Tier 2**: Switch to `jinaai/jina-embeddings-v2-base-code` (768d, 8k-token context, code-specific) + native Qdrant `prefetch+Fusion.RRF` hybrid search (single round-trip replaces two-query manual RRF)
- **Tier 3**: `BAAI/bge-reranker-base` cross-encoder reranking as final precision stage (fetch 4× candidates, rerank, return top-k)
- **Benchmark**: `scripts/search_benchmark.py` — 12 eval queries with MRR@5, Hit@1/3/5, latency. Baseline before changes: MRR@5=0.375, Hit@1=33%
- Version sentinel renamed `_BM25_VERSION` → `_INDEX_VERSION` (v5), automatic full rebuild on mismatch

## Test plan
- [x] 1833 tests pass
- [x] mypy strict, zero errors
- [x] typing_audit --max-any 0 passes