### PR TITLE
feat: suppress implementing/reviewing status badge on active-lane cards

### DIFF
--- a/agentception/templates/_build_board.html
+++ b/agentception/templates/_build_board.html
@@ -97,9 +97,9 @@
   {% if lane == 'active' and active_run %}
   <div class="build-issue__footer">
     <div class="build-issue__run">
-      <span class="build-issue__status build-issue__status--{{ active_run.agent_status }}">
-        {%- if active_run.agent_status == 'stale' %}⚠ stale{%- else %}{{ active_run.agent_status }}{%- endif %}
-      </span>
+      {% if active_run.agent_status == 'stale' %}
+      <span class="build-issue__status build-issue__status--stale">⚠ stale</span>
+      {% endif %}
     </div>
     {% if active_run.current_step %}
     <p class="build-issue__step">{{ active_run.current_step }}</p>

--- a/agentception/tests/test_build_board_partial.py
+++ b/agentception/tests/test_build_board_partial.py
@@ -194,8 +194,8 @@ def test_build_board_partial_shows_status_badge(client: TestClient) -> None:
         resp = client.get("/ship/agentception/phase-1/board")
 
     assert resp.status_code == 200
-    # The agent_status "implementing" must appear as a badge in the card.
-    assert "implementing" in resp.text
+    # The agent_status badge is suppressed for "implementing" — only stale renders a badge.
+    assert "build-issue__status" not in resp.text
 
 
 def test_build_board_partial_shows_current_step(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

Replaces the unconditional `<span class="build-issue__status ...">` in `_build_board.html` with a conditional block that only renders when `agent_status == 'stale'`. The lane column header already communicates normal active states; the badge is now reserved for the exceptional `stale` case.

## Changes

- `agentception/templates/_build_board.html`: conditional stale-only badge
- `agentception/tests/test_build_board_partial.py`: updated `test_build_board_partial_shows_status_badge` assertion to verify badge is absent for `implementing`

## Acceptance criteria

- [x] `implementing` → no `<span class="build-issue__status ...">` rendered
- [x] `reviewing` → no `<span class="build-issue__status ...">` rendered  
- [x] `stale` → `<span class="build-issue__status build-issue__status--stale">⚠ stale</span>` still renders
- [x] Only `_build_board.html` template modified (test updated to match new behavior)
- [x] 23/23 tests pass

Closes #758