### PR TITLE
feat: merge status badge and step counter into one row in _build_board.html

### DIFF
--- a/agentception/templates/_build_board.html
+++ b/agentception/templates/_build_board.html
@@ -97,18 +97,13 @@
   {% if lane == 'active' and active_run %}
   <div class="build-issue__footer">
     <div class="build-issue__run">
-      {% if active_run.agent_status == 'stale' %}
-      <span class="build-issue__status build-issue__status--stale">⚠ stale</span>
+      <span class="build-issue__status build-issue__status--{{ active_run.agent_status }}">
+        {%- if active_run.agent_status == 'stale' %}⚠ stale{%- else %}{{ active_run.agent_status }}{%- endif %}
+      </span>
+      {% if active_run.current_step %}
+      <span class="build-issue__step-badge">{{ active_run.current_step }}</span>
       {% endif %}
     </div>
-    {% if active_run.current_step %}
-    <p class="build-issue__step">{{ active_run.current_step }}</p>
-    {% endif %}
-    {% if active_run.steps_completed > 1 %}
-    <div class="build-issue__progress">
-      <span class="build-issue__step-count">{{ active_run.steps_completed }} steps</span>
-    </div>
-    {% endif %}
     {% if issue.body_excerpt %}
     <p class="build-issue__excerpt">{{ issue.body_excerpt }}</p>
     {% endif %}

--- a/agentception/tests/test_build_board_partial.py
+++ b/agentception/tests/test_build_board_partial.py
@@ -195,8 +195,8 @@ def test_build_board_partial_shows_status_badge(client: TestClient) -> None:
         resp = client.get("/ship/agentception/phase-1/board")
 
     assert resp.status_code == 200
-    # The agent_status badge is suppressed for "implementing" — only stale renders a badge.
-    assert "build-issue__status" not in resp.text
+    # The status badge is always rendered; for "implementing" it shows the status text.
+    assert "build-issue__status--implementing" in resp.text
 
 
 def test_build_board_partial_reviewing_suppresses_status_badge(client: TestClient) -> None:
@@ -225,7 +225,8 @@ def test_build_board_partial_reviewing_suppresses_status_badge(client: TestClien
         resp = client.get("/ship/agentception/phase-1/board")
 
     assert resp.status_code == 200
-    assert "build-issue__status" not in resp.text
+    # The status badge is always rendered; for "reviewing" it shows the status text.
+    assert "build-issue__status--reviewing" in resp.text
 
 
 def test_build_board_partial_stale_renders_status_badge(client: TestClient) -> None:
@@ -282,7 +283,9 @@ def test_build_board_partial_shows_current_step(client: TestClient) -> None:
 
     assert resp.status_code == 200
     assert "Running mypy checks" in resp.text
-    assert "3 steps" in resp.text
+    assert "build-issue__step-badge" in resp.text
+    # steps_completed counter is removed from the template
+    assert "3 steps" not in resp.text
 
 
 def test_build_board_partial_no_run_renders_without_error(


### PR DESCRIPTION
Closes #708

## Changes

- Rewrites `build-issue__run` div to always render the status badge (all statuses, not just stale) and adds an inline `build-issue__step-badge` span as a sibling
- Removes the standalone `build-issue__step` `<p>` block
- Removes the `steps_completed` counter block entirely
- Updates test assertions to match new template behavior (status badge always present, step-badge class present, "N steps" text absent)