### PR TITLE
fix: move initiative-tabs endpoint to /api/ship/ to avoid Starlette route conflict

### DIFF
--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -240,17 +240,25 @@ async def ship_redirect() -> Response:
 
 
 # ---------------------------------------------------------------------------
-# GET /ship/{repo}/initiatives — HTMX initiative tab nav partial
+# GET /api/ship/{repo}/initiative-tabs — HTMX initiative tab nav partial
+# ---------------------------------------------------------------------------
+# NOTE: must NOT live under /ship/{repo}/* because Starlette matches the
+# parametric route /ship/{repo}/{initiative} before literal segments at the
+# same depth, so /ship/{repo}/initiatives would silently serve the full page.
 # ---------------------------------------------------------------------------
 
 
-@router.get("/ship/{repo}/initiatives", response_class=HTMLResponse)
+@router.get("/api/ship/{repo}/initiative-tabs", response_class=HTMLResponse)
 async def initiative_tabs_partial(
     request: Request,
     repo: str,
     initiative: str = "",
 ) -> HTMLResponse:
     """Return the initiative tab nav as an HTML partial for HTMX swapping.
+
+    Registered under ``/api/ship/`` (not ``/ship/``) to avoid the Starlette
+    route-ordering conflict where ``/ship/{repo}/{initiative}`` would shadow
+    ``/ship/{repo}/initiatives`` regardless of registration order.
 
     Validates *repo* against the configured ``settings.gh_repo`` and returns
     404 when it does not match.  Accepts an optional ``?initiative=<slug>``

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -36,7 +36,7 @@
     <!-- initiatives tab nav: must remain outside #build-board swap target -->
     <div
       id="initiative-tabs-nav"
-      hx-get="/ship/{{ repo_name }}/initiatives"
+      hx-get="/api/ship/{{ repo_name }}/initiative-tabs"
       hx-trigger="load, every 30s"
       hx-swap="innerHTML"
       hx-vals='{"initiative": "{{ initiative }}"}'

--- a/agentception/tests/test_build_initiative_tabs.py
+++ b/agentception/tests/test_build_initiative_tabs.py
@@ -1,4 +1,4 @@
-"""Tests for GET /ship/{repo}/initiatives — initiative tab nav partial."""
+"""Tests for GET /api/ship/{repo}/initiative-tabs — initiative tab nav partial."""
 from __future__ import annotations
 
 from contextlib import AbstractContextManager
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from agentception.app import app
 
 _REPO = "agentception"
-_URL = f"/ship/{_REPO}/initiatives"
+_URL = f"/api/ship/{_REPO}/initiative-tabs"
 _INITIATIVES = ["mcp-audit-remediation", "auth-rewrite", "ac-plan"]
 
 
@@ -28,7 +28,7 @@ def _patch_initiatives(initiatives: list[str]) -> AbstractContextManager[MagicMo
 
 
 def test_initiatives_endpoint_200(client: TestClient) -> None:
-    """GET /ship/{repo}/initiatives returns HTTP 200 with text/html content-type."""
+    """GET /api/ship/{repo}/initiative-tabs returns HTTP 200 with text/html content-type."""
     with _patch_initiatives(_INITIATIVES):
         response = client.get(_URL)
 
@@ -60,9 +60,9 @@ def test_initiatives_endpoint_marks_active_tab(client: TestClient) -> None:
 
 
 def test_initiatives_endpoint_unknown_repo_returns_404(client: TestClient) -> None:
-    """GET /ship/nonexistent-repo/initiatives returns HTTP 404."""
+    """GET /api/ship/nonexistent-repo/initiative-tabs returns HTTP 404."""
     with _patch_initiatives(_INITIATIVES):
-        response = client.get("/ship/nonexistent-repo/initiatives")
+        response = client.get("/api/ship/nonexistent-repo/initiative-tabs")
 
     assert response.status_code == 404
 
@@ -141,7 +141,7 @@ def test_full_page_has_htmx_polling_div(client: TestClient) -> None:
     body = response.text
 
     assert 'hx-get=' in body
-    assert '/initiatives' in body
+    assert '/initiative-tabs' in body
     assert 'hx-trigger=' in body
     assert 'every 30s' in body
     assert 'hx-swap=' in body


### PR DESCRIPTION
Starlette route conflict caused infinite header loop. Fix: rename endpoint to /api/ship/{repo}/initiative-tabs, update hx-get, update tests.