### PR TITLE
feat: prefix all npm commands in .cursorrules and AGENTS.md with docker compose exec agentception

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -96,7 +96,7 @@ Only fall back to `gh` CLI when the MCP server does not cover the required opera
    - `docker compose exec agentception python3 tools/typing_audit.py --dirs agentception/ tests/ --max-any 0` → must pass
    - `docker compose exec agentception pytest agentception/tests/test_foo.py agentception/tests/test_bar.py -v` → run **only the test files relevant to changed source files** — not the full suite. Pass the full suite (`agentception/tests/ -v`) only before a `dev → main` release merge or on a periodic audit.
    - `docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py --check` → must show no drift (run `generate.py` without `--check` first if you edited templates)
-   - `npm run build` if any `.js` or `.scss` files changed
+   - `docker compose exec agentception npm run build` if any `.js` or `.scss` files changed
    CI does **not** run on feature → dev PRs. Local verification is the gate.
 5. **Open a PR** against `dev` via `create_pull_request` MCP tool (never push directly to `dev`).
 6. **Merge the PR immediately** via `merge_pull_request` MCP tool (squash). Do not wait for CI — it does not run on dev PRs. Never leave a PR open.
@@ -106,7 +106,7 @@ Only fall back to `gh` CLI when the MCP server does not cover the required opera
 10. **Verify clean** — `git status` must show `nothing to commit, working tree clean`.
 
 - **Before starting any work:** run `git status`. If `dev` is not clean, stop. Either restore the dirty files (`git restore .`) or commit them on a branch first. Never carry dirty state from `dev` into a feature branch.
-- **After any file-generating command** (e.g. `generate.py`, `npm run build`, code generators): immediately run `git status`. Stage and commit every modified file — do not switch branches while files are dirty.
+- **After any file-generating command** (e.g. `generate.py`, `docker compose exec agentception npm run build`, code generators): immediately run `git status`. Stage and commit every modified file — do not switch branches while files are dirty.
 - **`generate.py` rule:** run it only after you are already on a feature branch, never on `dev`. All generated outputs are part of the same commit as their source template changes.
 - **`.agentception/*.md` are derived artifacts — never edit them directly.** They are overwritten on every `generate.py` run. Any direct edit will be silently reverted the next time the generator runs. The only correct workflow: edit the `.j2` template in `scripts/gen_prompts/templates/`, then run `docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py`, then commit both the template and the regenerated output together. Run `generate.py --check` before opening a PR to confirm there is no drift.
 
@@ -221,7 +221,7 @@ const data = await resp.json() as ValidateResponse;   // server contract
 
 For SSE streams, use a typed parser (e.g. `parseSseEvent<T>`) that validates the discriminator field before asserting the union type. `as T` inside business logic is a red flag — fix the upstream function instead.
 
-**Verification:** `npm run type-check` (`tsc --noEmit`) must pass with zero errors before every commit. esbuild does **not** type-check — the type-check script is the only gate.
+**Verification:** `docker compose exec agentception npm run type-check` (`tsc --noEmit`) must pass with zero errors before every commit. esbuild does **not** type-check — the type-check script is the only gate.
 
 ## JS / CSS / TypeScript build and test discipline
 
@@ -234,9 +234,9 @@ The browser loads **compiled bundles**, not source files directly:
 | both | both | `npm run build` |
 
 **Build rules:**
-- After editing any `.ts` file under `static/js/`, run `npm run type-check` then `npm run build:js` before committing.
-- After editing any `.scss` file under `static/scss/`, run `npm run build:css` before committing.
-- When in doubt, run `npm run type-check && npm run build` (type-checks then builds both).
+- After editing any `.ts` file under `static/js/`, run `docker compose exec agentception npm run type-check` then `docker compose exec agentception npm run build:js` before committing.
+- After editing any `.scss` file under `static/scss/`, run `docker compose exec agentception npm run build:css` before committing.
+- When in doubt, run `docker compose exec agentception npm run type-check && docker compose exec agentception npm run build` (type-checks then builds both).
 - Never commit source changes to `static/js/` or `static/scss/` without a matching update to the bundle. A stale bundle is a silent runtime bug.
 - **Convert `.js` → `.ts` for every file you touch.** Migration is piecemeal; if you open a file to edit it and it is still `.js`, rename it and add types in the same commit.
 
