### PR TITLE
fix: bump reviewer max iterations from 10 to 20

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -232,8 +232,9 @@ _REVIEWER_TOOL_ALLOWLIST: frozenset[str] = frozenset({
 })
 
 # Hard cap on reviewer iterations.  With warmup pre-loading all context,
-# a reviewer grades and acts in ≤5 iterations.  10 is a generous ceiling.
-_REVIEWER_MAX_ITERATIONS = 10
+# a reviewer grades and acts in ≤5 iterations.  20 gives headroom for edge
+# cases where the reviewer needs to request changes and wait for context.
+_REVIEWER_MAX_ITERATIONS = 20
 
 # When the loop guard fires, the tool palette switches to an ALLOWLIST:
 # only write tools and a minimal set of essential non-read tools remain.


### PR DESCRIPTION
Reviewer for #705 hit the 10-iteration ceiling mid-merge and was cancelled. 20 gives enough headroom for reviewers that need extra turns to write review comments, request changes, or handle slow tool responses.

- `_REVIEWER_MAX_ITERATIONS`: 10 → 20