### PR TITLE
diag: add OOM triangulation instrumentation

### DIFF
--- a/agentception/app.py
+++ b/agentception/app.py
@@ -16,11 +16,19 @@ Architecture:
 from __future__ import annotations
 
 import asyncio
+import atexit
+import faulthandler
 import logging
 import logging.config
+import os
+import signal
+import sys
+import traceback
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
+
+import psutil
 
 # Configure application-level logging before any module imports so that
 # every `logging.getLogger(__name__)` in agentception.* emits at INFO+.
@@ -85,6 +93,68 @@ logger = logging.getLogger(__name__)
 # Resolve paths relative to this file so the app works regardless of cwd.
 _HERE = Path(__file__).parent
 
+# ---------------------------------------------------------------------------
+# Diagnostic instrumentation — memory monitor + crash handlers
+# ---------------------------------------------------------------------------
+
+_diag_logger = logging.getLogger("agentception.diag")
+_proc = psutil.Process(os.getpid())
+
+
+def _rss_mb() -> int:
+    return int(_proc.memory_info().rss) // 1024 // 1024
+
+
+def _log_rss(label: str) -> None:
+    mem = _proc.memory_info()
+    rss = mem.rss // 1024 // 1024
+    vms = mem.vms // 1024 // 1024
+    _diag_logger.warning("📊 MEM [%s] RSS=%dMB VMS=%dMB", label, rss, vms)
+
+
+def _on_exit() -> None:
+    """atexit: log RSS + full stack of every thread when the process exits."""
+    _log_rss("atexit")
+    frames = sys._current_frames()
+    _diag_logger.warning("📊 EXIT stack — %d thread(s):", len(frames))
+    for tid, frame in frames.items():
+        import types as _types
+        if isinstance(frame, _types.FrameType):
+            tb = "".join(traceback.format_stack(frame))
+            _diag_logger.warning("📊 thread %d:\n%s", tid, tb)
+
+
+def _on_sigterm(signum: int, frame: object) -> None:
+    """SIGTERM: log RSS + stack before uvicorn's shutdown handler takes over."""
+    _log_rss("SIGTERM")
+    frames = sys._current_frames()
+    for tid, f in frames.items():
+        import types as _types
+        if isinstance(f, _types.FrameType):
+            tb = "".join(traceback.format_stack(f))
+            _diag_logger.warning("📊 SIGTERM thread %d:\n%s", tid, tb)
+    # Re-raise so uvicorn's own SIGTERM handler still runs.
+    signal.signal(signum, signal.SIG_DFL)
+    os.kill(os.getpid(), signum)
+
+
+# Enable faulthandler so SIGSEGV / SIGABRT dump a traceback to stderr.
+faulthandler.enable()
+
+# Register exit hooks.
+atexit.register(_on_exit)
+_original_sigterm = signal.getsignal(signal.SIGTERM)
+signal.signal(signal.SIGTERM, _on_sigterm)
+
+_diag_logger.warning("📊 DIAG instrumentation active — PID=%d RSS=%dMB", os.getpid(), _rss_mb())
+
+
+async def _memory_monitor_loop() -> None:
+    """Log RSS every 10 seconds so we can see the climb in docker logs."""
+    while True:
+        await asyncio.sleep(10)
+        _log_rss("heartbeat")
+
 
 async def _reaper_loop() -> None:
     """Periodic worktree reaper — runs every 15 minutes for the process lifetime."""
@@ -104,13 +174,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     poller = asyncio.create_task(polling_loop(), name="agentception-poller")
     reaper = asyncio.create_task(_reaper_loop(), name="agentception-reaper")
+    mem_monitor = asyncio.create_task(_memory_monitor_loop(), name="agentception-mem-monitor")
     logger.info("✅ AgentCeption poller and worktree reaper started")
     try:
         yield
     finally:
         poller.cancel()
         reaper.cancel()
-        for task in (poller, reaper):
+        mem_monitor.cancel()
+        for task in (poller, reaper, mem_monitor):
             try:
                 await task
             except asyncio.CancelledError:

--- a/agentception/requirements.txt
+++ b/agentception/requirements.txt
@@ -8,6 +8,7 @@ pydantic-settings>=2.3.0
 sse-starlette>=2.1.0
 httpx>=0.27.0
 psutil>=5.9.0
