### PR TITLE
feat: add ThoughtBlock component with Cursor-like collapse (#725)

### DIFF
--- a/agentception/static/js/__tests__/thought_block.test.ts
+++ b/agentception/static/js/__tests__/thought_block.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { attachThoughtHandler } from "../thought_block";
+
+function makeSource(): EventSource {
+  return {
+    onmessage: null,
+    addEventListener: vi.fn(),
+  } as unknown as EventSource;
+}
+
+function dispatch(src: EventSource, data: object): void {
+  const handler = (src as unknown as { onmessage: ((e: MessageEvent<string>) => void) | null }).onmessage;
+  if (handler) handler(new MessageEvent("message", { data: JSON.stringify(data) }));
+}
+
+describe("attachThoughtHandler", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="activity-feed"></div>';
+  });
+
+  it("test_renders_thought_text", () => {
+    const src = makeSource();
+    attachThoughtHandler(src);
+    dispatch(src, { t: "thought", role: "thinking", content: "hello", recorded_at: "" });
+    const text = document.querySelector(".thought-block__body")?.textContent;
+    expect(text).toBe("hello");
+  });
+
+  it("test_thought_icon_present_after_collapse", () => {
+    const src = makeSource();
+    attachThoughtHandler(src);
+    dispatch(src, { t: "thought", role: "thinking", content: "thinking...", recorded_at: "" });
+    dispatch(src, { t: "event", event_type: "step_start", payload: { step: "Step 2" }, recorded_at: "" });
+    const icon = document.querySelector(".thought-block__icon");
+    expect(icon?.textContent).toBe("◈");
+  });
+
+  it("test_second_step_opens_new_block", () => {
+    const src = makeSource();
+    attachThoughtHandler(src);
+    dispatch(src, { t: "thought", role: "thinking", content: "block1", recorded_at: "" });
+    dispatch(src, { t: "event", event_type: "step_start", payload: { step: "Step 2" }, recorded_at: "" });
+    dispatch(src, { t: "thought", role: "thinking", content: "block2", recorded_at: "" });
+    const blocks = document.querySelectorAll(".thought-block");
+    expect(blocks.length).toBe(2);
+  });
+
+  it("test_collapsed_block_has_aria_expanded_false", () => {
+    const src = makeSource();
+    attachThoughtHandler(src);
+    dispatch(src, { t: "thought", role: "thinking", content: "x", recorded_at: "" });
+    dispatch(src, { t: "event", event_type: "step_start", payload: { step: "Step 2" }, recorded_at: "" });
+    const btn = document.querySelector(".thought-block__header");
+    expect(btn?.getAttribute("aria-expanded")).toBe("false");
+  });
+});

