### PR TITLE
feat: pre-render FileEditEvent cards in inspector template for completed runs

### DIFF
--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -42,6 +42,7 @@ from agentception.db.queries import (
     RunTreeNodeRow,
     get_agent_events_tail,
     get_agent_thoughts_tail,
+    get_file_edit_events,
     get_initiatives,
     get_issues_grouped_by_phase,
     get_latest_active_batch_id,
@@ -397,6 +398,53 @@ async def _inspector_sse(run_id: str) -> AsyncGenerator[str, None]:
             yield 'data: {"t":"ping"}\n\n'
 
         await asyncio.sleep(0.5)
+
+
+# ---------------------------------------------------------------------------
+# GET /ship/runs/{run_id}/inspector — pre-rendered inspector panel partial
+# ---------------------------------------------------------------------------
+
+#: Statuses that indicate a run has finished and the SSE stream is closed.
+_TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "error", "cancelled", "failed"})
+
+
+@router.get("/ship/runs/{run_id}/inspector", response_class=HTMLResponse)
+async def inspector_partial(request: Request, run_id: str) -> HTMLResponse:
+    """Return the inspector panel HTML partial for *run_id*.
+
+    For completed runs (status in ``_TERMINAL_STATUSES``) the response
+    includes pre-rendered ``file-edit-card`` divs so the user can see the
+    file-edit history even though the SSE stream is closed.  For active runs
+    the ``memory_events`` list is empty and the SSE stream appends cards live.
+
+    Args:
+        run_id: The agent run id (e.g. ``issue-938``).
+
+    Returns:
+        HTML partial rendered from ``_inspector.html``.
+    """
+    run_status: str | None = None
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun.status).where(ACAgentRun.id == run_id)
+            )
+            run_status = result.scalar_one_or_none()
+    except Exception:
+        run_status = None
+
+    run_is_active = run_status not in _TERMINAL_STATUSES
+    memory_events = [] if run_is_active else await get_file_edit_events(run_id)
+
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "_inspector.html",
+        {
+            "run_id": run_id,
+            "run_is_active": run_is_active,
+            "memory_events": memory_events,
+        },
+    )
 
 
 @router.get("/ship/runs/{run_id}/tree", response_class=Response, response_model=None)