+types-psutil>=5.9.0
 python-multipart>=0.0.9
 # Vector store — Qdrant client + FastEmbed for local embeddings (ONNX, no API key)
 qdrant-client>=1.7.0

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -1473,6 +1473,11 @@ async def _run_recon_phase(
             return None
 
     async def _search_one(query: str) -> list[dict[str, object]]:
+        import os
+        import psutil as _psutil
+        _p = _psutil.Process(os.getpid())
+        _rss_before = _p.memory_info().rss // 1024 // 1024
+        logger.warning("📊 recon._search_one START query=%r RSS=%dMB", query[:60], _rss_before)
         # Prefer the worktree-scoped collection so results include any files
         # the agent has already written.  Fall back to the main "code"
         # collection if the worktree collection doesn't exist yet (indexing
@@ -1482,6 +1487,8 @@ async def _run_recon_phase(
             results = await search_codebase(query, 5, collection=_wt_collection)
             if not results:
                 results = await search_codebase(query, 5)
+            _rss_after = _p.memory_info().rss // 1024 // 1024
+            logger.warning("📊 recon._search_one DONE query=%r RSS=%dMB (+%dMB)", query[:60], _rss_after, _rss_after - _rss_before)
             return [
                 {"file": m["file"], "chunk": m["chunk"][:800], "score": m["score"]}
                 for m in results
@@ -1489,12 +1496,21 @@ async def _run_recon_phase(
         except Exception:  # noqa: BLE001
             try:
                 results = await search_codebase(query, 5)
+                _rss_after = _p.memory_info().rss // 1024 // 1024
+                logger.warning("📊 recon._search_one FALLBACK DONE query=%r RSS=%dMB (+%dMB)", query[:60], _rss_after, _rss_after - _rss_before)
                 return [
                     {"file": m["file"], "chunk": m["chunk"][:800], "score": m["score"]}
                     for m in results
                 ]
             except Exception:  # noqa: BLE001
+                logger.warning("📊 recon._search_one FAILED query=%r", query[:60])
                 return []
+
+    import os as _os
+    import psutil as _psutil_recon
+    _p_recon = _psutil_recon.Process(_os.getpid())
+    logger.warning("📊 recon: before gather RSS=%dMB files=%d searches=%d",
+                   _p_recon.memory_info().rss // 1024 // 1024, len(plan.files), len(plan.searches))
 
     file_tasks = [_read_one(f) for f in plan.files]
     search_tasks = [_search_one(q) for q in plan.searches]
@@ -1502,9 +1518,11 @@ async def _run_recon_phase(
     raw_file_results: list[str | None | BaseException] = list(
         await asyncio.gather(*file_tasks, return_exceptions=True)
     )
+    logger.warning("📊 recon: after file gather RSS=%dMB", _p_recon.memory_info().rss // 1024 // 1024)
     raw_search_results: list[object] = list(
         await asyncio.gather(*search_tasks, return_exceptions=True)
     )
+    logger.warning("📊 recon: after search gather RSS=%dMB", _p_recon.memory_info().rss // 1024 // 1024)
 
     # ── Bundle results ────────────────────────────────────────────────────────
 

--- a/agentception/services/code_indexer.py
+++ b/agentception/services/code_indexer.py
@@ -190,10 +190,17 @@ def _get_model() -> object:
     """Return the cached dense TextEmbedding model, initialising it on first call."""
     global _cached_model
     if _cached_model is None:
+        import os
+        import psutil as _psutil
+        _p = _psutil.Process(os.getpid())
+        _rss_before = _p.memory_info().rss // 1024 // 1024
+        logger.warning("📊 _get_model: LOADING embed model RSS_before=%dMB", _rss_before)
         from fastembed import TextEmbedding  # noqa: PLC0415
 
         logger.info("✅ code_indexer — loading embed model: %s", settings.embed_model)
         _cached_model = TextEmbedding(model_name=settings.embed_model)
+        _rss_after = _p.memory_info().rss // 1024 // 1024
+        logger.warning("📊 _get_model: LOADED embed model RSS_after=%dMB (+%dMB)", _rss_after, _rss_after - _rss_before)
     return _cached_model
 
 
@@ -207,10 +214,17 @@ def _get_bm25_model() -> object:
     """Return the cached SparseTextEmbedding BM25 model, initialising it on first call."""
     global _bm25_model
     if _bm25_model is None:
+        import os
+        import psutil as _psutil
+        _p = _psutil.Process(os.getpid())
+        _rss_before = _p.memory_info().rss // 1024 // 1024
+        logger.warning("📊 _get_bm25_model: LOADING BM25 RSS_before=%dMB", _rss_before)
         from fastembed.sparse import SparseTextEmbedding  # noqa: PLC0415
 
         logger.info("✅ code_indexer — loading BM25 sparse model: Qdrant/bm25")
         _bm25_model = SparseTextEmbedding("Qdrant/bm25")
+        _rss_after = _p.memory_info().rss // 1024 // 1024
+        logger.warning("📊 _get_bm25_model: LOADED BM25 RSS_after=%dMB (+%dMB)", _rss_after, _rss_after - _rss_before)
     return _bm25_model
 
 
@@ -224,12 +238,19 @@ def _get_rerank_model() -> object:
     """Return the cached TextCrossEncoder reranker, initialising it on first call."""
     global _rerank_model
     if _rerank_model is None:
+        import os
+        import psutil as _psutil
+        _p = _psutil.Process(os.getpid())
+        _rss_before = _p.memory_info().rss // 1024 // 1024
+        logger.warning("📊 _get_rerank_model: LOADING reranker RSS_before=%dMB", _rss_before)
         from fastembed.rerank.cross_encoder import TextCrossEncoder  # noqa: PLC0415
 
         logger.info(
             "✅ code_indexer — loading reranker model: %s", settings.rerank_model
         )
         _rerank_model = TextCrossEncoder(settings.rerank_model)
+        _rss_after = _p.memory_info().rss // 1024 // 1024
+        logger.warning("📊 _get_rerank_model: LOADED reranker RSS_after=%dMB (+%dMB)", _rss_after, _rss_after - _rss_before)
     return _rerank_model
 
 
@@ -1142,6 +1163,14 @@ async def search_codebase(
         list when the collection has not been indexed yet or Qdrant is
         unavailable.
     """
+    import os as _os_sc
+    import psutil as _psutil_sc
+    import time as _time_sc
+    _p_sc = _psutil_sc.Process(_os_sc.getpid())
+    _sc_rss_start = _p_sc.memory_info().rss // 1024 // 1024
+    _sc_t0 = _time_sc.monotonic()
+    logger.warning("📊 search_codebase START query=%r coll=%s RSS=%dMB", query[:60], collection or "(default)", _sc_rss_start)
+
     from qdrant_client import AsyncQdrantClient  # noqa: PLC0415
     from qdrant_client.models import (  # noqa: PLC0415
         Fusion,
@@ -1162,6 +1191,7 @@ async def search_codebase(
             _embed([query]),
             _compute_bm25_vectors([query]),
         )
+        logger.warning("📊 search_codebase VECTORS_DONE query=%r RSS=%dMB elapsed=%.1fs", query[:60], _p_sc.memory_info().rss // 1024 // 1024, _time_sc.monotonic() - _sc_t0)
         dense_query = dense_vecs[0]
         sparse_dict = bm25_vecs[0]
         sparse_query = SparseVector(
@@ -1223,6 +1253,7 @@ async def search_codebase(
             ))
 
         if not valid:
+            logger.warning("📊 search_codebase NO_RESULTS query=%r RSS=%dMB elapsed=%.1fs", query[:60], _p_sc.memory_info().rss // 1024 // 1024, _time_sc.monotonic() - _sc_t0)
             return []
 
         # Cross-encoder reranking: score each candidate against the query and
@@ -1235,7 +1266,7 @@ async def search_codebase(
                 key=lambda pair: pair[1],
                 reverse=True,
             )
-            return [
+            _result = [
                 SearchMatch(
                     file=c.file,
                     chunk=c.chunk,
@@ -1245,9 +1276,11 @@ async def search_codebase(
                 )
                 for c, score in ranked[:n_results]
             ]
+            logger.warning("📊 search_codebase DONE query=%r hits=%d RSS=%dMB elapsed=%.1fs", query[:60], len(_result), _p_sc.memory_info().rss // 1024 // 1024, _time_sc.monotonic() - _sc_t0)
+            return _result
 
         # Reranking disabled: return top n_results by RRF score.
-        return [
+        _result2 = [
             SearchMatch(
                 file=c.file,
                 chunk=c.chunk,
@@ -1257,7 +1290,10 @@ async def search_codebase(
             )
             for c in valid[:n_results]
         ]
+        logger.warning("📊 search_codebase DONE(no-rerank) query=%r hits=%d RSS=%dMB elapsed=%.1fs", query[:60], len(_result2), _p_sc.memory_info().rss // 1024 // 1024, _time_sc.monotonic() - _sc_t0)
+        return _result2
 
     except Exception as exc:
+        logger.warning("📊 search_codebase FAILED query=%r exc=%s RSS=%dMB elapsed=%.1fs", query[:60], exc, _p_sc.memory_info().rss // 1024 // 1024, _time_sc.monotonic() - _sc_t0)
         logger.warning("⚠️ code_indexer — search failed: %s", exc)
         return []


### PR DESCRIPTION
## Summary
- **10-second RSS/VMS heartbeat** in `app.py` — every memory climb is now visible in `docker logs`
- **atexit + SIGTERM handlers** — full thread stacks + RSS logged on every exit path so we can see exactly where the process was when it died
- **faulthandler enabled** — SIGSEGV/SIGABRT produce a C-level traceback to stderr
- **Model load instrumentation** in `code_indexer.py` — RSS before/after each of the three ONNX model loads (`_get_model`, `_get_bm25_model`, `_get_rerank_model`) with delta
- **`search_codebase` instrumentation** — START / VECTORS_DONE / DONE / FAILED log lines with RSS and elapsed seconds for every query
- **Recon phase instrumentation** in `agent_loop.py` — RSS before/after file gather and search gather; per-query RSS delta in `_search_one`
- `types-psutil` added to `requirements.txt` for mypy compliance

## Test plan
- [ ] Confirm `docker logs agentception-app` shows `📊 DIAG instrumentation active` on startup
- [ ] Dispatch an agent and confirm `📊 search_codebase START` / `DONE` lines appear with RSS values
- [ ] Confirm `📊 MEM [heartbeat]` lines appear every 10s
- [ ] On next crash: `docker logs agentception-app` will show exactly which model load step caused the RSS spike and whether the atexit/SIGTERM handler fired