### PR TITLE
feat: replace role pill with body_excerpt in active lane Kanban cards

### DIFF
--- a/agentception/templates/_build_board.html
+++ b/agentception/templates/_build_board.html
@@ -55,8 +55,8 @@
     <a class="build-issue__number" href="{{ issue.url }}" target="_blank" rel="noopener" @click.stop>
       #{{ issue.number }}
     </a>
-    {# Role label pill — shown in TODO and Active #}
-    {% if lane in ('todo', 'active') %}
+    {# Role label pill — shown in TODO lane only #}
+    {% if lane == 'todo' %}
     {% set lns = namespace(role_label=none) %}
     {% for lbl in issue.labels %}
       {% if lns.role_label is none and lbl != initiative and "/" not in lbl and not lbl.startswith('phase-') %}
@@ -97,7 +97,6 @@
   {% if lane == 'active' and active_run %}
   <div class="build-issue__footer">
     <div class="build-issue__run">
-      <span class="build-issue__role">{{ active_run.role | replace('-', ' ') | title }}</span>
       <span class="build-issue__status build-issue__status--{{ active_run.agent_status }}">
         {%- if active_run.agent_status == 'stale' %}⚠ stale{%- else %}{{ active_run.agent_status }}{%- endif %}
       </span>
@@ -109,6 +108,9 @@
     <div class="build-issue__progress">
       <span class="build-issue__step-count">{{ active_run.steps_completed }} steps</span>
     </div>
+    {% endif %}
+    {% if issue.body_excerpt %}
+    <p class="build-issue__excerpt">{{ issue.body_excerpt }}</p>
     {% endif %}
   </div>
 


### PR DESCRIPTION
## What

Two targeted changes to `agentception/templates/_build_board.html`, active lane only:

1. **Remove role pill from active lane** — changed the header pill condition from `lane in ('todo', 'active')` to `lane == 'todo'`. The role is already conveyed by the agent status dot color and the swimlane column heading; the pill was redundant noise.

2. **Add body_excerpt to active lane footer** — removed the `<span class="build-issue__role">` element from the active footer's `build-issue__run` div, and appended a guarded `{% if issue.body_excerpt %}<p class="build-issue__excerpt">…</p>{% endif %}` after the step count block. Uses the existing stylesheet class — no new CSS.

## Why

Active cards showed a role badge ("Developer", "Reviewer") that duplicated information already present in the column heading and status dot. Meanwhile `body_excerpt` was populated but invisible on active cards, leaving viewers with no issue description at a glance. This is a classic Don Norman signifier failure: the card communicated less than it could while repeating what was already visible elsewhere.

## Scope

- Template-only change (`_build_board.html`)
- No Python, SCSS, JS, or test modifications
- `todo`, `pr_open`, `reviewing`, and `done` lane markup is byte-for-byte identical to pre-patch state
- `IMPLEMENTING` status badge and step count elements are structurally unchanged

## Tests

`pytest agentception/tests/test_build_board_partial.py` — 23 passed ✅
