### PR TITLE
fix: auto-track writes in working memory + inject symbol-matched middle sections

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -136,6 +136,11 @@ _AC_FILE_FULL_LINES: int = 500
 _AC_FILE_HEAD_LINES: int = 120
 # …and this many lines from the tail (most recently added functions / patterns).
 _AC_FILE_TAIL_LINES: int = 200
+# Context window (lines above + below) around each symbol match in large files.
+_AC_SYMBOL_WINDOW: int = 25
+
+# Regex to pull snake_case identifiers from backtick-quoted spans in the issue body.
+_BACKTICK_SYMBOL_RE = re.compile(r"`([a-z][a-z0-9_]{2,})`")
 
 
 def _extract_ac_items(issue_body: str) -> list[str]:
@@ -193,21 +198,56 @@ def _extract_ac_file_paths(issue_body: str) -> list[str]:
     return sorted(paths)
 
 
-def _build_ac_file_sections(worktree_path: Path, file_paths: list[str]) -> list[str]:
+def _symbol_windows(
+    raw_lines: list[str], symbols: set[str], window: int
+) -> list[tuple[int, int]]:
+    """Return merged (start, end) line-index ranges covering each symbol match.
+
+    Scans *raw_lines* for occurrences of any name in *symbols*, then grows a
+    ±*window* buffer around each hit.  Overlapping ranges are merged so the
+    agent receives one contiguous block instead of duplicated lines.
+    """
+    ranges: list[tuple[int, int]] = []
+    total = len(raw_lines)
+    for i, line in enumerate(raw_lines):
+        for sym in symbols:
+            if sym in line:
+                lo = max(0, i - window)
+                hi = min(total, i + window + 1)
+                ranges.append((lo, hi))
+                break
+    if not ranges:
+        return []
+    ranges.sort()
+    merged: list[tuple[int, int]] = [ranges[0]]
+    for lo, hi in ranges[1:]:
+        prev_lo, prev_hi = merged[-1]
+        if lo <= prev_hi:
+            merged[-1] = (prev_lo, max(prev_hi, hi))
+        else:
+            merged.append((lo, hi))
+    return merged
+
+
+def _build_ac_file_sections(
+    worktree_path: Path,
+    file_paths: list[str],
+    issue_symbols: set[str] | None = None,
+) -> list[str]:
     """Read each AC-mentioned file from *worktree_path* and return Markdown sections.
 
     Injection strategy:
     - Files ≤ _AC_FILE_FULL_LINES: inject verbatim — agent has complete context.
-    - Files > _AC_FILE_FULL_LINES: inject head (_AC_FILE_HEAD_LINES) + tail
-      (_AC_FILE_TAIL_LINES) with an omission marker in the middle.  The head
-      covers imports and class structure; the tail covers the most recently
-      added functions — the exact patterns the agent should emulate when adding
-      a new function at the end of the file.
+    - Files > _AC_FILE_FULL_LINES: inject head + symbol-matched middle windows +
+      tail.  The head covers imports; the middle windows expose the exact
+      registration blocks, TOOLS lists, and dispatch handlers the agent needs
+      to emulate; the tail covers the most recently added functions.
 
     For files that do not yet exist (e.g. a new Alembic migration): list the
     most-recent sibling files in the same directory so the agent knows the
     naming convention and can write the new file without any discovery reads.
     """
+    symbols: set[str] = issue_symbols or set()
     sections: list[str] = []
     for rel_path in file_paths:
         full_path = worktree_path / rel_path