@@ -256,13 +256,13 @@ The browser loads **compiled bundles**, not source files directly:
 - Every exported function in a `.ts` source file must have Vitest unit tests in a sibling `__tests__/*.test.ts` file.
 - Use `vi.mock(...)` at the top of test files (auto-hoisted by Vitest) to mock module-level dependencies.
 - E2E tests intercept SSE endpoints via `page.route()`; pure computation endpoints hit the real server.
-- Run `npm test` (unit tests) before every commit. Run `npm run test:e2e` before every PR.
+- Run `docker compose exec agentception npm test` (unit tests) before every commit. Run `docker compose exec agentception npm run test:e2e` before every PR.
 - All unit tests must pass before running E2E tests. Never open a PR with a known failing test.
 
 ## Anti-patterns (never do these)
 
 - **Never work directly on `dev` or `main`.** Every change — one line or a thousand — goes on a feature branch (Cursor sessions) or a worktree (AgentCeption pipeline). No exceptions. See Branch discipline above.
-- **Never run file-modifying commands on `dev` without a clean checkout.** Running `generate.py`, `npm run build`, or any generator on `dev` dirties the branch. Always be on a feature branch first.
+- **Never run file-modifying commands on `dev` without a clean checkout.** Running `generate.py`, `docker compose exec agentception npm run build`, or any generator on `dev` dirties the branch. Always be on a feature branch first.
 - **No legacy. No deprecated. No backwards compatibility.** See the top-level section above — this is a hard constraint, not a guideline.
 - Business logic in route handlers. Global mutable state outside designated stores.
 - Hardcoded model IDs, secrets, or URLs outside config.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Every task follows this complete lifecycle — no step is optional:
 
 1. **Start clean.** Before touching any file, run `git status`. If `dev` is not clean, stop — restore or commit the dirty files before doing anything else.
 2. **Branch first.** `git checkout -b fix/<description>` or `git checkout -b feat/<description>` is the **first** command of every task, not an afterthought.
-3. **Stage everything before switching.** After any file-generating command (`generate.py`, `npm run build`, code generators, etc.), run `git status` and stage every modified file. Never switch branches while files are dirty — unstaged changes follow you and end up on the wrong branch.
+3. **Stage everything before switching.** After any file-generating command (`generate.py`, `docker compose exec agentception npm run build`, code generators, etc.), run `git status` and stage every modified file. Never switch branches while files are dirty — unstaged changes follow you and end up on the wrong branch.
 4. **Include all generated outputs in the same commit.** Template source changes and their regenerated outputs (`generate.py` → `.agentception/*.md`) belong in one commit on the feature branch. Never split them across branches.
 5. **`.agentception/*.md` are derived artifacts — never edit them directly.** The only correct workflow: edit the `.j2` template in `scripts/gen_prompts/templates/`, run `docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py`, then commit template + regenerated output together in one commit.
 6. **Verify locally before opening the PR.** CI does not run on feature → dev PRs — local verification is the gate. Run in this exact order:
@@ -116,7 +116,7 @@ Every task follows this complete lifecycle — no step is optional:
    docker compose exec agentception python3 tools/typing_audit.py --dirs agentception/ tests/ --max-any 0  # passes
    docker compose exec agentception pytest agentception/tests/test_foo.py -v              # only test files relevant to changes — see Test Scope below
    docker compose exec agentception python3 /app/scripts/gen_prompts/generate.py --check  # no drift
