### PR TITLE
feat: add GET /api/runs/{run_id}/memory endpoint returning FileEditEvent list

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -485,6 +485,9 @@ class AgentThoughtRow(TypedDict):
 
 logger = logging.getLogger(__name__)
 
+# Imported here to avoid a circular import at module top-level.
+from agentception.models import FileEditEvent  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Board issues — replaces live gh CLI call in the overview sidebar
@@ -3003,3 +3006,46 @@ async def load_execution_plan(run_id: str) -> str | None:
             "⚠️  load_execution_plan DB query failed (non-fatal): %s", exc
         )
         return None
+
+# ---------------------------------------------------------------------------
+# File-edit events — inspector panel memory surface
+# ---------------------------------------------------------------------------
+
+
+async def get_file_edit_events(run_id: str) -> list[FileEditEvent]:
+    """Return all file-edit events for *run_id* from ``agent_events``.
+
+    Queries ``ACAgentEvent`` rows where ``agent_run_id = run_id`` AND
+    ``event_type = 'file_edit'``, then deserializes each row's ``payload``
+    JSON field as a :class:`~agentception.models.FileEditEvent`.  Rows whose
+    payload cannot be deserialized are silently skipped.  Falls back to ``[]``
+    on DB error (non-fatal).
+    """
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentEvent)
+                .where(
+                    ACAgentEvent.agent_run_id == run_id,
+                    ACAgentEvent.event_type == "file_edit",
+                )
+                .order_by(ACAgentEvent.id)
+            )
+            rows = result.scalars().all()
+
+        events: list[FileEditEvent] = []
+        for row in rows:
+            try:
+                payload = json.loads(row.payload or "{}")
+                events.append(FileEditEvent(**payload))
+            except Exception as parse_exc:
+                logger.warning(
+                    "⚠️  get_file_edit_events: skipping unparseable payload id=%d: %s",
+                    row.id,
+                    parse_exc,
+                )
+        return events
+    except Exception as exc:
+        logger.warning("⚠️  get_file_edit_events DB query failed (non-fatal): %s", exc)
+        return []
+

--- a/agentception/routes/api/runs.py
+++ b/agentception/routes/api/runs.py
@@ -24,10 +24,52 @@ from sqlalchemy import func, select
 
 from agentception.db.engine import get_session
 from agentception.db.models import ACAgentMessage, ACAgentRun
