### PR TITLE
fix(dns): bypass Docker UDP block with TCP DNS (use-vc) + public fallbacks

### DIFF
--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -70,7 +70,7 @@ _MAX_RETRIES = 4
 # short hard cap would cancel valid responses.  Instead we pre-check DNS in an
 # asyncio-cancellable thread-pool call, fail fast if DNS is hung, and then let
 # the actual HTTP call use the full httpx timeout budget.
-_DNS_PREFLIGHT_TIMEOUT_SECS: float = 10.0
+_DNS_PREFLIGHT_TIMEOUT_SECS: float = 15.0
 _DNS_PREFLIGHT_HOST = "api.anthropic.com"
 _DNS_PREFLIGHT_PORT = 443
 # Minimum seconds to wait after a 429 before retrying.  Anthropic's rolling

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,11 @@ services:
     networks:
       - agentception-net
     command: >
-      sh -c "cd /app && alembic -c agentception/alembic.ini upgrade head && exec uvicorn agentception.app:app --host 0.0.0.0 --port 10003"
+      sh -c 'printf "nameserver 127.0.0.11\nnameserver 1.1.1.1\nnameserver 8.8.8.8\noptions ndots:0 timeout:3 attempts:1 use-vc\n" > /etc/resolv.conf &&
+      cd /app &&
+      (alembic -c agentception/alembic.ini upgrade head ||
+        (echo "[startup] alembic failed, retrying in 5s" && sleep 5 && alembic -c agentception/alembic.ini upgrade head)) &&
+      exec uvicorn agentception.app:app --host 0.0.0.0 --port 10003'
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Root cause

Docker Desktop on macOS **blocks outbound UDP port 53** to external IPs. This means the `dns: [1.1.1.1, 8.8.8.8]` directive in docker-compose only changes what Docker's embedded resolver *forwards to* internally — the resolver itself (`127.0.0.11`) was the sole DNS path for containers, and it is intermittently slow (4–17s per uncached lookup) or drops queries entirely.

Confirmed via diagnostics:
- `UDP 53 to 1.1.1.1` → **times out** (3s)
- `TCP 53 to 1.1.1.1` → **0.02s**
- `TCP DNS query for api.anthropic.com` → **0.03s**

## Fix

Patch `/etc/resolv.conf` at container startup:
```
nameserver 127.0.0.11   ← keeps Docker internal resolution (postgres, etc.)
nameserver 1.1.1.1      ← fallback via TCP
nameserver 8.8.8.8      ← second fallback
options ndots:0 timeout:3 attempts:1 use-vc
```

`use-vc` forces glibc to use **TCP** for all DNS queries. When `127.0.0.11` times out (3s), glibc falls back to `1.1.1.1` via TCP and resolves in ~0.03s.

**After fix:** `api.anthropic.com`, `github.com`, `api.github.com`, `postgres` all resolve in **<100ms** (previously 4–17s, sometimes failing entirely).

Also adds alembic startup retry and bumps `_DNS_PREFLIGHT_TIMEOUT_SECS` from 10s → 15s.