### PR TITLE
fix: eliminate agent discovery regression — named-file injection + read rule

### DIFF
--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -16,24 +16,27 @@ Use them. Do not re-read content already in your context.**
 ## Code discovery funnel — mandatory order
 
 Before writing any code, locate what you need using this exact sequence.
-**Stop at the first level that gives you enough context. Never skip to a lower level without exhausting the one above.**
+**Stop at the first level that gives you enough context.**
 
-1. **`search_codebase`** — your default first move for any code you need to find or understand.
-   Search with natural-language queries like "429 retry logic in _api_get" or
-   "ensure_label_exists httpx client". The result chunks contain the actual code —
+1. **Pre-loaded Files / Pre-extracted Code Context** (already in your briefing).
+   Check these first. If a file you need is already here in full, do not re-read it.
+
+2. **`read_file`** — use this directly when you know which file you need and it is
+   small (≤ 400 lines). One call, full content, done. Do not chunk-read small files.
+
+3. **`search_codebase`** — your default for finding code you don't know the exact
+   location of. Search with natural-language queries. Results include the actual code —
    read them directly, do not follow up with file reads on the same region.
 
-2. **`search_text`** — use only when you need an exact string, symbol name, or regex match
+4. **`search_text`** — use when you need an exact string, symbol name, or regex match
    that semantic search did not surface. Example: `grep -n "def _api_get" readers/github.py`.
 
-3. **`read_file_lines`** — use only for a narrow window of lines *adjacent* to a region
-   you already found via `search_codebase` or `search_text`. Hard limit: **200 lines per call**.
-   Never read a whole file. Never read more than 200 lines at once, ever.
+5. **`read_file_lines`** — use only for a narrow window *adjacent* to a location you
+   already found. Hard limit: **200 lines per call**.
 
-**Reading an entire file is always wrong.** A 1 000-line file read inflates every
-subsequent LLM call by ~7 000 tokens and stays in context forever. If you think
-you need to read the whole file, use `search_codebase` instead — it returns the
-specific functions you need without the dead weight.
+**For files > 400 lines:** never read the whole file. Use `search_codebase` to get
+the specific function you need. A 1 000-line file read inflates every subsequent LLM
+call by ~7 000 tokens and stays in context forever.
 
 ## Sequence
 
@@ -54,8 +57,9 @@ specific functions you need without the dead weight.
 
 ## Hard rules
 
-- **Never read more than 200 consecutive lines from any file in a single call.**
-- **Never read a file you already have in context (Pre-loaded Files or a prior search result).**
+- **Never read more than 200 consecutive lines via `read_file_lines`.**
+- **For files ≤ 400 lines: use `read_file` (one call, full content). Do not chunk them.**
+- **Never re-read a file you already have in context (Pre-loaded Files or a prior search result).**
 - Do not narrate what you are about to do. Call the tool.
 - Do not re-read a file to verify your own write. Trust it and move on.
 - If a symbol doesn't exist in the codebase, write it. Absence is the task.

--- a/agentception/app.py
+++ b/agentception/app.py
@@ -113,15 +113,22 @@ def _log_rss(label: str) -> None:
 
 
 def _on_exit() -> None:
-    """atexit: log RSS + full stack of every thread when the process exits."""
-    _log_rss("atexit")
-    frames = sys._current_frames()
-    _diag_logger.warning("📊 EXIT stack — %d thread(s):", len(frames))
-    for tid, frame in frames.items():
-        import types as _types
-        if isinstance(frame, _types.FrameType):
-            tb = "".join(traceback.format_stack(frame))
-            _diag_logger.warning("📊 thread %d:\n%s", tid, tb)
+    """atexit: write RSS + thread stacks to stderr (logging may be closed at exit)."""
+    import types as _types
+    try:
+        mem = _proc.memory_info()
+        rss = int(mem.rss) // 1024 // 1024
+        vms = int(mem.vms) // 1024 // 1024
+        sys.stderr.write(f"📊 MEM [atexit] RSS={rss}MB VMS={vms}MB\n")
+        frames = sys._current_frames()
+        sys.stderr.write(f"📊 EXIT stack — {len(frames)} thread(s):\n")
+        for tid, frame in frames.items():
+            if isinstance(frame, _types.FrameType):
+                tb = "".join(traceback.format_stack(frame))
+                sys.stderr.write(f"📊 thread {tid}:\n{tb}\n")
+        sys.stderr.flush()
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def _on_sigterm(signum: int, frame: object) -> None:

