### PR TITLE
fix: disable worktree indexing to prevent OOM during agent runs

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -197,6 +197,20 @@ class AgentCeptionSettings(BaseSettings):
     with acceptable CPU latency (~50 ms for 10 candidates).  Set to an empty
     string to disable reranking.
     """
+    worktree_index_enabled: bool = True
+    """Whether to index each agent worktree into a per-run Qdrant collection.
+
+    When ``true`` (default), every dispatched agent run triggers a background
+    ``index_codebase`` pass over its worktree, creating a ``worktree-<run_id>``
+    collection the agent can search with ``search_codebase``.
+
+    Set to ``false`` (via ``WORKTREE_INDEX_ENABLED=false``) to skip per-run
+    indexing entirely.  The main ``code`` collection (full-repo index) remains
+    available for all ``search_codebase`` calls — it is sufficient for code
+    discovery on the current codebase.  Disabling saves ~500 MB+ of peak RSS
+    per agent run by avoiding the concurrent ONNX embed batches that otherwise
+    run alongside the first LLM call.
+    """
     database_url: str | None = None
     """Async database URL for AgentCeption's own ac_* tables.
 

--- a/agentception/services/run_factory.py
+++ b/agentception/services/run_factory.py
@@ -110,7 +110,10 @@ async def create_and_launch_run(
     # identical to the main repo at spawn time — the worktree-specific index
     # becomes more valuable as the agent writes new or modified files.
     # Non-blocking: indexing failure never prevents the run from launching.
-    asyncio.create_task(_index_worktree(worktree_path, run_id))
+    # Disabled via WORKTREE_INDEX_ENABLED=false to avoid the concurrent ONNX
+    # embed batches that spike RSS by ~500 MB alongside the first LLM call.
+    if settings.worktree_index_enabled:
+        asyncio.create_task(_index_worktree(worktree_path, run_id))
 
     if launch:
         # Import here to avoid a circular import at module load time.

--- a/agentception/services/spawn_child.py
+++ b/agentception/services/spawn_child.py
@@ -309,7 +309,10 @@ async def spawn_child(
 
     # Index the worktree into a per-run Qdrant collection so agents can use
     # search_codebase with the run-specific collection.  Non-blocking.
-    asyncio.create_task(_index_worktree(Path(worktree_path), run_id))
+    # Disabled via WORKTREE_INDEX_ENABLED=false to avoid the concurrent ONNX
+    # embed batches that spike RSS by ~500 MB alongside the first LLM call.
+    if settings.worktree_index_enabled:
+        asyncio.create_task(_index_worktree(Path(worktree_path), run_id))
 
     # Persist DB record — all task context goes to the DB row.
     # file is written.  Agents read their full briefing from the DB via the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,12 @@ services:
       # Disable HuggingFace tokenizers Rust parallelism — it spawns its own
       # thread pool that stacks on top of ORT's, making contention worse.
       TOKENIZERS_PARALLELISM: "false"
+      # ── Worktree indexing ─────────────────────────────────────────────────
+      # Disable per-run worktree indexing to prevent the concurrent ONNX embed
+      # batches from spiking RSS by ~500 MB alongside the first LLM call.
+      # The main `code` collection (full-repo index) remains available for all
+      # search_codebase calls — sufficient for code discovery on this codebase.
+      WORKTREE_INDEX_ENABLED: "false"
     volumes:
       # Mount cursor dir at same absolute path so worktree paths resolve correctly.
       - ${HOME}/.cursor:${HOME}/.cursor


### PR DESCRIPTION
## Summary

- Add `WORKTREE_INDEX_ENABLED` bool config flag (default `true`) to `agentception/config.py`
- Gate both `asyncio.create_task(_index_worktree(...))` call sites in `run_factory.py` and `spawn_child.py` on the flag
- Set `WORKTREE_INDEX_ENABLED=false` in `docker-compose.yml`

## Root cause

The per-run worktree indexer runs concurrent ONNX embed batches (15 chunks at a time, jina-v2 model) in the same process as the agent loop. The first embed batch spikes RSS by ~500 MB — pushing the container from the 5.7 GB post-dispatch baseline to 6.3 GB — causing an OOM restart before the agent can make meaningful progress. Observed deterministically on every dispatch of issue #407.

The main `code` collection (full-repo index) is already available for all `search_codebase` calls and is sufficient for code discovery. The per-run worktree collection provides marginal additional value (searching only files the agent has modified) at the cost of a container-killing memory spike on the very first iteration.

## Test plan
- [ ] Restart container, dispatch issue #407, verify agent proceeds past iteration 1 without OOM restart
- [ ] Confirm `search_codebase` still works in the agent using the main `code` collection