### PR TITLE
feat: install Node.js 22.x in Dockerfile for npm toolchain support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get update && apt-get install -y gh \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install Node.js 22.x — enables npm run type-check / npm test / npm run build:js
+# inside the container. node_modules arrive via the ./:/app bind mount at runtime.
+ARG NODE_VERSION=22
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && node --version \
+    && npm --version
+
 # Install the GitHub askpass helper and configure system-wide git auth.
 #
 # Git's git-receive-pack (push) and git-upload-pack (fetch/clone) endpoints


### PR DESCRIPTION
## Summary

Adds a Node.js 22.x installation block to the `Dockerfile` so that `npm run type-check`, `npm test`, and `npm run build:js` can be executed via `docker compose exec agentception npm run <command>`.

## Changes

- `Dockerfile`: inserted Node.js 22.x install block immediately after the existing `apt-get clean` line in the main apt block, before the GitHub askpass block.

## Implementation notes

- Uses the official nodesource setup script (`setup_22.x`) — the canonical, distro-agnostic install path for Debian-based images.
- `NODE_VERSION=22` is an `ARG` so it can be overridden at build time without touching the Dockerfile.
- Does **not** run `npm install` during build — `node_modules` arrives via the `./:/app` bind mount at runtime.
- No other lines in the Dockerfile are modified.

## Verification

```bash
docker compose build agentception
docker compose exec agentception node --version   # → v22.x.x
docker compose exec agentception npm --version    # → version string
docker compose exec agentception npm run type-check
docker compose exec agentception npm test
```

Closes #718