### PR TITLE
feat: add file_edit_card.ts with buildFileEditCard and Vitest tests (#713)

### DIFF
--- a/agentception/static/js/__tests__/file_edit_card.test.ts
+++ b/agentception/static/js/__tests__/file_edit_card.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { buildFileEditCard } from '../file_edit_card';
+
+const base = { path: 'foo.py', diff: '', lines_omitted: 0, timestamp: '' };
+
+describe('buildFileEditCard', () => {
+  it('renders diff-add class for + lines', () => {
+    const card = buildFileEditCard({ ...base, diff: '+foo\n' });
+    const spans = card.querySelectorAll('.diff-add');
+    expect(spans.length).toBe(1);
+    expect(spans[0].textContent).toContain('+foo');
+  });
+
+  it('renders diff-remove class for - lines', () => {
+    const card = buildFileEditCard({ ...base, diff: '-bar\n' });
+    expect(card.querySelectorAll('.diff-remove').length).toBe(1);
+  });
+
+  it('starts collapsed', () => {
+    const card = buildFileEditCard(base);
+    expect(card.classList.contains('collapsed')).toBe(true);
+  });
+
+  it('toggles collapsed on header click', () => {
+    const card = buildFileEditCard(base);
+    const header = card.querySelector('.file-edit-card__header') as HTMLElement;
+    header.click();
+    expect(card.classList.contains('collapsed')).toBe(false);
+  });
+
+  it('shows omitted lines message when lines_omitted > 0', () => {
+    const card = buildFileEditCard({ ...base, lines_omitted: 5 });
+    const msg = card.querySelector('.diff-omitted');
+    expect(msg?.textContent).toContain('5 more lines');
+  });
+});

--- a/agentception/static/js/file_edit_card.ts
+++ b/agentception/static/js/file_edit_card.ts
@@ -1,0 +1,65 @@
+export interface FileEditEventPayload {
+  path: string;
+  diff: string;
+  lines_omitted: number;
+  timestamp: string;
+}
+
+/** Build and return a collapsed diff card DOM node. Does NOT append to the DOM. */
+export function buildFileEditCard(payload: FileEditEventPayload): HTMLElement {
+  const card = document.createElement('div');
+  card.className = 'file-edit-card collapsed';
+
+  const header = document.createElement('div');
+  header.className = 'file-edit-card__header';
+  const pathEl = document.createElement('span');
+  pathEl.className = 'file-edit-card__path';
+  pathEl.textContent = payload.path;
+  header.appendChild(pathEl);
+  header.addEventListener('click', () => card.classList.toggle('collapsed'));
+  card.appendChild(header);
+
+  const pre = document.createElement('pre');
+  const code = document.createElement('code');
+  for (const line of payload.diff.split('\n')) {
+    const span = document.createElement('span');
+    span.textContent = line + '\n';
+    if (line.startsWith('+')) span.className = 'diff-add';
+    else if (line.startsWith('-')) span.className = 'diff-remove';
+    else if (line.startsWith('@@')) span.className = 'diff-hunk';
+    code.appendChild(span);
+  }
+  pre.appendChild(code);
+  card.appendChild(pre);
+
+  if (payload.lines_omitted > 0) {
+    const omit = document.createElement('p');
+    omit.className = 'diff-omitted';
+    omit.textContent = `… ${payload.lines_omitted} more lines not shown`;
+    card.appendChild(omit);
+  }
+
+  return card;
+}
+
+/**
+ * Register a handler on `source` that appends FileEditCards to `#activity-feed`.
+ * The `#activity-feed` element must exist in the DOM before this is called.
+ * Events arrive as `{t:"event", event_type:"file_edit", payload: FileEditEventPayload}`
+ * via `onmessage` — there are no named SSE event types.
+ */
+export function attachFileEditHandler(source: EventSource): void {
+  source.addEventListener('message', (e: MessageEvent<string>) => {
+    let msg: { t: string; event_type?: string; payload?: FileEditEventPayload };
+    try {
+      msg = JSON.parse(e.data) as typeof msg;
+    } catch {
+      return;
+    }
+    if (msg.t !== 'event' || msg.event_type !== 'file_edit' || !msg.payload) return;
+    const feed = document.getElementById('activity-feed');
+    if (!feed) return;
+    feed.appendChild(buildFileEditCard(msg.payload));
+    feed.scrollTop = feed.scrollHeight;
+  });
+}


### PR DESCRIPTION
## Summary

Implements Part 1 of #684 (decomposed as #713).

Creates two new files:

### `agentception/static/js/file_edit_card.ts`

Pure TypeScript module with two exports:

- **`buildFileEditCard(payload: FileEditEventPayload): HTMLElement`** — builds a collapsed diff card DOM node without appending it to the DOM. Uses only `document.createElement` — no `innerHTML` anywhere.
- **`attachFileEditHandler(source: EventSource): void`** — registers a `message` listener on an `EventSource` that appends `FileEditCard` nodes to `#activity-feed` when `file_edit` events arrive.

### `agentception/static/js/__tests__/file_edit_card.test.ts`

Five Vitest unit tests covering:
1. `diff-add` class applied to `+` lines
2. `diff-remove` class applied to `-` lines
3. Card starts in `collapsed` state
4. Header click toggles `collapsed`
5. Omitted-lines message shown when `lines_omitted > 0`

## What was deferred

- SCSS styling (tracked in #684-B)
- Wiring into `build.ts` and `build.html` (tracked in #684-C)
- `npm run type-check` and `npm test` could not be run in this container (Node.js not installed); these gates run in CI.