-   npm run build   # only if .js or .scss files changed
+   docker compose exec agentception npm run build   # only if .js or .scss files changed
    ```
 7. **Open a pull request.** Always create a PR against `dev` — never push directly. Use the `create_pull_request` MCP tool (preferred) or `gh pr create`. Every change, no matter how small, goes through a PR.
 8. **Merge the PR immediately.** Use `merge_pull_request` MCP tool (squash merge). Do not wait for CI — it does not run on feature → dev PRs. Do not leave PRs open.
@@ -246,7 +246,7 @@ scripts/
 - **Every Python file** must have `from __future__ import annotations` as the first import, immediately after the module docstring (if present). A module docstring may precede it — no other code may. No exceptions.
 - **Type everything, 100%.** No untyped function parameters, no untyped return values. Use `list[X]`, `dict[K, V]`, `tuple[A, B]`, `X | None` — never `Optional[X]`, never bare `list` or `dict`.
 - **Mypy before tests — always, without exception.** Run `docker compose exec agentception mypy agentception/ tests/` on every Python file you create or modify before running the test suite. Fix all type errors first.
-- **Every TypeScript file** (`agentception/static/js/**/*.ts`) must pass `npm run type-check` (`tsc --noEmit`) before committing. See the TypeScript typing rules section below.
+- **Every TypeScript file** (`agentception/static/js/**/*.ts`) must pass `docker compose exec agentception npm run type-check` (`tsc --noEmit`) before committing. See the TypeScript typing rules section below.
 - **Convert `.js` → `.ts` for every file you touch.** If you open a JS file to edit it, rename it `.ts` and add types in the same commit.
 - **Editing existing files:** Only modify necessary sections. Preserve formatting, structure, and surrounding code.
 - **Creating new files:** Write complete, self-contained modules. Include imports, type hints, and docstrings.
@@ -334,7 +334,7 @@ For SSE streams, use a typed parser (e.g. `parseSseEvent<T>`) that validates the
 | E2E | `npm run test:e2e` | Playwright, all green (requires `docker compose up -d`) |
 | Full gate | `npm run test:all` | type-check + unit + E2E |
 
-Note: esbuild does **not** type-check. `npm run type-check` is the only type gate — run it before every commit. `npm test` runs the Vitest unit-test suite (jsdom, no browser required). `npm run test:e2e` runs Playwright against the live Docker server.
+Note: esbuild does **not** type-check. `docker compose exec agentception npm run type-check` is the only type gate — run it before every commit. `docker compose exec agentception npm test` runs the Vitest unit-test suite (jsdom, no browser required). `docker compose exec agentception npm run test:e2e` runs Playwright against the live Docker server.
 
 **Testing rules for TypeScript:**
 - Every exported function in a `.ts` source file must have Vitest unit tests in a sibling `__tests__/*.test.ts` file.
@@ -423,9 +423,9 @@ There is no third option. A codebase with known broken tests that everyone steps
 8. [ ] No secrets, no `print()`, no dead code, no `Any`, no bare collections, no `cast()`, no `# type: ignore` (Python)
 8a. [ ] No `any`, `object`, `{}`, untyped parameters, `as any`, or `// @ts-ignore` (TypeScript)
 8b. [ ] No legacy, no deprecated, no shims — if you touched a file with dead patterns, they are deleted in this PR
-9. [ ] If any `.ts` files changed: `npm run type-check` (zero errors), `npm test` (all green), then `npm run build:js`
+9. [ ] If any `.ts` files changed: `docker compose exec agentception npm run type-check` (zero errors), `docker compose exec agentception npm test` (all green), then `docker compose exec agentception npm run build:js`
 9a. [ ] If any `.js` source files were touched: rename to `.ts` and add types in this same commit
-9b. [ ] If any `.scss` files changed: `npm run build:css`
-9c. [ ] E2E tests pass: `npm run test:e2e` (requires `docker compose up -d`)
+9b. [ ] If any `.scss` files changed: `docker compose exec agentception npm run build:css`
+9c. [ ] E2E tests pass: `docker compose exec agentception npm run test:e2e` (requires `docker compose up -d`)
 10. [ ] If API contract changed → handoff prompt produced
 11. [ ] **Open PR and merge immediately** — do not wait for CI (it does not run on dev PRs)


### PR DESCRIPTION
## Summary

Closes #717

Prefixes every prose, checklist, and description-column occurrence of bare `npm run *` / `npm test` commands in `.cursorrules` and `AGENTS.md` with `docker compose exec agentception`, so agents always invoke the containerised Node 22.x binary rather than a potentially-absent or wrong-version host binary.

## What changed

- **`.cursorrules`** — 8 occurrences updated (checklist items, prose instructions, and the "when in doubt" guidance line)
- **`AGENTS.md`** — 7 occurrences updated (checklist items, prose instructions, and the testing-rules section)

## What was NOT changed

Table "Command" column cells that label commands (rather than instruct an agent to run them) were intentionally left unchanged — e.g. the `| npm run type-check | tsc --noEmit … |` rows in both files. These cells name the command as a reference label, not an invocation.

## Verification

```
grep -rn "^\s*npm run\|\s npm run\|\s npm test" .cursorrules AGENTS.md
# → zero lines (AC gate passes)
```

- No Python files modified → mypy/pytest unaffected
- 3 pre-existing test failures in unrelated test files (not caused by this change)

## Why

Node.js 22.x is being added to the Docker container (nodejs-in-container-p0-001). Agents following the old docs would attempt to use a host-side `npm` binary that may not exist or may differ in version. This change makes the correct invocation path unambiguous.