+from agentception.db.queries import get_file_edit_events
+from agentception.models import FileEditEvent
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/runs", tags=["runs"])
+
+
+# ---------------------------------------------------------------------------
+# GET /api/runs/{run_id}/memory — file-edit history for the inspector panel
+# ---------------------------------------------------------------------------
+
+
+class MemoryResponse(BaseModel):
+    """Response for GET /api/runs/{run_id}/memory.
+
+    ``files_written`` is the ordered list of file-edit events recorded by the
+    agent during its run, each carrying a unified diff for inspector rendering.
+    """
+
+    files_written: list[FileEditEvent]
+
+
+@router.get("/{run_id}/memory", response_model=MemoryResponse)
+async def get_run_memory(run_id: str) -> MemoryResponse:
+    """Return file-edit history for a run.
+
+    Queries ``ACAgentEvent`` rows with ``event_type='file_edit'`` for the
+    given run.  Returns HTTP 404 when the run does not exist in the ``runs``
+    table.
+    """
+    try:
+        async with get_session() as session:
+            run_exists = await session.scalar(
+                select(func.count()).select_from(ACAgentRun).where(ACAgentRun.id == run_id)
+            )
+        if not run_exists:
+            raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("❌ get_run_memory run-check failed: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to check run existence") from exc
+
+    events = await get_file_edit_events(run_id)
+    return MemoryResponse(files_written=events)
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/tests/test_memory_api.py
+++ b/agentception/tests/test_memory_api.py
@@ -1,0 +1,186 @@
+"""Tests for GET /api/runs/{run_id}/memory.
+
+Covers:
+    - HTTP 404 when run_id does not exist in the runs table.
+    - HTTP 200 with correct ``files_written`` payload when the run exists and
+      has ``file_edit`` events seeded in ``ACAgentEvent``.
+
+No real database is used; all SQLAlchemy calls are replaced by AsyncMock so
+these tests run fully in-process without Postgres.
+
+Run targeted:
+    pytest agentception/tests/test_memory_api.py -v
+"""
+from __future__ import annotations
+
+import datetime
+import json
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agentception.app import app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def client() -> Generator[TestClient, None, None]:
+    """Module-scoped test client; lifespan runs once for the whole file."""
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Session-mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_check_session(*, run_exists: bool) -> MagicMock:
+    """Build a session mock for the run-existence check in get_run_memory.
+
+    ``session.scalar()`` returns 1 when the run exists, 0 otherwise.
+    """
+    session = AsyncMock()
+    session.scalar = AsyncMock(return_value=1 if run_exists else 0)
+
+    ctx: MagicMock = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+def _make_event_row(
+    *,
+    row_id: int,
+    run_id: str,
+    path: str,
+    diff: str,
+    lines_omitted: int = 0,
+    timestamp: datetime.datetime | None = None,
+) -> MagicMock:
+    """Build a mock ACAgentEvent row with a valid file_edit payload."""
+    ts = timestamp or datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    payload = json.dumps(
+        {
+            "timestamp": ts.isoformat(),
+            "path": path,
+            "diff": diff,
+            "lines_omitted": lines_omitted,
+        }
+    )
+    row = MagicMock()
+    row.id = row_id
+    row.agent_run_id = run_id
+    row.event_type = "file_edit"
+    row.payload = payload
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_memory_endpoint_returns_404_for_nonexistent_run(
+    client: TestClient,
+) -> None:
+    """GET /api/runs/nonexistent-run/memory returns HTTP 404."""
+    with patch(
+        "agentception.routes.api.runs.get_session",
+        return_value=_run_check_session(run_exists=False),
+    ):
+        response = client.get("/api/runs/nonexistent-run/memory")
+
+    assert response.status_code == 404
+    assert "nonexistent-run" in response.json()["detail"]
+
+
+def test_memory_endpoint_returns_file_edit_events(
+    client: TestClient,
+) -> None:
+    """GET /api/runs/{run_id}/memory returns HTTP 200 with both seeded events.
+
+    Seeds two ACAgentEvent rows with event_type='file_edit' and valid payload
+    JSON, then asserts:
+    - HTTP 200
+    - Both events appear in ``files_written``
+    - All four fields (timestamp, path, diff, lines_omitted) are present on each
+    """
+    run_id = "issue-783-test"
+    ts1 = datetime.datetime(2024, 6, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    ts2 = datetime.datetime(2024, 6, 1, 10, 5, 0, tzinfo=datetime.timezone.utc)
+
+    row1 = _make_event_row(
+        row_id=1,
+        run_id=run_id,
+        path="agentception/models/__init__.py",
+        diff="--- a/agentception/models/__init__.py\n+++ b/agentception/models/__init__.py\n@@ -1 +1 @@\n-old\n+new",
+        lines_omitted=0,
+        timestamp=ts1,
+    )
+    row2 = _make_event_row(
+        row_id=2,
+        run_id=run_id,
+        path="agentception/routes/api/runs.py",
+        diff="--- a/agentception/routes/api/runs.py\n+++ b/agentception/routes/api/runs.py\n@@ -1 +1 @@\n-x\n+y",
+        lines_omitted=5,
+        timestamp=ts2,
+    )
+
+    # Mock the DB session for the run-existence check
+    run_check_ctx = _run_check_session(run_exists=True)
+
+    # Mock get_file_edit_events to return deserialized FileEditEvent objects
+    from agentception.models import FileEditEvent
+
+    fake_events = [
+        FileEditEvent(
+            timestamp=ts1,
+            path="agentception/models/__init__.py",
+            diff="--- a/agentception/models/__init__.py\n+++ b/agentception/models/__init__.py\n@@ -1 +1 @@\n-old\n+new",
+            lines_omitted=0,
+        ),
+        FileEditEvent(
+            timestamp=ts2,
+            path="agentception/routes/api/runs.py",
+            diff="--- a/agentception/routes/api/runs.py\n+++ b/agentception/routes/api/runs.py\n@@ -1 +1 @@\n-x\n+y",
+            lines_omitted=5,
+        ),
+    ]
+
+    with (
+        patch(
+            "agentception.routes.api.runs.get_session",
+            return_value=run_check_ctx,
+        ),
+        patch(
+            "agentception.routes.api.runs.get_file_edit_events",
+            new=AsyncMock(return_value=fake_events),
+        ),
+    ):
+        response = client.get(f"/api/runs/{run_id}/memory")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "files_written" in body
+    assert len(body["files_written"]) == 2
+
+    for event in body["files_written"]:
+        assert "timestamp" in event
+        assert "path" in event
+        assert "diff" in event
+        assert "lines_omitted" in event
+
+    paths = [e["path"] for e in body["files_written"]]
+    assert "agentception/models/__init__.py" in paths
+    assert "agentception/routes/api/runs.py" in paths
+
+    # Verify lines_omitted is correctly propagated
+    runs_event = next(e for e in body["files_written"] if "runs.py" in e["path"])
+    assert runs_event["lines_omitted"] == 5


### PR DESCRIPTION
## Summary

Implements `GET /api/runs/{run_id}/memory` returning `MemoryResponse { files_written: list[FileEditEvent] }` for the inspector panel's file-edit history surface.

## Changes

### `agentception/db/queries.py`
- Added `get_file_edit_events(run_id: str) -> list[FileEditEvent]` — queries `ACAgentEvent` rows where `agent_run_id = run_id` AND `event_type = 'file_edit'`, deserializes each row's `payload` JSON as `FileEditEvent`. Rows with unparseable payloads are skipped with a warning. Falls back to `[]` on DB error (non-fatal, consistent with all other query helpers).

### `agentception/routes/api/runs.py`
- Added `MemoryResponse(BaseModel)` with `files_written: list[FileEditEvent]`.
- Added `GET /{run_id}/memory` route that:
  1. Checks run existence via `ACAgentRun` count query — raises HTTP 404 if not found.
  2. Delegates to `get_file_edit_events(run_id)` for the event list.
  3. Returns `MemoryResponse`.

### `agentception/tests/test_memory_api.py` (new)
- `test_memory_endpoint_returns_404_for_nonexistent_run` — asserts HTTP 404 with run_id in detail.
- `test_memory_endpoint_returns_file_edit_events` — seeds two fake `FileEditEvent` objects, asserts HTTP 200, both events in `files_written`, all four fields (`timestamp`, `path`, `diff`, `lines_omitted`) present on each.

## Acceptance criteria

- [x] `GET /api/runs/{run_id}/memory` returns HTTP 200 with `{"files_written": [...]}` for a run that exists.
- [x] Returns HTTP 404 when `run_id` does not exist in the `runs` table.
- [x] Each `FileEditEvent` includes `timestamp`, `path`, `diff`, and `lines_omitted`.
- [x] `get_file_edit_events` queries only `ACAgentEvent` — no reference to any legacy table.
- [x] `mypy --follow-imports=silent` reports zero errors on changed files.
- [x] `pytest agentception/tests/test_memory_api.py` exits 0 (2 passed).

## Design notes

- No reference to `old_string`, `new_string`, or `file_edit_events` table anywhere.
- Route handler contains zero business logic — one existence check + one service call.
- `get_file_edit_events` follows the same non-fatal fallback pattern as all other query helpers in `queries.py`.

Closes #783