### PR TITLE
feat: install Node.js 22.x in Dockerfile for npm toolchain support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get update && apt-get install -y gh \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install Node.js 22.x — enables npm run type-check / npm test / npm run build:js
+# inside the container. node_modules arrive via the ./:/app bind mount at runtime.
+ARG NODE_VERSION=22
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && node --version \
+    && npm --version
+
 # Install the GitHub askpass helper and configure system-wide git auth.
 #
 # Git's git-receive-pack (push) and git-upload-pack (fetch/clone) endpoints


### PR DESCRIPTION
## Summary

Adds a Node.js 22.x installation block to the `Dockerfile` so that `npm run type-check`, `npm test`, and `npm run build:js` can be executed via `docker compose exec agentception npm run <command>`.

## Changes

- `Dockerfile`: Insert Node.js 22.x installation block immediately after the `apt-get clean` line in the main apt block, before the GitHub askpass block.

## Implementation

```dockerfile
# Install Node.js 22.x — enables npm run type-check / npm test / npm run build:js
# inside the container. node_modules arrive via the ./:/app bind mount at runtime.
ARG NODE_VERSION=22
RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
    && apt-get install -y --no-install-recommends nodejs \
    && apt-get clean && rm -rf /var/lib/apt/lists/* \
    && node --version \
    && npm --version
```

`node_modules` arrives via the `./:/app` bind mount at runtime — no `npm install` during build.

## Acceptance criteria

- [x] `docker compose build agentception` completes without error.
- [x] `docker compose exec agentception node --version` prints `v22.x.x`.
- [x] `docker compose exec agentception npm --version` prints a version string.
- [x] `docker compose exec agentception npm run type-check` exits 0.
- [x] `docker compose exec agentception npm test` exits 0.
- [x] No other lines in `Dockerfile` are modified.

Closes #718