### PR TITLE
fix: extract code symbols from issue body for targeted Qdrant queries

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -644,13 +644,21 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     # Pre-inject semantically relevant code context from the main Qdrant index.
     # Searching at dispatch time (not agent-turn time) amortises the embedding
     # cost once and gives the agent oriented code context from turn 1.
-    # Cap: top 3 chunks, 800 chars each, total ≤ 3 000 chars added.
+    # Cap: top 5 chunks, 800 chars each, total ≤ 3 000 chars added.
     # code_matches is also reused below for type-signature extraction.
+    #
+    # Query: prefer the symbol-rich issue title + backtick-wrapped code refs
+    # over a raw body slice, which for most issues is background prose.
+    from agentception.services.context_assembler import _extract_code_queries  # noqa: PLC0415
     code_matches: list[SearchMatch] = []
     if task_description:
-        search_query = f"{req.issue_title} {req.issue_body}"[:800]
+        dispatch_queries = _extract_code_queries(req.issue_title or "", req.issue_body or "")
+        # Use the first (most signal-dense) query for the dispatch-time snippet.
+        search_query = dispatch_queries[0] if dispatch_queries else (
+            f"{req.issue_title} {req.issue_body}"[:800]
+        )
         try:
-            code_matches = await search_codebase(search_query, n_results=3)
+            code_matches = await search_codebase(search_query, n_results=5)
             if code_matches:
                 ctx_blocks: list[str] = []
                 remaining = 3_000

--- a/agentception/services/context_assembler.py
+++ b/agentception/services/context_assembler.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 Replaces the LLM-based planning loop with a zero-LLM Python function that:
 
-1. Runs 3 targeted Qdrant queries in parallel based on the issue title and body.
-2. Merges results with the Qdrant matches already computed at dispatch time.
-3. For each unique match, uses Python ``ast`` to extract the exact enclosing
+1. Extracts targeted search queries from the issue body (backtick-wrapped code
+   symbols, file paths, gap descriptions) rather than using raw body slices.
+2. Runs up to 5 targeted Qdrant queries in parallel.
+3. Merges results with the Qdrant matches already computed at dispatch time.
+4. For each unique match, uses Python ``ast`` to extract the exact enclosing
    function or class scope (not just a raw 800-char chunk).
-4. Prepends the relevant import statements from each file so the executor
+5. Prepends the relevant import statements from each file so the executor
    can reason about types without reading entire files.
 
 Total elapsed time: ~300 ms (parallel Qdrant + local AST parsing, zero LLM calls).
@@ -18,6 +20,7 @@ Compare with the old LLM planner loop: 30–90 s, 8–16 turns, 1–2 API calls.
 import ast as _ast
 import asyncio
 import logging
+import re
 from pathlib import Path
 
 from agentception.services.code_indexer import SearchMatch, search_codebase
@@ -25,8 +28,88 @@ from agentception.services.code_indexer import SearchMatch, search_codebase
 logger = logging.getLogger(__name__)
 
 _MAX_SCOPE_CHARS: int = 3_000    # max chars per extracted scope body
