### PR TITLE
fix: build frontend assets at startup using Linux-native node_modules volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get update && apt-get install -y gh \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 22.x — enables npm run type-check / npm test / npm run build:js
-# inside the container. node_modules arrive via the ./:/app bind mount at runtime.
+# Install Node.js 22.x — enables sass/esbuild builds at container startup
+# and npm run type-check / npm test inside the container.
 ARG NODE_VERSION=22
 RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
@@ -69,6 +69,12 @@ RUN ARCH=$(dpkg --print-architecture) \
     && ln -s /usr/local/dart-sass/sass /usr/local/bin/sass \
     && sass --version
 
+# Install Node.js dependencies — Linux-native binaries baked into the image.
+# A named volume (node_modules) in docker-compose preserves this layer at runtime
+# so the ./:/app bind mount cannot shadow it with macOS host binaries.
+COPY package.json package-lock.json tsconfig.json /app/
+RUN npm ci --include=dev
+
 # Install Python dependencies.
 COPY agentception/requirements.txt /app/agentception/requirements.txt
 RUN pip install --no-cache-dir -r /app/agentception/requirements.txt
@@ -80,11 +86,5 @@ COPY pyproject.toml /app/pyproject.toml
 # Install the package itself so `agentception.*` imports resolve.
 RUN pip install --no-cache-dir -e /app
 
-# Compile SCSS → CSS and TypeScript → JS at build time.
-RUN sass --style=compressed --no-source-map \
-    /app/agentception/static/scss/app.scss \
-    /app/agentception/static/app.css
-COPY package.json package-lock.json tsconfig.json /app/
-RUN cd /app && npm ci --include=dev && npm run build:js
 
 CMD ["uvicorn", "agentception.app:app", "--host", "0.0.0.0", "--port", "10003"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,11 @@ services:
       - ${HOME}/.config/gh:${HOME}/.config/gh:ro
       # Repo itself (for git operations)
       - ./:/app
+      # Linux-native node_modules — sits on top of the ./:/app bind mount so the
+      # container's esbuild/tsc binaries (ELF) are never replaced by the host's
+      # macOS binaries. Populated from the image layer on first run via Docker's
+      # volume-init copy (image content wins when the named volume is empty).
+      - node_modules:/app/node_modules
       # Agent worktrees: bind-mount the host directory into the container so that
       # git worktrees created inside the container are immediately visible to Cursor
       # agents running on the host at the same absolute path.
@@ -85,6 +90,8 @@ services:
     command: >
       sh -c 'printf "nameserver 127.0.0.11\nnameserver 1.1.1.1\nnameserver 8.8.8.8\noptions ndots:0 timeout:3 attempts:1 use-vc\n" > /etc/resolv.conf &&
       cd /app &&
+      sass --style=compressed --no-source-map agentception/static/scss/app.scss agentception/static/app.css &&
+      npm run build:js &&
       (alembic -c agentception/alembic.ini upgrade head ||
         (echo "[startup] alembic failed, retrying in 5s" && sleep 5 && alembic -c agentception/alembic.ini upgrade head)) &&
       exec uvicorn agentception.app:app --host 0.0.0.0 --port 10003'
@@ -145,6 +152,8 @@ volumes:
     name: agentception-qdrant-data
   model_cache:
     name: agentception-model-cache
+  node_modules:
+    name: agentception-node-modules
 
 networks:
   agentception-net:


### PR DESCRIPTION
The `./:/app` bind mount shadows image-layer artifacts at runtime, so compiling SCSS/TS in the Dockerfile is useless — the output is immediately hidden.

**Fix:**
- Move `sass` and `npm run build:js` into the startup `command` in `docker-compose.yml`, after the bind mount takes effect
- Add `npm ci` to the Dockerfile to bake Linux-native node_modules into the image
- Add a named volume `agentception-node-modules` that overlays `/app/node_modules`, preventing the macOS host binaries from shadowing the container's Linux esbuild/tsc binaries
- Remove the now-dead build `RUN` steps from the Dockerfile