@@ -223,12 +263,35 @@ def _build_ac_file_sections(worktree_path: Path, file_paths: list[str]) -> list[
             else:
                 head = raw_lines[:_AC_FILE_HEAD_LINES]
                 tail = raw_lines[-_AC_FILE_TAIL_LINES:]
-                omitted = total - _AC_FILE_HEAD_LINES - _AC_FILE_TAIL_LINES
-                body = (
-                    "\n".join(head)
-                    + f"\n\n# ... {omitted} lines omitted (use search_text or read_file_lines) ...\n\n"
-                    + "\n".join(tail)
-                )
+                head_end = _AC_FILE_HEAD_LINES
+                tail_start = total - _AC_FILE_TAIL_LINES
+
+                # Find middle windows around symbols, excluding head/tail overlap.
+                windows = _symbol_windows(raw_lines, symbols, _AC_SYMBOL_WINDOW)
+                middle_windows = [
+                    (lo, hi) for lo, hi in windows
+                    if hi > head_end and lo < tail_start
+                ]
+
+                parts: list[str] = ["\n".join(head)]
+                prev_end = head_end
+                for lo, hi in middle_windows:
+                    lo = max(lo, head_end)
+                    hi = min(hi, tail_start)
+                    if lo >= hi:
+                        continue
+                    omitted = lo - prev_end
+                    if omitted > 0:
+                        parts.append(f"\n# ... {omitted} lines omitted ...\n")
+                    parts.append("\n".join(raw_lines[lo:hi]))
+                    prev_end = hi
+
+                omitted_before_tail = tail_start - prev_end
+                if omitted_before_tail > 0:
+                    parts.append(f"\n# ... {omitted_before_tail} lines omitted ...\n")
+                parts.append("\n".join(tail))
+                body = "\n".join(parts)
+
             sections.append(
                 f"### `{rel_path}` ({total} lines)\n"
                 f"```{lang}\n"
@@ -726,8 +789,13 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     # with all the context it needs and can go straight to IMPLEMENT.
     if effective_issue_body and task_description:
         ac_file_paths = _extract_ac_file_paths(effective_issue_body)
+        issue_symbols: set[str] = {
+            m.group(1) for m in _BACKTICK_SYMBOL_RE.finditer(effective_issue_body)
+        }
         if ac_file_paths:
-            ac_file_sections = _build_ac_file_sections(Path(worktree_path), ac_file_paths)
+            ac_file_sections = _build_ac_file_sections(
+                Path(worktree_path), ac_file_paths, issue_symbols
+            )
             if ac_file_sections:
                 task_description += (
                     "\n\n---\n\n## Pre-loaded Files\n\n"

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -1719,6 +1719,25 @@ def _auto_track_file_read(file_path: Path, worktree_path: Path) -> None:
         pass
 
 
+def _auto_track_file_write(rel_path: str, worktree_path: Path) -> None:
+    """Record *rel_path* in ``files_written`` after every successful file write.
+
+    Mirrors ``_auto_track_file_read`` — runtime-owned, never raises.  The agent
+    sees this list at the top of its working memory every iteration so it cannot
+    accidentally re-implement something it already wrote.
+    """
+    try:
+        existing = read_memory(worktree_path)
+        current: list[str] = list(existing.get("files_written", [])) if existing else []
+        if rel_path not in current:
+            current.append(rel_path)
+            update = WorkingMemory(files_written=current)
+            merged = merge_memory(existing, update)
+            write_memory(worktree_path, merged)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 async def _dispatch_tool_calls(
     tool_calls: list[ToolCall],
     worktree_path: Path,
@@ -1878,12 +1897,15 @@ async def _dispatch_local_tool(
             return {"ok": False, "error": "replace_in_file: 'new_string' must be a string"}
         allow_raw = args.get("allow_multiple", False)
         allow = bool(allow_raw) if isinstance(allow_raw, bool) else False
-        return replace_in_file(
+        result = replace_in_file(
             _resolve(path_raw, worktree_path),
             old_raw,
             new_raw,
             allow_multiple=allow,
         )
+        if result.get("ok"):
+            _auto_track_file_write(path_raw, worktree_path)
+        return result
 
     if name == "insert_after_in_file":
         path_raw = args.get("path")
@@ -1895,11 +1917,14 @@ async def _dispatch_local_tool(
             return {"ok": False, "error": "insert_after_in_file: 'anchor' must be a string"}
         if not isinstance(new_content_raw, str):
             return {"ok": False, "error": "insert_after_in_file: 'new_content' must be a string"}
-        return insert_after_in_file(
+        result = insert_after_in_file(
             _resolve(path_raw, worktree_path),
             anchor_raw,
             new_content_raw,
         )
+        if result.get("ok"):
+            _auto_track_file_write(path_raw, worktree_path)
+        return result
 
     if name == "write_file":
         path_raw = args.get("path")
@@ -1908,7 +1933,10 @@ async def _dispatch_local_tool(
             return {"ok": False, "error": "write_file: 'path' must be a string"}
         if not isinstance(content_raw, str):
             return {"ok": False, "error": "write_file: 'content' must be a string"}
-        return write_file(_resolve(path_raw, worktree_path), content_raw)
+        result = write_file(_resolve(path_raw, worktree_path), content_raw)
+        if result.get("ok"):
+            _auto_track_file_write(path_raw, worktree_path)
+        return result
 
     if name == "list_directory":
         path = _resolve(args.get("path", "."), worktree_path)

--- a/agentception/services/working_memory.py
+++ b/agentception/services/working_memory.py
@@ -34,6 +34,9 @@ class WorkingMemory(TypedDict, total=False):
     plan: str
     """High-level implementation plan for this session."""
 
+    files_written: list[str]
+    """Paths of files already written this session — do not re-implement these."""
+
     files_examined: list[str]
     """Paths of files already read or inspected — skip re-reading these."""
 
@@ -71,6 +74,12 @@ def read_memory(worktree_path: Path) -> WorkingMemory | None:
         plan = raw.get("plan")
         if isinstance(plan, str):
             result["plan"] = plan
+        files_written = raw.get("files_written")
+        if (
+            isinstance(files_written, list)
+            and all(isinstance(f, str) for f in files_written)
+        ):
+            result["files_written"] = list(files_written)
         files_examined = raw.get("files_examined")
         if (
             isinstance(files_examined, list)
@@ -123,6 +132,8 @@ def merge_memory(existing: WorkingMemory | None, update: WorkingMemory) -> Worki
     if existing is not None:
         if "plan" in existing:
             result["plan"] = existing["plan"]
+        if "files_written" in existing:
+            result["files_written"] = existing["files_written"]
         if "files_examined" in existing:
             result["files_examined"] = existing["files_examined"]
         if "findings" in existing:
@@ -136,6 +147,8 @@ def merge_memory(existing: WorkingMemory | None, update: WorkingMemory) -> Worki
 
     if "plan" in update:
         result["plan"] = update["plan"]
+    if "files_written" in update:
+        result["files_written"] = update["files_written"]
     if "files_examined" in update:
         result["files_examined"] = update["files_examined"]
     if "findings" in update:
@@ -164,6 +177,11 @@ def render_memory(memory: WorkingMemory) -> str:
     eliminates the mypy-fix loop and test-collision discovery turns.
     """
     lines: list[str] = ["## Working Memory"]
+
+    files_written = memory.get("files_written")
+    if files_written:
+        files_str = ", ".join(f"`{f}`" for f in files_written)
+        lines.append(f"**Already written this session (do NOT re-implement):** {files_str}")
 
     findings = memory.get("findings")
     if findings:


### PR DESCRIPTION
## Summary

- Runtime now auto-tracks `files_written` after every successful `replace_in_file` / `write_file` / `insert_after_in_file` — mirrors the existing `files_examined` read tracker. Rendered **first** in working memory every iteration so the agent cannot re-implement a function it already wrote.
- For large files (>500 lines), dispatch now greps for snake_case symbols from the issue body and injects ±25-line windows around each match between the head and tail sections. Fixes the `server.py` problem where TOOLS list (line ~580) and dispatch handler (line ~1135) were in the dead zone between injected head and tail.