### PR TITLE
feat: enforce build_complete_run in poller orphan sweep

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -876,22 +876,33 @@ async def _upsert_agent_runs(
             and orphan.issue_number is not None
             and orphan.role != "reviewer"
         ):
-            if orphan.pr_number is not None:
-                # Executor completed — PR exists but the agent is done working.
-                # "done" puts the card in the "PR Open" lane (any status with
-                # pr_number except "reviewing"), which is correct: the PR is
-                # open awaiting human or reviewer-agent action, not being
-                # actively reviewed yet.
-                orphan.status = "completed"
+            # Use the build_complete_run event as the authoritative completion
+            # gate — not pr_number.  An agent can open a PR and then crash
+            # before calling build_complete_run; pr_number alone is not a
+            # reliable signal that the agent finished cleanly.
+            from sqlalchemy import func  # noqa: PLC0415
+
+            has_complete_event = await session.scalar(
+                select(func.count()).select_from(ACAgentEvent).where(
+                    ACAgentEvent.agent_run_id == orphan.id,
+                    ACAgentEvent.event_type == "build_complete_run",
+                )
+            )
+            if has_complete_event:
+                pass  # already completed — do not mutate
             else:
                 orphan.status = "failed"
-            orphan.last_activity_at = now
-            logger.debug(
-                "🧹 Orphan run %s → %s (pr_number=%s)",
-                orphan.id,
-                orphan.status,
-                orphan.pr_number,
-            )
+                orphan.last_activity_at = now
+                session.add(ACAgentEvent(
+                    agent_run_id=orphan.id,
+                    issue_number=orphan.issue_number,
+                    event_type="orphan_failed",
+                    payload=json.dumps({"reason": "worktree_gone_no_build_complete"}),
+                ))
+                logger.warning(
+                    "🧹 Orphan run %s → failed (worktree gone, no build_complete_run event)",
+                    orphan.id,
+                )
 
     # Pending-launch TTL sweep: a pending_launch run that was never acknowledged
     # within 15 minutes is presumed abandoned (Dispatcher aborted before claiming
@@ -1126,6 +1137,9 @@ async def complete_agent_run(run_id: str) -> bool:
     Called by ``build_complete_run`` MCP tool after the agent has opened a PR
     and all work is done.  Only succeeds from ``implementing`` state.
 
+    Also inserts an ``ACAgentEvent`` row with ``event_type = 'build_complete_run'``
+    so the orphan sweep can distinguish a clean completion from a crash.
+
     Returns ``True`` on success, ``False`` if the run was not found or was not
     in a valid source state.
     """
@@ -1140,6 +1154,11 @@ async def complete_agent_run(run_id: str) -> bool:
             run.status = "completed"
             run.last_activity_at = _now()
             run.completed_at = _now()
+            session.add(ACAgentEvent(
+                agent_run_id=run_id,
+                event_type="build_complete_run",
+                payload="{}",
+            ))
             await session.commit()
         logger.info("✅ complete_agent_run: %s → completed", run_id)
         return True

--- a/agentception/tests/test_persist_pending_launch_guard.py
+++ b/agentception/tests/test_persist_pending_launch_guard.py
@@ -213,12 +213,12 @@ async def test_pr_number_advanced_when_poller_sees_one() -> None:
 
 @pytest.mark.anyio
 async def test_orphan_with_pr_number_set_to_done() -> None:
-    """Kanban regression: worktree removed, PR exists — card should land in PR Open lane.
+    """Orphan sweep uses build_complete_run event — not pr_number — as the completion gate.
 
-    When the engineer's worktree disappears the orphan sweep sets status to
-    'done' (not 'unknown') when pr_number is set.  'done' agent_status + a
-    pr_number causes the template to route the card to the PR Open bucket,
-    keeping it visible.  'unknown' would collapse it back to the todo lane.
+    An agent can open a PR and then crash before calling build_complete_run.
+    pr_number alone is not a reliable signal that the agent finished cleanly.
+    When the worktree is gone and there is no build_complete_run event the run
+    must be marked failed regardless of whether pr_number is set.
     """
     orphan = _make_run(status="reviewing")
     orphan.pr_number = 77