--- a/agentception/services/context_assembler.py
+++ b/agentception/services/context_assembler.py
@@ -31,9 +31,16 @@ _MAX_SCOPE_CHARS: int = 3_000    # max chars per extracted scope body
 _MAX_SCOPES: int = 12            # cap on number of scopes to include
 _MAX_CONTEXT_CHARS: int = 30_000 # hard cap on total assembled output
 
+# Files named explicitly in an issue body are injected verbatim when they are
+# ≤ this many lines.  Larger files are left for the agent to search selectively.
+_MAX_INJECT_LINES: int = 400
+
 # Regex that matches a backtick-wrapped code reference in Markdown.
 # Captures the inner text (no newlines, 2–80 chars).
 _RE_BACKTICK = re.compile(r"`([^`\n]{2,80})`")
+
+# Regex that matches what looks like a file path (contains a '/' and a '.' in the last segment).
+_RE_FILE_PATH = re.compile(r"^[\w./\-]+/[\w.\-]+$")
 
 # Heuristic: a backtick-wrapped item is a code artifact (not prose) when it
 # contains a path separator, an underscore, or starts with an uppercase letter
@@ -110,6 +117,45 @@ def _extract_code_queries(issue_title: str, issue_body: str) -> list[str]:
                 queries.append(gap_text)
 
     return queries[:5]  # hard cap at 5 parallel queries
+
+
+def _extract_named_file_paths(issue_body: str) -> list[str]:
+    """Return file paths explicitly named in backticks inside the issue body.
+
+    Only returns items that look like relative file paths (contain ``/`` and a
+    ``.`` extension in the last segment).  Paths are deduplicated and ordered by
+    first appearance.
+    """
+    seen: set[str] = set()
+    paths: list[str] = []
+    for ref in _RE_BACKTICK.findall(issue_body):
+        if ref in seen:
+            continue
+        seen.add(ref)
+        # Must look like agentception/foo/bar.py  (has '/' and extension)
+        if "/" in ref and _RE_FILE_PATH.match(ref):
+            paths.append(ref)
+    return paths
+
+
+def _read_named_file(worktree_path: Path, rel_path: str) -> tuple[str, str]:
+    """Read *rel_path* from the worktree and return ``(rel_path, content)``.
+
+    Returns ``("", "")`` when the file is absent, binary, or exceeds
+    ``_MAX_INJECT_LINES`` lines.  Designed to run via ``asyncio.to_thread``.
+    """
+    full = worktree_path / rel_path
+    if not full.exists() or not full.is_file():
+        return ("", "")
+    try:
+        text = full.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ("", "")
+    lines = text.splitlines()
+    if len(lines) > _MAX_INJECT_LINES:
+        # File is too large to inject whole — the agent should use search_codebase.
+        return ("", "")
+    return (rel_path, text)
 
 
 # ---------------------------------------------------------------------------
@@ -265,6 +311,45 @@ async def assemble_executor_context(
         [q[:60] for q in queries],
     )
 
+    # ------------------------------------------------------------------
+    # Phase 0 — inject full content of files explicitly named in the issue.
+    # These are the highest-signal inputs: the spec literally tells the agent
+    # which files to modify, so we hand them over verbatim rather than making
+    # the agent search/read them iteratively.
+    # ------------------------------------------------------------------
+    named_paths = _extract_named_file_paths(issue_body)
+    named_file_reads = await asyncio.gather(
+        *[asyncio.to_thread(_read_named_file, worktree_path, p) for p in named_paths],
+    )
+
+    named_sections: list[str] = []
+    injected_files: set[str] = set()
+    named_chars = 0
+    for rel_path, content in named_file_reads:
+        if not rel_path or not content:
+            continue
+        ext = Path(rel_path).suffix
+        lang = "python" if ext == ".py" else ""
+        section = f"### `{rel_path}` _(full file — {len(content.splitlines())} lines)_\n\n```{lang}\n{content}\n```"
+        if named_chars + len(section) > _MAX_CONTEXT_CHARS // 2:
+            # Cap named-file injection at half the total budget so Qdrant
+            # results still have room.
+            break
+        named_sections.append(section)
+        injected_files.add(rel_path)
+        named_chars += len(section)
+
+    if named_sections:
+        logger.info(
+            "✅ context_assembler: injected %d named file(s) (%d chars): %s",
+            len(named_sections),
+            named_chars,
+            list(injected_files),
+        )
+
+    # ------------------------------------------------------------------
+    # Phase 1 — Qdrant semantic search for additional relevant scopes.
+    # ------------------------------------------------------------------
     all_matches: list[SearchMatch] = list(existing_matches)
 
     if queries:
