### PR TITLE
feat: block mypy directory scans in run_command (OOM Holtzman shield)

### DIFF
--- a/agentception/tests/test_shell_tools.py
+++ b/agentception/tests/test_shell_tools.py
@@ -13,7 +13,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from agentception.tools.shell_tools import _is_safe, git_commit_and_push, run_command
+from agentception.tools.shell_tools import (
+    _check_oom_risk,
+    _is_safe,
+    git_commit_and_push,
+    run_command,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +82,69 @@ class TestIsSafe:
     def test_npm_command_is_safe(self) -> None:
         safe, _ = _is_safe("npm run build")
         assert safe is True
+
+    # -- mypy OOM-risk guard --------------------------------------------------
+
+    def test_mypy_dir_scan_bare_is_blocked(self) -> None:
+        safe, reason = _is_safe("mypy agentception/")
+        assert safe is False
+        assert "BLOCKED" in reason
+        assert "--follow-imports=silent" in reason
+
+    def test_mypy_dir_scan_python3_m_is_blocked(self) -> None:
+        safe, reason = _is_safe("python3 -m mypy agentception/")
+        assert safe is False
+        assert "BLOCKED" in reason
+
+    def test_mypy_dir_scan_python_m_is_blocked(self) -> None:
+        safe, reason = _is_safe("python -m mypy agentception/")
+        assert safe is False
+        assert "BLOCKED" in reason
+
+    def test_mypy_dir_scan_no_trailing_slash_is_blocked(self) -> None:
+        """agentception without trailing slash is still a directory target."""
+        safe, reason = _is_safe("mypy agentception")
+        assert safe is False
+        assert "BLOCKED" in reason
+
+    def test_mypy_dir_scan_tests_is_blocked(self) -> None:
+        safe, reason = _is_safe("mypy tests/")
+        assert safe is False
+        assert "BLOCKED" in reason
+
+    def test_mypy_dir_scan_both_dirs_is_blocked(self) -> None:
+        safe, reason = _is_safe("mypy agentception/ tests/")
+        assert safe is False
+        assert "BLOCKED" in reason
+
+    def test_mypy_dir_scan_python3_both_dirs_is_blocked(self) -> None:
+        safe, reason = _is_safe("python3 -m mypy agentception/ tests/")
+        assert safe is False
+        assert "BLOCKED" in reason
+
+    def test_mypy_safe_form_specific_files_is_allowed(self) -> None:
+        safe, _ = _is_safe(
+            "mypy --follow-imports=silent agentception/db/persist.py agentception/mcp/log_tools.py"
+        )
+        assert safe is True
+
+    def test_mypy_safe_form_python3_m_is_allowed(self) -> None:
+        safe, _ = _is_safe(
+            "python3 -m mypy --follow-imports=silent agentception/services/agent_loop.py"
+        )
+        assert safe is True
+
+    def test_mypy_safe_form_single_file_is_allowed(self) -> None:
+        safe, _ = _is_safe(
+            "mypy --follow-imports=silent agentception/tools/shell_tools.py"
+        )
+        assert safe is True
+
+    def test_check_oom_risk_returns_actionable_message(self) -> None:
+        safe, reason = _check_oom_risk("mypy agentception/ tests/")
+        assert safe is False
+        assert "follow-imports=silent" in reason
+        assert "OOM" in reason or "container" in reason.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/tools/shell_tools.py
+++ b/agentception/tools/shell_tools.py
@@ -12,12 +12,17 @@ Safety is enforced via a denylist of obviously destructive patterns rather
 than an allowlist — the model needs broad access (git, pytest, mypy, rg, gh,
 docker, npm, python3, …) so an allowlist would be too brittle.  Catastrophic
 accidents (``rm -rf /``, fork bombs, privilege escalation) are blocked.
+
+A second, smarter check blocks commands that are not destructive but are
+known to OOM-kill the container due to its memory profile (see
+``_check_oom_risk``).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import shlex
 from pathlib import Path
 
@@ -53,16 +58,69 @@ _BLOCKED_PATTERNS: frozenset[str] = frozenset(
     }
 )
 
