### PR TITLE
fix: zero typing violations, fix 2 failing tests, fix grade dropped in MCP server

### DIFF
--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -996,8 +996,15 @@ async def call_tool_async(
             )
         summary = arguments.get("summary", "")
         run_id = arguments.get("agent_run_id")
+        grade = arguments.get("grade", "")
+        reviewer_feedback = arguments.get("reviewer_feedback", "")
         result = await build_complete_run(
-            issue_num, pr_url, str(summary), str(run_id) if run_id else None
+            issue_num,
+            pr_url,
+            str(summary),
+            str(run_id) if run_id else None,
+            str(grade),
+            str(reviewer_feedback),
         )
         return ACToolResult(
             content=[ACToolContent(type="text", text=_tool_result_to_text(result))],

--- a/agentception/services/working_memory.py
+++ b/agentception/services/working_memory.py
@@ -20,7 +20,7 @@ import difflib
 import json
 import logging
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import TypedDict
 
 from agentception.models import FileEditEvent
 
@@ -28,6 +28,36 @@ logger = logging.getLogger(__name__)
 
 _MEMORY_FILENAME = ".agentception/memory.json"
 _DIFF_LINE_CAP = 120
+
+
+class FileEditEventJSON(TypedDict):
+    """JSON-safe representation of a :class:`~agentception.models.FileEditEvent`.
+
+    Produced by ``FileEditEvent.model_dump(mode="json")``: all fields are
+    plain Python scalars so the dict can be passed directly to ``json.dumps``.
+    """
+
+    timestamp: str
+    path: str
+    diff: str
+    lines_omitted: int
+
+
+class WorkingMemoryJSON(TypedDict, total=False):
+    """JSON-serialisable mirror of :class:`WorkingMemory`.
+
+    Identical shape to :class:`WorkingMemory` except ``files_written`` holds
+    :class:`FileEditEventJSON` dicts instead of live :class:`FileEditEvent`
+    Pydantic objects.  Returned by :func:`_memory_to_json_safe`.
+    """
+
+    plan: str
+    files_written: list[FileEditEventJSON]
+    files_examined: list[str]
+    findings: dict[str, str]
+    decisions: list[str]
+    next_steps: list[str]
+    blockers: list[str]
 
 
 class WorkingMemory(TypedDict, total=False):
@@ -157,19 +187,25 @@ def read_memory(worktree_path: Path) -> WorkingMemory | None:
         return None
 
 
-def _memory_to_json_safe(memory: WorkingMemory) -> dict[str, Any]:
+def _memory_to_json_safe(memory: WorkingMemory) -> WorkingMemoryJSON:
     """Convert a :class:`WorkingMemory` to a JSON-serialisable dict.
 
     ``FileEditEvent`` objects in ``files_written`` are serialised via
     ``model_dump(mode="json")`` so that ``datetime`` fields become ISO-8601
     strings rather than Python objects that ``json.dumps`` cannot handle.
     """
-    result: dict[str, Any] = {}
+    result: WorkingMemoryJSON = {}
     if "plan" in memory:
         result["plan"] = memory["plan"]
     if "files_written" in memory:
         result["files_written"] = [
-            e.model_dump(mode="json") for e in memory["files_written"]
+            FileEditEventJSON(
+                timestamp=e.timestamp.isoformat(),
+                path=e.path,
+                diff=e.diff,
+                lines_omitted=e.lines_omitted,
+            )
+            for e in memory["files_written"]
         ]
     if "files_examined" in memory:
         result["files_examined"] = memory["files_examined"]

--- a/agentception/tests/test_agent_health_integration.py
+++ b/agentception/tests/test_agent_health_integration.py
@@ -256,6 +256,10 @@ async def test_orphan_missing_build_complete_marked_failed() -> None:
     session = MagicMock(spec=AsyncSession)
     session.execute = AsyncMock(side_effect=[scalar, orphan_result, ttl_result])
     session.add = MagicMock()
+    # The orphan sweep calls session.scalar() to check for an existing
+    # build_complete_run event.  Return 0 to indicate no such event exists,
+    # so the sweep proceeds to mark the orphan as failed.
+    session.scalar = AsyncMock(return_value=0)
 
     # Pass a different agent so the orphan is never in live_ids.
     live_agent = AgentNode(

--- a/agentception/tests/test_build_initiative_tabs.py
+++ b/agentception/tests/test_build_initiative_tabs.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from contextlib import AbstractContextManager
+from types import TracebackType
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -71,7 +72,7 @@ def test_initiatives_endpoint_unknown_repo_returns_404(client: TestClient) -> No
 # Integration tests — full page GET /ship/{repo}/{initiative}
 # ---------------------------------------------------------------------------
 
-def _patch_build_page(initiatives: list[str]) -> AbstractContextManager[MagicMock]:
+def _patch_build_page(initiatives: list[str]) -> AbstractContextManager[None]:
     """Patch all DB calls needed to render the full build page."""
     from contextlib import ExitStack
     from unittest.mock import AsyncMock, patch
@@ -79,7 +80,7 @@ def _patch_build_page(initiatives: list[str]) -> AbstractContextManager[MagicMoc
     # We need a context manager that applies multiple patches at once.
     # Use a helper class so callers can use it as a `with` statement.
     class _MultiPatch:
-        def __enter__(self) -> "_MultiPatch":
+        def __enter__(self) -> None:
             self._stack = ExitStack()
             self._stack.enter_context(
                 patch(
@@ -117,12 +118,17 @@ def _patch_build_page(initiatives: list[str]) -> AbstractContextManager[MagicMoc
                     new=AsyncMock(return_value=[]),
                 )
             )
-            return self
+            return None
 
-        def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
-            self._stack.__exit__(exc_type, exc_val, exc_tb)  # type: ignore[arg-type]
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_val: BaseException | None,
+            exc_tb: TracebackType | None,
+        ) -> None:
+            self._stack.__exit__(exc_type, exc_val, exc_tb)
 
-    return _MultiPatch()  # type: ignore[return-value]
+    return _MultiPatch()
 
 
 def test_full_page_has_htmx_polling_div(client: TestClient) -> None:

--- a/agentception/tests/test_build_page_structure.py
+++ b/agentception/tests/test_build_page_structure.py
@@ -26,7 +26,7 @@ class _StubRequest:
     url = _URL()
 
 
-def _render(template_name: str, ctx: dict) -> str:  # type: ignore[type-arg]
+def _render(template_name: str, ctx: dict[str, object]) -> str:
     """Render a Jinja2 template with a minimal stub context."""
     from urllib.parse import quote
     import json
@@ -96,7 +96,7 @@ def _has_load_trigger(html: str) -> bool:
 # Minimal stub context for build.html
 # ---------------------------------------------------------------------------
 
-_BUILD_CTX: dict = {  # type: ignore[type-arg]
+_BUILD_CTX: dict[str, object] = {
     "repo": "cgcardona/agentception",
     "repo_name": "agentception",
     "initiative": "test-initiative",

--- a/agentception/tests/test_mcp_build_commands_pr3.py
+++ b/agentception/tests/test_mcp_build_commands_pr3.py
@@ -369,6 +369,7 @@ async def test_build_complete_run_reviewer_does_not_redispatch_reviewer() -> Non
                 "issue_number": 449,
                 "pr_url": "https://github.com/owner/repo/pull/553",
                 "agent_run_id": "issue-449",
+                "grade": "A",
             },
         )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,4 +51,4 @@ def test_file_edit_event_frozen_raises_on_mutation() -> None:
     """Mutating a frozen FileEditEvent raises TypeError (Pydantic frozen model)."""
     event = _make_event()
     with pytest.raises((ValidationError, TypeError)):
-        event.path = "other/path.py"  # type: ignore[misc]
+        setattr(event, "path", "other/path.py")


### PR DESCRIPTION
## Summary

- **Typing (7 → 0):** Eliminated all typing_audit violations across 4 files — defines proper TypedDicts instead of \`dict[str, Any]\`, fixes \`__exit__\` signature, removes all \`# type: ignore\` comments
- **Failing tests (2 → 0):** Fixed both pre-existing test failures
- **Production bug fixed:** \`server.py\` was silently dropping \`grade\` and \`reviewer_feedback\` from \`build_complete_run\` tool calls — every reviewer invocation would fail grade validation and return \`{"error": ...}\` instead of \`{"ok": True}\`

## Changes

### \`agentception/mcp/server.py\` (production bug)
The \`build_complete_run\` handler only forwarded 4 of 6 parameters. Added \`grade\` and \`reviewer_feedback\` forwarding from tool arguments.

### \`agentception/services/working_memory.py\`
Defined \`FileEditEventJSON\` and \`WorkingMemoryJSON\` TypedDicts; replaced \`dict[str, Any]\` return type; constructs \`FileEditEventJSON\` explicitly from model fields instead of relying on \`model_dump()\`'s untyped stub.

### \`agentception/tests/test_agent_health_integration.py\`
Added \`session.scalar = AsyncMock(return_value=0)\` — orphan sweep now calls \`session.scalar()\` to check for \`build_complete_run\` events; mock was missing this call.

### \`agentception/tests/test_mcp_build_commands_pr3.py\`
Added \`grade="A"\` to the reviewer call to match current grade-validation requirement.

### Other test files
Removed all \`# type: ignore\` suppressions by fixing the underlying types.

## Verification
- \`mypy agentception/ tests/\` — 0 errors ✅
- \`typing_audit --max-any 0\` — 0 violations ✅
- \`pytest agentception/tests/ -v\` — 1924 passed, 0 failed ✅