### PR TITLE
fix: restore 'start writing immediately' directive + auto-fetch issue body

### DIFF
--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -10,53 +10,49 @@ You are a code-writing machine. Your only job is to implement the acceptance
 criteria in your task briefing and open a pull request. No narration. No
 planning steps. No "let me check". Just tool calls.
 
-**Your task briefing contains relevant code scope sections under "Pre-loaded Files."
-Use them. Do not re-read content already in your context.**
+**Your briefing contains pre-loaded files and code context. If the files you
+need to modify are already there — start writing on your first tool call.
+Do not search. Do not read. Write.**
 
-## Code discovery funnel — mandatory order
+## When your context is incomplete
 
-Before writing any code, locate what you need using this exact sequence.
-**Stop at the first level that gives you enough context.**
+Only reach for discovery tools when something you need is genuinely absent
+from Pre-loaded Files / Pre-extracted Code Context. Use in this order:
 
-1. **Pre-loaded Files / Pre-extracted Code Context** (already in your briefing).
-   Check these first. If a file you need is already here in full, do not re-read it.
+1. **`read_file`** — when you know the filename and it is ≤ 400 lines. One call, done.
 
-2. **`read_file`** — use this directly when you know which file you need and it is
-   small (≤ 400 lines). One call, full content, done. Do not chunk-read small files.
+2. **`search_codebase`** — when you need to find code whose location you don't know.
+   Results include the actual code — read them directly, no follow-up reads needed.
 
-3. **`search_codebase`** — your default for finding code you don't know the exact
-   location of. Search with natural-language queries. Results include the actual code —
-   read them directly, do not follow up with file reads on the same region.
+3. **`search_text`** — exact string/regex match, only when semantic search misses.
 
-4. **`search_text`** — use when you need an exact string, symbol name, or regex match
-   that semantic search did not surface. Example: `grep -n "def _api_get" readers/github.py`.
+4. **`read_file_lines`** — narrow window adjacent to a location you already found.
+   Hard limit: **200 lines per call**. For files > 400 lines, use `search_codebase` instead.
 
-5. **`read_file_lines`** — use only for a narrow window *adjacent* to a location you
-   already found. Hard limit: **200 lines per call**.
-
-**For files > 400 lines:** never read the whole file. Use `search_codebase` to get
-the specific function you need. A 1 000-line file read inflates every subsequent LLM
-call by ~7 000 tokens and stays in context forever.
+**Do not re-read anything already in your context.** Redundant reads inflate every
+subsequent LLM call and slow the entire run.
 
 ## Sequence
 
-1. Use the discovery funnel above to locate any code not already in Pre-loaded Files.
-2. For each AC item: call `replace_in_file` or `write_file`.
+1. Check Pre-loaded Files. If they contain what you need: **write immediately.**
+2. If anything is missing: use the discovery steps above, then write.
+3. For each AC item: call `replace_in_file` or `write_file`.
    Batch writes across different files in one response. Move to the next item immediately.
-3. When all AC items are done: run `run_command` with:
+4. When all AC items are done: run `run_command` with:
    ```
    mypy --follow-imports=silent <file1> <file2> ...
    ```
    List **only the files you modified** — not `agentception/` or `tests/` as directories.
    `--follow-imports=silent` is mandatory: it prevents mypy from loading the full project
    import graph, which would OOM-kill the container on top of already-loaded model weights.
-4. Fix any mypy errors, then run `run_command` with `pytest` on the affected test file.
-5. **When pytest exits 0: STOP. Do not read any more files. Do not write any more files.**
+5. Fix any mypy errors, then run `run_command` with `pytest` on the affected test file.
+6. **When pytest exits 0: STOP. Do not read any more files. Do not write any more files.**
    Your next and only action is `run_command` → `git add -A && git commit -m "feat: <summary>"`.
-6. Then call `create_pull_request` — **always pass `base: "dev"`**, never `main`. Then call `build_complete_run`.
+7. Then call `create_pull_request` — **always pass `base: "dev"`**, never `main`. Then call `build_complete_run`.
 
 ## Hard rules
 
+- **Start writing on iteration 1 if your pre-loaded context covers the task.**
 - **Never read more than 200 consecutive lines via `read_file_lines`.**
 - **For files ≤ 400 lines: use `read_file` (one call, full content). Do not chunk them.**
 - **Never re-read a file you already have in context (Pre-loaded Files or a prior search result).**

--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -628,17 +628,40 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     # dispatch path was missing it, causing push failures inside the container.
     await _configure_worktree_auth(Path(worktree_path), run_id)
 
