### PR TITLE
feat: lower poll_interval_seconds default from 10 to 5

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -108,11 +108,11 @@ class AgentCeptionSettings(BaseSettings):
     actually read.  Set via ``HOST_REPO_DIR`` in docker-compose or .env.
     """
     gh_repo: str = "cgcardona/agentception"
-    poll_interval_seconds: int = 10
+    poll_interval_seconds: int = 5
     agent_max_iterations: int = 100
-    # TTL must be strictly less than poll_interval_seconds (currently 10) so every
+    # TTL must be strictly less than poll_interval_seconds (currently 5) so every
     # poller tick sees live GitHub data.  Keep GITHUB_CACHE_SECONDS < POLL_INTERVAL_SECONDS.
-    github_cache_seconds: int = 5
+    github_cache_seconds: int = 4
     ac_api_key: str = ""
     """Shared secret for authenticating requests to the ``/api/*`` routes.
 

--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -70,9 +70,8 @@ def _cache_set(key: str, value: JsonValue) -> None:
     """Store *value* in the cache with a TTL of ``github_cache_seconds``.
 
     Invariant: TTL < poll_interval_seconds so every poller tick receives fresh
-    data from GitHub.  Default TTL is min(poll_interval_seconds / 2, 30) = 15 s
-    against the default 30 s poll interval.  If you raise the poll interval,
-    keep GITHUB_CACHE_SECONDS strictly below it.
+    data from GitHub.  Default TTL is 4 s against the default 5 s poll interval.
+    If you raise the poll interval, keep GITHUB_CACHE_SECONDS strictly below it.
     """
     expires_at = time.monotonic() + settings.github_cache_seconds
     _cache[key] = (value, expires_at)

--- a/agentception/tests/test_agentception_scaffold.py
+++ b/agentception/tests/test_agentception_scaffold.py
@@ -49,8 +49,8 @@ def test_settings_loads_defaults() -> None:
     """
     s = AgentCeptionSettings()
     assert s.gh_repo == "cgcardona/agentception"
-    assert s.poll_interval_seconds == 10
-    assert s.github_cache_seconds == 5
+    assert s.poll_interval_seconds == 5
+    assert s.github_cache_seconds == 4
     assert isinstance(s.worktrees_dir, __import__("pathlib").Path)
     assert str(s.worktrees_dir) != ""
 


### PR DESCRIPTION
## Summary

Lowers `poll_interval_seconds` default from `10` to `5` so the dashboard feels more responsive out of the box.

## Changes

- **`agentception/config.py`**: `poll_interval_seconds` default `10 → 5`; `github_cache_seconds` default `5 → 4` (invariant: TTL must be strictly less than poll interval — `4 < 5` ✓); updated inline comment to reflect new values.
- **`agentception/readers/github.py`**: Updated docstring comment referencing the old poll interval to reflect the new 5 s default.
- **`agentception/tests/test_agentception_scaffold.py`**: Updated `test_settings_loads_defaults` assertions to match new defaults (`poll_interval_seconds == 5`, `github_cache_seconds == 4`).

## Invariant preserved

`github_cache_seconds (4) < poll_interval_seconds (5)` — every poller tick still sees live GitHub data.

Closes #745