### PR TITLE
fix: datetime not JSON serializable in log_file_edit_event

### DIFF
--- a/agentception/mcp/log_tools.py
+++ b/agentception/mcp/log_tools.py
@@ -71,7 +71,7 @@ async def log_file_edit_event(
     await persist_agent_event(
         issue_number=issue_number,
         event_type="file_edit",
-        payload=event.model_dump(),
+        payload=event.model_dump(mode="json"),
         agent_run_id=agent_run_id,
     )
     logger.info(

--- a/agentception/tests/test_mcp_log_tools.py
+++ b/agentception/tests/test_mcp_log_tools.py
@@ -351,3 +351,41 @@ class TestLogRunHeartbeat:
         from agentception.mcp.server import list_tools
         names = [t["name"] for t in list_tools()]
         assert "log_run_heartbeat" in names
+
+
+# ---------------------------------------------------------------------------
+# log_file_edit_event — datetime serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestLogFileEditEvent:
+    @pytest.mark.anyio
+    async def test_datetime_timestamp_serialised_to_string(self) -> None:
+        """model_dump(mode='json') must convert datetime → str before persist_agent_event."""
+        from agentception.mcp.log_tools import log_file_edit_event
+        from agentception.models import FileEditEvent
+
+        fixed_ts = datetime.datetime(2024, 6, 1, 10, 30, 0, tzinfo=datetime.timezone.utc)
+        event = FileEditEvent(
+            path="agentception/foo.py",
+            diff="--- a/foo.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new\n",
+            lines_omitted=0,
+            timestamp=fixed_ts,
+        )
+
+        with patch(
+            "agentception.mcp.log_tools.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist:
+            await log_file_edit_event(issue_number=42, event=event, agent_run_id="issue-42")
+
+        mock_persist.assert_awaited_once()
+        call_kwargs = mock_persist.call_args.kwargs
+        assert call_kwargs["event_type"] == "file_edit"
+        payload = call_kwargs["payload"]
+        # timestamp must be a string, not a datetime — json.dumps would raise otherwise
+        assert isinstance(payload["timestamp"], str), (
+            "payload['timestamp'] must be a str (ISO 8601), not a datetime object"
+        )
+        # Verify it round-trips correctly
+        assert datetime.datetime.fromisoformat(payload["timestamp"]) == fixed_ts


### PR DESCRIPTION
## Summary

Fixes `TypeError: Object of type datetime is not JSON serializable` that surfaced on every `log_file_edit_event` call in production logs.

## Root cause

`FileEditEvent.timestamp` is a `datetime` object. Pydantic's default `model_dump()` returns native Python objects, so when `persist_agent_event` called `json.dumps()` on the resulting dict it raised a `TypeError`.

## Change

**`agentception/mcp/log_tools.py`** — one-line fix in `log_file_edit_event`:

```python
# Before
payload=event.model_dump(),

# After
payload=event.model_dump(mode="json"),
```

`mode="json"` instructs Pydantic to serialise all fields to JSON-compatible types (e.g. `datetime` → ISO 8601 string) before returning the dict.

## Test coverage

Added `TestLogFileEditEvent.test_datetime_timestamp_serialised_to_string` in `agentception/tests/test_mcp_log_tools.py`. The test:
- Constructs a `FileEditEvent` with a real `datetime` timestamp
- Calls `log_file_edit_event` with `persist_agent_event` mocked
- Asserts `payload["timestamp"]` is a `str`, not a `datetime`
- Verifies the string round-trips back to the original `datetime`

## Out of scope

No changes to `persist_agent_event`, other `model_dump()` call sites, or schema migrations.