### PR TITLE
feat: increase call_anthropic_with_tools default max_tokens to 32000 (Tier 4)

### DIFF
--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -530,7 +530,7 @@ async def call_anthropic_with_tools(
     tools: list[ToolDefinition],
     model: str = _MODEL,
     temperature: float = 0.0,
-    max_tokens: int = 16384,
+    max_tokens: int = 32000,
     extra_system_blocks: list[dict[str, object]] | None = None,
 ) -> ToolResponse:
     """Call Claude via the Anthropic API with tool-use support.
@@ -551,7 +551,8 @@ async def call_anthropic_with_tools(
         tools: OpenAI-format tool definitions the model may call.
         model: Anthropic model ID.
         temperature: Sampling temperature.  Defaults to 0 for determinism.
-        max_tokens: Maximum tokens the model may emit per turn.
+        max_tokens: Maximum tokens the model may emit per turn.  32 000 is safe
+            at Tier 4 (400K output TPM) with up to 10 concurrent agents.
         extra_system_blocks: Additional Anthropic content blocks appended
             after the cached system prompt block.  Used to inject dynamic
             context (e.g. working memory) without invalidating the cache.


### PR DESCRIPTION
## Summary

Increases the default `max_tokens` in `call_anthropic_with_tools` from `16384` to `32000`.

## Changes

- `agentception/services/llm.py`: `max_tokens: int = 32000` in the signature
- Updated docstring to document the Tier 4 rationale: 400K output TPM ÷ 10 concurrent agents = 40K headroom per agent; 32K is a safe ceiling

## Rationale

At Tier 4 (400K output tokens/minute), 10 concurrent agents each producing 32K tokens/turn consumes exactly 320K TPM — well within the limit. The old 16K ceiling caused `stop_reason: "length"` mid-response on large diffs, long test files, and detailed reasoning chains.

## Test coverage

No `16384` references existed in `test_agent_loop.py` or `test_llm.py`. All 79 existing tests pass unchanged.

Closes #723