### PR TITLE
Remove redundant '· In Review' suffix and show body_excerpt on pr_open/reviewing Kanban cards

### DIFF
--- a/agentception/templates/_build_board.html
+++ b/agentception/templates/_build_board.html
@@ -124,7 +124,6 @@
          href="https://github.com/{{ repo }}/pull/{{ pr_num }}"
          target="_blank" rel="noopener" @click.stop>
         PR #{{ pr_num }}
-        {%- if lane == 'reviewing' %} · In Review{%- endif %}
       </a>
       {% if active_run and active_run.branch %}
       <span class="build-issue__branch">{{ active_run.branch }}</span>
@@ -132,6 +131,9 @@
     </div>
     {% endif %}
   </div>
+  {% if issue.body_excerpt %}
+  <p class="build-issue__excerpt">{{ issue.body_excerpt }}</p>
+  {% endif %}
   {% endif %}
   {# Done lane: no footer — the grayed row is the signal #}
 


### PR DESCRIPTION
## Summary

Two minimal edits to `agentception/templates/_build_board.html`:

1. **Remove `· In Review` suffix** from the PR chip in the `reviewing` lane. The column header already reads "Reviewing" — the suffix was redundant.
2. **Render `issue.body_excerpt`** after the `build-issue__footer` closing `</div>`, inside the `{% elif lane in ('pr_open', 'reviewing') %}` branch. Reuses the existing `build-issue__excerpt` CSS class. Renders nothing when `body_excerpt` is empty/None.

No Python, SCSS, JS, or other template files were modified.

Closes #668