### PR TITLE
feat(tree-sitter): add HTML/Jinja2 grammar + fix node_modules symlink in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ logs/
 alembic/versions/__pycache__/
 
 # Node
+node_modules
 node_modules/
 package-lock.json
 

--- a/agentception/requirements.txt
+++ b/agentception/requirements.txt
@@ -36,3 +36,4 @@ tree-sitter-go>=0.23
 tree-sitter-rust>=0.23
 tree-sitter-java>=0.23
 tree-sitter-ruby>=0.23
+tree-sitter-html>=0.23

--- a/agentception/services/tree_sitter_scope.py
+++ b/agentception/services/tree_sitter_scope.py
@@ -67,6 +67,7 @@ def _make_dispatch() -> dict[str, _LangConfig]:
     import tree_sitter_rust
     import tree_sitter_java
     import tree_sitter_ruby
+    import tree_sitter_html
 
     py_cfg = _LangConfig(
         grammar=tree_sitter_python.language,
@@ -121,6 +122,11 @@ def _make_dispatch() -> dict[str, _LangConfig]:
         scope_types=frozenset({"method", "singleton_method", "class"}),
         import_types=frozenset(),
     )
+    html_cfg = _LangConfig(
+        grammar=tree_sitter_html.language,
+        scope_types=frozenset({"element", "script_element", "style_element"}),
+        import_types=frozenset(),
+    )
 
     return {
         ".py": py_cfg,
@@ -132,6 +138,8 @@ def _make_dispatch() -> dict[str, _LangConfig]:
         ".rs": rs_cfg,
         ".java": java_cfg,
         ".rb": rb_cfg,
+        ".html": html_cfg,
+        ".j2": html_cfg,
     }
 
 

--- a/agentception/tests/test_tree_sitter_scope.py
+++ b/agentception/tests/test_tree_sitter_scope.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 """Unit tests for agentception.services.tree_sitter_scope.
 
 Covers:
-- get_enclosing_scope: Python, TypeScript, Go, unsupported extension, syntax error.
-- get_imports: Python, TypeScript, unsupported extension.
+- get_enclosing_scope: Python, TypeScript, Go, HTML/Jinja2, unsupported extension,
+  syntax error.
+- get_imports: Python, TypeScript, HTML (no imports), unsupported extension.
 """
 
 import textwrap
@@ -69,11 +70,46 @@ def test_go_scope_extracts_function() -> None:
     assert end >= 4
 
 
+def test_html_scope_extracts_element() -> None:
+    """HTML source; target line inside a div; scope spans the element."""
+    source = textwrap.dedent("""\
+        <html>
+        <body>
+          <div class="container">
+            <p>hello world</p>
+          </div>
+        </body>
+        </html>
+    """)
+    # Line 4 is the <p> element inside the div; expect some enclosing element scope.
+    start, end, name = get_enclosing_scope(source, ".html", 4)
+    assert start <= 4
+    assert end >= 4
+    assert isinstance(name, str) and len(name) > 0
+
+
+def test_j2_extension_uses_html_grammar() -> None:
+    """Jinja2 templates (.j2) are parsed as HTML and return a valid scope."""
+    source = textwrap.dedent("""\
+        {% extends "base.html" %}
+        {% block content %}
+        <div class="page">
+          <h1>{{ title }}</h1>
+        </div>
+        {% endblock %}
+    """)
+    # Line 4 is the <h1> tag; parser should not raise even for Jinja2 syntax.
+    start, end, name = get_enclosing_scope(source, ".j2", 4)
+    assert start <= 4
+    assert end >= 4
+    assert isinstance(name, str) and len(name) > 0
+
+
 def test_unsupported_extension_falls_back() -> None:
-    """Unsupported extension returns ±20-line window with name starting 'line '."""
-    source = "\n".join(f"<p>line {i}</p>" for i in range(1, 60))
+    """Truly unsupported extension returns ±20-line window with name starting 'line '."""
+    source = "\n".join(f"line {i}" for i in range(1, 60))
     target = 30
-    start, end, name = get_enclosing_scope(source, ".html", target)
+    start, end, name = get_enclosing_scope(source, ".xyz", target)
     assert start <= target
     assert end >= target
     assert end - start <= 41  # ±20 window = at most 41 lines
@@ -126,8 +162,15 @@ def test_get_imports_typescript() -> None:
     assert "path" in result
 
 
-def test_get_imports_unsupported_returns_empty() -> None:
-    """Unsupported extension returns empty string."""
+def test_get_imports_html_returns_empty() -> None:
+    """HTML has no import concept — get_imports returns empty string by design."""
     source = "<html><body>hello</body></html>"
     result = get_imports(source, ".html")
+    assert result == ""
+
+
+def test_get_imports_unsupported_returns_empty() -> None:
+    """Truly unsupported extension returns empty string."""
+    source = "SELECT * FROM users;"
+    result = get_imports(source, ".sql")
     assert result == ""

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/app/node_modules


### PR DESCRIPTION
## Summary

- Extends `tree_sitter_scope.py` with `tree-sitter-html>=0.23` to parse `.html` and `.j2` files (scope nodes: `element`, `script_element`, `style_element`; no import extraction — HTML has none).
- Adds two new tests (`test_html_scope_extracts_element`, `test_j2_extension_uses_html_grammar`) and corrects the existing `.html` test that was labelled "unsupported" — it now tests a truly unsupported extension (`.xyz`).
- Removes the `node_modules -> /app/node_modules` symlink that was erroneously committed to `dev` by a prior agent; this symlink was causing Docker volume mount to fail with "too many levels of symbolic links" on container restart. Tightens `.gitignore` to block both `node_modules/` and `node_modules` (bare, catches symlinks).

Closes #756

## Test plan

- [x] `mypy agentception/ tests/` — 0 errors (264 files)
- [x] `typing_audit.py --max-any 0` — passes
- [x] `pytest agentception/tests/test_tree_sitter_scope.py -v` — 11/11 green