### PR TITLE
fix: recover from stop_reason='length' instead of cancelling the run

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -661,7 +661,7 @@ async def run_agent_loop(
             )
             return
 
-        if response["stop_reason"] == "tool_calls":
+        if response["stop_reason"] in ("tool_calls", "length") and response["tool_calls"]:
             # During guard mode: intercept read-only tool calls and return
             # synthetic error results BEFORE dispatching.  The model "remembers"
             # tools from prior iterations and may call them even when they are
@@ -748,9 +748,33 @@ async def run_agent_loop(
 
             continue
 
-        # Unexpected stop reason (e.g. "length").
+        # stop_reason="length" with no tool calls means the response was
+        # genuinely truncated mid-generation — nothing actionable was produced.
+        # (If tool_calls were present we already handled it in the branch above.)
+        if response["stop_reason"] == "length":
+            logger.warning(
+                "⚠️ agent_loop stop_reason=length with no tool calls on iteration %d"
+                " — response truncated mid-generation, injecting recovery hint",
+                iteration,
+            )
+            # Inject a synthetic tool result that tells the model to produce a
+            # smaller response.  This is cheaper than cancelling — the agent
+            # may still finish the task in the next turn.
+            messages.append({
+                "role": "user",
+                "content": (
+                    "⚠️ Your previous response was cut off (max output tokens reached) "
+                    "before you issued a tool call.  Please issue ONE tool call now — "
+                    "no reasoning preamble.  If you need to write a large block of code, "
+                    "split it into smaller replace_in_file calls targeting specific "
+                    "sections rather than rewriting the whole file."
+                ),
+            })
+            continue
+
+        # Truly unexpected stop reason — cancel.
         logger.warning(
-            "⚠️ agent_loop unexpected stop_reason=%s on iteration %d",
+            "⚠️ agent_loop unexpected stop_reason=%r on iteration %d",
             response["stop_reason"],
             iteration,
         )

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -1988,3 +1988,170 @@ class TestExtractExplicitFilePaths:
         )
         result = _extract_explicit_file_paths(text)
         assert result.count("agentception/routes/api/ping.py") == 1
+
+
+# ---------------------------------------------------------------------------
+# stop_reason="length" recovery
+# ---------------------------------------------------------------------------
+
+
+class TestStopReasonLengthRecovery:
+    """stop_reason='length' must not immediately cancel the run.
+
+    Two cases:
+    - With tool_calls present: dispatched normally (tool call was complete).
+    - Without tool_calls: a recovery hint is injected and the loop continues.
+    Neither case should call build_cancel_run.
+    """
+
+    @pytest.mark.anyio
+    async def test_length_with_tool_calls_continues_normally(
+        self, tmp_path: Path
+    ) -> None:
+        """stop_reason='length' with a complete tool call is treated as tool_calls."""
+        worktree = tmp_path / "run-len-tc"
+        worktree.mkdir()
+        task_spec = _make_task_spec(worktree)
+
+        length_with_tc = ToolResponse(
+            stop_reason="length",
+            content="",
+            tool_calls=[
+                ToolCall(
+                    id="call_len",
+                    type="function",
+                    function=ToolCallFunction(
+                        name="read_file", arguments='{"file_path": "foo.py"}'
+                    ),
+                )
+            ],
+        )
+        responses = [length_with_tc, _stop_response("Done after recovery.")]
+        file_result: dict[str, object] = {"ok": True, "content": "# stub", "truncated": False}
+        cancel_calls: list[str] = []
+
+        async def fake_cancel(run_id: str) -> dict[str, object]:
+            cancel_calls.append(run_id)
+            return {"ok": True}
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic",
+                new_callable=AsyncMock,
+                return_value='{"files": [], "searches": [], "plan": "no-op"}',
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic_with_tools",
+                new_callable=AsyncMock,
+                side_effect=responses,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.build_cancel_run",
+                side_effect=fake_cancel,
+            ),
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
+            patch(
+                "agentception.services.agent_loop.persist_agent_messages_async",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+            mock_settings.ac_min_turn_delay_secs = 0.0
+
+            from agentception.services import agent_loop as al
+
+            with patch.object(al, "read_file", return_value=file_result):
+                await al.run_agent_loop("run-len-tc")
+
+        assert cancel_calls == [], (
+            "build_cancel_run must NOT be called when stop_reason='length' has tool_calls"
+        )
+
+    @pytest.mark.anyio
+    async def test_length_without_tool_calls_injects_recovery_hint_and_continues(
+        self, tmp_path: Path
+    ) -> None:
+        """stop_reason='length' with no tool calls injects a hint; run continues."""
+        worktree = tmp_path / "run-len-notc"
+        worktree.mkdir()
+        task_spec = _make_task_spec(worktree)
+
+        length_no_tc = ToolResponse(stop_reason="length", content="", tool_calls=[])
+        responses = [length_no_tc, _stop_response("Recovered.")]
+        cancel_calls: list[str] = []
+
+        async def fake_cancel(run_id: str) -> dict[str, object]:
+            cancel_calls.append(run_id)
+            return {"ok": True}
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic",
+                new_callable=AsyncMock,
+                return_value='{"files": [], "searches": [], "plan": "no-op"}',
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic_with_tools",
+                new_callable=AsyncMock,
+                side_effect=responses,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.build_cancel_run",
+                side_effect=fake_cancel,
+            ),
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
+            patch(
+                "agentception.services.agent_loop.persist_agent_messages_async",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+            mock_settings.ac_min_turn_delay_secs = 0.0
+
+            from agentception.services import agent_loop as al
+
+            await al.run_agent_loop("run-len-notc")
+
+        assert cancel_calls == [], (
+            "build_cancel_run must NOT be called when stop_reason='length' — recovery hint is injected"
+        )


### PR DESCRIPTION
## Summary
- `stop_reason='length'` (Anthropic max output tokens hit) was falling through to the fatal-error branch and immediately calling `build_cancel_run`
- Root cause of issue-275 agent being cancelled at iteration 20 — it had issued a valid `replace_in_file` tool call that happened to be accompanied by long reasoning text that pushed the response to 16,384 tokens

## Two recovery paths
- **With tool_calls present**: tool call was fully generated before truncation — dispatch it normally (same path as `stop_reason='tool_calls'`)
- **Without tool_calls**: genuinely truncated mid-generation — inject a synthetic user message asking the agent to issue one small tool call now; loop continues

## Test plan
- [ ] `docker compose exec agentception python3 -m pytest agentception/tests/test_agent_loop.py -k StopReasonLength -v` — 2 passed