### PR TITLE
feat: wire #activity-feed mount point and remove stale CoT block (issue #737)

### DIFF
--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -194,6 +194,7 @@
           </template>
 
           {# structured events timeline #}
+          <div id="activity-feed" class="build-inspector__activity" role="log" aria-live="polite" aria-label="Agent activity"></div>
           <div class="build-inspector__timeline" x-show="events.length > 0">
             <h4 class="build-inspector__section-label">Timeline</h4>
             <ul class="build-timeline">
@@ -209,18 +210,6 @@
                 </li>
               </template>
             </ul>
-          </div>
-
-          {# raw chain-of-thought #}
-          <div class="build-inspector__cot" x-show="thoughts.length > 0">
-            <h4 class="build-inspector__section-label">Chain of thought</h4>
-            <div class="build-cot" x-ref="cotScroll">
-              <template x-for="(t, idx) in thoughts" :key="idx">
-                <p class="build-cot__entry"
-                   :class="'build-cot__entry--' + t.role"
-                   x-text="t.content"></p>
-              </template>
-            </div>
           </div>
 
           <template x-if="activeIssue.run && ['implementing','reviewing','stale','pending_launch'].includes(activeIssue.run.agent_status) && !streamOpen">


### PR DESCRIPTION
## What

Two surgical edits to `agentception/templates/build.html`:

1. **Insert `#activity-feed` mount point** — a `<div id="activity-feed" class="build-inspector__activity" role="log" aria-live="polite" aria-label="Agent activity"></div>` is placed directly above the `build-inspector__timeline` div. This is the DOM anchor the new `thought_block.ts` component targets to render structured thought events.

2. **Delete the `build-inspector__cot` block** — the raw chain-of-thought section (11 lines, from the `{# raw chain-of-thought #}` comment through the closing `</div>`) is removed. It was superseded by the structured activity feed and would have produced duplicate output.

## Why

The `thought_block.ts` component renders structured thought events into `#activity-feed`. The old `build-inspector__cot` block rendered the same data as raw text. Keeping both would show duplicate content; the structured feed is strictly better (accessible `role="log"`, `aria-live="polite"`, semantic class).

## Tests

- No existing test asserted `build-inspector__cot` presence — nothing to update.
- `test_build_ui.py` (2 tests) passes: `test_force_resync_button_present`, `test_inspector_sse_poll_interval`.

## Out of scope

SCSS rules, TypeScript wiring, Alpine.js data changes — all deferred per spec.