### PR TITLE
feat: scrub executor role label from persist.py and build_commands.py

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -897,7 +897,7 @@ async def _upsert_agent_runs(
         # orphan sweep so the polling tick never flips an in-progress adhoc
         # run to "failed" just because it isn't backed by a GitHub issue.
         #
-        # Reviewer runs are also excluded: unlike executor runs (where
+        # Reviewer runs are also excluded: unlike developer runs (where
         # pr_number is set only after the PR is opened and the run is done),
         # reviewer runs have pr_number set AT DISPATCH TIME because the PR
         # already exists.  Applying the pr_number → completed heuristic to a
@@ -1072,7 +1072,7 @@ async def persist_agent_run_dispatch(
                     run_id, existing.status,
                 )
                 existing.status = "pending_launch"
-                existing.role = role  # always update — role may change (e.g. developer → executor)
+                existing.role = role  # always update — role field is persisted as-is
                 existing.spawn_mode = spawn_mode_json
                 # Reset spawned_at so the pending_launch TTL sweep (15 min window)
                 # does not immediately re-fail a re-dispatched run whose original
@@ -1844,7 +1844,7 @@ async def _write_messages(
 async def persist_execution_plan(run_id: str, plan_json: str, issue_number: int) -> None:
     """Store the serialised ExecutionPlan for *run_id*.
 
-    Called once by the planner before the executor starts.  Subsequent calls
+    Called once by the planner before the developer starts.  Subsequent calls
     for the same ``run_id`` are silently ignored (the plan is immutable).
 
     Args:

--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -298,9 +298,9 @@ async def build_complete_run(
             )
     else:
         # Non-reviewer (implementer) completed: release worktree and dispatch reviewer.
-        # Release the executor's worktree before dispatching the reviewer.
+        # Release the developer's worktree before dispatching the reviewer.
         # Git forbids the same branch in two worktrees simultaneously; if the
-        # executor's worktree still holds the branch the reviewer dispatch will
+        # developer's worktree still holds the branch the reviewer dispatch will
         # fail with "already used by worktree at …".  We only remove the
         # worktree directory and prune refs — branches are left intact because
         # the open PR still references the remote branch.


### PR DESCRIPTION
Closes #691

## Changes

- `agentception/db/persist.py`: replaced two stale "executor" role-label occurrences in comments with accurate language ("developer" / "role field is persisted as-is")
- `agentception/mcp/build_commands.py`: replaced two "executor's worktree" comment references with "developer's worktree"

No logic changes — comments only. `asyncio.run_in_executor` untouched.