### PR TITLE
feat: lower ac_min_turn_delay_secs default from 1.5 to 0.5 for Tier 4

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -146,14 +146,14 @@ class AgentCeptionSettings(BaseSettings):
     tools are unavailable in the agent loop.
     """
     ac_task_runner: TaskRunnerChoice = TaskRunnerChoice.anthropic
-    ac_min_turn_delay_secs: float = 1.5
+    ac_min_turn_delay_secs: float = 0.5
     """Minimum seconds between consecutive LLM calls in the agent loop.
 
     Proactive pacing guard that keeps token consumption under the Anthropic
-    rate limit ceiling.  Calibrated for **Tier 3** (800K input / 160K output
-    TPM, 2K RPM): 1.5 s allows up to ~3 concurrent agents at ~1 000 output
-    tokens per turn before the output-TPM cap is reached.  Lower this further
-    if running fewer concurrent agents; raise it when running many in parallel.
+    rate limit ceiling.  Calibrated for **Tier 4** (2M input / 400K output
+    TPM, 4K RPM): 0.5 s allows up to ~10 concurrent agents at ~1 000 output
+    tokens per turn before the output-TPM cap is reached.  Raise this value
+    if observing 429 rate-limit errors in the logs.
 
     Set via ``AC_MIN_TURN_DELAY_SECS`` env var.
     """

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -319,8 +319,8 @@ _HISTORY_TAIL: int = 14
 # ---------------------------------------------------------------------------
 
 # Minimum seconds between consecutive LLM calls.  A fixed cadence beats a
-# reactive burst-then-sleep TPM guard.  Calibrated for **Tier 3** (800K input /
-# 160K output TPM, 2K RPM): the default 1.5 s floor allows ~3 concurrent agents
+# reactive burst-then-sleep TPM guard.  Calibrated for **Tier 4** (2M input /
+# 400K output TPM, 4K RPM): the default 0.5 s floor allows ~10 concurrent agents
 # at ~1 000 output tokens per turn before the output-TPM cap is reached.
 # Tunable via the ``AC_MIN_TURN_DELAY_SECS`` env var (see config.py).
 _last_llm_call_at: float = 0.0

--- a/agentception/tests/test_config.py
+++ b/agentception/tests/test_config.py
@@ -388,5 +388,5 @@ def test_agent_max_iterations_default() -> None:
 
 def test_ac_min_turn_delay_secs_default() -> None:
     s = AgentCeptionSettings()
-    assert s.ac_min_turn_delay_secs == 1.5
+    assert s.ac_min_turn_delay_secs == 0.5
 


### PR DESCRIPTION
## Summary

Lowers the `ac_min_turn_delay_secs` default from `1.5` to `0.5` following the Anthropic account upgrade to Tier 4 (2M input / 400K output TPM, 4K RPM).

## Changes

- **`agentception/config.py`**: Field default changed to `0.5`; docstring updated to reference Tier 4 limits and the `AC_MIN_TURN_DELAY_SECS` env var.
- **`agentception/services/agent_loop.py`**: Calibration comment updated to reference Tier 4 and the 0.5 s floor.
- **`agentception/tests/test_config.py`**: Stale assertion `== 1.5` updated to `== 0.5`.

## Why

The previous 1.5 s floor was calibrated for Tier 3 (800K input / 160K output TPM, 2K RPM). At Tier 4 the output-TPM cap is 2.5× higher, so the floor can be reduced to 0.5 s — allowing ~10 concurrent agents at ~1 000 output tokens per turn before hitting the cap.

Closes #722