### PR TITLE
fix: skip alembic/versions from index and tighten embed char cap

### DIFF
--- a/agentception/services/code_indexer.py
+++ b/agentception/services/code_indexer.py
@@ -121,6 +121,21 @@ _SKIP_DIRS: frozenset[str] = frozenset(
     }
 )
 
+# Path-segment pairs that together identify auto-generated subtrees with no
+# search value.  A file is skipped when ALL segments in any pair appear (in
+# order) as consecutive components of its path.
+#
+# ``("alembic", "versions")`` — Alembic migration files are DDL generated
+# from SQLAlchemy models.  The models in ``agentception/db/models.py`` are the
+# source of truth; indexing both creates duplicate, lower-quality signal.
+# Migrations also contain large monolithic ``upgrade()`` functions (10k+ chars)
+# that cause O(n²) ONNX attention stalls even with the _MAX_EMBED_CHARS cap.
+_SKIP_PATH_PAIRS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("alembic", "versions"),
+    }
+)
+
 # ── Public result types ───────────────────────────────────────────────────────
 
 
@@ -315,8 +330,18 @@ def _walk_files(repo_path: Path) -> list[Path]:
     for child in sorted(repo_path.rglob("*")):
         if child.is_dir():
             continue
-        # Prune whole subtrees early.
-        if any(part in _SKIP_DIRS for part in child.parts):
+        parts = child.parts
+        # Prune whole subtrees matching single-directory skip list.
+        if any(part in _SKIP_DIRS for part in parts):
+            continue
+        # Prune subtrees matching consecutive path-segment pairs (e.g. alembic/versions).
+        if any(
+            any(
+                parts[i] == a and i + 1 < len(parts) and parts[i + 1] == b
+                for i in range(len(parts) - 1)
+            )
+            for a, b in _SKIP_PATH_PAIRS
+        ):
             continue
         if _should_index(child):
             results.append(child)
@@ -616,12 +641,14 @@ async def _fetch_indexed_hashes(
 _UPSERT_BATCH = 16  # points per upsert call — smaller batches give more frequent progress logs
                     # and reduce the per-batch latency spike from large code chunks.
 
-# Jina jina-embeddings-v2-base-code has an 8192-token context window.
-# At ~4 chars/token for code, 8192 tokens ≈ 32 768 characters.  We cap
-# embed text at 24 000 chars (~6 000 tokens) as a safety margin, since ONNX
-# attention is O(n²) — runaway large sequences cause per-batch stalls of
-# several minutes even when the model technically supports the length.
-_MAX_EMBED_CHARS = 24_000
+# Safety cap on the embed text length fed to the dense model.
+# ONNX attention is O(n²) in sequence length — a single 10k-char chunk in a
+# batch pads all 15 other chunks to that length too, multiplying batch latency
+# by (10000/1500)² ≈ 44×.  4 000 chars ≈ 1 000 tokens is ample for any
+# application-level function signature, docstring, and core logic; the only
+# files that genuinely exceed this are auto-generated ones (migrations, etc.)
+# which are excluded from the index by _SKIP_PATH_SEGMENTS below.
+_MAX_EMBED_CHARS = 4_000
 
 
 async def _ensure_collection(client: "AsyncQdrantClient", collection: str) -> None:

--- a/agentception/tests/test_code_indexer.py
+++ b/agentception/tests/test_code_indexer.py
@@ -132,6 +132,22 @@ def test_walk_files_skips_git_and_pycache(tmp_path: Path) -> None:
     assert "mod.pyc" not in paths
 
 
+def test_walk_files_skips_alembic_versions(tmp_path: Path) -> None:
+    """Alembic migration files are excluded — they are auto-generated DDL noise."""
+    (tmp_path / "alembic").mkdir()
+    (tmp_path / "alembic" / "env.py").write_text("# alembic env")
+    (tmp_path / "alembic" / "versions").mkdir()
+    (tmp_path / "alembic" / "versions" / "0001_schema.py").write_text("def upgrade(): pass")
+    (tmp_path / "app.py").write_text("pass")
+
+    files = _walk_files(tmp_path)
+    names = {f.name for f in files}
+
+    assert "app.py" in names
+    assert "env.py" in names          # alembic/env.py IS indexed (hand-authored)
+    assert "0001_schema.py" not in names  # alembic/versions/ is skipped
+
+
 def test_walk_files_includes_multiple_extensions(tmp_path: Path) -> None:
     (tmp_path / "code.py").write_text("pass")
     (tmp_path / "readme.md").write_text("# Hello")


### PR DESCRIPTION
## Summary
- Exclude `alembic/versions/` from the Qdrant index via `_SKIP_PATH_PAIRS` — migration files are auto-generated DDL that duplicates the SQLAlchemy models and caused the Jina model to stall on `0001_initial_schema.py::upgrade()` (10k chars → O(n²) attention padding across entire batches)
- Keep `alembic/env.py` indexed (hand-authored, useful)
- Lower `_MAX_EMBED_CHARS` from 24k → 4k as a safety net for any remaining outlier chunks in application code
- Add `test_walk_files_skips_alembic_versions` regression test

## Test plan
- [ ] `pytest agentception/tests/test_code_indexer.py` — 54 pass
- [ ] `mypy agentception/services/code_indexer.py` — clean
- [ ] Fresh index completes without stalling at batch 24
