### PR TITLE
feat: log tool args in dispatch_tool and display them in watch_run.py

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -1884,12 +1884,28 @@ async def _dispatch_single_tool(
     name = tool_call["function"]["name"]
     args_str = tool_call["function"]["arguments"]
 
-    logger.info("✅ dispatch_tool — run_id=%s tool=%s", run_id, name)
-
     try:
         args: dict[str, object] = json.loads(args_str)
     except json.JSONDecodeError as exc:
         return {"ok": False, "error": f"Invalid tool arguments (JSON parse error): {exc}"}
+
+    # Log tool name + the single most useful arg so watch_run.py can show
+    # what was searched / read / written without needing a second log line.
+    _KEY_ARG: dict[str, str] = {
+        "search_codebase": "query",
+        "search_text": "pattern",
+        "read_file": "path",
+        "read_file_lines": "path",
+        "write_file": "path",
+        "replace_in_file": "path",
+        "insert_after_in_file": "path",
+        "create_directory": "path",
+        "list_directory": "path",
+    }
+    _key = _KEY_ARG.get(name)
+    _val = args.get(_key) if _key else None
+    _arg_tag = f" {_key}={str(_val)!r}" if isinstance(_val, str) else ""
+    logger.info("✅ dispatch_tool — run_id=%s tool=%s%s", run_id, name, _arg_tag)
 
     if name in _LOCAL_TOOL_NAMES:
         return await _dispatch_local_tool(name, args, worktree_path)

--- a/scripts/watch_run.py
+++ b/scripts/watch_run.py
@@ -41,8 +41,10 @@ _RE_RUN_STEP = re.compile(
 _RE_ITERATION = re.compile(r"Step\s+(?P<n>\d+)")
 
 # dispatch_tool — run_id tag (agent_loop.py)
+# Optional trailing: key='value' (e.g. query='…', path='…', pattern='…')
 _RE_DISPATCH_TOOL = re.compile(
     r"dispatch_tool — run_id=(?P<run_id>\S+) tool=(?P<tool>\S+)"
+    r"(?:\s+\S+=(?P<arg>'[^']*'|\"[^\"]*\"|[^'\"\s]+))?"
 )
 
 # file_tools result lines (agentception.tools.file_tools)
@@ -110,6 +112,7 @@ class _State:
     current_run_id: str | None = None
     iteration: int = 0
     history_len: int = 0
+    pending_arg: str = ""  # key arg from last dispatch_tool, used by result-line renderers
 
 
 _state = _State()
@@ -238,18 +241,30 @@ def process_line(raw: str, run_id_filter: str | None) -> str | None:
             return None
         _state.current_run_id = rid
         tool_name = dtm.group("tool")
+        raw_arg = dtm.group("arg") or ""
+        # Strip surrounding quotes from the captured arg value
+        arg_val = raw_arg.strip("'\"") if raw_arg else ""
+        # Truncate long values (e.g. long search queries) for display
+        if len(arg_val) > 90:
+            arg_val = arg_val[:90] + "…"
+        arg_suffix = f"  {GREY}{arg_val}{RESET}" if arg_val else ""
+
         if tool_name in _RESULT_LINE_TOOLS:
-            return None  # wait for the file_tools result line
+            # File-tool result lines already show path — store arg for them
+            # to use, but suppress the dispatch line itself.
+            _state.pending_arg = arg_val
+            return None
         if tool_name in _DISPATCH_ONLY_TOOLS:
-            return f"{ts}  {BLUE}{_tool_icon('read_file_lines')} {tool_name}{RESET}"
+            path = _shorten_path(arg_val) if arg_val else tool_name
+            return f"{ts}  {BLUE}{_tool_icon('read_file_lines')} read{RESET}  {WHITE}{path}{RESET}"
         if tool_name in ("search_codebase", "search_text"):
-            return f"{ts}  {BLUE}🔍 {tool_name}{RESET}"
+            return f"{ts}  {BLUE}🔍 {tool_name}{RESET}{arg_suffix}"
         if tool_name in ("log_run_step", "git_commit_and_push", "run_command"):
             return None  # rendered via dedicated patterns below
         # GitHub MCP tools and anything else — show immediately
         if any(gh in tool_name for gh in ("pull_request", "issue_", "create_branch", "list_branch", "get_me", "search_")):
-            return f"{ts}  {CYAN}🐙 {tool_name}{RESET}"
-        return f"{ts}  {BLUE}{_tool_icon(tool_name)} {tool_name}{RESET}"
+            return f"{ts}  {CYAN}🐙 {tool_name}{RESET}{arg_suffix}"
+        return f"{ts}  {BLUE}{_tool_icon(tool_name)} {tool_name}{RESET}{arg_suffix}"
 
     # ── file_tools result lines (rendered independently of dispatch) ───────────
 


### PR DESCRIPTION
Previously `dispatch_tool` only logged the tool name. The terminal watcher showed `🔍 search_codebase` with no indication of what was searched, and `📄 read_file` with no path.

**agent_loop.py:**
- Move log line to after JSON-parsing args
- Append the key arg for each tool type: `query=` for searches, `path=` for file ops, `pattern=` for text search

**watch_run.py:**
- Update `_RE_DISPATCH_TOOL` to capture the optional key=value arg
- Show query/pattern inline: `🔍 search_codebase  how does WorkingMemory store events?`
- Show path inline for `read_file` and `list_directory`
- Truncate long values to 90 chars