### PR TITLE
feat: lower _REVIEWER_MAX_ITERATIONS from 40 to 10

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -231,9 +231,9 @@ _REVIEWER_TOOL_ALLOWLIST: frozenset[str] = frozenset({
     "build_cancel_run",
 })
 
-# Hard cap on reviewer iterations.  A reviewer should read, decide, and act
-# in well under 40 turns.  100 (the default) allows too many re-read loops.
-_REVIEWER_MAX_ITERATIONS = 40
+# Hard cap on reviewer iterations.  With warmup pre-loading all context,
+# a reviewer grades and acts in ≤5 iterations.  10 is a generous ceiling.
+_REVIEWER_MAX_ITERATIONS = 10
 
 # When the loop guard fires, the tool palette switches to an ALLOWLIST:
 # only write tools and a minimal set of essential non-read tools remain.


### PR DESCRIPTION
## Summary

Lowers `_REVIEWER_MAX_ITERATIONS` from 40 to 10 in `agentception/services/agent_loop.py` and updates the accompanying comment to accurately document the rationale.

## Changes

- `_REVIEWER_MAX_ITERATIONS = 10` (was 40)
- Comment updated: "With warmup pre-loading all context, a reviewer grades and acts in ≤5 iterations. 10 is a generous ceiling."

## Rationale

With reviewer warmup pre-loading diff + mypy + pytest + issue context, a reviewer needs ≤5 iterations to grade and act. 40 was an unnecessarily generous ceiling that allowed runaway reviewer loops to waste compute. 10 is still 2× the expected maximum, providing headroom without enabling pathological loops.

## Test coverage

All 50 existing tests pass. No test hard-codes the value 40 for `_REVIEWER_MAX_ITERATIONS` — confirmed by green test run.

Closes #672