### PR TITLE
fix: correct non-greedy regex in watch_run.py write_file path capture

### DIFF
--- a/scripts/watch_run.py
+++ b/scripts/watch_run.py
@@ -56,7 +56,7 @@ _RE_INSERT = re.compile(
     r"insert_after_in_file — (?P<path>\S+) \(inserted at byte"
 )
 _RE_WRITE = re.compile(
-    r"write_file — (?P<path>\S+?)(?:\s+\((?P<bytes>\d+) bytes\))?"
+    r"write_file — (?P<path>\S+)(?:\s+\((?P<bytes>\d+) bytes\))?"
 )
 # shell commands (agent_loop.py run_command lines)
 _RE_SHELL_CMD = re.compile(


### PR DESCRIPTION
## Summary

`_RE_WRITE` used `\S+?` (non-greedy) for the path group. Since the bytes-count suffix `(N bytes)` is optional, the regex engine satisfied the pattern with `path='/'` — the shortest valid match — producing `💾 wrote  /` in the terminal.

Change to `\S+` (greedy) so the full path is captured before the optional byte-count suffix. Verified against paths with and without the byte count.