### PR TITLE
feat: reject empty/invalid reviewer grade in build_complete_run

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -245,8 +245,18 @@ async def build_complete_run(
     # redispatch a corrected developer run.
     caller_role = await get_agent_run_role(agent_run_id) if agent_run_id else None
     if caller_role == "reviewer":
+        VALID_REVIEWER_GRADES: frozenset[str] = frozenset({"A", "B", "C", "D", "F"})
         _FAILING_GRADES: frozenset[str] = frozenset({"C", "D", "F"})
         normalised_grade = grade.strip().upper()
+        # Reviewer must commit to a valid grade before merge/redispatch logic runs.
+        if normalised_grade not in VALID_REVIEWER_GRADES:
+            return {
+                "error": (
+                    f"Invalid grade {normalised_grade!r}. "
+                    "Reviewer must supply one of: A, B, C, D, F. "
+                    "Call build_complete_run again with a valid grade."
+                )
+            }
         if normalised_grade in _FAILING_GRADES:
             logger.info(
                 "ℹ️ build_complete_run: reviewer rejected (grade=%r) — "

--- a/agentception/tests/test_build_commands.py
+++ b/agentception/tests/test_build_commands.py
@@ -266,3 +266,110 @@ async def test_redispatch_skipped_after_passing_grade() -> None:
 
     # The mock should never have been called (create_task wraps the coroutine).
     mock_redispatch.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_rejects_empty_grade_from_reviewer() -> None:
+    """build_complete_run returns an error dict when reviewer passes grade=''.
+
+    Regression: an empty grade must be caught before merge/redispatch logic
+    runs so the LLM sees a structured error and can retry with a valid grade.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    reviewer_run_id = "reviewer-issue-99-empty"
+
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="reviewer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.auto_redispatch_after_rejection",
+            new_callable=AsyncMock,
+        ) as mock_redispatch,
+        patch(
+            "agentception.mcp.build_commands.teardown_agent_worktree",
+            new_callable=AsyncMock,
+        ) as mock_teardown,
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+        ) as mock_create_task,
+    ):
+        result = await build_complete_run(
+            issue_number=99,
+            pr_url="https://github.com/cgcardona/agentception/pull/999",
+            agent_run_id=reviewer_run_id,
+            grade="",
+            reviewer_feedback="",
+        )
+
+    assert "error" in result
+    assert "A, B, C, D, F" in str(result["error"])
+    mock_redispatch.assert_not_called()
+    mock_teardown.assert_not_called()
+    mock_create_task.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_rejects_whitespace_grade_from_reviewer() -> None:
+    """build_complete_run returns an error dict when reviewer passes grade='   '.
+
+    Whitespace-only input must be caught after normalisation (strip + upper)
+    the same way an empty string is caught.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    reviewer_run_id = "reviewer-issue-99-whitespace"
+
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="reviewer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.auto_redispatch_after_rejection",
+            new_callable=AsyncMock,
+        ) as mock_redispatch,
+        patch(
+            "agentception.mcp.build_commands.teardown_agent_worktree",
+            new_callable=AsyncMock,
+        ) as mock_teardown,
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+        ) as mock_create_task,
+    ):
+        result = await build_complete_run(
+            issue_number=99,
+            pr_url="https://github.com/cgcardona/agentception/pull/999",
+            agent_run_id=reviewer_run_id,
+            grade="   ",
+            reviewer_feedback="",
+        )
+
+    assert "error" in result
+    assert "A, B, C, D, F" in str(result["error"])
+    mock_redispatch.assert_not_called()
+    mock_teardown.assert_not_called()
+    mock_create_task.assert_not_called()
+


### PR DESCRIPTION
## Summary

Adds an explicit validation gate in `build_complete_run` that rejects any `normalised_grade` that is not a non-empty member of `{"A","B","C","D","F"}` when `caller_role == "reviewer"`. The gate fires before any merge or redispatch logic, returning a structured `{"error": ...}` dict so the LLM can retry with a valid grade.

## Changes

### `agentception/mcp/build_commands.py`
- Added `VALID_REVIEWER_GRADES = frozenset({"A", "B", "C", "D", "F"})` inside the reviewer branch of `build_complete_run`.
- Added guard block immediately after `normalised_grade = grade.strip().upper()` that returns `{"error": ...}` containing `"A, B, C, D, F"` when the grade is not valid.
- Added one-line comment: `# Reviewer must commit to a valid grade before merge/redispatch logic runs.`
- The existing `_FAILING_GRADES = frozenset({"C", "D", "F"})` and all downstream redispatch logic are untouched.

### `agentception/tests/test_build_commands.py`
- Added `test_build_complete_run_rejects_empty_grade_from_reviewer`: verifies `grade=""` returns `{"error": ...}` and neither `auto_redispatch_after_rejection` nor `teardown_agent_worktree` is called.
- Added `test_build_complete_run_rejects_whitespace_grade_from_reviewer`: same pattern with `grade="   "` to verify whitespace-only input is caught after normalisation.

## Acceptance Criteria

- [x] `grade=""` from reviewer → returns `{"error": ...}` containing `"A, B, C, D, F"`
- [x] `grade=""` from reviewer → neither `auto_redispatch_after_rejection` nor `teardown_agent_worktree` called
- [x] `grade="C"` from reviewer → existing redispatch path exercised (no regression)
- [x] `grade="A"` from reviewer → existing approved/merge path exercised (no regression)
- [x] `caller_role != "reviewer"` → guard skipped entirely
- [x] mypy passes with zero errors

Closes #653