### PR TITLE
feat: Add POST /api/control/resync-issues endpoint (fixes reviewer defects)

### DIFF
--- a/agentception/routes/api/__init__.py
+++ b/agentception/routes/api/__init__.py
@@ -27,6 +27,7 @@ from .mcp import router as _mcp
 from .pipeline import router as _pipeline
 from .plan import router as _plan
 from .presets import router as _presets
+from .resync import router as _resync
 from .telemetry import router as _telemetry
 from .wizard import router as _wizard
 from .worktrees import router as _worktrees
@@ -39,6 +40,7 @@ router.include_router(_runs)
 router.include_router(_ship_api)
 router.include_router(_pipeline)
 router.include_router(_control)
+router.include_router(_resync)
 router.include_router(_config)
 router.include_router(_health)
 router.include_router(_version)

--- a/agentception/routes/api/resync.py
+++ b/agentception/routes/api/resync.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Route: POST /api/control/resync-issues.
+
+Triggers a forced full GitHub issue sync (open + closed) without a server
+restart.  Intended for Mission Control and operator tooling.
+"""
+
+import logging
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from agentception.config import settings
+from agentception.services.resync_service import resync_all_issues
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/control", tags=["control"])
+
+
+class ResyncOkResponse(BaseModel):
+    """Successful resync response."""
+
+    ok: bool
+    open: int
+    closed: int
+    upserted: int
+
+
+class ResyncErrorResponse(BaseModel):
+    """Error resync response."""
+
+    ok: bool
+    error: str
+
+
+@router.post("/resync-issues")
+async def post_resync_issues() -> JSONResponse:
+    """Force a full open+closed issue sync from the configured GitHub repository.
+
+    Always uses ``settings.gh_repo`` — no repo parameter is accepted so there
+    is no risk of fetching from one repo while writing to another.
+
+    Returns
+    -------
+    200
+        ``ResyncOkResponse`` — counts of open, closed, and upserted issues.
+    422
+        ``ResyncErrorResponse`` — ``GH_REPO`` is not configured.
+    503
+        ``ResyncErrorResponse`` — GitHub API raised an error.
+    """
+    if not settings.gh_repo:
+        body = ResyncErrorResponse(
+            ok=False,
+            error="No repository configured. Set GH_REPO in the environment.",
+        )
+        return JSONResponse(status_code=422, content=body.model_dump())
+
+    try:
+        counts = await resync_all_issues()
+    except Exception as exc:
+        logger.exception("resync_all_issues failed: %s", exc)
+        body_err = ResyncErrorResponse(ok=False, error=str(exc))
+        return JSONResponse(status_code=503, content=body_err.model_dump())
+
+    body_ok = ResyncOkResponse(ok=True, **counts)
+    return JSONResponse(status_code=200, content=body_ok.model_dump())

--- a/agentception/services/resync_service.py
+++ b/agentception/services/resync_service.py
@@ -11,36 +11,34 @@ Typical usage::
 
     from agentception.services.resync_service import resync_all_issues
 
-    result = await resync_all_issues("owner/repo")
+    result = await resync_all_issues()
     # {"open": 42, "closed": 137, "upserted": 179}
 """
 
+import asyncio
 import logging
 
+from agentception.config import settings
 from agentception.db.persist import upsert_issues
 from agentception.readers.github import get_closed_issues, get_open_issues
 
 logger = logging.getLogger(__name__)
 
 
-async def resync_all_issues(repo: str) -> dict[str, int]:
+async def resync_all_issues() -> dict[str, int]:
     """Fetch all open and up to 1 000 closed issues, then upsert them into the DB.
 
     Fetches open issues (no label filter) and up to 1 000 recently-closed
     issues from GitHub in parallel, combines them, and passes the full list to
     :func:`~agentception.db.persist.upsert_issues`.
 
+    Always uses ``settings.gh_repo`` for both the GitHub API calls and the DB
+    upsert key — there is no repo parameter so there is no risk of fetching
+    from one repo while writing under a different key.
+
     The underlying upsert is hash-diff idempotent: rows are only written when
     content has changed, so concurrent calls with identical data produce no
     extra DB writes and raise no errors.
-
-    Parameters
-    ----------
-    repo:
-        GitHub repository slug (e.g. ``"owner/repo"``).  Passed through to
-        the DB upsert so rows are scoped to the correct repo.  The GitHub
-        reader functions derive the repo from ``settings.gh_repo``; this
-        parameter is used only for the DB write.
 
     Returns
     -------
@@ -51,7 +49,7 @@ async def resync_all_issues(repo: str) -> dict[str, int]:
         - ``closed``   — number of closed issues fetched from GitHub.
         - ``upserted`` — total rows passed to the upsert (open + closed).
     """
