### PR TITLE
feat: rebase worktree onto origin/dev before dispatching reviewer

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -308,6 +308,63 @@ async def build_complete_run(
             teardown_info = await get_agent_run_teardown(agent_run_id)
             wt_path = teardown_info.get("worktree_path") if teardown_info else None
             if wt_path is not None:
+                # Ensure branch is up-to-date with dev before dispatching reviewer
+                proc = await asyncio.create_subprocess_exec(
+                    "git", "fetch", "origin", "dev",
+                    cwd=wt_path,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                await proc.communicate()
+
+                proc = await asyncio.create_subprocess_exec(
+                    "git", "rebase", "origin/dev",
+                    cwd=wt_path,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, stderr = await proc.communicate()
+
+                if proc.returncode != 0:
+                    abort_proc = await asyncio.create_subprocess_exec(
+                        "git", "rebase", "--abort",
+                        cwd=wt_path,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                    )
+                    await abort_proc.communicate()
+                    logger.error(
+                        "❌ build_complete_run: rebase onto origin/dev failed for run_id=%r — %s",
+                        agent_run_id,
+                        stderr.decode(errors="replace").strip(),
+                    )
+                    return {
+                        "status": "error",
+                        "reason": "rebase_conflict",
+                        "message": (
+                            "Rebase onto origin/dev failed. "
+                            "Resolve the conflicts manually and call build_complete_run again."
+                        ),
+                    }
+
+                # Rebase succeeded — force-push the updated branch.
+                branch_proc = await asyncio.create_subprocess_exec(
+                    "git", "rev-parse", "--abbrev-ref", "HEAD",
+                    cwd=wt_path,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                branch_stdout, _ = await branch_proc.communicate()
+                branch_name = branch_stdout.decode().strip()
+
+                proc = await asyncio.create_subprocess_exec(
+                    "git", "push", "--force-with-lease", "origin", branch_name,
+                    cwd=wt_path,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                await proc.communicate()
+
                 await release_worktree(
                     worktree_path=wt_path,
                     repo_dir=str(settings.repo_dir),


### PR DESCRIPTION
Closes #698

## What

Before `build_complete_run` dispatches the reviewer, it now:

1. Fetches `origin/dev` to get the latest state of the base branch.
2. Rebases the worktree branch onto `origin/dev`.
3. On success: force-pushes the rebased branch, then proceeds to `release_worktree` and `auto_dispatch_reviewer` as normal.
4. On failure: runs `git rebase --abort` and returns a structured error dict (`{"status": "error", "reason": "rebase_conflict", ...}`) — reviewer dispatch is **not** reached.

## Why

When `dev` advances after a worktree is created, the reviewer sees a stale branch. This change ensures the reviewer always reviews a branch that is up-to-date with `dev`, preventing stale-branch merge conflicts downstream.

## Checklist

- [x] `mypy --follow-imports=silent agentception/mcp/build_commands.py` — zero errors
- [x] `python3 tools/typing_audit.py --dirs agentception/ tests/ --max-any 0` — passes
- [x] No `Any` introduced; return type stays `dict[str, object]`
- [x] Uses `asyncio.create_subprocess_exec` (matches existing patterns)