### PR TITLE
feat: raise get_closed_issues limit to 1000 and paginate to exhaustion

### DIFF
--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -96,7 +96,7 @@ async def build_github_board() -> GitHubBoard:
         get_open_issues(),
         get_open_prs(),
         get_wip_issues(),
-        get_closed_issues(limit=100),
+        get_closed_issues(),
         get_merged_prs_full(limit=100),
     )
     return GitHubBoard(

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -420,7 +420,7 @@ def _normalize_pr(raw: dict[str, object]) -> dict[str, object]:
 # Public read API
 # ---------------------------------------------------------------------------
 
-async def get_closed_issues(limit: int = 100) -> list[dict[str, object]]:
+async def get_closed_issues(limit: int = 1000) -> list[dict[str, object]]:
     """List recently closed issues (most recent first, capped at *limit*).
 
     Used by the poller to sync closed issues into the DB so it retains a
@@ -429,9 +429,14 @@ async def get_closed_issues(limit: int = 100) -> list[dict[str, object]]:
     Parameters
     ----------
     limit:
-        Maximum number of closed issues to fetch.  Keeps API cost proportional
-        — closed issues change rarely so a small window captures all recent
-        transitions.
+        Maximum number of closed issues to fetch per poller tick.  Default is
+        1000 — large enough to capture any realistic bulk-close event (e.g. an
+        initiative completing 500 tickets at once) without unbounded API cost.
+        Scale assumption: repositories with >1000 issues closed between two
+        consecutive poller ticks will still miss the oldest ones; raise this
+        cap or add a full-resync endpoint if that becomes a real scenario.
+        Callers that pass an explicit ``limit`` override receive at most that
+        many results — the default is intentionally generous.
     """
     repo = settings.gh_repo
     cache_key = f"get_closed_issues:limit={limit}"

--- a/agentception/tests/test_github_reader.py
+++ b/agentception/tests/test_github_reader.py
@@ -105,3 +105,75 @@ async def test_api_get_all_cache_expires_before_poll() -> None:
 
     # Clean up.
     _cache_invalidate()
+
+
+# ---------------------------------------------------------------------------
+# test_get_closed_issues_default_limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_closed_issues_default_limit() -> None:
+    """get_closed_issues() with no args returns all 150 items from the API.
+
+    The old limit=100 default would have truncated the result to 100.  With
+    limit=1000 all 150 items pass through untruncated.
+
+    Scale assumption: this test validates the 100→1000 change; it would need
+    updating if the default is raised further or made configurable.
+    """
+    import json as _json
+
+    from agentception.readers.github import get_closed_issues
+
+    # Build 150 fake closed issues (no pull_request key → all pass the filter).
+    fake_issues: list[object] = [
+        {"number": i, "title": f"issue {i}", "state": "closed"}
+        for i in range(1, 151)
+    ]
+
+    # _api_get_all paginates with per_page=100, so we need two pages.
+    page1 = fake_issues[:100]
+    page2 = fake_issues[100:]
+
+    def _make_page(items: list[object]) -> httpx.Response:
+        request = httpx.Request("GET", "https://api.github.com/repos/owner/repo/issues")
+        return httpx.Response(
+            status_code=200,
+            content=_json.dumps(items).encode(),
+            headers={"content-type": "application/json"},
+            request=request,
+        )
+
+    responses = [_make_page(page1), _make_page(page2), _make_page([])]
+    call_index = 0
+
+    async def _fake_get(*args: object, **kwargs: object) -> httpx.Response:
+        nonlocal call_index
+        resp = responses[min(call_index, len(responses) - 1)]
+        call_index += 1
+        return resp
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = _fake_get
+
+    _cache_invalidate()
+
+    with (
+        patch("agentception.readers.github.settings") as mock_settings,
+        patch("agentception.readers.github._headers", return_value={"Authorization": "Bearer test"}),
+        patch("httpx.AsyncClient", return_value=mock_client),
+    ):
+        mock_settings.github_cache_seconds = 30
+        mock_settings.gh_repo = "owner/repo"
+
+        result = await get_closed_issues()
+
+    assert len(result) == 150, (
+        f"Expected 150 issues (old limit=100 would have truncated), got {len(result)}"
+    )
+
+    _cache_invalidate()
+


### PR DESCRIPTION
## Summary

Fixes the root cause of stale initiative tabs and board columns after bulk issue closes.

`get_closed_issues()` previously capped at 100 items. After a bulk close of >100 issues the older ones never entered the sync window, leaving `ACIssue.state = "open"` in Postgres indefinitely.

## Changes

- **`agentception/readers/github.py`**: Changed `get_closed_issues(limit: int = 100)` → `limit: int = 1000`. The underlying `_api_get_all` already paginates (100 items/page via GitHub REST), so this transparently fetches up to 10 pages per tick. Added inline doc comment naming the scale assumption (>1000 closes between ticks = edge case requiring a full-resync endpoint, tracked separately).
- **`agentception/poller.py`**: Updated `build_github_board` to call `get_closed_issues()` without an explicit limit override, picking up the new default.
- **`agentception/tests/test_github_reader.py`**: Added `test_get_closed_issues_default_limit` — mocks the GitHub client to return 150 items across two pages and asserts all 150 are returned (the old limit=100 would have truncated to 100).

## Acceptance criteria

- [x] `get_closed_issues()` with no arguments fetches up to 1000 closed issues.
- [x] Callers that pass `limit=N` explicitly receive at most `N` results (unchanged behaviour).
- [x] No other behaviour in `agentception/readers/github.py` changes.
- [x] mypy passes with zero errors on modified files.
- [x] `test_get_closed_issues_default_limit` added and passing.

Closes #645