### PR TITLE
feat: add Force resync button to Mission Control build page

### DIFF
--- a/agentception/routes/api/resync.py
+++ b/agentception/routes/api/resync.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 Triggers a forced full GitHub issue sync (open + closed) without a server
 restart.  Intended for Mission Control and operator tooling.
+
+When the request carries ``Accept: text/html`` (e.g. from an HTMX button),
+the endpoint returns a bare HTML fragment rendered from
+``_resync_result.html`` instead of JSON.  JSON is the default for all other
+callers (curl, API clients, tests).
 """
 
 import logging
 
-from fastapi import APIRouter
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
 from agentception.config import settings
@@ -18,6 +24,8 @@ from agentception.services.resync_service import resync_all_issues
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/control", tags=["control"])
+
+_TEMPLATES = Jinja2Templates(directory="agentception/templates")
 
 
 class ResyncOkResponse(BaseModel):
@@ -36,8 +44,18 @@ class ResyncErrorResponse(BaseModel):
     error: str
 
 
-@router.post("/resync-issues")
-async def post_resync_issues() -> JSONResponse:
+def _wants_html(request: Request) -> bool:
+    """Return True when the caller prefers an HTML fragment over JSON.
+
+    HTMX sends ``Accept: text/html, */*`` by default; plain API clients
+    send ``Accept: application/json`` or omit the header entirely.
+    """
+    accept = request.headers.get("accept", "")
+    return "text/html" in accept
+
+
+@router.post("/resync-issues", response_model=None)
+async def post_resync_issues(request: Request) -> HTMLResponse | JSONResponse:
     """Force a full open+closed issue sync from the configured GitHub repository.
 
     Always uses ``settings.gh_repo`` — no repo parameter is accepted so there
@@ -47,24 +65,50 @@ async def post_resync_issues() -> JSONResponse:
     -------
     200
         ``ResyncOkResponse`` — counts of open, closed, and upserted issues.
+        When ``Accept: text/html``, returns a bare HTML fragment instead.
     422
         ``ResyncErrorResponse`` — ``GH_REPO`` is not configured.
     503
         ``ResyncErrorResponse`` — GitHub API raised an error.
+        When ``Accept: text/html``, returns a bare HTML fragment instead.
     """
+    html_response = _wants_html(request)
+
     if not settings.gh_repo:
-        body = ResyncErrorResponse(
-            ok=False,
-            error="No repository configured. Set GH_REPO in the environment.",
-        )
+        error_msg = "No repository configured. Set GH_REPO in the environment."
+        if html_response:
+            return _TEMPLATES.TemplateResponse(
+                "_resync_result.html",
+                {"request": request, "ok": False, "error": error_msg},
+                status_code=422,
+            )
+        body = ResyncErrorResponse(ok=False, error=error_msg)
         return JSONResponse(status_code=422, content=body.model_dump())
 
     try:
         counts = await resync_all_issues()
     except Exception as exc:
         logger.exception("resync_all_issues failed: %s", exc)
-        body_err = ResyncErrorResponse(ok=False, error=str(exc))
+        error_msg = str(exc)
+        if html_response:
+            return _TEMPLATES.TemplateResponse(
+                "_resync_result.html",
+                {"request": request, "ok": False, "error": error_msg},
+                status_code=503,
+            )
+        body_err = ResyncErrorResponse(ok=False, error=error_msg)
         return JSONResponse(status_code=503, content=body_err.model_dump())
 
+    if html_response:
+        return _TEMPLATES.TemplateResponse(
+            "_resync_result.html",
+            {
+                "request": request,
+                "ok": True,
+                "open": counts["open"],
+                "closed": counts["closed"],
+                "upserted": counts["upserted"],
+            },
+        )
     body_ok = ResyncOkResponse(ok=True, **counts)
     return JSONResponse(status_code=200, content=body_ok.model_dump())

--- a/agentception/templates/_resync_result.html
+++ b/agentception/templates/_resync_result.html
@@ -1,0 +1,21 @@
+{#
+  Inline result fragment — swapped into #resync-result after
+  POST /api/control/resync-issues completes.  Returned as raw HTML
+  (Content-Type: text/html) when the request carries Accept: text/html.
+
+  Context variables:
+  - ok       bool   — True on success, False on error
+  - open     int    — count of open issues upserted (success only)
+  - closed   int    — count of closed issues upserted (success only)
+  - upserted int    — total issues written to DB (success only)
+  - error    str    — error message (failure only)
+#}
+{% if ok %}
+<span class="controls-resync-ok">
+  ✅ Synced — {{ open }} open · {{ closed }} closed · {{ upserted }} upserted
+</span>
+{% else %}
+<span class="controls-resync-error">
+  ⚠️ {{ error | e }}
+</span>
+{% endif %}

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -30,6 +30,18 @@
           Design org →
         </button>
         <span class="build-header__live" title="Board refreshes every 5 s">● LIVE</span>
+
+        {# ── Force resync ─────────────────────────────────────────────── #}
+        <button
+          class="build-header__resync-btn"
+          hx-post="/api/control/resync-issues"
+          hx-target="#resync-result"
+          hx-swap="innerHTML"
+          hx-indicator="#resync-indicator"
+          title="Force a full GitHub issue sync without restarting the server"
+        >🔃 Force resync</button>
+        <span id="resync-indicator" class="htmx-indicator" aria-hidden="true">⏳</span>
+        <div id="resync-result" class="build-header__resync-result"></div>
       </div>
     </header>
 

--- a/agentception/tests/test_build_ui.py
+++ b/agentception/tests/test_build_ui.py
@@ -1,0 +1,73 @@
+"""Tests for the Mission Control build page UI.
+
+Covers the Force resync button added to build.html (issue #649).
+
+Run targeted:
+    pytest agentception/tests/test_build_ui.py -v
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """Synchronous test client for the full app."""
+    with TestClient(app) as c:
+        return c
+
+
+def test_force_resync_button_present(client: TestClient) -> None:
+    """The build page must contain the Force resync HTMX button and its result div.
+
+    Fetches the build page and asserts that:
+    - The button carries ``hx-post="/api/control/resync-issues"``.
+    - A ``<div id="resync-result">`` exists to receive the HTMX swap.
+    """
+    with (
+        patch(
+            "agentception.routes.ui.build_ui.get_initiatives",
+            new_callable=AsyncMock,
+            return_value=["phase-1"],
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_issues_grouped_by_phase",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_runs_for_issue_numbers",
+            new_callable=AsyncMock,
+            return_value={},
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
+            new_callable=AsyncMock,
+            return_value={},
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_latest_active_batch_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_run_tree_by_batch_id",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        response = client.get("/ship/agentception/phase-1")
+
+    assert response.status_code == 200
+    html = response.text
+    assert 'hx-post="/api/control/resync-issues"' in html, (
+        "Force resync button must carry hx-post pointing to /api/control/resync-issues"
+    )
+    assert 'id="resync-result"' in html, (
+        "A div with id='resync-result' must exist to receive the HTMX swap"
+    )

--- a/docs/reference/mission-control.md
+++ b/docs/reference/mission-control.md
@@ -1,0 +1,24 @@
+# Mission Control
+
+Mission Control is the primary operator dashboard for the AgentCeption pipeline.
+It is served at `/ship/<repo>/<initiative>` and auto-refreshes the phase board
+every 5 seconds.
+
+## Controls
+
+### Force resync
+
+The **Force resync** button (🔃) in the Mission Control header triggers a full
+GitHub issue sync — fetching all open issues and up to 1 000 recently-closed
+issues from the configured repository — without restarting the server or waiting
+for the next poller tick.
+
+Use it when you have just created, labelled, or closed issues on GitHub and want
+the board to reflect those changes immediately rather than waiting for the next
+automatic poll cycle.
+
+The button POSTs to `POST /api/control/resync-issues` via HTMX and displays an
+inline confirmation (open / closed / upserted counts) or an error message
+directly below the button — no full page reload occurs.
+
+See also: [`POST /api/control/resync-issues`](api.md#post-apicontrolresync-issues).


### PR DESCRIPTION
## Summary

Adds a **Force resync** button to the Mission Control build page (`build.html`) that POSTs to `POST /api/control/resync-issues` via HTMX and displays an inline confirmation (open/closed/upserted counts or error message) without a full page reload.

## Changes

### `agentception/templates/build.html`
- Added a "Force resync" section to the `build-header__right` controls area.
- Button carries `hx-post="/api/control/resync-issues"`, `hx-target="#resync-result"`, `hx-swap="innerHTML"`, and `hx-indicator="#resync-indicator"` for a loading spinner.
- `<div id="resync-result">` placed immediately below to receive the HTMX swap.

### `agentception/routes/api/resync.py`
- Updated `POST /api/control/resync-issues` to detect `Accept: text/html` and return a Jinja2 partial (`_resync_result.html`) instead of JSON when called from HTMX.

### `agentception/templates/_resync_result.html`
- New bare HTML fragment (no `base.html` extension) rendering success counts or an error message.

### `agentception/tests/test_build_ui.py`
- New test `test_force_resync_button_present` — fetches the build page with all DB calls mocked and asserts `hx-post="/api/control/resync-issues"` and `id="resync-result"` are present in the rendered HTML.

### `docs/reference/mission-control.md`
- New reference doc describing the Mission Control page, including a note on the Force resync button.

## Acceptance criteria

- [x] "Force resync" button is visible in the Mission Control controls section.
- [x] Clicking the button POSTs to `/api/control/resync-issues`.
- [x] On success, the result div shows open/closed/upserted counts.
- [x] On failure (503), the result div shows the error message.
- [x] No full page reload occurs — swap is HTMX only.
- [x] Button is disabled / shows a loading indicator while the request is in flight (`hx-indicator`).

## Out of scope (deferred)
- Auto-refresh of the board after resync completes.
- Role-based access control on the resync endpoint.
- Audit logging of resync events.
