### PR TITLE
feat: change log_run_step label from 'Iteration N/M' to 'Step N'

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -519,7 +519,7 @@ async def run_agent_loop(
     for iteration in range(1, max_iterations + 1):
         await log_run_step(
             issue_number,
-            f"Iteration {iteration}/{max_iterations}",
+            f"Step {iteration}",
             run_id,
         )
 

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -1500,7 +1500,7 @@ class TestReviewerToolAllowlist:
         async def fake_log_step(
             issue_number: int, label: str, run_id: str, **kwargs: object
         ) -> dict[str, object]:
-            if label.startswith("Iteration "):
+            if label.startswith("Step "):
                 iteration_labels.append(label)
             return {"ok": True}
 
@@ -1556,13 +1556,13 @@ class TestReviewerToolAllowlist:
             # Pass 100 — must be silently capped to _REVIEWER_MAX_ITERATIONS.
             await run_agent_loop("review-cap-run", max_iterations=100)
 
-        assert iteration_labels, "No iteration labels captured — loop did not run"
+        assert iteration_labels, "No step labels captured — loop did not run"
         last_label = iteration_labels[-1]
-        # The label format is "Iteration N/M" — extract M (the effective cap).
-        effective_cap = int(last_label.split("/")[-1])
-        assert effective_cap == _REVIEWER_MAX_ITERATIONS, (
+        # The label format is "Step N" — extract N (the last step reached).
+        last_step = int(last_label.split(" ")[-1])
+        assert last_step == _REVIEWER_MAX_ITERATIONS, (
             f"Expected reviewer cap={_REVIEWER_MAX_ITERATIONS}, "
-            f"got effective_cap={effective_cap} from label {last_label!r}"
+            f"got last_step={last_step} from label {last_label!r}"
         )
 
 


### PR DESCRIPTION
## Summary

Changes `log_run_step` call in the main `for iteration` loop from `f"Iteration {iteration}/{max_iterations}"` to `f"Step {iteration}"`, hiding the iteration cap from Mission Control's Kanban card display.

## Changes

- `agentception/services/agent_loop.py`: step label simplified to `f"Step {iteration}"`
- `agentception/tests/test_agent_loop.py`: `test_reviewer_iteration_cap_applied` updated to match new label format (`"Step N"` instead of `"Iteration N/M"`)

## Acceptance criteria

- [x] `agentception/services/agent_loop.py` no longer contains the string `"Iteration"`
- [x] The `log_run_step` call passes `f"Step {iteration}"`
- [x] All 52 tests pass

Closes #710