+# Matches any mypy invocation that targets a directory rather than specific
+# files.  The container runs ONNX embedding models that consume ~5.7 GB RSS.
+# Spawning a mypy subprocess that cold-loads the full project type graph adds
+# another ~1.5-2 GB and deterministically OOM-kills the container.
+#
+# Safe form:  mypy --follow-imports=silent <file1> <file2> ...
+# Unsafe form: mypy agentception/   mypy agentception/ tests/   etc.
+#
+# The regex matches the unsafe form: a mypy invocation where at least one
+# positional argument ends with "/" (a directory) or is exactly "agentception",
+# "tests", or "agentception/tests" — the common culprits.  It does NOT match
+# when --follow-imports=silent is present AND no directory args appear, so the
+# correct invocation is always allowed through.
+_MYPY_DIR_SCAN_RE: re.Pattern[str] = re.compile(
+    r"""
+    (?:python3?\s+-m\s+)?   # optional: python3 -m  or  python -m
+    mypy\b                  # the mypy invocation
+    (?!.*--follow-imports=silent.*\s+\S+\.py)  # NOT already safe form
+    .*                      # any flags
+    (?:
+        \bagentception/?    # directory arg: agentception  or  agentception/
+      | \btests/?           # directory arg: tests  or  tests/
+    )
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+_MYPY_OOM_ERROR = (
+    "BLOCKED — mypy directory scan would OOM-kill the container.\n"
+    "\n"
+    "The container runs ONNX embedding models (~5.7 GB RSS). Spawning "
+    "`mypy agentception/` or `mypy agentception/ tests/` cold-loads the "
+    "full project type graph in a new subprocess (~1.5-2 GB extra) and "
+    "crashes the container.\n"
+    "\n"
+    "Use the scoped form instead:\n"
+    "  mypy --follow-imports=silent agentception/path/to/file1.py agentception/path/to/file2.py\n"
+    "\n"
+    "Only list the files YOU modified — not entire directories."
+)
+
+
+def _check_oom_risk(command: str) -> tuple[bool, str]:
+    """Return *(safe, reason)* for commands that are not destructive but are
+    known to cause OOM crashes due to the container's memory profile.
+
+    Currently guards against mypy full-directory scans.  Returns ``(False,
+    human-readable explanation)`` when the command matches a known OOM pattern.
+    """
+    if _MYPY_DIR_SCAN_RE.search(command):
+        return False, _MYPY_OOM_ERROR
+    return True, ""
+
 
 def _is_safe(command: str) -> tuple[bool, str]:
     """Return *(safe, reason)*.  ``safe`` is ``False`` when the command matches
-    a blocked pattern.
+    a blocked pattern or a known OOM-risk pattern.
     """
     lower = command.lower().strip()
     for pattern in _BLOCKED_PATTERNS:
         if pattern in lower:
             return False, f"Blocked pattern detected: {pattern!r}"
-    return True, ""
+    return _check_oom_risk(command)
 
 
 async def run_command(


### PR DESCRIPTION
## Summary
- Adds `_check_oom_risk()` and `_MYPY_DIR_SCAN_RE` to `shell_tools.py` — any `run_command` call targeting a mypy directory scan is rejected at the tool layer with a structured, actionable error
- The error message explains the memory constraint and shows the correct `--follow-imports=silent <files>` form
- Safe invocations pass through unmodified
- 12 new unit tests cover all blocked/allowed variants

## Defence-in-depth layers for mypy OOM (all now active)
1. Developer role prompt template — instructs `--follow-imports=silent` (PR #610)
2. `_RUNTIME_ENV_NOTE` in `agent_loop.py` — shows ✅ scoped form, ❌ directory form (PR #614)
3. `_run_reviewer_warmup` — scoped to changed files only (PR #613)
4. **This PR** — hard block at `run_command` tool layer, unbreakable by any prompt

## Test plan
- [ ] `docker compose exec agentception python3 -m pytest agentception/tests/test_shell_tools.py -v` — 37 passed