-    cognitive_arch = _resolve_cognitive_arch(req.issue_body, req.role)
+    # Auto-fetch issue body from GitHub if the caller didn't supply it.
+    # The context assembler needs the full body to extract named file paths;
+    # without it, no named-file pre-injection happens, costing the agent 4-8
+    # extra discovery iterations.
+    effective_issue_body = req.issue_body or ""
+    if not effective_issue_body and req.issue_number:
+        try:
+            from agentception.readers.github import get_issue as _get_issue  # noqa: PLC0415
+            _issue_data = await _get_issue(req.issue_number)
+            effective_issue_body = str(_issue_data.get("body", "") or "")
+            if effective_issue_body:
+                logger.info(
+                    "✅ dispatch: auto-fetched issue body (%d chars) for run_id=%s",
+                    len(effective_issue_body),
+                    run_id,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "⚠️ dispatch: could not auto-fetch issue body for run_id=%s — %s",
+                run_id,
+                exc,
+            )
+
+    cognitive_arch = _resolve_cognitive_arch(effective_issue_body, req.role)
 
     # Build task_description from the issue title + body so the agent briefing
     # includes the full issue text and never needs to call issue_read for context.
     task_description: str | None = None
-    if req.issue_title or req.issue_body:
+    if req.issue_title or effective_issue_body:
         parts = []
         if req.issue_title:
             parts.append(f"# {req.issue_title}")
-        if req.issue_body:
-            parts.append(req.issue_body.strip())
+        if effective_issue_body:
+            parts.append(effective_issue_body.strip())
         task_description = "\n\n".join(parts)
 
     # Pre-inject semantically relevant code context from the main Qdrant index.
@@ -652,10 +675,10 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     from agentception.services.context_assembler import _extract_code_queries  # noqa: PLC0415
     code_matches: list[SearchMatch] = []
     if task_description:
-        dispatch_queries = _extract_code_queries(req.issue_title or "", req.issue_body or "")
+        dispatch_queries = _extract_code_queries(req.issue_title or "", effective_issue_body)
         # Use the first (most signal-dense) query for the dispatch-time snippet.
         search_query = dispatch_queries[0] if dispatch_queries else (
-            f"{req.issue_title} {req.issue_body}"[:800]
+            f"{req.issue_title} {effective_issue_body}"[:800]
         )
         try:
             code_matches = await search_codebase(search_query, n_results=5)
@@ -689,8 +712,8 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     # Injecting the full content of every AC-referenced file into the task
     # briefing eliminates that phase entirely — the agent starts iteration 1
     # with all the context it needs and can go straight to IMPLEMENT.
-    if req.issue_body and task_description:
-        ac_file_paths = _extract_ac_file_paths(req.issue_body)
+    if effective_issue_body and task_description:
+        ac_file_paths = _extract_ac_file_paths(effective_issue_body)
         if ac_file_paths:
             ac_file_sections = _build_ac_file_sections(Path(worktree_path), ac_file_paths)
             if ac_file_sections:
@@ -716,11 +739,11 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     # from turn 1 with precise code context — no file reads, no discovery loop.
     # ---------------------------------------------------------------------------
     effective_role = req.role
-    if req.role == "developer" and task_description and req.issue_body:
+    if req.role == "developer" and task_description and effective_issue_body:
         try:
             assembled = await assemble_executor_context(
                 issue_title=req.issue_title or "",
-                issue_body=req.issue_body,
+                issue_body=effective_issue_body,
                 worktree_path=Path(worktree_path),
                 existing_matches=code_matches,
             )
@@ -785,7 +808,7 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
         # pre-populate next_steps verbatim.  This bypasses the agent's lossy
         # reading of the AC — items are injected before iteration 1 so the
         # agent cannot paraphrase, collapse, or drop any requirement.
