### PR TITLE
fix: remove discovery funnel from developer prompt + head-tail file injection

### DIFF
--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -14,29 +14,10 @@ planning steps. No "let me check". Just tool calls.
 need to modify are already there — start writing on your first tool call.
 Do not search. Do not read. Write.**
 
-## When your context is incomplete
-
-Only reach for discovery tools when something you need is genuinely absent
-from Pre-loaded Files / Pre-extracted Code Context. Use in this order:
-
-1. **`read_file`** — when you know the filename and it is ≤ 400 lines. One call, done.
-
-2. **`search_codebase`** — when you need to find code whose location you don't know.
-   Results include the actual code — read them directly, no follow-up reads needed.
-
-3. **`search_text`** — exact string/regex match, only when semantic search misses.
-
-4. **`read_file_lines`** — narrow window adjacent to a location you already found.
-   Hard limit: **200 lines per call**. For files > 400 lines, use `search_codebase` instead.
-
-**Do not re-read anything already in your context.** Redundant reads inflate every
-subsequent LLM call and slow the entire run.
-
 ## Sequence
 
-1. Check Pre-loaded Files. If they contain what you need: **write immediately.**
-2. If anything is missing: use the discovery steps above, then write.
-3. For each AC item: call `replace_in_file` or `write_file`.
+1. **Write immediately.** Your pre-loaded files contain what you need.
+2. For each AC item: call `replace_in_file` or `write_file`.
    Batch writes across different files in one response. Move to the next item immediately.
 4. When all AC items are done: run `run_command` with:
    ```

--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -130,9 +130,12 @@ _AC_FILE_PATH_RE = re.compile(r"`([a-zA-Z0-9_./-]+\.[a-zA-Z0-9]+)`")
 # Requires at least one slash so bare words like "foo.py" are not matched.
 _PLAIN_FILE_PATH_RE = re.compile(r"\b([a-zA-Z0-9_.][a-zA-Z0-9_./]*(?:/[a-zA-Z0-9_.]+)+\.[a-zA-Z0-9]+)\b")
 
-# Max lines to inject per file.  Beyond this, the tail is truncated with a
-# notice — the agent can always read_file_lines for deeper context if needed.
-_AC_FILE_MAX_LINES: int = 250
+# For files that fit within this limit, inject the full content.
+_AC_FILE_FULL_LINES: int = 500
+# For files larger than _AC_FILE_FULL_LINES, inject this many lines from the head…
+_AC_FILE_HEAD_LINES: int = 120
+# …and this many lines from the tail (most recently added functions / patterns).
+_AC_FILE_TAIL_LINES: int = 200
 
 
 def _extract_ac_items(issue_body: str) -> list[str]:
@@ -193,8 +196,13 @@ def _extract_ac_file_paths(issue_body: str) -> list[str]:
 def _build_ac_file_sections(worktree_path: Path, file_paths: list[str]) -> list[str]:
     """Read each AC-mentioned file from *worktree_path* and return Markdown sections.
 
-    For files that exist: inject up to ``_AC_FILE_MAX_LINES`` lines with a
-    truncation notice when the file is longer.
+    Injection strategy:
+    - Files ≤ _AC_FILE_FULL_LINES: inject verbatim — agent has complete context.
+    - Files > _AC_FILE_FULL_LINES: inject head (_AC_FILE_HEAD_LINES) + tail
+      (_AC_FILE_TAIL_LINES) with an omission marker in the middle.  The head
+      covers imports and class structure; the tail covers the most recently
+      added functions — the exact patterns the agent should emulate when adding
+      a new function at the end of the file.
 
     For files that do not yet exist (e.g. a new Alembic migration): list the
     most-recent sibling files in the same directory so the agent knows the
@@ -209,18 +217,22 @@ def _build_ac_file_sections(worktree_path: Path, file_paths: list[str]) -> list[
             except OSError:
                 continue
             total = len(raw_lines)
-            head = raw_lines[:_AC_FILE_MAX_LINES]
-            suffix = (
-                f"\n... ({total - _AC_FILE_MAX_LINES} more lines — use read_file_lines for the rest)"
-                if total > _AC_FILE_MAX_LINES
-                else ""
-            )
             lang = "python" if rel_path.endswith(".py") else ""
+            if total <= _AC_FILE_FULL_LINES:
+                body = "\n".join(raw_lines)
+            else:
+                head = raw_lines[:_AC_FILE_HEAD_LINES]
+                tail = raw_lines[-_AC_FILE_TAIL_LINES:]
+                omitted = total - _AC_FILE_HEAD_LINES - _AC_FILE_TAIL_LINES
+                body = (
+                    "\n".join(head)
+                    + f"\n\n# ... {omitted} lines omitted (use search_text or read_file_lines) ...\n\n"
+                    + "\n".join(tail)
+                )
             sections.append(
                 f"### `{rel_path}` ({total} lines)\n"
                 f"```{lang}\n"
-                + "\n".join(head)
-                + suffix
+                + body
                 + "\n```"
             )
         else:

--- a/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
+++ b/scripts/gen_prompts/templates/snippets/developer-worker-base.md.j2
@@ -6,29 +6,10 @@ planning steps. No "let me check". Just tool calls.
 need to modify are already there — start writing on your first tool call.
 Do not search. Do not read. Write.**
 
-## When your context is incomplete
-
-Only reach for discovery tools when something you need is genuinely absent
-from Pre-loaded Files / Pre-extracted Code Context. Use in this order:
-
-1. **`read_file`** — when you know the filename and it is ≤ 400 lines. One call, done.
-
-2. **`search_codebase`** — when you need to find code whose location you don't know.
-   Results include the actual code — read them directly, no follow-up reads needed.
-
-3. **`search_text`** — exact string/regex match, only when semantic search misses.
-
-4. **`read_file_lines`** — narrow window adjacent to a location you already found.
-   Hard limit: **200 lines per call**. For files > 400 lines, use `search_codebase` instead.
-
-**Do not re-read anything already in your context.** Redundant reads inflate every
-subsequent LLM call and slow the entire run.
-
 ## Sequence
 
-1. Check Pre-loaded Files. If they contain what you need: **write immediately.**
-2. If anything is missing: use the discovery steps above, then write.
-3. For each AC item: call `replace_in_file` or `write_file`.
+1. **Write immediately.** Your pre-loaded files contain what you need.
+2. For each AC item: call `replace_in_file` or `write_file`.
    Batch writes across different files in one response. Move to the next item immediately.
 4. When all AC items are done: run `run_command` with:
    ```


### PR DESCRIPTION
## Summary

- Removes the "When your context is incomplete" 4-step search funnel from `developer-worker-base.md.j2` — it was the root cause of agents searching 60+ iterations instead of writing on iteration 1
- Also removes the leftover step 2 "use the discovery steps above" from the Sequence section
- Raises AC file injection from 250-line head-only to head+tail (120 head + 200 tail) so agents see both imports and the most recently added functions without searching

Regresses to the pre-funnel behavior: write immediately, no discovery ceremony.