### PR TITLE
feat: always tear down reviewer worktree after build_complete_run regardless of grade

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -272,6 +272,20 @@ async def build_complete_run(
                 grade,
                 agent_run_id,
             )
+
+        # Always tear down the reviewer's own worktree regardless of grade.
+        # Leaving the reviewer worktree on disk blocks re-dispatch of the same
+        # issue because git worktree add refuses to check out a branch that is
+        # already active in another worktree.
+        if agent_run_id:
+            asyncio.create_task(
+                teardown_agent_worktree(agent_run_id),
+                name=f"teardown-{agent_run_id}",
+            )
+            logger.info(
+                "🧹 build_complete_run: reviewer worktree teardown queued for run_id=%r",
+                agent_run_id,
+            )
     else:
         # Non-reviewer (implementer) completed: release worktree and dispatch reviewer.
         # Release the executor's worktree before dispatching the reviewer.

--- a/agentception/tests/test_build_commands.py
+++ b/agentception/tests/test_build_commands.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+"""Tests for build_complete_run reviewer worktree teardown behaviour.
+
+Coverage:
+- Reviewer worktree is torn down after a failing grade (C/D/F).
+- Reviewer worktree is torn down after a passing grade (A/B).
+- Teardown task name follows the expected convention.
+
+Run targeted:
+    pytest agentception/tests/test_build_commands.py -v
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+@pytest.mark.anyio
+async def test_reviewer_worktree_torn_down_after_failing_grade() -> None:
+    """build_complete_run schedules reviewer worktree teardown on a failing grade (C).
+
+    Regression: the reviewer worktree was left on disk after a C/D/F grade,
+    blocking re-dispatch of the same issue because git worktree add refuses to
+    check out a branch already active in another worktree.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    reviewer_run_id = "reviewer-issue-42-abc123"
+
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="reviewer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.auto_redispatch_after_rejection",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.teardown_agent_worktree",
+            new_callable=AsyncMock,
+        ) as mock_teardown,
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+        ) as mock_create_task,
+    ):
+        result = await build_complete_run(
+            issue_number=42,
+            pr_url="https://github.com/cgcardona/agentception/pull/99",
+            agent_run_id=reviewer_run_id,
+            grade="C",
+            reviewer_feedback="Missing tests for the happy path.",
+        )
+
+    assert result["ok"] is True
+    assert result["status"] == "completed"
+
+    # Verify that a teardown task was scheduled for the reviewer's run_id.
+    task_names = [
+        c.kwargs.get("name", "") for c in mock_create_task.call_args_list
+    ]
+    assert f"teardown-{reviewer_run_id}" in task_names, (
+        f"Expected teardown task for reviewer run_id={reviewer_run_id!r}; "
+        f"got task names: {task_names}"
+    )
+
+
+@pytest.mark.anyio
+async def test_reviewer_worktree_torn_down_after_passing_grade() -> None:
+    """build_complete_run schedules reviewer worktree teardown on a passing grade (A).
+
+    Teardown must be unconditional — not only on failing grades — so the
+    reviewer worktree is always cleaned up and never blocks future dispatches.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    reviewer_run_id = "reviewer-issue-55-def456"
+
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="reviewer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.teardown_agent_worktree",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+        ) as mock_create_task,
+    ):
+        result = await build_complete_run(
+            issue_number=55,
+            pr_url="https://github.com/cgcardona/agentception/pull/100",
+            agent_run_id=reviewer_run_id,
+            grade="A",
+            reviewer_feedback="",
+        )
+
+    assert result["ok"] is True
+    assert result["status"] == "completed"
+
+    # Verify that a teardown task was scheduled for the reviewer's run_id.
+    task_names = [
+        c.kwargs.get("name", "") for c in mock_create_task.call_args_list
+    ]
+    assert f"teardown-{reviewer_run_id}" in task_names, (
+        f"Expected teardown task for reviewer run_id={reviewer_run_id!r}; "
+        f"got task names: {task_names}"
+    )


### PR DESCRIPTION
## Summary

Fixes #634 — reviewer worktree was left on disk after a failing grade (C/D/F), blocking re-dispatch of the same issue because `git worktree add` refuses to check out a branch already active in another worktree.

## Changes

### `agentception/mcp/build_commands.py`

In `build_complete_run`, after the grade-branch resolves (both passing A/B and failing C/D/F), unconditionally schedule `teardown_agent_worktree` for the reviewer's own `agent_run_id` via `asyncio.create_task`. The teardown is placed after the grade branch so it fires regardless of outcome.

The existing non-reviewer path (implementer completing) is unchanged — it still calls `release_worktree` (branch-preserving) before dispatching the reviewer, not full teardown.

### `agentception/tests/test_build_commands.py` (new file)

- `test_reviewer_worktree_torn_down_after_failing_grade` — mocks `build_complete_run` with grade C and asserts a `teardown-{run_id}` task was scheduled.
- `test_reviewer_worktree_torn_down_after_passing_grade` — same assertion for grade A, guarding against regression.

## Acceptance criteria

- [x] After a reviewer calls `build_complete_run` with grade C, D, or F, the reviewer worktree teardown is queued.
- [x] After a reviewer calls `build_complete_run` with grade A or B, the reviewer worktree teardown is also queued (unconditional).
- [x] Re-dispatching the same issue to a new developer worktree no longer fails with `git worktree add` refusing a duplicate branch checkout.
- [x] No existing passing-grade teardown behavior is regressed (all 25 tests pass).
- [x] mypy passes with zero new errors on modified files.
