### PR TITLE
feat: reduce _inspector_sse poll interval from 2s to 0.5s

### DIFF
--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -349,7 +349,8 @@ async def _inspector_sse(run_id: str) -> AsyncGenerator[str, None]:
     """Yield SSE events for the inspector panel.
 
     Interleaves structured MCP events (``ac_agent_events``) and raw thinking
-    messages (``ac_agent_messages``) in near-real-time.  Polls DB every 2 s.
+    messages (``ac_agent_messages``) in near-real-time.  Polls DB every 0.5 s
+    for near-real-time thought delivery.
 
     Event shapes::
 
@@ -395,7 +396,7 @@ async def _inspector_sse(run_id: str) -> AsyncGenerator[str, None]:
         if ping_counter % 10 == 0:
             yield 'data: {"t":"ping"}\n\n'
 
-        await asyncio.sleep(2)
+        await asyncio.sleep(0.5)
 
 
 @router.get("/ship/runs/{run_id}/tree", response_class=Response, response_model=None)

--- a/agentception/tests/test_build_ui.py
+++ b/agentception/tests/test_build_ui.py
@@ -1,13 +1,15 @@
 """Tests for the Mission Control build page UI.
 
-Covers the Force resync button added to build.html (issue #649).
+Covers the Force resync button added to build.html (issue #649) and the
+inspector SSE poll interval (issue #724).
 
 Run targeted:
     pytest agentception/tests/test_build_ui.py -v
 """
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -79,4 +81,48 @@ def test_force_resync_button_present(client: TestClient) -> None:
     )
     assert "<svg" in html and 'aria-hidden="true"' in html, (
         "Force resync button must contain an inline SVG icon with aria-hidden='true'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_inspector_sse_poll_interval() -> None:
+    """_inspector_sse must call asyncio.sleep(0.5) — not 2 s — on each loop iteration.
+
+    Mocks the DB query helpers so the generator can advance one iteration
+    without a real database, then asserts the sleep value is 0.5.
+    """
+    from agentception.routes.ui.build_ui import _inspector_sse
+
+    sleep_calls: list[float] = []
+
+    class _StopLoop(Exception):
+        pass
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+        raise _StopLoop  # break after first iteration
+
+    with (
+        patch(
+            "agentception.routes.ui.build_ui.get_agent_events_tail",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_agent_thoughts_tail",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch("agentception.routes.ui.build_ui.asyncio.sleep", side_effect=fake_sleep),
+    ):
+        gen = _inspector_sse("test-run-id")
+        try:
+            async for _ in gen:
+                pass
+        except _StopLoop:
+            pass
+
+    assert sleep_calls, "asyncio.sleep was never called inside _inspector_sse"
+    assert sleep_calls[0] == 0.5, (
+        f"Expected asyncio.sleep(0.5) but got asyncio.sleep({sleep_calls[0]})"
     )


### PR DESCRIPTION
## Summary

Reduces the `asyncio.sleep` interval in `_inspector_sse` from 2 s to 0.5 s so agent chain-of-thought thoughts appear near-real-time in the inspector panel.

## Changes

- `agentception/routes/ui/build_ui.py`: `asyncio.sleep(2)` → `asyncio.sleep(0.5)` in `_inspector_sse`; docstring updated to reflect the new interval.
- `agentception/tests/test_build_ui.py`: added `test_inspector_sse_poll_interval` — mocks `asyncio.sleep` and asserts it is called with `0.5`.

## Why 0.5 s?

Agent thoughts are written to the DB at the end of each LLM streaming chunk. At 2 s polling, a thought that lands at t=0.1 s isn't visible until t=2 s. At 0.5 s the worst-case latency drops to 0.5 s, which feels near-real-time. The DB query is a lightweight tail-read (indexed by `run_id` + `seq`), so 4× the call rate has negligible load impact.

## Out of scope

ThoughtBlock frontend component, SSE message format changes, DB schema changes.

Closes #724