### PR TITLE
fix: raise _MAX_EMBED_CHARS 4k→8k to avoid truncating real application code

### DIFF
--- a/agentception/services/code_indexer.py
+++ b/agentception/services/code_indexer.py
@@ -642,13 +642,17 @@ _UPSERT_BATCH = 16  # points per upsert call — smaller batches give more frequ
                     # and reduce the per-batch latency spike from large code chunks.
 
 # Safety cap on the embed text length fed to the dense model.
-# ONNX attention is O(n²) in sequence length — a single 10k-char chunk in a
-# batch pads all 15 other chunks to that length too, multiplying batch latency
-# by (10000/1500)² ≈ 44×.  4 000 chars ≈ 1 000 tokens is ample for any
-# application-level function signature, docstring, and core logic; the only
-# files that genuinely exceed this are auto-generated ones (migrations, etc.)
-# which are excluded from the index by _SKIP_PATH_SEGMENTS below.
-_MAX_EMBED_CHARS = 4_000
+# ONNX attention is O(n²) in sequence length — a single outlier chunk in a
+# batch pads every other chunk to the same length, multiplying batch latency.
+#
+# Observed maximums in this codebase's application code: ~6 060 chars
+# (get_issues_grouped_by_phase, get_prs_grouped_by_phase).  8 000 chars
+# ≈ 2 000 tokens covers all legitimate functions with comfortable headroom.
+# Worst-case batch time for an 8k chunk: (8000/1500)² ≈ 28× a 375-char batch
+# ≈ 15-20 s — acceptable.  Auto-generated files that previously caused
+# catastrophic stalls (alembic/versions, 10k+ chars) are excluded by
+# _SKIP_PATH_PAIRS and never reach this path.
+_MAX_EMBED_CHARS = 8_000
 
 
 async def _ensure_collection(client: "AsyncQdrantClient", collection: str) -> None:


### PR DESCRIPTION
## Summary
- Bump `_MAX_EMBED_CHARS` from 4 000 → 8 000 characters
- Application functions like `get_issues_grouped_by_phase` (6 060 chars) and `persist_pr_link_and_recompute` (4 403 chars) were being silently truncated at 4k, degrading their embeddings
- 8k covers all observed application-level functions with headroom; worst-case batch latency for an 8k-char chunk is ~15-20s — acceptable
- The catastrophic-stall case (alembic migration DDL at 10k+ chars) is already excluded by `_SKIP_PATH_PAIRS` and never reaches this limit

## Test plan
- [ ] `mypy agentception/services/code_indexer.py` — clean
- [ ] Fresh index runs to completion without stalls and without truncation warnings on application code
