### PR TITLE
feat: add .gitattributes to prevent text-merging compiled frontend bundles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Compiled frontend bundles — always regenerate from source, never
+# text-merge. "ours" keeps the current branch's version during a
+# rebase/merge; the correct artifact is produced by npm run build.
+agentception/static/app.css     merge=ours
+agentception/static/app.css.map merge=ours
+agentception/static/app.js      merge=ours

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -241,6 +241,20 @@ The container volume-mounts `~/.config/gh` read-only. Run `gh auth login` on the
 
 ---
 
+## Initial setup
+
+### Git merge driver for compiled assets
+
+Run once after cloning:
+
+```bash
+git config merge.ours.driver true
+```
+
+This prevents Git from text-merging compiled frontend bundles (app.css, app.css.map, app.js). Always run `npm run build` after a merge or rebase to regenerate the correct artifacts.
+
+---
+
 ## Step N — Cursor MCP setup (one-time)
 
 AgentCeption exposes its planning and dispatch tools over MCP. Cursor must be configured to connect to it and, ideally, to run those tools without prompting you on every call.


### PR DESCRIPTION
Closes #699

## What

- Adds `.gitattributes` at the repo root marking `agentception/static/app.css`, `app.css.map`, and `app.js` with `merge=ours`.
- Documents the required one-time `git config merge.ours.driver true` command in `docs/guides/setup.md` under a new **Initial setup** heading.

## Why

These three files are compiled artifacts. Git's default text-merge produces impossible conflicts during rebase/merge. The `merge=ours` strategy keeps the current branch's version intact; the correct artifact is always regenerated by `npm run build` after the merge completes.