### PR TITLE
feat: raise get_closed_issues limit to 1000 to capture bulk closes

### DIFF
--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -96,7 +96,7 @@ async def build_github_board() -> GitHubBoard:
         get_open_issues(),
         get_open_prs(),
         get_wip_issues(),
-        get_closed_issues(limit=100),
+        get_closed_issues(limit=1000),
         get_merged_prs_full(limit=100),
     )
     return GitHubBoard(

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -414,7 +414,7 @@ def _normalize_pr(raw: dict[str, object]) -> dict[str, object]:
 # Public read API
 # ---------------------------------------------------------------------------
 
-async def get_closed_issues(limit: int = 100) -> list[dict[str, object]]:
+async def get_closed_issues(limit: int = 1000) -> list[dict[str, object]]:
     """List recently closed issues (most recent first, capped at *limit*).
 
     Used by the poller to sync closed issues into the DB so it retains a
@@ -423,9 +423,13 @@ async def get_closed_issues(limit: int = 100) -> list[dict[str, object]]:
     Parameters
     ----------
     limit:
-        Maximum number of closed issues to fetch.  Keeps API cost proportional
-        — closed issues change rarely so a small window captures all recent
-        transitions.
+        Maximum number of closed issues to fetch.  Default 1000 — large enough
+        to capture any realistic bulk-close event (e.g. end-of-sprint mass
+        close) so stale ``ACIssue.state`` rows are corrected on the next tick.
+        Scale assumption: repos with >1000 issues closed between ticks are
+        out of scope; raise this cap if that assumption breaks.
+        Callers that pass an explicit ``limit`` override receive at most that
+        many results.
     """
     repo = settings.gh_repo
     cache_key = f"get_closed_issues:limit={limit}"

--- a/agentception/tests/test_github_reader.py
+++ b/agentception/tests/test_github_reader.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Tests for agentception/readers/github.py — focused on get_closed_issues."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from agentception.readers.github import get_closed_issues, _cache_invalidate
+
+
+@pytest.fixture(autouse=True)
+def clear_cache() -> None:
+    """Ensure each test starts with a cold cache."""
+    _cache_invalidate()
+
+
+@pytest.mark.anyio
+async def test_get_closed_issues_default_limit() -> None:
+    """Default limit is 1000 — 150 items returned by the API must all come back.
+
+    Regression guard: the old limit=100 default would have truncated the result
+    to 100 items.  This test fails if the default is ever lowered below 150.
+    """
+    # Build 150 fake closed issues (no pull_request key → all pass the filter).
+    fake_issues = [{"number": i, "title": f"issue {i}", "state": "closed"} for i in range(150)]
+
+    with patch(
+        "agentception.readers.github._api_get_all",
+        new_callable=AsyncMock,
+        return_value=fake_issues,
+    ) as mock_get_all:
+        result = await get_closed_issues()
+
+    assert len(result) == 150, (
+        f"Expected 150 issues but got {len(result)} — "
+        "default limit may have been lowered below 150"
+    )
+    # Confirm the call was made with the new default.
+    mock_get_all.assert_called_once()
+    _args, kwargs = mock_get_all.call_args
+    assert kwargs.get("limit", _args[3] if len(_args) > 3 else None) == 1000
+
+
+@pytest.mark.anyio
+async def test_get_closed_issues_explicit_limit_respected() -> None:
+    """Callers that pass limit=N receive at most N results."""
+    fake_issues = [{"number": i, "state": "closed"} for i in range(50)]
+
+    with patch(
+        "agentception.readers.github._api_get_all",
+        new_callable=AsyncMock,
+        return_value=fake_issues,
+    ) as mock_get_all:
+        result = await get_closed_issues(limit=50)
+
+    assert len(result) == 50
+    mock_get_all.assert_called_once()
+    _args, kwargs = mock_get_all.call_args
+    assert kwargs.get("limit", _args[3] if len(_args) > 3 else None) == 50
+
+
+@pytest.mark.anyio
+async def test_get_closed_issues_filters_pull_requests() -> None:
+    """Items with a ``pull_request`` key are excluded from the result."""
+    fake_items = [
+        {"number": 1, "state": "closed"},
+        {"number": 2, "state": "closed", "pull_request": {"url": "https://..."}},
+        {"number": 3, "state": "closed"},
+    ]
+
+    with patch(
+        "agentception.readers.github._api_get_all",
+        new_callable=AsyncMock,
+        return_value=fake_items,
+    ):
+        result = await get_closed_issues()
+
+    assert len(result) == 2
+    assert all("pull_request" not in item for item in result)


### PR DESCRIPTION
## Summary

Fixes the root cause of stale `ACIssue.state` rows after bulk issue closes.

## Changes

- **`agentception/readers/github.py`** — `get_closed_issues` default `limit` raised from `100` → `1000`. Added inline doc comment explaining the cap and the scale assumption (repos closing >1000 issues between ticks are out of scope).
- **`agentception/poller.py`** — `build_github_board` updated to call `get_closed_issues(limit=1000)` explicitly, matching the new default.
- **`agentception/tests/test_github_reader.py`** — new test file with three tests:
  - `test_get_closed_issues_default_limit` — mocks 150 items, asserts all 150 returned (regression guard against the old 100-item truncation).
  - `test_get_closed_issues_explicit_limit_respected` — explicit `limit=50` is forwarded correctly.
  - `test_get_closed_issues_filters_pull_requests` — PR items are still excluded.

## Interface invariant

`get_closed_issues(limit=N)` returns at most `N` closed issues (no PRs), paginating to exhaustion via `_api_get_all`. The 1000-item cap is a brute-force bound; it holds as long as no single poller tick spans a window where >1000 issues are closed.

Closes #645