### PR TITLE
feat: add tree-sitter and core language grammar packages to requirements.txt

### DIFF
--- a/agentception/requirements.txt
+++ b/agentception/requirements.txt
@@ -27,3 +27,12 @@ anyio>=4.0.0
 mypy>=1.8.0
 types-aiofiles>=23.2.0
 types-PyYAML>=6.0.0
+# Tree-sitter runtime and language grammars for multi-language code parsing
+tree-sitter>=0.23
+tree-sitter-python>=0.23
+tree-sitter-typescript>=0.23
+tree-sitter-javascript>=0.23
+tree-sitter-go>=0.23
+tree-sitter-rust>=0.23
+tree-sitter-java>=0.23
+tree-sitter-ruby>=0.23

--- a/agentception/tests/test_tree_sitter_import.py
+++ b/agentception/tests/test_tree_sitter_import.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+import tree_sitter_python
+import tree_sitter_typescript
+import tree_sitter_javascript
+import tree_sitter_go
+import tree_sitter_rust
+import tree_sitter_java
+import tree_sitter_ruby
+from tree_sitter import Language, Parser
+
+def test_all_grammars_load() -> None:
+    cases: list[tuple[object, str]] = [
+        (tree_sitter_python, "language"),
+        (tree_sitter_typescript, "language_typescript"),
+        (tree_sitter_javascript, "language"),
+        (tree_sitter_go, "language"),
+        (tree_sitter_rust, "language"),
+        (tree_sitter_java, "language"),
+        (tree_sitter_ruby, "language"),
+    ]
+    for lang_mod, fn_name in cases:
+        Language(getattr(lang_mod, fn_name)())  # must not raise

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/app/node_modules


### PR DESCRIPTION
Closes #753

## Summary

Adds `tree-sitter` runtime and seven first-tier language grammar packages to `requirements.txt` so they are available inside the Docker container and importable from Python.

## Changes

- **`agentception/requirements.txt`** — appended eight new entries with `>=0.23` version pins:
  - `tree-sitter>=0.23`
  - `tree-sitter-python>=0.23`
  - `tree-sitter-typescript>=0.23`
  - `tree-sitter-javascript>=0.23`
  - `tree-sitter-go>=0.23`
  - `tree-sitter-rust>=0.23`
  - `tree-sitter-java>=0.23`
  - `tree-sitter-ruby>=0.23`

- **`agentception/tests/test_tree_sitter_import.py`** — new test file asserting all grammar packages are importable and `Language(...)` construction succeeds for each.

## Rebuild required

Since `requirements.txt` changed, the container image must be rebuilt:

```bash
docker compose build agentception && docker compose up -d agentception
```

## Verification

- `test_all_grammars_load` passes ✅
- `mypy` clean ✅
- `import tree_sitter_python; print('ok')` prints `ok` ✅