### PR TITLE
feat: lower poll_interval_seconds to 10 and github_cache_seconds to 5

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -108,12 +108,11 @@ class AgentCeptionSettings(BaseSettings):
     actually read.  Set via ``HOST_REPO_DIR`` in docker-compose or .env.
     """
     gh_repo: str = "cgcardona/agentception"
-    poll_interval_seconds: int = 30
+    poll_interval_seconds: int = 10
     agent_max_iterations: int = 100
-    # TTL must be strictly less than poll_interval_seconds so every poller tick
-    # sees live GitHub data.  Default: min(poll_interval_seconds / 2, 30) = 15 s.
-    # If you change POLL_INTERVAL_SECONDS, keep GITHUB_CACHE_SECONDS < that value.
-    github_cache_seconds: int = 15
+    # TTL must be strictly less than poll_interval_seconds (currently 10) so every
+    # poller tick sees live GitHub data.  Keep GITHUB_CACHE_SECONDS < POLL_INTERVAL_SECONDS.
+    github_cache_seconds: int = 5
     ac_api_key: str = ""
     """Shared secret for authenticating requests to the ``/api/*`` routes.
 

--- a/agentception/tests/test_agentception_scaffold.py
+++ b/agentception/tests/test_agentception_scaffold.py
@@ -49,8 +49,8 @@ def test_settings_loads_defaults() -> None:
     """
     s = AgentCeptionSettings()
     assert s.gh_repo == "cgcardona/agentception"
-    assert s.poll_interval_seconds == 30
-    assert s.github_cache_seconds == 60
+    assert s.poll_interval_seconds == 10
+    assert s.github_cache_seconds == 5
     assert isinstance(s.worktrees_dir, __import__("pathlib").Path)
     assert str(s.worktrees_dir) != ""
 


### PR DESCRIPTION
## Summary

Reduces worst-case new-issue visibility latency from ~45 s to ~15 s by lowering both timing defaults in `agentception/config.py`.

## Changes

- `poll_interval_seconds`: `30` → `10`
- `github_cache_seconds`: `15` → `5`
- Updated the inline invariant comment to reflect the new values: `# must be strictly less than poll_interval_seconds (currently 10)`
- Updated the assertion in `test_agentception_scaffold.py` that checked the old defaults

## Why

The HTMX board already polls the DB every 5 s, so the bottleneck was how quickly fresh GitHub data landed in the DB. The worst-case delay was `poll_interval_seconds + github_cache_seconds = 30 + 15 = 45 s`. With the new defaults it is `10 + 5 = 15 s`.

No logic changes — the poller loop and `_cache_set` already read these values dynamically at call time.

Closes #666