### PR TITLE
feat: forward file_edit SSE events via log_file_edit_event (issue #682)

### DIFF
--- a/agentception/mcp/log_tools.py
+++ b/agentception/mcp/log_tools.py
@@ -13,6 +13,7 @@ Event type catalogue
 ``decision``    — agent made a significant architectural choice
 ``message``     — free-form informational note
 ``error``       — unrecoverable failure or crash (semantic; use before cancelling)
+``file_edit``   — a file-mutating tool call completed successfully
 
 Rules
 -----
@@ -24,6 +25,7 @@ Rules
 import logging
 
 from agentception.db.persist import persist_agent_event, persist_run_heartbeat
+from agentception.models import FileEditEvent
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +55,31 @@ async def log_run_step(
     )
     logger.info("✅ log_run_step: issue=%d step=%r", issue_number, step_name)
     return {"ok": True, "event": "step_start"}
+
+
+async def log_file_edit_event(
+    issue_number: int,
+    event: FileEditEvent,
+    agent_run_id: str | None = None,
+) -> None:
+    """Persist a file_edit agent event so the inspector SSE stream picks it up.
+
+    The payload is the FileEditEvent serialised to a dict.  The SSE generator
+    in build_ui.py forwards all event_types generically, so no change there
+    is required.
+    """
+    await persist_agent_event(
+        issue_number=issue_number,
+        event_type="file_edit",
+        payload=event.model_dump(),
+        agent_run_id=agent_run_id,
+    )
+    logger.info(
+        "✅ log_file_edit_event: issue=%d path=%r lines_omitted=%d",
+        issue_number,
+        event.path,
+        event.lines_omitted,
+    )
 
 
 async def log_run_blocker(

--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -373,6 +373,7 @@ async def _inspector_sse(run_id: str) -> AsyncGenerator[str, None]:
                     "recorded_at": ev["recorded_at"],
                 }
             )