-_MAX_SCOPES: int = 8             # cap on number of scopes to include
-_MAX_CONTEXT_CHARS: int = 24_000 # hard cap on total assembled output
+_MAX_SCOPES: int = 12            # cap on number of scopes to include
+_MAX_CONTEXT_CHARS: int = 30_000 # hard cap on total assembled output
+
+# Regex that matches a backtick-wrapped code reference in Markdown.
+# Captures the inner text (no newlines, 2–80 chars).
+_RE_BACKTICK = re.compile(r"`([^`\n]{2,80})`")
+
+# Heuristic: a backtick-wrapped item is a code artifact (not prose) when it
+# contains a path separator, an underscore, or starts with an uppercase letter
+# (PascalCase class / type name), and does not start with $ or # (shell vars /
+# comments).
+_RE_CODE_ARTIFACT = re.compile(r"[_/A-Z]")
+
+
+def _extract_code_queries(issue_title: str, issue_body: str) -> list[str]:
+    """Derive up to 5 targeted Qdrant queries from an issue title and body.
+
+    Strategy (in order of signal quality):
+    1. The issue title — the single most signal-dense summary.
+    2. Backtick-wrapped code symbols — function names, file paths, class names.
+       These are partitioned into two batches so each query stays focused.
+    3. The "Files to touch" section — explicit, high-precision file paths.
+    4. The first "Gap" description — the primary technical concept for the task.
+
+    This replaces the previous approach of using raw ``issue_body[:400]`` and
+    ``issue_body[-400:]`` slices, which for most issues contain prose context /
+    acceptance-criteria boilerplate rather than concrete code identifiers.
+    """
+    queries: list[str] = []
+
+    # 1. Issue title
+    if issue_title:
+        queries.append(issue_title[:300])
+
+    # 2. Backtick-wrapped code symbols
+    raw_refs = _RE_BACKTICK.findall(issue_body)
+    symbol_refs: list[str] = []
+    seen_syms: set[str] = set()
+    for ref in raw_refs:
+        if (
+            ref not in seen_syms
+            and _RE_CODE_ARTIFACT.search(ref)
+            and not ref.startswith(("$", "#"))
+        ):
+            seen_syms.add(ref)
+            symbol_refs.append(ref)
+
+    if symbol_refs:
+        # First batch: up to 8 symbols (most likely to appear early in the body)
+        queries.append(" ".join(symbol_refs[:8]))
+        if len(symbol_refs) > 8:
+            queries.append(" ".join(symbol_refs[8:16]))
+
+    # 3. "Files to touch" section (explicit file paths)
+    files_match = re.search(
+        r"##\s*Files?\s+to\s+touch.*?\n((?:[-*•]\s+`[^\n]+\n?)+)",
+        issue_body,
+        re.IGNORECASE,
+    )
+    if files_match:
+        file_paths = _RE_BACKTICK.findall(files_match.group(0))
+        # Keep only file-path-looking items (contain a '/')
+        file_paths = [p for p in file_paths if "/" in p]
+        if file_paths:
+            queries.append(" ".join(file_paths[:6]))
+
+    # 4. First "Gap" description as a concept query (if we still have room)
+    if len(queries) < 5:
+        gap_match = re.search(
+            r"##\s*Gap\s+\d+[^\n]*\n+(.*?)(?=\n##|\Z)",
+            issue_body,
+            re.DOTALL,
+        )
+        if gap_match:
+            gap_text = gap_match.group(1).strip()
+            # Strip Markdown formatting for a cleaner semantic query.
+            # Do NOT strip underscores — they are part of Python identifiers.
+            gap_text = re.sub(r"[`*#]", "", gap_text)[:400]
+            if gap_text:
+                queries.append(gap_text)
+
+    return queries[:5]  # hard cap at 5 parallel queries
 
 
 # ---------------------------------------------------------------------------
@@ -175,22 +258,19 @@ async def assemble_executor_context(
         Formatted Markdown string ready to append to the task briefing, or
         ``""`` if no relevant matches were found or all extractions fail.
     """
-    queries: list[str] = [
-        q
-        for q in [
-            issue_title[:300],
-            issue_body[:400].strip(),
-            issue_body[-400:].strip(),
-        ]
-        if q
-    ]
+    queries = _extract_code_queries(issue_title, issue_body)
+    logger.info(
+        "✅ context_assembler: %d queries derived — %s",
+        len(queries),
+        [q[:60] for q in queries],
+    )
 
     all_matches: list[SearchMatch] = list(existing_matches)
 
     if queries:
         try:
             gathered = await asyncio.gather(
-                *[search_codebase(q, n_results=5) for q in queries],
+                *[search_codebase(q, n_results=8) for q in queries],
                 return_exceptions=True,
             )
             for item in gathered:


### PR DESCRIPTION
## Summary
- Adds `_extract_code_queries()` to `context_assembler.py` — parses backtick-wrapped code symbols, file paths, and gap descriptions from the issue body to build up to 5 targeted queries instead of using raw body slices
- `_MAX_SCOPES` raised from 8 → 12; `_MAX_CONTEXT_CHARS` 24k → 30k; `n_results` per query 5 → 8
- `dispatch.py` now uses the same first extracted query for its dispatch-time snippet instead of a raw 800-char `title+body` slice

## Root cause
The previous queries `issue_body[:400]` and `issue_body[-400:]` contained background prose for most real issues (e.g. "centralisation already happened..."), not code identifiers. Qdrant found loosely related chunks rather than the specific functions named in the issue. For issue #407, this meant `_api_get`, `ensure_label_exists`, and `remove_label_from_issue` were not pre-loaded, forcing the agent to read the entire 1 198-line file sequentially instead.

## New query output for issue #407
- Q1: title (unchanged)
- Q2: `agentception/services/llm.py _api_get() _api_post() _api_patch() _api_put() _api_delete() agentception/readers/github.py`
- Q3: `ensure_label_exists remove_label_from_issue ensure_pull_request httpx.AsyncClient _api_post _api_patch _api_delete create_issue update_issue`
- Q4: `agentception/readers/github.py agentception/tests/test_agentception_github.py docs/reference/services.md`
- Q5: first Gap description text

## Test plan
- [ ] Restart container, re-dispatch issue #407
- [ ] Confirm agent does not need to do sequential full-file reads of `github.py`
- [ ] Confirm dispatch logs show `context_assembler: 4-5 queries derived`