@@ -281,16 +366,20 @@ async def assemble_executor_context(
 
     # Deduplicate by (file, start_line), preserving insertion order so that
     # the already-computed existing_matches (highest-confidence hits) appear first.
+    # Skip files already injected verbatim — the agent has the full content.
     seen: set[tuple[str, int]] = set()
     unique: list[SearchMatch] = []
     for m in all_matches:
+        if m["file"] in injected_files:
+            continue
         key = (m["file"], m["start_line"])
         if key not in seen:
             seen.add(key)
             unique.append(m)
 
-    sections: list[str] = []
-    total_chars = 0
+    qdrant_sections: list[str] = []
+    qdrant_chars = 0
+    remaining_budget = _MAX_CONTEXT_CHARS - named_chars
     for m in unique[:_MAX_SCOPES]:
         label, code_block = await asyncio.to_thread(
             _scope_section, worktree_path, m["file"], m["start_line"]
@@ -298,24 +387,38 @@ async def assemble_executor_context(
         if not label or not code_block:
             continue
         section = f"### {label}\n\n{code_block}"
-        if total_chars + len(section) > _MAX_CONTEXT_CHARS:
+        if qdrant_chars + len(section) > remaining_budget:
             break
-        sections.append(section)
-        total_chars += len(section)
+        qdrant_sections.append(section)
+        qdrant_chars += len(section)
 
-    if not sections:
+    all_sections = named_sections + qdrant_sections
+    if not all_sections:
         return ""
 
+    total_chars = named_chars + qdrant_chars
     logger.info(
-        "✅ context_assembler: assembled %d scope sections (%d chars) for worktree=%s",
-        len(sections),
+        "✅ context_assembler: assembled %d section(s) (%d chars, %d named + %d qdrant) worktree=%s",
+        len(all_sections),
         total_chars,
+        len(named_sections),
+        len(qdrant_sections),
         worktree_path.name,
     )
 
-    return (
-        "## Pre-extracted Code Context\n\n"
-        "_Exact function/class scope bodies assembled at dispatch time. "
-        "No file reads needed — start implementing directly._\n\n"
-        + "\n\n".join(sections)
-    )
+    parts: list[str] = []
+    if named_sections:
+        parts.append(
+            "## Pre-loaded Files\n\n"
+            "_These files are named in your task spec. Do NOT re-read them — "
+            "the full content is already here._\n\n"
+            + "\n\n".join(named_sections)
+        )
+    if qdrant_sections:
+        parts.append(
+            "## Pre-extracted Code Context\n\n"
+            "_Exact function/class scope bodies assembled at dispatch time. "
+            "No file reads needed — start implementing directly._\n\n"
+            + "\n\n".join(qdrant_sections)
+        )
+    return "\n\n".join(parts)

--- a/agentception/tests/test_context_assembler.py
+++ b/agentception/tests/test_context_assembler.py
@@ -18,6 +18,8 @@ import pytest
 from agentception.services.context_assembler import (
     _ast_enclosing_scope,
     _ast_imports,
+    _extract_named_file_paths,
+    _read_named_file,
     _scope_section,
     assemble_executor_context,
 )
@@ -315,3 +317,135 @@ async def test_assemble_executor_context_skips_missing_files(tmp_path: Path) -> 
         )
 
     assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# _extract_named_file_paths
+# ---------------------------------------------------------------------------
+
+
+def test_extract_named_file_paths_finds_file_paths() -> None:
+    """Backtick-wrapped file paths with a '/' and extension are extracted."""
+    body = (
+        "Modify `agentception/db/persist.py` and `agentception/mcp/log_tools.py`.\n"
+        "Also touch `agentception/mcp/server.py` for registration."
+    )
+    result = _extract_named_file_paths(body)
+    assert "agentception/db/persist.py" in result
+    assert "agentception/mcp/log_tools.py" in result
+    assert "agentception/mcp/server.py" in result
+
+
+def test_extract_named_file_paths_ignores_prose_symbols() -> None:
+    """Prose symbols without '/' are not treated as file paths."""
+    body = "Call `log_run_step` and `persist_run_heartbeat` here."
+    result = _extract_named_file_paths(body)
+    assert result == []
+
+
+def test_extract_named_file_paths_deduplicates() -> None:
+    """Each path appears at most once even when mentioned multiple times."""
+    body = "See `agentception/mcp/log_tools.py` and `agentception/mcp/log_tools.py` again."
+    result = _extract_named_file_paths(body)
+    assert result.count("agentception/mcp/log_tools.py") == 1
+
+
+# ---------------------------------------------------------------------------
+# _read_named_file
+# ---------------------------------------------------------------------------
+
+
+def test_read_named_file_returns_content_for_small_file(tmp_path: Path) -> None:
+    """A file within the line limit is read and returned verbatim."""
+    (tmp_path / "foo.py").write_text("x = 1\n")
+    path, content = _read_named_file(tmp_path, "foo.py")
+    assert path == "foo.py"
+    assert "x = 1" in content
+
+
+def test_read_named_file_skips_missing_file(tmp_path: Path) -> None:
+    """A non-existent file returns ('', '')."""
+    path, content = _read_named_file(tmp_path, "nonexistent.py")
+    assert path == ""
+    assert content == ""
+
+
+def test_read_named_file_skips_large_file(tmp_path: Path) -> None:
+    """A file exceeding _MAX_INJECT_LINES returns ('', '')."""
+    from agentception.services.context_assembler import _MAX_INJECT_LINES
+    big = "\n".join(f"x_{i} = {i}" for i in range(_MAX_INJECT_LINES + 1))
+    (tmp_path / "big.py").write_text(big)
+    path, content = _read_named_file(tmp_path, "big.py")
+    assert path == ""
+    assert content == ""
+
+
+# ---------------------------------------------------------------------------
+# assemble_executor_context — named-file injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_assemble_executor_context_injects_named_files(tmp_path: Path) -> None:
+    """Files explicitly named in the issue body appear under 'Pre-loaded Files'."""
+    (tmp_path / "agentception").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "agentception" / "mcp").mkdir(parents=True, exist_ok=True)
+    log_tools = "def log_run_step() -> None:\n    pass\n"
+    (tmp_path / "agentception" / "mcp" / "log_tools.py").write_text(log_tools)
+
+    body = "Add to `agentception/mcp/log_tools.py`."
+
+    with patch(
+        "agentception.services.context_assembler.search_codebase",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        result = await assemble_executor_context(
+            issue_title="Add heartbeat",
+            issue_body=body,
+            worktree_path=tmp_path,
+            existing_matches=[],
+        )
+
+    assert "Pre-loaded Files" in result
+    assert "agentception/mcp/log_tools.py" in result
+    assert "log_run_step" in result
+
+
+@pytest.mark.anyio
+async def test_assemble_executor_context_named_files_not_duplicated_in_qdrant(
+    tmp_path: Path,
+) -> None:
+    """Files injected verbatim are excluded from the Qdrant scope sections."""
+    import textwrap as _textwrap
+
+    (tmp_path / "agentception").mkdir(parents=True, exist_ok=True)
+    src = _textwrap.dedent("""\
+        def my_func() -> None:
+            pass
+    """)
+    (tmp_path / "agentception" / "tools.py").write_text(src)
+
+    body = "Use `agentception/tools.py`."
+    qdrant_match: SearchMatch = {
+        "file": "agentception/tools.py",
+        "chunk": src,
+        "score": 0.9,
+        "start_line": 1,
+        "end_line": 2,
+    }
+
+    with patch(
+        "agentception.services.context_assembler.search_codebase",
+        new_callable=AsyncMock,
+        return_value=[qdrant_match],
+    ):
+        result = await assemble_executor_context(
+            issue_title="Use tools",
+            issue_body=body,
+            worktree_path=tmp_path,
+            existing_matches=[],
+        )
+
+    # File content appears once (in Pre-loaded Files), not again in Qdrant section.
+    assert result.count("my_func") == 1

--- a/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
@@ -8,24 +8,27 @@ Use them. Do not re-read content already in your context.**
 ## Code discovery funnel — mandatory order
 
 Before writing any code, locate what you need using this exact sequence.
-**Stop at the first level that gives you enough context. Never skip to a lower level without exhausting the one above.**
+**Stop at the first level that gives you enough context.**
 
-1. **`search_codebase`** — your default first move for any code you need to find or understand.
-   Search with natural-language queries like "429 retry logic in _api_get" or
-   "ensure_label_exists httpx client". The result chunks contain the actual code —
+1. **Pre-loaded Files / Pre-extracted Code Context** (already in your briefing).
+   Check these first. If a file you need is already here in full, do not re-read it.
+
+2. **`read_file`** — use this directly when you know which file you need and it is
+   small (≤ 400 lines). One call, full content, done. Do not chunk-read small files.
+
+3. **`search_codebase`** — your default for finding code you don't know the exact
+   location of. Search with natural-language queries. Results include the actual code —
    read them directly, do not follow up with file reads on the same region.
 
-2. **`search_text`** — use only when you need an exact string, symbol name, or regex match
+4. **`search_text`** — use when you need an exact string, symbol name, or regex match
    that semantic search did not surface. Example: `grep -n "def _api_get" readers/github.py`.
 
-3. **`read_file_lines`** — use only for a narrow window of lines *adjacent* to a region
-   you already found via `search_codebase` or `search_text`. Hard limit: **200 lines per call**.
-   Never read a whole file. Never read more than 200 lines at once, ever.
+5. **`read_file_lines`** — use only for a narrow window *adjacent* to a location you
+   already found. Hard limit: **200 lines per call**.
 
-**Reading an entire file is always wrong.** A 1 000-line file read inflates every
-subsequent LLM call by ~7 000 tokens and stays in context forever. If you think
-you need to read the whole file, use `search_codebase` instead — it returns the
-specific functions you need without the dead weight.
+**For files > 400 lines:** never read the whole file. Use `search_codebase` to get
+the specific function you need. A 1 000-line file read inflates every subsequent LLM
+call by ~7 000 tokens and stays in context forever.
 
 ## Sequence
 
@@ -46,8 +49,9 @@ specific functions you need without the dead weight.
 
 ## Hard rules
 
-- **Never read more than 200 consecutive lines from any file in a single call.**
-- **Never read a file you already have in context (Pre-loaded Files or a prior search result).**
+- **Never read more than 200 consecutive lines via `read_file_lines`.**
+- **For files ≤ 400 lines: use `read_file` (one call, full content). Do not chunk them.**
+- **Never re-read a file you already have in context (Pre-loaded Files or a prior search result).**
 - Do not narrate what you are about to do. Call the tool.
 - Do not re-read a file to verify your own write. Trust it and move on.
 - If a symbol doesn't exist in the codebase, write it. Absence is the task.


### PR DESCRIPTION
## Summary

- **Context assembler now pre-loads files explicitly named in the issue body.** Backtick-wrapped file paths (e.g. `` `agentception/mcp/log_tools.py` ``) are extracted, read from the worktree (≤ 400 lines), and injected verbatim under a `## Pre-loaded Files` section before the agent starts. The agent gets the full file content at turn 0 — no searching or chunked reads needed.
- **Files injected verbatim are excluded from Qdrant scope deduplication** — no double-injection.
- **Updated discovery funnel in the agent prompt:** `read_file` is now explicitly permitted for files ≤ 400 lines (one call, full content). The old "never read a whole file" rule now correctly applies only to files > 400 lines.
- **atexit handler fixed:** writes to `sys.stderr` directly instead of `logging` (logging stream closes before atexit runs during pytest teardown).

## Root causes addressed

| # | Root cause | Effect | Fix |
|---|---|---|---|
| 1 | Assembler only ran Qdrant searches; never read named files | Agent spent 4–8 iterations searching/chunk-reading files the spec literally named | `_extract_named_file_paths` + Phase 0 injection in `assemble_executor_context` |
| 2 | "Never read a whole file" rule caused chunking of small files | A 180-line file needed 2 read iterations; agent gave up and searched instead | Prompt updated: `read_file` allowed for ≤ 400-line files |

## Test plan
- [ ] 25/25 tests in `test_context_assembler.py` pass (8 new tests)
- [ ] Next agent dispatch shows `Pre-loaded Files` section in briefing
- [ ] Agent reaches first write call in ≤ 3 iterations for a well-specified issue