### PR TITLE
feat: guard auto_reviewer dispatch against empty or malformed pr_url

### DIFF
--- a/agentception/services/auto_reviewer.py
+++ b/agentception/services/auto_reviewer.py
@@ -30,6 +30,28 @@ _SERVICE_URL = "http://localhost:10003/api/dispatch/issue"
 _REVIEWER_DELAY_SECS: float = 5.0
 
 
+def extract_pr_number(pr_url: str) -> int | None:
+    """Extract the integer PR number from a GitHub PR URL.
+
+    Returns ``None`` and logs a structured warning when *pr_url* is empty or
+    does not contain a recognisable ``/pull/<digits>`` segment.  Never raises.
+
+    Args:
+        pr_url: Full GitHub PR URL, e.g.
+            ``https://github.com/owner/repo/pull/537``.
+            An empty string or any URL that does not match the pattern causes
+            a structured warning log and a ``None`` return — no exception.
+    """
+    if not pr_url:
+        logger.warning("auto_reviewer: pr_url is empty, skipping dispatch")
+        return None
+    match = re.search(r"/pull/(\d+)$", pr_url)
+    if not match:
+        logger.warning("auto_reviewer: cannot parse PR number from %r", pr_url)
+        return None
+    return int(match.group(1))
+
+
 async def auto_dispatch_reviewer(
     issue_number: int,
     pr_url: str,
@@ -47,15 +69,9 @@ async def auto_dispatch_reviewer(
         pr_branch: Branch the implementer pushed.  Defaults to
             ``feat/issue-{issue_number}`` when omitted.
     """
-    pr_match = _PR_URL_RE.search(pr_url)
-    if not pr_match:
-        logger.error(
-            "❌ auto_reviewer: cannot parse PR number from %r — reviewer not dispatched",
-            pr_url,
-        )
+    pr_number = extract_pr_number(pr_url)
+    if pr_number is None:
         return
-
-    pr_number = int(pr_match.group(1))
     branch = pr_branch or f"feat/issue-{issue_number}"
 
     # Small delay so GitHub has time to register the pushed branch before the

--- a/agentception/tests/test_dispatch.py
+++ b/agentception/tests/test_dispatch.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from agentception.services.auto_reviewer import extract_pr_number
+
+
+def test_extract_pr_number_empty_url_returns_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Empty string returns None and logs a structured warning — no exception raised."""
+    with caplog.at_level(logging.WARNING, logger="agentception.services.auto_reviewer"):
+        result = extract_pr_number("")
+    assert result is None
+    assert any("pr_url is empty" in record.message for record in caplog.records)
+
+
+def test_extract_pr_number_malformed_url_returns_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-empty but unparseable string returns None and logs a structured warning."""
+    with caplog.at_level(logging.WARNING, logger="agentception.services.auto_reviewer"):
+        result = extract_pr_number("not-a-url")
+    assert result is None
+    assert any("cannot parse PR number" in record.message for record in caplog.records)
+
+
+def test_extract_pr_number_valid_url_returns_integer() -> None:
+    """A valid GitHub PR URL returns the correct integer PR number."""
+    result = extract_pr_number("https://github.com/org/repo/pull/42")
+    assert result == 42


### PR DESCRIPTION
## Summary
Closes #635 — adds `extract_pr_number` helper to `auto_reviewer.py` with explicit structured warning guards for empty and malformed `pr_url` values, replacing the bare `logger.error` path that produced the `❌ auto_reviewer: cannot parse PR number from ''` log line.

## Root Cause / Motivation
`auto_dispatch_reviewer` used `_PR_URL_RE.search(pr_url)` directly. When `pr_url` was an empty string the regex returned `None` and the function logged an error-level message with the `❌` prefix — indistinguishable from a real failure. The empty-string case is a distinct upstream condition (PR URL not yet written to the run record) and deserves its own structured warning so operators can distinguish "URL not available yet" from "URL is malformed".

## Solution
- Added `extract_pr_number(pr_url: str) -> int | None` as a public helper in `agentception/services/auto_reviewer.py`:
  - Empty string → `logger.warning("auto_reviewer: pr_url is empty, skipping dispatch")` + `None`
  - Non-empty but unparseable → `logger.warning("auto_reviewer: cannot parse PR number from %r", pr_url)` + `None`
  - Valid URL → integer PR number
- Updated `auto_dispatch_reviewer` to call `extract_pr_number` and return early on `None`, removing the inline regex match.
- Added `agentception/tests/test_dispatch.py` with three tests covering all three branches.

## Upstream TODO
The root cause of `pr_url` being empty at call time (PR URL not persisted to the run record before the poller reads it) is a separate race condition. It is documented in the existing codebase and is out of scope for this issue per the spec. The structured warning now makes it easy to grep for and correlate with the upstream write path.

## Verification
- [x] mypy clean (`Success: no issues found in 2 source files`)
- [x] All 10 tests pass (3 new + 7 existing auto_reviewer tests)
- [x] `extract_pr_number("")` returns `None` and logs warning
- [x] `extract_pr_number("not-a-url")` returns `None` and logs warning
- [x] `extract_pr_number("https://github.com/org/repo/pull/42")` returns `42`
