### PR TITLE
fix(git): symlink node_modules and npm config into new worktrees

### DIFF
--- a/agentception/readers/git.py
+++ b/agentception/readers/git.py
@@ -440,5 +440,34 @@ async def ensure_worktree(
         raise RuntimeError(f"git worktree add failed: {err}")
 
     logger.info("✅ Created worktree %s on branch %s", worktree_path, branch)
+    _symlink_frontend_resources(worktree_path)
     return True
+
+
+def _symlink_frontend_resources(worktree_path: Path) -> None:
+    """Symlink frontend build resources from /app into the new worktree.
+
+    Agents run npm commands (type-check, test, build:js) from within the
+    worktree.  node_modules, package.json, tsconfig.json, and vitest.config.ts
+    live in /app (the main repo mount) and are gitignored, so they are never
+    present in a freshly-created worktree.  Without these symlinks agents waste
+    iterations discovering they must cd to /app before running npm commands.
+
+    The symlinks are created only when the target in /app actually exists, so
+    this is safe to call in environments where Node is not installed.
+    """
+    app_root = Path("/app")
+    resources = ["node_modules", "package.json", "package-lock.json", "tsconfig.json", "vitest.config.ts"]
+    for name in resources:
+        src = app_root / name
+        dst = worktree_path / name
+        if not src.exists():
+            continue
+        if dst.exists() or dst.is_symlink():
+            continue
+        try:
+            dst.symlink_to(src)
+            logger.debug("🔗 Symlinked %s → %s", dst, src)
+        except OSError as exc:
+            logger.warning("⚠️ Could not symlink %s → %s: %s", dst, src, exc)
 


### PR DESCRIPTION
## Summary
- Agents running `npm run type-check`, `npm test`, or `npm run build:js` inside a worktree fail immediately because `node_modules`, `package.json`, `tsconfig.json`, and `vitest.config.ts` live in `/app` and are never present in a freshly-created linked worktree
- Adds `_symlink_frontend_resources()` called right after every successful `git worktree add` — symlinks the five frontend resources from `/app` into the worktree root
- Symlinks are skipped silently when the source doesn't exist (non-Node environments) or the destination is already present
- Zero mypy errors

## Before
Agent discovers `npm` commands fail → wastes iterations figuring out `cd /app` → sometimes never recovers

## After
`npm run type-check` works from the worktree root immediately, no iteration wasted