### PR TITLE
fix: add 529 (Anthropic overloaded) to retryable status codes

### DIFF
--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -368,7 +368,7 @@ async def call_anthropic(
             if exc.response.status_code == 429:
                 await _rate_limit_sleep(exc.response, attempt)
                 continue
-            if exc.response.status_code in (500, 502, 503, 504):
+            if exc.response.status_code in (500, 502, 503, 504, 529):
                 backoff = 2 ** (attempt + 1)
                 logger.warning("⚠️ LLM retry %d/%d after %ds", attempt + 1, _MAX_RETRIES, backoff)
                 await asyncio.sleep(backoff)
@@ -619,7 +619,7 @@ async def call_anthropic_with_tools(
             if exc.response.status_code == 429:
                 await _rate_limit_sleep(exc.response, attempt)
                 continue
-            if exc.response.status_code in (500, 502, 503, 504):
+            if exc.response.status_code in (500, 502, 503, 504, 529):
                 backoff = 2 ** (attempt + 1)
                 logger.warning("⚠️ LLM retry %d/%d after %ds", attempt + 1, _MAX_RETRIES, backoff)
                 await asyncio.sleep(backoff)


### PR DESCRIPTION
529 means Anthropic is temporarily overloaded. Both agents for #747 and #748 failed today because concurrent runs triggered 529 responses that were not retried — they exhausted the 500/502/503/504 retry set and were cancelled.\n\nAdds 529 to both retry blocks in `llm.py` (streaming and non-streaming paths).