--- a/agentception/static/js/thought_block.ts
+++ b/agentception/static/js/thought_block.ts
@@ -1,0 +1,140 @@
+/**
+ * ThoughtBlock — renders a collapsible Cursor-style thought block in the
+ * activity feed.
+ *
+ * Listens for SSE messages on the supplied EventSource:
+ *   {t: "thought", role: "thinking", content: string, recorded_at: string}
+ *   {t: "event", event_type: "step_start", ...}
+ *   {t: "event", event_type: "done", ...}
+ *
+ * Each iteration opens a new block that streams text, then collapses
+ * to "◈ Thought for Xs ›" when the next step_start / done arrives.
+ *
+ * Appends to #activity-feed. No innerHTML usage.
+ */
+
+interface ThoughtSseMessage {
+  t: "thought";
+  role: string;
+  content: string;
+  recorded_at: string;
+}
+
+interface EventSseMessage {
+  t: "event";
+  event_type: string;
+  payload: Record<string, string>;
+  recorded_at: string;
+}
+
+type SseMessage = ThoughtSseMessage | EventSseMessage | { t: "ping" };
+
+interface ActiveBlock {
+  wrapper: HTMLElement;
+  textNode: Text;
+  startMs: number;
+  lastMs: number;
+}
+
+function buildThoughtBlock(): ActiveBlock {
+  const wrapper = document.createElement("div");
+  wrapper.className = "thought-block thought-block--open";
+  wrapper.setAttribute("role", "note");
+  wrapper.setAttribute("aria-label", "Agent thought");
+
+  const body = document.createElement("p");
+  body.className = "thought-block__body";
+  const textNode = document.createTextNode("");
+  body.appendChild(textNode);
+  wrapper.appendChild(body);
+
+  return { wrapper, textNode, startMs: Date.now(), lastMs: Date.now() };
+}
+
+function collapseBlock(block: ActiveBlock): void {
+  const durationSecs = Math.max(
+    1,
+    Math.round((block.lastMs - block.startMs) / 1000),
+  );
+
+  const header = document.createElement("button");
+  header.className = "thought-block__header";
+  header.type = "button";
+  header.setAttribute("aria-expanded", "false");
+
+  const icon = document.createElement("span");
+  icon.className = "thought-block__icon";
+  icon.setAttribute("aria-hidden", "true");
+  icon.textContent = "◈";
+
+  const label = document.createElement("span");
+  label.className = "thought-block__label";
+  label.textContent = `Thought for ${durationSecs}s`;
+
+  const chevron = document.createElement("span");
+  chevron.className = "thought-block__chevron";
+  chevron.setAttribute("aria-hidden", "true");
+  chevron.textContent = "›";
+
+  header.appendChild(icon);
+  header.appendChild(label);
+  header.appendChild(chevron);
+
+  // Toggle expand on click
+  header.addEventListener("click", () => {
+    const isExpanded = header.getAttribute("aria-expanded") === "true";
+    header.setAttribute("aria-expanded", String(!isExpanded));
+    block.wrapper.classList.toggle("thought-block--open", !isExpanded);
+  });
+
+  block.wrapper.insertBefore(header, block.wrapper.firstChild);
+  block.wrapper.classList.remove("thought-block--open");
+  block.wrapper.classList.add("thought-block--collapsed");
+  header.setAttribute("aria-expanded", "false");
+}
+
+export function attachThoughtHandler(source: EventSource): void {
+  let active: ActiveBlock | null = null;
+
+  const feed = document.getElementById("activity-feed");
+  if (!feed) return;
+
+  function closeActive(): void {
+    if (active) {
+      collapseBlock(active);
+      active = null;
+    }
+  }
+
+  source.onmessage = (evt: MessageEvent<string>) => {
+    let msg: SseMessage;
+    try {
+      msg = JSON.parse(evt.data) as SseMessage;
+    } catch {
+      return;
+    }
+
+    if (msg.t === "ping") return;
+
+    if (msg.t === "thought" && msg.role === "thinking") {
+      if (!active) {
+        active = buildThoughtBlock();
+        feed.appendChild(active.wrapper);
+      }
+      active.textNode.textContent += msg.content;
+      active.lastMs = Date.now();
+      if (typeof active.wrapper.scrollIntoView === "function") {
+        active.wrapper.scrollIntoView({ block: "end", behavior: "smooth" });
+      }
+      return;
+    }
+
+    if (msg.t === "event") {
+      if (msg.event_type === "step_start" || msg.event_type === "done") {
+        closeActive();
+      }
+    }
+  };
+
+  source.addEventListener("error", () => closeActive());
+}


### PR DESCRIPTION
## Summary

Implements `agentception/static/js/thought_block.ts` — a Cursor-style collapsible thought block component for the activity feed.

## What this does

- **`thought_block.ts`** exports a single function `attachThoughtHandler(source: EventSource)` that:
  1. Listens for `{t: "thought", role: "thinking", ...}` SSE messages and streams text into an open block appended to `#activity-feed`.
  2. When a `step_start` or `done` event arrives, collapses the block to a single header line: `◈ Thought for Xs ›`.
  3. Clicking the header toggles the block open/closed (with `aria-expanded` tracking).
  4. Each new step opens a fresh block below the collapsed one.
  5. No `innerHTML` usage — all DOM construction via `createElement`/`createTextNode`.

- **`__tests__/thought_block.test.ts`** — four Vitest tests covering:
  - `test_renders_thought_text` — thought content appears in `.thought-block__body`
  - `test_thought_icon_present_after_collapse` — `◈` icon present after `step_start`
  - `test_second_step_opens_new_block` — two blocks exist after two iterations
  - `test_collapsed_block_has_aria_expanded_false` — collapsed header has correct ARIA state

## Acceptance criteria

- [x] `agentception/static/js/thought_block.ts` exists and exports only `attachThoughtHandler`
- [x] `npm run type-check` exits 0
- [x] No `innerHTML` in the file
- [x] All four Vitest tests pass (`npm test` → 59/59)

## Out of scope (follow-on issues)

- Wiring `attachThoughtHandler` into `build.ts`
- Removing the old `build-inspector__cot` section from `build.html`
- SCSS for `.thought-block`
