### PR TITLE
feat: assert step-badge renders Step 7 inside build-issue__step-badge (#711)

### DIFF
--- a/agentception/tests/test_build_board_partial.py
+++ b/agentception/tests/test_build_board_partial.py
@@ -288,6 +288,42 @@ def test_build_board_partial_shows_current_step(client: TestClient) -> None:
     assert "3 steps" not in resp.text
 
 
+def test_build_board_partial_step_badge_renders_step_text(client: TestClient) -> None:
+    """GET /build/board renders current_step inside the build-issue__step-badge element.
+
+    When current_step is "Step 7", the rendered HTML must contain "Step 7" and
+    that text must appear inside a tag with class="build-issue__step-badge".
+    """
+    with (
+        patch(
+            "agentception.routes.ui.build_ui.get_issues_grouped_by_phase",
+            new_callable=AsyncMock,
+            return_value=_mock_group(),
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_runs_for_issue_numbers",
+            new_callable=AsyncMock,
+            return_value={82: _mock_run_dict(current_step="Step 7")},
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_workflow_states_by_issue",
+            new_callable=AsyncMock,
+            return_value={82: {"lane": "active", "pr_number": None}},
+        ),
+    ):
+        resp = client.get("/ship/agentception/phase-1/board")
+
+    assert resp.status_code == 200
+    assert "Step 7" in resp.text
+    # "Step 7" must appear inside the step-badge element, not just anywhere in the page.
+    assert 'class="build-issue__step-badge"' in resp.text
+    badge_start = resp.text.find('class="build-issue__step-badge"')
+    badge_end = resp.text.find("</span>", badge_start)
+    assert "Step 7" in resp.text[badge_start:badge_end], (
+        "Step 7 must appear inside the build-issue__step-badge span"
+    )
+
+
 def test_build_board_partial_no_run_renders_without_error(
     client: TestClient,
 ) -> None:


### PR DESCRIPTION
## What

Adds a new test `test_build_board_partial_step_badge_renders_step_text` to `agentception/tests/test_build_board_partial.py`.

The test verifies that when `current_step="Step 7"` is provided:
1. `"Step 7"` appears in the rendered HTML.
2. `class="build-issue__step-badge"` is present in the rendered HTML.
3. `"Step 7"` appears *inside* the `<span class="build-issue__step-badge">` element (not just anywhere on the page).

The existing `test_build_board_partial_shows_current_step` already had the correct assertions (`"3 steps" not in resp.text`, `"build-issue__step-badge" in resp.text`) — no changes were needed there.

## Why

Closes #711. The kanban-step-display-p0-001/002 changes removed the "Iteration N/M" and "N steps" elements from the template. This PR adds the positive assertion for the step-badge class with a concrete `"Step 7"` value as required by the acceptance criteria.

## Tests

```
26 passed in 0.60s
```

All 26 tests in `test_build_board_partial.py` pass. No other files modified.