+            # Supported event_types: step_start, done, file_edit, build_complete_run, orphan_failed
             yield f"data: {payload}\n\n"
 
         thoughts = await get_agent_thoughts_tail(

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -40,7 +40,7 @@ from agentception.db.models import ACAgentRun
 from agentception.db.queries import get_run_by_id
 from agentception.db.persist import accumulate_token_usage, persist_agent_messages_async
 from agentception.mcp.build_commands import build_cancel_run, build_complete_run
-from agentception.mcp.log_tools import log_run_error, log_run_step
+from agentception.mcp.log_tools import log_run_error, log_run_step, log_file_edit_event
 from agentception.workflow.status import is_terminal
 from agentception.mcp.prompts import get_prompt
 from agentception.mcp.server import TOOLS, call_tool_async
@@ -378,7 +378,6 @@ async def run_agent_loop(
     run_id: str,
     *,
     max_iterations: int = _DEFAULT_MAX_ITERATIONS,
-    file_edit_queue: asyncio.Queue[FileEditEvent] | None = None,
 ) -> None:
     """Run the full agent conversation loop for *run_id*.
 
@@ -389,9 +388,6 @@ async def run_agent_loop(
     Args:
         run_id: The run identifier, used to locate the worktree and task file.
         max_iterations: Upper bound on LLM turns (prevents runaway loops).
-        file_edit_queue: Optional queue that receives a :class:`FileEditEvent`
-            after each successful file-mutating tool call.  ``None`` (the
-            default) disables SSE emission so existing callers are unaffected.
     """
     worktree_path = settings.worktrees_dir / run_id
 
@@ -735,42 +731,42 @@ async def run_agent_loop(
                 except (json.JSONDecodeError, AttributeError):
                     pass
 
-            # Emit file_edit SSE events for every file-mutating tool call that
-            # succeeded this iteration. Payload is the FileEditEvent appended by
-            # _auto_track_file_write — one event per file write, in order.
-            # file_edit_queue is None during unit tests that don't wire up SSE.
-            if file_edit_queue is not None:
-                mem = read_memory(worktree_path)
-                written_events: list[FileEditEvent] = (
-                    list(mem.get("files_written", [])) if mem else []
-                )
-                for tc in response["tool_calls"]:
-                    if tc["function"]["name"] not in _FILE_MUTATING_TOOL_NAMES:
-                        continue
-                    try:
-                        feq_args: dict[str, object] = json.loads(tc["function"]["arguments"])
-                        path_raw = str(
-                            feq_args.get("path", feq_args.get("file_path", ""))
-                        ).strip()
-                    except (json.JSONDecodeError, AttributeError):
-                        path_raw = ""
-                    if not path_raw:
-                        continue
-                    # Find the most recent FileEditEvent for this path.
-                    matching = [
-                        e for e in written_events
-                        if isinstance(e, FileEditEvent) and e.path == path_raw
-                    ]
-                    if matching:
-                        await file_edit_queue.put(matching[-1])
+            # Emit file_edit events to the DB so the inspector SSE stream picks
+            # them up. One event per file write, in tool-call order.
+            # event_type: "file_edit" | payload: FileEditEvent.model_dump()
+            mem = read_memory(worktree_path)
+            raw_written: object = mem.get("files_written", []) if mem else []
+            written_events: list[FileEditEvent] = (
+                [e for e in raw_written if isinstance(e, FileEditEvent)]
+                if isinstance(raw_written, list) else []
+            )
+            for tc in response["tool_calls"]:
+                if tc["function"]["name"] not in _FILE_MUTATING_TOOL_NAMES:
+                    continue
+                try:
+                    tc_args: dict[str, object] = json.loads(tc["function"]["arguments"])
+                    path_raw = str(
+                        tc_args.get("path", tc_args.get("file_path", ""))
+                    ).strip()
+                except (json.JSONDecodeError, AttributeError):
+                    path_raw = ""
+                if not path_raw:
+                    continue
+                matching = [e for e in written_events if e.path == path_raw]
+                if matching:
+                    await log_file_edit_event(
+                        issue_number,
+                        matching[-1],
+                        agent_run_id=run_id,
+                    )
 
             # Accumulate search queries for symbol-absence detection.
             for tc in response["tool_calls"]:
                 if tc["function"]["name"] not in _SEARCH_TOOL_NAMES:
                     continue
                 try:
-                    tc_args: dict[str, object] = json.loads(tc["function"]["arguments"])
-                    raw_query = tc_args.get("query", tc_args.get("pattern", ""))
+                    search_args: dict[str, object] = json.loads(tc["function"]["arguments"])
+                    raw_query = search_args.get("query", search_args.get("pattern", ""))
                     query_str = str(raw_query).strip()[:100]
                     if query_str:
                         search_query_counts[query_str] = (

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -2163,17 +2163,15 @@ class TestStopReasonLengthRecovery:
 
 
 class TestFileEditQueue:
-    """run_agent_loop emits FileEditEvent items on file_edit_queue after writes.
+    """run_agent_loop calls log_file_edit_event after file-mutating tool calls.
 
-    The queue is optional (defaults to None) so all existing callers are
-    unaffected.  When supplied, one event is put per successful file-mutating
-    tool call whose path matches a FileEditEvent in working memory.
+    File edit events are written directly to the DB via log_file_edit_event
+    so the inspector SSE stream picks them up generically.  No queue is involved.
     """
 
     @pytest.mark.anyio
-    async def test_file_edit_queue_receives_event(self, tmp_path: Path) -> None:
-        """A replace_in_file call puts a FileEditEvent on the queue."""
-        import asyncio
+    async def test_file_edit_event_logged_after_write(self, tmp_path: Path) -> None:
+        """A replace_in_file call triggers log_file_edit_event with the matching event."""
         import datetime
 
         from agentception.models import FileEditEvent
@@ -2202,8 +2200,6 @@ class TestFileEditQueue:
 
         fake_memory = {"files_written": [fake_event]}
 
-        queue: asyncio.Queue[FileEditEvent] = asyncio.Queue()
-
         with (
             patch("agentception.services.agent_loop.settings") as mock_settings,
             patch(
@@ -2232,6 +2228,10 @@ class TestFileEditQueue:
                 return_value={"ok": True},
             ),
             patch(
+                "agentception.services.agent_loop.log_file_edit_event",
+                new_callable=AsyncMock,
+            ) as mock_log_edit,
+            patch(
                 "agentception.services.agent_loop.GitHubMCPClient",
                 return_value=_mock_github_client(),
             ),
@@ -2253,17 +2253,15 @@ class TestFileEditQueue:
             mock_settings.repo_dir = tmp_path
             mock_settings.ac_min_turn_delay_secs = 0.0
 
-            await run_agent_loop("run-feq-write", file_edit_queue=queue)
+            await run_agent_loop("run-feq-write")
 
-        assert not queue.empty(), "Expected one FileEditEvent on the queue"
-        event = queue.get_nowait()
-        assert isinstance(event, FileEditEvent)
-        assert event.path == written_path
+        mock_log_edit.assert_awaited_once()
+        call_args = mock_log_edit.call_args
+        assert call_args.args[1].path == written_path
 
     @pytest.mark.anyio
-    async def test_file_edit_queue_not_emitted_for_read(self, tmp_path: Path) -> None:
-        """A read_file call does NOT put anything on the queue."""
-        import asyncio
+    async def test_file_edit_event_not_logged_for_read(self, tmp_path: Path) -> None:
+        """A read_file call does NOT trigger log_file_edit_event."""
         import datetime
 
         from agentception.models import FileEditEvent
@@ -2287,8 +2285,6 @@ class TestFileEditQueue:
 
         fake_memory = {"files_written": [fake_event]}
 
-        queue: asyncio.Queue[FileEditEvent] = asyncio.Queue()
-
         with (
             patch("agentception.services.agent_loop.settings") as mock_settings,
             patch(
@@ -2317,6 +2313,10 @@ class TestFileEditQueue:
                 return_value={"ok": True},
             ),
             patch(
+                "agentception.services.agent_loop.log_file_edit_event",
+                new_callable=AsyncMock,
+            ) as mock_log_edit,
+            patch(
                 "agentception.services.agent_loop.GitHubMCPClient",
                 return_value=_mock_github_client(),
             ),
@@ -2338,7 +2338,7 @@ class TestFileEditQueue:
             mock_settings.repo_dir = tmp_path
             mock_settings.ac_min_turn_delay_secs = 0.0
 
-            await run_agent_loop("run-feq-read", file_edit_queue=queue)
+            await run_agent_loop("run-feq-read")
 
-        assert queue.empty(), "Queue must be empty — read_file is not a file-mutating tool"
+        mock_log_edit.assert_not_awaited()
 

--- a/agentception/tests/test_log_tools.py
+++ b/agentception/tests/test_log_tools.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Tests for agentception/mcp/log_tools.py — specifically log_file_edit_event."""
+
+import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentception.models import FileEditEvent
+
+
+@pytest.mark.anyio
+async def test_log_file_edit_event_persists_row() -> None:
+    """log_file_edit_event calls persist_agent_event with event_type='file_edit'
+    and a payload containing the expected FileEditEvent fields."""
+    event = FileEditEvent(
+        timestamp=datetime.datetime(2024, 1, 1, 12, 0, 0),
+        path="agentception/mcp/log_tools.py",
+        diff="--- a/log_tools.py\n+++ b/log_tools.py\n@@ -1 +1 @@\n-old\n+new",
+        lines_omitted=0,
+    )
+
+    with patch(
+        "agentception.mcp.log_tools.persist_agent_event",
+        new_callable=AsyncMock,
+    ) as mock_persist:
+        from agentception.mcp.log_tools import log_file_edit_event
+
+        await log_file_edit_event(42, event, agent_run_id="issue-42")
+
+    mock_persist.assert_awaited_once()
+    call_kwargs = mock_persist.call_args.kwargs
+    assert call_kwargs["issue_number"] == 42
+    assert call_kwargs["event_type"] == "file_edit"
+    assert call_kwargs["agent_run_id"] == "issue-42"
+
+    payload = call_kwargs["payload"]
+    assert "path" in payload
+    assert "diff" in payload
+    assert "lines_omitted" in payload
+    assert "timestamp" in payload
+    assert payload["path"] == "agentception/mcp/log_tools.py"
+    assert payload["lines_omitted"] == 0


### PR DESCRIPTION
## Summary

Implements issue #682: forward `file_edit` events to the browser inspector SSE stream by persisting them to `ac_agent_events` via a new `log_file_edit_event` helper.

## Changes

### `agentception/mcp/log_tools.py`
- Added `log_file_edit_event(issue_number, event, agent_run_id)` — persists a `file_edit` row to `ac_agent_events` with `payload = event.model_dump()`.
- Added `from agentception.models import FileEditEvent` import.

### `agentception/services/agent_loop.py`
- Removed `file_edit_queue` parameter from `run_agent_loop` — no longer needed.
- Replaced the `if file_edit_queue is not None:` block with a direct `await log_file_edit_event(...)` call after each successful file-mutating tool call.
- Updated import: `from agentception.mcp.log_tools import log_run_error, log_run_step, log_file_edit_event`.
- Renamed `tc_args` → `search_args` in the search-query accumulation loop to avoid the `no-redef` mypy error (two `tc_args` declarations in the same scope).

### `agentception/routes/ui/build_ui.py`
- Added a one-line comment above the `yield f"data: ..."` line in `_inspector_sse` listing the known event types: `step_start, done, file_edit, build_complete_run, orphan_failed`. No functional change — the generator already forwards all event types generically.

### `agentception/tests/test_log_tools.py` (new file)
- `test_log_file_edit_event_persists_row`: mocks `persist_agent_event`, calls `log_file_edit_event`, asserts it was called with `event_type="file_edit"` and payload containing `path`, `diff`, `lines_omitted`, `timestamp`.

### `agentception/tests/test_agent_loop.py`
- Updated `TestFileEditQueue` tests to remove the `file_edit_queue` parameter and instead mock `log_file_edit_event` directly.

## Design decision

The `file_edit_queue` approach required the caller to wire up an `asyncio.Queue` and a separate consumer task. Replacing it with a direct DB write via `log_file_edit_event` is simpler: the inspector SSE generator already polls `ac_agent_events` every 2 s and forwards all event types generically — no changes to `build_ui.py` were needed beyond the documentation comment.

## Test results

All 53 tests pass. mypy reports zero errors on the 5 modified files.