### PR TITLE
feat: add FileEditEvent Pydantic model to agentception/models

### DIFF
--- a/agentception/models/__init__.py
+++ b/agentception/models/__init__.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -1275,3 +1275,23 @@ class ExecutionPlan(BaseModel):
         if not v:
             raise ValueError("ExecutionPlan must contain at least one operation")
         return v
+
+
+class FileEditEvent(BaseModel):
+    """A single file-edit event carrying a unified diff for inspector-panel rendering.
+
+    Immutable by design — once emitted, the diff payload must not change.
+    ``lines_omitted`` is 0 when the diff fits within 120 visible lines; it
+    carries the count of hidden lines when the diff is truncated so the UI
+    can surface a "N lines omitted" notice without re-computing the diff.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    timestamp: datetime.datetime
+    path: str
+    """Relative path in the worktree, e.g. ``agentception/models/__init__.py``."""
+    diff: str
+    """Unified diff string, at most 120 visible lines."""
+    lines_omitted: int = 0
+    """Count of hidden lines when the diff exceeds 120 visible lines; 0 otherwise."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Tests for FileEditEvent and other domain models in agentception.models."""
+
+import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from agentception.models import FileEditEvent
+
+
+def _make_event(**overrides: object) -> FileEditEvent:
+    defaults: dict[str, object] = {
+        "timestamp": datetime.datetime(2024, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc),
+        "path": "agentception/models/__init__.py",
+        "diff": "@@ -1,3 +1,4 @@\n+from __future__ import annotations\n context\n",
+        "lines_omitted": 0,
+    }
+    defaults.update(overrides)
+    return FileEditEvent(**defaults)
+
+
+def test_file_edit_event_fields() -> None:
+    """FileEditEvent instantiates correctly with all four fields present."""
+    ts = datetime.datetime(2024, 6, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    event = FileEditEvent(
+        timestamp=ts,
+        path="agentception/config.py",
+        diff="--- a/agentception/config.py\n+++ b/agentception/config.py\n@@ -1 +1 @@\n-old\n+new\n",
+        lines_omitted=5,
+    )
+
+    assert event.timestamp == ts
+    assert event.path == "agentception/config.py"
+    assert "old" in event.diff
+    assert event.lines_omitted == 5
+
+
+def test_file_edit_event_lines_omitted_defaults_to_zero() -> None:
+    """lines_omitted defaults to 0 when not supplied."""
+    event = FileEditEvent(
+        timestamp=datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+        path="agentception/app.py",
+        diff="--- a\n+++ b\n@@ -1 +1 @@\n-x\n+y\n",
+    )
+    assert event.lines_omitted == 0
+
+
+def test_file_edit_event_frozen_raises_on_mutation() -> None:
+    """Mutating a frozen FileEditEvent raises TypeError (Pydantic frozen model)."""
+    event = _make_event()
+    with pytest.raises((ValidationError, TypeError)):
+        event.path = "other/path.py"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Adds `FileEditEvent` — a frozen Pydantic v2 model that carries the four fields needed by the inspector panel to render per-file diffs from agent tool calls.

## Changes

### `agentception/models/__init__.py`
- Added `FileEditEvent(BaseModel)` with:
  - `timestamp: datetime` — when the edit occurred
  - `path: str` — relative path in the worktree
  - `diff: str` — unified diff string (≤ 120 visible lines)
  - `lines_omitted: int = 0` — count of hidden lines when diff is truncated
  - `model_config = ConfigDict(frozen=True)` — instances are immutable

### `tests/test_models.py` (new file)
- `test_file_edit_event_fields` — happy-path instantiation with all four fields
- `test_file_edit_event_lines_omitted_defaults_to_zero` — default value check
- `test_file_edit_event_frozen_raises_on_mutation` — immutability contract

## Acceptance criteria

- [x] `FileEditEvent` is importable from `agentception.models`
- [x] All four fields present; only `lines_omitted` has a default (`0`)
- [x] `mypy --follow-imports=silent` passes with zero errors
- [x] `pytest tests/test_models.py` exits 0 (3/3 passed)

## Out of scope

WorkingMemory changes, SSE emission, and diff computation are handled in subsequent issues.