-    import asyncio
+    repo = settings.gh_repo
 
     open_issues, closed_issues = await asyncio.gather(
         get_open_issues(),

--- a/agentception/tests/test_resync_route.py
+++ b/agentception/tests/test_resync_route.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Tests for POST /api/control/resync-issues."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.mark.anyio
+async def test_resync_issues_returns_200_on_success() -> None:
+    """POST /api/control/resync-issues returns 200 with ok/open/closed/upserted on success."""
+    from agentception.app import app
+
+    with (
+        patch(
+            "agentception.routes.api.resync.settings",
+        ) as mock_settings,
+        patch(
+            "agentception.routes.api.resync.resync_all_issues",
+            new_callable=AsyncMock,
+            return_value={"open": 5, "closed": 3, "upserted": 8},
+        ),
+    ):
+        mock_settings.gh_repo = "owner/repo"
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post("/api/control/resync-issues")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["open"] == 5
+    assert body["closed"] == 3
+    assert body["upserted"] == 8
+
+
+@pytest.mark.anyio
+async def test_resync_issues_returns_503_on_github_error() -> None:
+    """POST /api/control/resync-issues returns 503 with ok:false and error when GitHub raises."""
+    from agentception.app import app
+
+    with (
+        patch(
+            "agentception.routes.api.resync.settings",
+        ) as mock_settings,
+        patch(
+            "agentception.routes.api.resync.resync_all_issues",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("GitHub API unavailable"),
+        ),
+    ):
+        mock_settings.gh_repo = "owner/repo"
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post("/api/control/resync-issues")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["ok"] is False
+    assert "GitHub API unavailable" in body["error"]
+
+
+@pytest.mark.anyio
+async def test_resync_issues_returns_422_when_no_repo_configured() -> None:
+    """POST /api/control/resync-issues returns 422 with a clear message when GH_REPO is not set."""
+    from agentception.app import app
+
+    with patch(
+        "agentception.routes.api.resync.settings",
+    ) as mock_settings:
+        mock_settings.gh_repo = ""
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post("/api/control/resync-issues")
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["ok"] is False
+    assert "GH_REPO" in body["error"]

--- a/agentception/tests/test_resync_service.py
+++ b/agentception/tests/test_resync_service.py
@@ -29,9 +29,14 @@ async def test_resync_all_issues_returns_counts() -> None:
             new_callable=AsyncMock,
             return_value=8,
         ),
+        patch(
+            "agentception.services.resync_service.settings",
+        ) as mock_settings,
     ):
+        mock_settings.gh_repo = "owner/repo"
+
         from agentception.services.resync_service import resync_all_issues
 
-        result = await resync_all_issues("owner/repo")
+        result = await resync_all_issues()
 
     assert result == {"open": 5, "closed": 3, "upserted": 8}

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -529,6 +529,28 @@ Legacy orchestration control endpoints. Prefer MCP tools for new integrations.
 | `POST` | `/api/control/sweep` | Sweep stale runs |
 | `POST` | `/api/control/reset-build` | Full reset: remove all worktrees, clear all agent/wip, set active runs to unknown |
 | `POST` | `/api/control/trigger-poll` | Trigger an immediate GitHub poll |
+| `POST` | `/api/control/resync-issues` | Force a full open+closed issue sync from GitHub |
+
+#### `POST /api/control/resync-issues`
+
+Forces an immediate, complete sync of all open issues and up to 1 000 recently-closed issues from the configured GitHub repository (`GH_REPO`). Useful for Mission Control and operator tooling to refresh the DB without restarting the server or waiting for the next poller tick.
+
+No request body is required. The repository is always taken from `settings.gh_repo` (`GH_REPO` env var).
+
+**Response (200 — success):**
+```json
+{"ok": true, "open": 42, "closed": 137, "upserted": 179}
+```
+
+**Response (422 — no repo configured):**
+```json
+{"ok": false, "error": "No repository configured. Set GH_REPO in the environment."}
+```
+
+**Response (503 — GitHub API error):**
+```json
+{"ok": false, "error": "<error message from GitHub>"}
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Implements `POST /api/control/resync-issues` and resolves all three defects flagged in the Attempt 1 review.

## Defects Fixed

### Defect 1 — Logic Error (repo passthrough bug)
`resync_all_issues()` no longer accepts a `repo` parameter. It always reads `settings.gh_repo` internally, so the GitHub API call and the DB upsert key are guaranteed to use the same repo. There is no way for a caller to pass a mismatched repo.

### Defect 2 — Dead Code
`ResyncOkResponse` and `ResyncErrorResponse` are now used by the route handler via `.model_dump()` instead of raw dicts. No dead code remains.

### Defect 3 — Missing 422 test
`test_resync_issues_returns_422_when_no_repo_configured` added to `test_resync_route.py`. Patches `settings.gh_repo = ""` and asserts 422 with `"GH_REPO"` in the error message.

## Files Changed

- `agentception/services/resync_service.py` — removed `repo` param, hardcoded `settings.gh_repo`
- `agentception/routes/api/resync.py` — route uses Pydantic models for all responses
- `agentception/routes/api/__init__.py` — resync router registered
- `agentception/tests/test_resync_route.py` — 3 route tests (200, 503, 422)
- `agentception/tests/test_resync_service.py` — 1 service unit test
- `docs/reference/api.md` — endpoint documented under Control section

## Test Results

```
4 passed in 0.52s
```

mypy: `Success: no issues found in 3 source files`
