### PR TITLE
feat: replace executor role label with developer in reviewer.md.j2 and planner.md.j2

### DIFF
--- a/.agentception/roles/planner.md
+++ b/.agentception/roles/planner.md
@@ -20,7 +20,7 @@ Rules:
   file. Never add tests to a differently-named existing file when the AC names
   a specific new file. The file path in the plan must match the AC exactly.
 - Prefer `replace_in_file` for edits to existing files — it is the most
-  precise and easiest for the executor to apply correctly.
+  precise and easiest for the developer to apply correctly.
 - `old_string` must appear verbatim in the pre-loaded file and must be unique.
 - Do not add extra tests, validators, docstrings, or new files beyond what the
   issue explicitly requests or requires.

--- a/.agentception/roles/reviewer.md
+++ b/.agentception/roles/reviewer.md
@@ -3,7 +3,7 @@
 
 You review one pull request. You verify it, grade it, and either merge it or
 reject it. **You do not write code. You do not edit files. You do not fix
-defects.** That is the executor's job. If the code is not ready, reject it.
+defects.** That is the developer's job. If the code is not ready, reject it.
 
 ## Context
 
@@ -98,10 +98,10 @@ build_complete_run(
 
 **`grade` is not optional.** If you omit it or pass an empty string, the
 system treats the run as approved and no redispatch fires. The next
-executor will never receive your feedback. Always pass the literal grade
+developer will never receive your feedback. Always pass the literal grade
 letter ("C", "D", or "F") as the `grade` argument.
 
-The system automatically closes the PR and redispatches the executor with
+The system automatically closes the PR and redispatches the developer with
 your defect list injected at the top of the briefing — no human needed.
 Up to 3 attempts are allowed before the loop is abandoned.
 

--- a/scripts/gen_prompts/templates/roles/planner.md.j2
+++ b/scripts/gen_prompts/templates/roles/planner.md.j2
@@ -19,7 +19,7 @@ Rules:
   file. Never add tests to a differently-named existing file when the AC names
   a specific new file. The file path in the plan must match the AC exactly.
 - Prefer `replace_in_file` for edits to existing files — it is the most
-  precise and easiest for the executor to apply correctly.
+  precise and easiest for the developer to apply correctly.
 - `old_string` must appear verbatim in the pre-loaded file and must be unique.
 - Do not add extra tests, validators, docstrings, or new files beyond what the
   issue explicitly requests or requires.

--- a/scripts/gen_prompts/templates/roles/reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/reviewer.md.j2
@@ -2,7 +2,7 @@
 
 You review one pull request. You verify it, grade it, and either merge it or
 reject it. **You do not write code. You do not edit files. You do not fix
-defects.** That is the executor's job. If the code is not ready, reject it.
+defects.** That is the developer's job. If the code is not ready, reject it.
 
 ## Context
 
@@ -97,10 +97,10 @@ build_complete_run(
 
 **`grade` is not optional.** If you omit it or pass an empty string, the
 system treats the run as approved and no redispatch fires. The next
-executor will never receive your feedback. Always pass the literal grade
+developer will never receive your feedback. Always pass the literal grade
 letter ("C", "D", or "F") as the `grade` argument.
 
-The system automatically closes the PR and redispatches the executor with
+The system automatically closes the PR and redispatches the developer with
 your defect list injected at the top of the briefing — no human needed.
 Up to 3 attempts are allowed before the loop is abandoned.
 


### PR DESCRIPTION
Closes #694

Replaces all references to "executor" with "developer" in:
- `scripts/gen_prompts/templates/roles/reviewer.md.j2`
- `scripts/gen_prompts/templates/roles/planner.md.j2`

Regenerated `.agentception/roles/planner.md` and `.agentception/roles/reviewer.md` via `generate.py`. Verified with `generate.py --check` (exits 0).