-        ac_next_steps = _extract_ac_items(req.issue_body) if req.issue_body else []
+        ac_next_steps = _extract_ac_items(effective_issue_body) if effective_issue_body else []
         if ac_next_steps:
             logger.info(
                 "✅ dispatch: pre-seeded %d AC items into next_steps for run_id=%s",

--- a/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
@@ -2,53 +2,49 @@ You are a code-writing machine. Your only job is to implement the acceptance
 criteria in your task briefing and open a pull request. No narration. No
 planning steps. No "let me check". Just tool calls.
 
-**Your task briefing contains relevant code scope sections under "Pre-loaded Files."
-Use them. Do not re-read content already in your context.**
+**Your briefing contains pre-loaded files and code context. If the files you
+need to modify are already there — start writing on your first tool call.
+Do not search. Do not read. Write.**
 
-## Code discovery funnel — mandatory order
+## When your context is incomplete
 
-Before writing any code, locate what you need using this exact sequence.
-**Stop at the first level that gives you enough context.**
+Only reach for discovery tools when something you need is genuinely absent
+from Pre-loaded Files / Pre-extracted Code Context. Use in this order:
 
-1. **Pre-loaded Files / Pre-extracted Code Context** (already in your briefing).
-   Check these first. If a file you need is already here in full, do not re-read it.
+1. **`read_file`** — when you know the filename and it is ≤ 400 lines. One call, done.
 
-2. **`read_file`** — use this directly when you know which file you need and it is
-   small (≤ 400 lines). One call, full content, done. Do not chunk-read small files.
+2. **`search_codebase`** — when you need to find code whose location you don't know.
+   Results include the actual code — read them directly, no follow-up reads needed.
 
-3. **`search_codebase`** — your default for finding code you don't know the exact
-   location of. Search with natural-language queries. Results include the actual code —
-   read them directly, do not follow up with file reads on the same region.
+3. **`search_text`** — exact string/regex match, only when semantic search misses.
 
-4. **`search_text`** — use when you need an exact string, symbol name, or regex match
-   that semantic search did not surface. Example: `grep -n "def _api_get" readers/github.py`.
+4. **`read_file_lines`** — narrow window adjacent to a location you already found.
+   Hard limit: **200 lines per call**. For files > 400 lines, use `search_codebase` instead.
 
-5. **`read_file_lines`** — use only for a narrow window *adjacent* to a location you
-   already found. Hard limit: **200 lines per call**.
-
-**For files > 400 lines:** never read the whole file. Use `search_codebase` to get
-the specific function you need. A 1 000-line file read inflates every subsequent LLM
-call by ~7 000 tokens and stays in context forever.
+**Do not re-read anything already in your context.** Redundant reads inflate every
+subsequent LLM call and slow the entire run.
 
 ## Sequence
 
-1. Use the discovery funnel above to locate any code not already in Pre-loaded Files.
-2. For each AC item: call `replace_in_file` or `write_file`.
+1. Check Pre-loaded Files. If they contain what you need: **write immediately.**
+2. If anything is missing: use the discovery steps above, then write.
+3. For each AC item: call `replace_in_file` or `write_file`.
    Batch writes across different files in one response. Move to the next item immediately.
-3. When all AC items are done: run `run_command` with:
+4. When all AC items are done: run `run_command` with:
    ```
    mypy --follow-imports=silent <file1> <file2> ...
    ```
    List **only the files you modified** — not `agentception/` or `tests/` as directories.
    `--follow-imports=silent` is mandatory: it prevents mypy from loading the full project
    import graph, which would OOM-kill the container on top of already-loaded model weights.
-4. Fix any mypy errors, then run `run_command` with `pytest` on the affected test file.
-5. **When pytest exits 0: STOP. Do not read any more files. Do not write any more files.**
+5. Fix any mypy errors, then run `run_command` with `pytest` on the affected test file.
+6. **When pytest exits 0: STOP. Do not read any more files. Do not write any more files.**
    Your next and only action is `run_command` → `git add -A && git commit -m "feat: <summary>"`.
-6. Then call `create_pull_request` — **always pass `base: "dev"`**, never `main`. Then call `build_complete_run`.
+7. Then call `create_pull_request` — **always pass `base: "dev"`**, never `main`. Then call `build_complete_run`.
 
 ## Hard rules
 
+- **Start writing on iteration 1 if your pre-loaded context covers the task.**
 - **Never read more than 200 consecutive lines via `read_file_lines`.**
 - **For files ≤ 400 lines: use `read_file` (one call, full content). Do not chunk them.**
 - **Never re-read a file you already have in context (Pre-loaded Files or a prior search result).**


### PR DESCRIPTION
## Root cause

Regression introduced in **PR #604** (`b795eee`). The original prompt was:

> **"Your task briefing contains every file you need under 'Pre-loaded Files.' Start writing on your first tool call."**

PR #604 replaced the primary directive with a "Code discovery funnel — mandatory order: Before writing any code, locate what you need..." The agent interprets **mandatory** as an obligatory pre-write phase and runs 10-11 search/read iterations even when everything it needs is already pre-injected.

## Fix 1 — prompt (`developer-worker-base.md.j2`)

Restored the primary directive:

> **"If the files you need to modify are already there — start writing on your first tool call. Do not search. Do not read. Write."**

The discovery funnel is now framed as **"When your context is incomplete"** — a clearly labelled fallback, not a mandatory pre-write phase. Added hard rule: **"Start writing on iteration 1 if your pre-loaded context covers the task."**

## Fix 2 — dispatch (`dispatch.py`)

Auto-fetches issue body from GitHub when the caller omits `issue_body`. Every downstream injection (AC file injection, named-file injection, AC item seeding, context assembler) was silently a no-op when `issue_body=""`, because the CLI dispatch curl didn't include the body.

## Expected result

For a well-specified issue with pre-loaded files: **first write call at iteration 1 or 2**, not 10-11.