--- a/agentception/templates/_inspector.html
+++ b/agentception/templates/_inspector.html
@@ -1,0 +1,27 @@
+{# Inspector panel partial — rendered server-side for a specific run.
+   Loaded via HTMX when the user selects an issue card.
+#}
+<!DOCTYPE html>
+<html>
+<body>
+<div id="activity-feed">
+  {# SSE handles live runs; this block covers completed runs only.
+     For active runs the client appends file-edit-card divs via the SSE stream.
+     For completed runs the SSE stream is closed, so we pre-render the cards here. #}
+  {% if not run_is_active %}
+    {% for event in memory_events %}
+      <div class="file-edit-card collapsed"
+           data-diff="{{ event.diff | e }}"
+           data-path="{{ event.path | e }}"
+           data-lines-omitted="{{ event.lines_omitted }}">
+        <button class="card-header">{{ event.path }}</button>
+        <pre class="card-body"><code></code></pre>
+        {% if event.lines_omitted > 0 %}
+          <p class="diff-omitted">… {{ event.lines_omitted }} more lines not shown</p>
+        {% endif %}
+      </div>
+    {% endfor %}
+  {% endif %}
+</div>
+</body>
+</html>

--- a/agentception/tests/test_build_ui.py
+++ b/agentception/tests/test_build_ui.py
@@ -252,3 +252,115 @@ async def test_sse_stream_emits_file_edit_event_after_str_replace() -> None:
     )
     assert validated.diff == fake_diff, "FileEditEvent.diff must match the original diff"
     assert validated.lines_omitted == 0, "lines_omitted must be 0 for a short diff"
+
+
+# ---------------------------------------------------------------------------
+# Inspector partial: pre-rendered file-edit-card divs for completed runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completed_run_prerendered_cards() -> None:
+    """Inspector partial renders file-edit-card divs for completed runs.
+
+    A run with status ``"done"`` is a terminal run — the SSE stream is closed.
+    The inspector partial must pre-render one ``file-edit-card`` div per
+    ``FileEditEvent`` returned by ``get_file_edit_events``.
+    """
+    import datetime
+
+    from agentception.models import FileEditEvent
+    from agentception.routes.ui.build_ui import inspector_partial
+    from starlette.requests import Request as StarletteRequest
+    from starlette.testclient import TestClient
+
+    known_path = "agentception/models.py"
+    fake_event = FileEditEvent(
+        timestamp=datetime.datetime(2024, 6, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+        path=known_path,
+        diff="--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new\n",
+        lines_omitted=0,
+    )
+
+    with (
+        patch(
+            "agentception.routes.ui.build_ui.get_session",
+        ) as mock_get_session,
+        patch(
+            "agentception.routes.ui.build_ui.get_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=[fake_event],
+        ),
+    ):
+        # Simulate a DB session that returns status="done"
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = "done"
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_get_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_get_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        from agentception.app import app
+
+        with TestClient(app) as tc:
+            response = tc.get("/ship/runs/issue-999/inspector")
+
+    assert response.status_code == 200
+    html = response.text
+    assert 'class="file-edit-card' in html, (
+        "Inspector partial must render file-edit-card divs for completed runs"
+    )
+    assert known_path in html, (
+        f"Inspector partial must include the file path {known_path!r} in the rendered card"
+    )
+
+
+@pytest.mark.asyncio
+async def test_active_run_no_prerendered_cards() -> None:
+    """Inspector partial does NOT render file-edit-card divs for active runs.
+
+    A run with status ``"implementing"`` is active — the SSE stream is open
+    and will append cards live.  The inspector partial must not pre-render any
+    ``file-edit-card`` divs so the live stream is the single source of truth.
+    """
+    import datetime
+
+    from agentception.models import FileEditEvent
+
+    known_path = "agentception/models.py"
+    fake_event = FileEditEvent(
+        timestamp=datetime.datetime(2024, 6, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+        path=known_path,
+        diff="--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new\n",
+        lines_omitted=0,
+    )
+
+    with (
+        patch(
+            "agentception.routes.ui.build_ui.get_session",
+        ) as mock_get_session,
+        patch(
+            "agentception.routes.ui.build_ui.get_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=[fake_event],
+        ),
+    ):
+        # Simulate a DB session that returns status="implementing"
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = "implementing"
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_get_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_get_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        from agentception.app import app
+
+        with TestClient(app) as tc:
+            response = tc.get("/ship/runs/issue-999/inspector")
+
+    assert response.status_code == 200
+    html = response.text
+    assert 'class="file-edit-card' not in html, (
+        "Inspector partial must NOT render file-edit-card divs for active runs"
+    )
+


### PR DESCRIPTION
## Summary

Closes #784.

When a run is complete the SSE stream is closed and no live cards will be appended. This PR injects `memory_events` and `run_is_active` into the inspector template context and pre-renders `file-edit-card` divs for completed runs inside `#activity-feed`.

## Changes

### `agentception/routes/ui/build_ui.py`
- Imported `get_file_edit_events` from `agentception.db.queries`.
- Added `_TERMINAL_STATUSES` constant (`{"done", "error", "cancelled", "failed"}`).
- Added `GET /ship/runs/{run_id}/inspector` route (`inspector_partial`) that:
  - Looks up the run's status from the DB.
  - Derives `run_is_active = run_status not in _TERMINAL_STATUSES`.
  - Calls `await get_file_edit_events(run_id)` only for terminal runs (empty list for active runs).
  - Passes `run_id`, `run_is_active`, and `memory_events` to `_inspector.html`.

### `agentception/templates/_inspector.html`
- New template partial for the inspector panel.
- Inside `#activity-feed`, a `{% if not run_is_active %}` block (with inline comment explaining SSE handles live runs) pre-renders one `file-edit-card` div per `FileEditEvent`.
- Each card includes `data-diff`, `data-path`, `data-lines-omitted`, `.card-header`, and `.card-body code`.
- `{% if event.lines_omitted > 0 %}` renders the omission notice only when needed.

### `agentception/tests/test_build_ui.py`
- `test_completed_run_prerendered_cards`: asserts `file-edit-card` appears for a `"done"` run.
- `test_active_run_no_prerendered_cards`: asserts `file-edit-card` does NOT appear for an `"implementing"` run.

## Out of scope (deferred)
TypeScript `renderDiffLines` wiring, collapse/expand behaviour, diff syntax highlighting — next phase.
