### PR TITLE
fix: move #resync-result div outside header in build.html

### DIFF
--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -48,9 +48,10 @@
           <polyline points="10 1 10 4 13 4"/>
         </svg></button>
         <span id="resync-indicator" class="htmx-indicator" aria-hidden="true">⏳</span>
-        <div id="resync-result" class="build-header__resync-result"></div>
       </div>
     </header>
+    {# resync-result sits outside <header> so injected content appears below the header row #}
+    <div id="resync-result" class="build-header__resync-result"></div>
 
     <!-- initiatives tab nav: must remain outside #build-board swap target -->
     <div


### PR DESCRIPTION
## What

Moves `<div id="resync-result">` from inside `<header class="build-header">` to immediately after the closing `</header>` tag, still within `.build-subnav`.

## Why

When HTMX swaps content into `#resync-result` (e.g. an error message after a failed resync), the injected content was appearing inline inside the header bar — alongside the nav controls — causing a jarring layout shift. Placing the div below the header row means any feedback renders in its own space without disturbing the header layout.

## Changes

- `agentception/templates/build.html`: removed `<div id="resync-result">` from inside `<div class="build-header__right">` and placed it immediately after `</header>` with a Jinja comment explaining the placement.
- The Force resync button's `hx-target="#resync-result"` and `hx-swap="innerHTML"` attributes are **unchanged**.
- No new CSS classes, inline styles, or JavaScript added.

## Acceptance criteria

- [x] `id="resync-result"` appears exactly once in `build.html`
- [x] The div is NOT a descendant of any `<header>` element
- [x] `hx-target="#resync-result"` on the Force resync button is unchanged
- [x] Header bar layout unaffected when result div is empty
- [x] `test_force_resync_button_present` passes ✅