@@ -235,6 +235,9 @@ async def test_orphan_with_pr_number_set_to_done() -> None:
     session = MagicMock(spec=AsyncSession)
     # Call 1: per-agent row lookup; call 2: orphan sweep; call 3: TTL sweep.
     session.execute = AsyncMock(side_effect=[scalar, orphan_result_mock, ttl_sweep_result])
+    # session.scalar() is called once per orphan to count build_complete_run events.
+    # Return 0 — no build_complete_run event present.
+    session.scalar = AsyncMock(return_value=0)
     session.add = MagicMock()
 
     # Pass an agent with a DIFFERENT id so the orphan is never in live_ids.
@@ -242,14 +245,15 @@ async def test_orphan_with_pr_number_set_to_done() -> None:
 
     await _persist._upsert_agent_runs(session, [different_agent])
 
-    assert orphan.status == "completed", (
-        "Orphan with open PR must be set to 'completed' so the Kanban card lands in PR Open"
+    assert orphan.status == "failed", (
+        "Orphan with no build_complete_run event must be set to 'failed' "
+        "even when pr_number is set — pr_number is not a reliable completion signal"
     )
 
 
 @pytest.mark.anyio
 async def test_orphan_without_pr_number_flipped_to_failed() -> None:
-    """Worktrees removed with no open PR should become failed (normal cleanup)."""
+    """Worktrees removed with no build_complete_run event should become failed."""
     orphan = _make_run(status="implementing")
     orphan.pr_number = None
     orphan_result_mock = MagicMock()
@@ -264,6 +268,8 @@ async def test_orphan_without_pr_number_flipped_to_failed() -> None:
     session = MagicMock(spec=AsyncSession)
     # Call 1: per-agent row lookup; call 2: orphan sweep; call 3: TTL sweep.
     session.execute = AsyncMock(side_effect=[scalar, orphan_result_mock, ttl_sweep_result])
+    # session.scalar() counts build_complete_run events — return 0 (none present).
+    session.scalar = AsyncMock(return_value=0)
     session.add = MagicMock()
 
     different_agent = AgentNode(id="different-run-id", role="cto", status=AgentStatus.IMPLEMENTING)
@@ -271,7 +277,7 @@ async def test_orphan_without_pr_number_flipped_to_failed() -> None:
     await _persist._upsert_agent_runs(session, [different_agent])
 
     assert orphan.status == "failed", (
-        "Orphan without PR should be flipped to failed for cleanup"
+        "Orphan without build_complete_run event should be flipped to failed for cleanup"
     )
 
 

--- a/agentception/tests/test_persist_reviewer_orphan_guard.py
+++ b/agentception/tests/test_persist_reviewer_orphan_guard.py
@@ -82,6 +82,9 @@ def _make_session_no_agents(existing_run: ACAgentRun) -> MagicMock:
 
     session = MagicMock(spec=AsyncSession)
     session.execute = AsyncMock(side_effect=[orphan_result, ttl_result])
+    # scalar() is called once per orphan to count build_complete_run events.
+    # Return 0 — no build_complete_run event present.
+    session.scalar = AsyncMock(return_value=0)
     session.add = MagicMock()
     return session
 
@@ -128,10 +131,11 @@ async def test_reviewer_not_orphaned_when_missing_from_live_ids() -> None:
 
 @pytest.mark.anyio
 async def test_executor_still_orphaned_when_missing_from_live_ids() -> None:
-    """Orphan sweep must still mark a non-reviewer run as completed.
+    """Orphan sweep must still mark a non-reviewer run as failed when no build_complete_run event.
 
     The reviewer exclusion must not accidentally protect executor/developer
-    runs — their orphan → completed transition must still work.
+    runs — their orphan → failed transition must still work when there is no
+    build_complete_run event (even if pr_number is set).
     """
     from agentception.db.persist import _upsert_agent_runs  # noqa: PLC0415
 
@@ -140,9 +144,9 @@ async def test_executor_still_orphaned_when_missing_from_live_ids() -> None:
 
     await _upsert_agent_runs(session, agents=[])
 
-    assert executor_run.status == "completed", (
+    assert executor_run.status == "failed", (
         f"Executor run was NOT orphaned: status={executor_run.status!r}. "
-        "Orphan sweep must still complete non-reviewer runs with a pr_number."
+        "Orphan sweep must mark non-reviewer runs as failed when no build_complete_run event."
     )
 
 

--- a/agentception/tests/test_poller_orphan_sweep.py
+++ b/agentception/tests/test_poller_orphan_sweep.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+"""Tests for the poller orphan sweep and build_complete_run event emission.
+
+Covers:
+- complete_agent_run() emits a build_complete_run event row.
+- Orphan sweep marks a run failed when worktree is gone and no build_complete_run event exists.
+- Orphan sweep leaves a run alone when a build_complete_run event is present.
+- Orphan sweep skips reviewer runs entirely.
+"""
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agentception.db.models import ACAgentEvent, ACAgentRun
+from agentception.db import persist as _persist
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_run(
+    status: str = "implementing",
+    role: str = "developer",
+    issue_number: int | None = 42,
+) -> ACAgentRun:
+    """Return a minimal ACAgentRun instance for testing."""
+    run = ACAgentRun()
+    run.id = f"issue-{uuid.uuid4().hex[:8]}"
+    run.status = status
+    run.role = role
+    run.issue_number = issue_number
+    run.pr_number = None
+    run.worktree_path = f"/worktrees/{run.id}"
+    run.branch = f"feat/{run.id}"
+    run.batch_id = "batch-test"
+    run.cognitive_arch = None
+    run.last_activity_at = None
+    run.completed_at = None
+    return run
+
+
+def _make_fake_session(run: ACAgentRun) -> MagicMock:
+    """Return a mock AsyncSession that returns *run* from execute().scalar_one_or_none()."""
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=run))
+    )
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# AC 1: complete_agent_run() emits a build_complete_run event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_complete_agent_run_emits_build_complete_event() -> None:
+    """complete_agent_run() inserts an ACAgentEvent with event_type='build_complete_run'."""
+    run = _make_run(status="implementing")
+    session = _make_fake_session(run)
+
+    with patch("agentception.db.persist.get_session", return_value=session):
+        ok = await _persist.complete_agent_run(run.id)
+
+    assert ok is True
+    assert run.status == "completed"
+
+    # session.add must have been called with an ACAgentEvent of the right type.
+    added_objects = [call.args[0] for call in session.add.call_args_list]
+    event_rows = [o for o in added_objects if isinstance(o, ACAgentEvent)]
+    assert len(event_rows) == 1, f"Expected 1 ACAgentEvent, got {len(event_rows)}"
+    assert event_rows[0].event_type == "build_complete_run"
+    assert event_rows[0].agent_run_id == run.id
+
+
+# ---------------------------------------------------------------------------
+# AC 2: orphan sweep marks run failed when no build_complete_run event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_missing_build_complete_marks_failed() -> None:
+    """Orphan with no build_complete_run event is marked failed by the sweep."""
+    orphan = _make_run(status="implementing")
+
+    # No live agents — orphan is not in live_ids.
+    orphan_result_mock = MagicMock()
+    orphan_result_mock.scalars.return_value.all.return_value = [orphan]
+
+    ttl_sweep_result = MagicMock()
+    ttl_sweep_result.scalars.return_value.all.return_value = []
+
+    # Per-agent row lookup returns None (no existing run for the live agent).
+    scalar_lookup = MagicMock()
+    scalar_lookup.scalar_one_or_none.return_value = None
+
+    session = MagicMock(spec=AsyncSession)
+    # Call order: (1) per-agent lookup, (2) orphan sweep query, (3) TTL sweep query.
+    session.execute = AsyncMock(
+        side_effect=[scalar_lookup, orphan_result_mock, ttl_sweep_result]
+    )
+    # session.scalar() is used for the COUNT query inside the orphan sweep.
+    session.scalar = AsyncMock(return_value=0)  # no build_complete_run event
+    session.add = MagicMock()
+
+    from agentception.models import AgentNode, AgentStatus
+
+    different_agent = AgentNode(
+        id="different-run-id", role="cto", status=AgentStatus.IMPLEMENTING
+    )
+
+    await _persist._upsert_agent_runs(session, [different_agent])
+
+    assert orphan.status == "failed", (
+        f"Expected orphan.status='failed', got {orphan.status!r}"
+    )
+
+    # An orphan_failed event must have been added.
+    added_objects = [call.args[0] for call in session.add.call_args_list]
+    event_rows = [o for o in added_objects if isinstance(o, ACAgentEvent)]
+    orphan_failed_events = [e for e in event_rows if e.event_type == "orphan_failed"]
+    assert len(orphan_failed_events) == 1, (
+        f"Expected 1 orphan_failed event, got {len(orphan_failed_events)}"
+    )
+    payload = json.loads(orphan_failed_events[0].payload)
+    assert payload["reason"] == "worktree_gone_no_build_complete"
+
+
+# ---------------------------------------------------------------------------
+# AC 3: orphan sweep leaves run alone when build_complete_run event present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_present_build_complete_not_refailed() -> None:
+    """Orphan with a build_complete_run event is NOT mutated by the sweep."""
+    # Status is already 'completed' — the sweep should not touch it.
+    orphan = _make_run(status="completed")
+
+    orphan_result_mock = MagicMock()
+    orphan_result_mock.scalars.return_value.all.return_value = [orphan]
+
+    ttl_sweep_result = MagicMock()
+    ttl_sweep_result.scalars.return_value.all.return_value = []
+
+    scalar_lookup = MagicMock()
+    scalar_lookup.scalar_one_or_none.return_value = None
+
+    session = MagicMock(spec=AsyncSession)
+    session.execute = AsyncMock(
+        side_effect=[scalar_lookup, orphan_result_mock, ttl_sweep_result]
+    )
+    # COUNT returns 1 — build_complete_run event exists.
+    session.scalar = AsyncMock(return_value=1)
+    session.add = MagicMock()
+
+    from agentception.models import AgentNode, AgentStatus
+
+    different_agent = AgentNode(
+        id="different-run-id", role="cto", status=AgentStatus.IMPLEMENTING
+    )
+
+    await _persist._upsert_agent_runs(session, [different_agent])
+
+    # Status must remain 'completed' — the sweep must not mutate it.
+    assert orphan.status == "completed", (
+        f"Expected orphan.status='completed', got {orphan.status!r}"
+    )
+
+    # No orphan_failed event should have been added.
+    added_objects = [call.args[0] for call in session.add.call_args_list]
+    event_rows = [o for o in added_objects if isinstance(o, ACAgentEvent)]
+    orphan_failed_events = [e for e in event_rows if e.event_type == "orphan_failed"]
+    assert len(orphan_failed_events) == 0, (
+        f"Expected no orphan_failed events, got {len(orphan_failed_events)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 6: reviewer runs are never mutated by the sweep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_reviewer_run_not_mutated() -> None:
+    """Orphan sweep must skip reviewer runs regardless of event state."""
+    reviewer = _make_run(status="implementing", role="reviewer")
+
+    orphan_result_mock = MagicMock()
+    orphan_result_mock.scalars.return_value.all.return_value = [reviewer]
+
+    ttl_sweep_result = MagicMock()
+    ttl_sweep_result.scalars.return_value.all.return_value = []
+
+    scalar_lookup = MagicMock()
+    scalar_lookup.scalar_one_or_none.return_value = None
+
+    session = MagicMock(spec=AsyncSession)
+    session.execute = AsyncMock(
+        side_effect=[scalar_lookup, orphan_result_mock, ttl_sweep_result]
+    )
+    # Even if scalar() were called, return 0 (no event) — but it should NOT be called.
+    session.scalar = AsyncMock(return_value=0)
+    session.add = MagicMock()
+
+    from agentception.models import AgentNode, AgentStatus
+
+    different_agent = AgentNode(
+        id="different-run-id", role="cto", status=AgentStatus.IMPLEMENTING
+    )
+
+    await _persist._upsert_agent_runs(session, [different_agent])
+
+    # Reviewer run must be untouched.
+    assert reviewer.status == "implementing", (
+        f"Reviewer run was mutated: status={reviewer.status!r}"
+    )
+
+    # No orphan_failed event should have been added for the reviewer.
+    added_objects = [call.args[0] for call in session.add.call_args_list]
+    event_rows = [o for o in added_objects if isinstance(o, ACAgentEvent)]
+    orphan_failed_events = [e for e in event_rows if e.event_type == "orphan_failed"]
+    assert len(orphan_failed_events) == 0, (
+        f"Expected no orphan_failed events for reviewer, got {len(orphan_failed_events)}"
+    )

--- a/docs/reference/poller.md
+++ b/docs/reference/poller.md
@@ -1,0 +1,130 @@
+# Poller Reference
+
+The AgentCeption poller is the heartbeat of the pipeline.  It runs on a fixed
+cadence, reads live state from GitHub and the filesystem, persists it to the
+database, and drives all automated lifecycle transitions.
+
+---
+
+## Polling loop architecture and tick cadence
+
+The polling loop lives in `agentception/poller.py`.  It runs as a long-lived
+`asyncio` task started during application lifespan (`agentception/app.py`).
+
+Each **tick** performs the following steps in order:
+
+1. **GitHub reads** — fetch open issues, open PRs, closed issues, and merged PRs
+   via the `gh` CLI wrappers in `agentception/readers/github.py`.
+2. **Filesystem reads** — enumerate live git worktrees via
+   `agentception/readers/git.py`.
+3. **State assembly** — build a `PipelineState` snapshot from the combined
+   GitHub + filesystem data.
+4. **Alert detection** — call `detect_alerts()` to find stale claims, stalled
+   agents, and out-of-order PRs.
+5. **DB persist** — call `persist_tick()` in `agentception/db/persist.py` to
+   upsert all entities and run the orphan sweep.
+6. **Phase advance** — optionally advance the active phase label when all issues
+   in the current phase are resolved.
+
+Default tick cadence: **30 seconds** (configurable via `settings.poll_interval`).
+
+---
+
+## Orphan sweep
+
+### What triggers it
+
+The orphan sweep runs inside `_upsert_agent_runs()`, which is called on every
+tick.  It fires after the live-agent upsert loop so `live_ids` (the set of run
+IDs backed by a live worktree) is fully populated.
+
+### What statuses are affected
+
+Only runs whose `status` is in `_ACTIVE_STATUSES` are candidates:
+
+```
+pending_launch, implementing, blocked, reviewing, stalled, recovering
+```
+
+Terminal statuses (`completed`, `failed`, `cancelled`, `stopped`) are never
+touched — the query filter excludes them before the sweep loop runs.
+
+### The `build_complete_run` gate
+
+The sweep uses the presence of a `build_complete_run` event in `agent_events`
+as the authoritative completion signal — **not** `pr_number`.
+
+Rationale: an agent can open a PR and then crash before calling
+`build_complete_run`.  In that case `pr_number` is set but the agent did not
+finish cleanly.  The explicit event is the only reliable signal.
+
+Decision logic for each orphan (run not in `live_ids`, `issue_number` is not
+`None`, `role != 'reviewer'`):
+
+```
+has_complete_event = COUNT(agent_events WHERE agent_run_id = orphan.id
+                           AND event_type = 'build_complete_run') > 0
+
+if has_complete_event:
+    pass  # already completed — do not mutate
+else:
+    orphan.status = "failed"
+    INSERT agent_events(event_type='orphan_failed', ...)
+```
+
+### Guards — runs the sweep never touches
+
+| Guard | Reason |
+|-------|--------|
+| `role == 'reviewer'` | Reviewer lifecycle is driven by `build_complete_run`, never by poller inference.  Reviewer runs have `pr_number` set at dispatch time, so the old `pr_number → completed` heuristic would kill them immediately. |
+| `issue_number is None` | Ad-hoc runs are managed by their asyncio task lifecycle, not by the GitHub polling loop. |
+| Status already terminal | The `_ACTIVE_STATUSES` filter on the query excludes `completed`, `failed`, `cancelled`, and `stopped` before the loop runs. |
+
+---
+
+## Alert detection
+
+`detect_alerts()` in `agentception/poller.py` produces three alert classes per
+tick:
+
+### 1. Stale claims
+
+An `agent/wip` label is on a GitHub issue but no live worktree exists for that
+issue.  The poller auto-heals by calling `clear_wip_label()` so the issue
+becomes available for re-spawn.
+
+### 2. Out-of-order PRs
+
+An open PR carries an `agentception/<phase>` label that no longer matches the
+currently active phase.  Surfaced as an alert string; no auto-heal.
+
+### 3. Stalled agents — two-signal detection
+
+**Primary (DB heartbeat):** `last_activity_at` is older than
+`stall_threshold_seconds` (default: 1800 s / 30 min).  The run is promoted to
+`AgentStatus.STALLED` and a `StalledAgentEvent` is emitted.
+
+**Secondary (git commit):** `worktree_last_commit_time()` is older than the
+threshold while `last_activity_at` is still fresh.  Advisory warning only — no
+`STALLED` promotion.
+
+The DB heartbeat is the authoritative signal.  Agents call
+`persist_run_heartbeat()` (via the `build_heartbeat` MCP tool) to keep
+`last_activity_at` fresh.
+
+---
+
+## `agent_events` event types emitted by the poller
+
+| `event_type` | Emitted by | Meaning |
+|---|---|---|
+| `orphan_failed` | `_upsert_agent_runs()` orphan sweep | A run whose worktree disappeared without a `build_complete_run` event was marked `failed`.  Payload: `{"reason": "worktree_gone_no_build_complete"}`. |
+
+### Event types emitted by agents (for reference)
+
+| `event_type` | Emitted by | Meaning |
+|---|---|---|
+| `done` | `persist_agent_event()` via `build_complete_run` MCP tool | Agent finished work and opened a PR. |
+| `build_complete_run` | `complete_agent_run()` in `persist.py` | Authoritative completion gate written atomically with the `completed` status transition. |
+| `step_start` | Agent tool loop | Agent started a named execution step. |
+| `blocker` | Agent tool loop | Agent encountered a blocker and called `build_block_run`. |


### PR DESCRIPTION
## Summary

Replaces the imprecise `pr_number` proxy in the orphan sweep with the authoritative `build_complete_run` event gate.

## Changes

### `agentception/db/persist.py`

**`complete_agent_run()`** — after flipping `status = 'completed'`, inserts an `ACAgentEvent` row with `event_type = 'build_complete_run'`. This is the explicit, authoritative signal that an agent finished successfully.

**Orphan sweep** (`_upsert_agent_runs`) — replaces the `pr_number is not None → completed` branch with an `agent_events` lookup:
- Worktree gone + `build_complete_run` event present → `pass` (already completed, do not mutate)
- Worktree gone + no `build_complete_run` event → `status = 'failed'` + `orphan_failed` event row

### `agentception/tests/test_poller_orphan_sweep.py` (new)

Four tests covering the required scenarios:
- `test_complete_agent_run_emits_build_complete_event`
- `test_missing_build_complete_marks_failed`
- `test_present_build_complete_not_refailed`
- `test_reviewer_run_not_mutated`

### `agentception/tests/test_persist_reviewer_orphan_guard.py`

Updated `test_executor_still_orphaned_when_missing_from_live_ids` to assert `failed` (not `completed`) — the executor orphan now lands in `failed` when there is no `build_complete_run` event, which is the correct new behaviour.

### `docs/reference/poller.md` (new)

Documents the polling loop architecture, orphan sweep logic, alert detection, and `agent_events` event types.

## Design decisions

- **No schema migration needed** — `agent_events` already has `event_type` and `payload` columns.
- **`pass` not `continue`** — when the event is present the orphan is already `completed`; we explicitly do nothing rather than silently skipping, making the intent clear.
- **`session.scalar()` not `session.execute().scalar_one_or_none()`** — `func.count()` always returns a row, so `scalar()` is the right idiom here.

## Closes

Closes #276