### PR TITLE
fix: persist FastEmbed model cache across container restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,12 @@ services:
       # git worktrees created inside the container are immediately visible to Cursor
       # agents running on the host at the same absolute path.
       - ${HOME}/.agentception/worktrees/agentception:/worktrees
+      # Persist FastEmbed / HuggingFace model files across container restarts.
+      # Without this volume the three ONNX models (jina-v2, BM25, bge-reranker)
+      # are re-downloaded from HuggingFace on every restart, adding ~50s to the
+      # first dispatch after each restart.  With the volume they are loaded from
+      # disk on first use (~5–10s) and stay warm for the lifetime of the volume.
+      - model_cache:/root/.cache/huggingface
     # Use Cloudflare DNS instead of Docker's embedded resolver.
     # Docker's embedded DNS caches whichever node it gets first, and GitHub
     # occasionally has dead nodes in rotation (e.g. 140.82.116.6) that refuse
@@ -127,6 +133,8 @@ volumes:
     name: agentception-postgres-data
   qdrant_data:
     name: agentception-qdrant-data
+  model_cache:
+    name: agentception-model-cache
 
 networks:
   agentception-net:


### PR DESCRIPTION
## Summary
- Adds `model_cache` named volume (`agentception-model-cache`) mounted at `/root/.cache/huggingface`
- Prevents the three ONNX models (jina-v2, BM25, bge-reranker) from being re-downloaded on every container restart

## Root cause
Every container restart wiped the model cache because `/root/.cache/huggingface` lived in the container's ephemeral filesystem. The three models take ~50s to download (`BM25: 5s, jina-v2: 19s, bge-reranker: 25s`), blocking the entire dispatch before Qdrant queries could even run. This was the cause of the apparent "Qdrant query hang" — the queries themselves are <1s, but model loading blocked them.

With the persistent volume: models download once on first start, then load from disk (~5–10s) on subsequent restarts.

## Test plan
- [ ] `docker compose up -d` (will recreate container with new volume)
- [ ] First dispatch: models download once (expected ~50s, one time only)
- [ ] Restart container, second dispatch: models load from disk (<10s)