### PR TITLE
feat: extract initiative tab nav into _build_initiative_tabs.html partial

### DIFF
--- a/agentception/templates/_build_initiative_tabs.html
+++ b/agentception/templates/_build_initiative_tabs.html
@@ -1,0 +1,17 @@
+{# Initiative tab nav partial.
+   Variables:
+     repo_name  — short repo slug (e.g. "agentception"), used to build href values.
+     initiative — currently active initiative slug; drives the active-tab highlight.
+     initiatives — list[str] of initiative slugs; renders nothing when empty.
+   Invariant: bare HTML fragment — no <html>/<head>/<body>. Safe to include or
+   serve standalone via TemplateResponse. #}
+{% if initiatives %}
+<nav class="build-initiative-tabs" aria-label="Initiatives">
+  {% for ini in initiatives %}
+  <a class="build-initiative-tab{% if ini == initiative %} build-initiative-tab--active{% endif %}"
+     href="/ship/{{ repo_name }}/{{ ini | urlencode }}">
+    {{ ini }}
+  </a>
+  {% endfor %}
+</nav>
+{% endif %}


### PR DESCRIPTION
Closes #627

## What

Extracts the initiative tab nav block from `build.html` lines 36-45 into a standalone Jinja2 partial `agentception/templates/_build_initiative_tabs.html`.

## Why

The tab bar is baked into the full-page render. Extracting it into a partial enables a future HTMX route to poll and refresh it independently — so deleted GitHub labels stop persisting in the UI until the user reloads.

## Interface contract

- **Accepts:** `repo_name` (short slug), `initiative` (active slug), `initiatives` (list of slugs)
- **Renders:** bare `<nav>` fragment — no `<html>`/`<head>`/`<body>` wrapper
- **Empty list:** renders nothing (the `{% if initiatives %}` guard)
- **Active tab:** `build-initiative-tab--active` class applied when `ini == initiative`

## Changes

- `agentception/templates/_build_initiative_tabs.html` — new file (extracted fragment)
- `build.html` — **untouched** (per issue scope; wiring is in `live-initiative-tabs-p1-001`)
