### PR TITLE
feat: set _api_get_all cache TTL below poller interval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,5 +46,16 @@ WORKTREES_DIR=/worktrees
 # Port the AgentCeption FastAPI app listens on (inside the container).
 PORT=10003
 
+# ── Polling / Cache ──────────────────────────────────────────────────────────
+# How often (seconds) the background poller fetches GitHub data.
+# Default: 30
+# POLL_INTERVAL_SECONDS=30
+
+# GitHub API response cache TTL in seconds.
+# MUST be strictly less than POLL_INTERVAL_SECONDS so every poller tick sees
+# live GitHub data.  Recommended: min(POLL_INTERVAL_SECONDS / 2, 30).
+# Default: 15  (half of the default 30 s poll interval)
+# GITHUB_CACHE_SECONDS=15
+
 # Log level: DEBUG, INFO, WARNING, ERROR
 LOG_LEVEL=INFO

--- a/agentception/config.py
+++ b/agentception/config.py
@@ -110,7 +110,10 @@ class AgentCeptionSettings(BaseSettings):
     gh_repo: str = "cgcardona/agentception"
     poll_interval_seconds: int = 30
     agent_max_iterations: int = 100
-    github_cache_seconds: int = 60
+    # TTL must be strictly less than poll_interval_seconds so every poller tick
+    # sees live GitHub data.  Default: min(poll_interval_seconds / 2, 30) = 15 s.
+    # If you change POLL_INTERVAL_SECONDS, keep GITHUB_CACHE_SECONDS < that value.
+    github_cache_seconds: int = 15
     ac_api_key: str = ""
     """Shared secret for authenticating requests to the ``/api/*`` routes.
 

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -67,7 +67,13 @@ def _cache_get(key: str) -> JsonValue:
 
 
 def _cache_set(key: str, value: JsonValue) -> None:
-    """Store *value* in the cache with a TTL of ``github_cache_seconds``."""
+    """Store *value* in the cache with a TTL of ``github_cache_seconds``.
+
+    Invariant: TTL < poll_interval_seconds so every poller tick receives fresh
+    data from GitHub.  Default TTL is min(poll_interval_seconds / 2, 30) = 15 s
+    against the default 30 s poll interval.  If you raise the poll interval,
+    keep GITHUB_CACHE_SECONDS strictly below it.
+    """
     expires_at = time.monotonic() + settings.github_cache_seconds
     _cache[key] = (value, expires_at)
 

--- a/agentception/tests/test_github_reader.py
+++ b/agentception/tests/test_github_reader.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+"""Tests for agentception/readers/github.py — cache TTL behaviour."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+import agentception.readers.github as gh_module
+from agentception.readers.github import _cache_invalidate
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response(items: list[object], status: int = 200) -> httpx.Response:
+    """Build a minimal httpx.Response carrying a JSON list payload."""
+    import json
+
+    request = httpx.Request("GET", "https://api.github.com/test")
+    return httpx.Response(
+        status_code=status,
+        content=json.dumps(items).encode(),
+        headers={"content-type": "application/json"},
+        request=request,
+    )
+
+
+# ---------------------------------------------------------------------------
+# test_api_get_all_cache_expires_before_poll
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_api_get_all_cache_expires_before_poll() -> None:
+    """_api_get_all makes a fresh HTTP call after the TTL has elapsed.
+
+    Scenario:
+    1. First call — cache miss → HTTP request made, result cached.
+    2. Cache entry back-dated to already-expired timestamp.
+    3. Second call — cache miss again → second HTTP request made.
+
+    This verifies that github_cache_seconds < poll_interval_seconds so every
+    poller tick receives live data rather than a stale cached response.
+    """
+    from agentception.config import settings
+
+    # Confirm the invariant: TTL must be strictly less than the poll interval.
+    assert settings.github_cache_seconds < settings.poll_interval_seconds, (
+        f"github_cache_seconds ({settings.github_cache_seconds}) must be "
+        f"< poll_interval_seconds ({settings.poll_interval_seconds})"
+    )
+
+    fake_items: list[object] = [{"number": 1, "title": "test issue"}]
+    response = _make_response(fake_items)
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=response)
+
+    # Clear any pre-existing cache state.
+    _cache_invalidate()
+
+    with (
+        patch("agentception.readers.github.settings") as mock_settings,
+        patch("agentception.readers.github._headers", return_value={"Authorization": "Bearer test"}),
+        patch("httpx.AsyncClient", return_value=mock_client),
+    ):
+        mock_settings.github_cache_seconds = settings.github_cache_seconds
+        mock_settings.gh_repo = "owner/repo"
+
+        # ── First call: cache miss → HTTP request ──────────────────────────
+        result1 = await gh_module._api_get_all(
+            "repos/owner/repo/issues",
+            {"state": "open"},
+            "test_cache_expiry_key",
+        )
+        assert result1 == fake_items
+        assert mock_client.get.call_count == 1
+
+        # ── Expire the cache entry by back-dating its expiry timestamp ─────
+        # Set expires_at to a time already in the past so _cache_get (which
+        # calls the real time.monotonic()) sees the entry as expired.
+        cache_key = "test_cache_expiry_key"
+        if cache_key in gh_module._cache:
+            value, _old_expires = gh_module._cache[cache_key]
+            gh_module._cache[cache_key] = (value, time.monotonic() - 1.0)
+
+        # ── Second call: cache miss (expired) → second HTTP request ────────
+        result2 = await gh_module._api_get_all(
+            "repos/owner/repo/issues",
+            {"state": "open"},
+            "test_cache_expiry_key",
+        )
+        assert result2 == fake_items
+        assert mock_client.get.call_count == 2, (
+            "Expected a second HTTP call after TTL expiry, "
+            f"but got {mock_client.get.call_count} total calls"
+        )
+
+    # Clean up.
+    _cache_invalidate()


### PR DESCRIPTION
## Summary

Fixes the cache TTL so every poller tick receives live GitHub data.

### Changes

- **`agentception/readers/github.py`**: Added inline comment explaining the TTL/interval invariant (`github_cache_seconds < poll_interval_seconds`).
- **`agentception/config.py`**: `github_cache_seconds` default set to `min(poll_interval_seconds / 2, 30)` so the invariant holds out of the box.
- **`.env.example`**: Documents the `GITHUB_CACHE_SECONDS` constraint relative to `POLL_INTERVAL_SECONDS`.
- **`agentception/tests/test_github_reader.py`**: New test `test_api_get_all_cache_expires_before_poll` — asserts the TTL invariant and verifies a second HTTP call is made after the cache entry expires.

### Invariant

`github_cache_seconds < poll_interval_seconds` — the cache TTL must be strictly less than the poller interval so each tick sees live GitHub data.

Closes #644