### PR TITLE
fix(git): use settings.repo_dir in symlink helper, guard against self-symlink, extract rebase helper

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -45,6 +45,72 @@ from agentception.services.teardown import release_worktree, teardown_agent_work
 logger = logging.getLogger(__name__)
 
 
+async def _rebase_and_push_worktree(wt_path: str, agent_run_id: str | None) -> dict[str, object] | None:
+    """Rebase the worktree branch onto origin/dev and force-push.
+
+    Returns ``None`` on success, or a structured error dict on rebase conflict
+    that the caller should return immediately to the agent.
+
+    Extracted into its own function so tests can mock it cleanly without
+    spawning real git subprocesses against non-existent paths.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "git", "fetch", "origin", "dev",
+        cwd=wt_path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await proc.communicate()
+
+    proc = await asyncio.create_subprocess_exec(
+        "git", "rebase", "origin/dev",
+        cwd=wt_path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+
+    if proc.returncode != 0:
+        abort_proc = await asyncio.create_subprocess_exec(
+            "git", "rebase", "--abort",
+            cwd=wt_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await abort_proc.communicate()
+        logger.error(
+            "❌ _rebase_and_push_worktree: rebase onto origin/dev failed for run_id=%r — %s",
+            agent_run_id,
+            stderr.decode(errors="replace").strip(),
+        )
+        return {
+            "status": "error",
+            "reason": "rebase_conflict",
+            "message": (
+                "Rebase onto origin/dev failed. "
+                "Resolve the conflicts manually and call build_complete_run again."
+            ),
+        }
+
+    branch_proc = await asyncio.create_subprocess_exec(
+        "git", "rev-parse", "--abbrev-ref", "HEAD",
+        cwd=wt_path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    branch_stdout, _ = await branch_proc.communicate()
+    branch_name = branch_stdout.decode().strip()
+
+    proc = await asyncio.create_subprocess_exec(
+        "git", "push", "--force-with-lease", "origin", branch_name,
+        cwd=wt_path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await proc.communicate()
+    return None
+
+
 async def build_claim_run(run_id: str) -> dict[str, object]:
     """Atomically claim a pending run before spawning its Task agent.
 
@@ -308,62 +374,10 @@ async def build_complete_run(
             teardown_info = await get_agent_run_teardown(agent_run_id)
             wt_path = teardown_info.get("worktree_path") if teardown_info else None
             if wt_path is not None:
-                # Ensure branch is up-to-date with dev before dispatching reviewer
-                proc = await asyncio.create_subprocess_exec(
-                    "git", "fetch", "origin", "dev",
-                    cwd=wt_path,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                await proc.communicate()
-
-                proc = await asyncio.create_subprocess_exec(
-                    "git", "rebase", "origin/dev",
-                    cwd=wt_path,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                stdout, stderr = await proc.communicate()
-
-                if proc.returncode != 0:
-                    abort_proc = await asyncio.create_subprocess_exec(
-                        "git", "rebase", "--abort",
-                        cwd=wt_path,
-                        stdout=asyncio.subprocess.PIPE,
-                        stderr=asyncio.subprocess.PIPE,
-                    )
-                    await abort_proc.communicate()
-                    logger.error(
-                        "❌ build_complete_run: rebase onto origin/dev failed for run_id=%r — %s",
-                        agent_run_id,
-                        stderr.decode(errors="replace").strip(),
-                    )
-                    return {
-                        "status": "error",
-                        "reason": "rebase_conflict",
-                        "message": (
-                            "Rebase onto origin/dev failed. "
-                            "Resolve the conflicts manually and call build_complete_run again."
-                        ),
-                    }
-
-                # Rebase succeeded — force-push the updated branch.
-                branch_proc = await asyncio.create_subprocess_exec(
-                    "git", "rev-parse", "--abbrev-ref", "HEAD",
-                    cwd=wt_path,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                branch_stdout, _ = await branch_proc.communicate()
-                branch_name = branch_stdout.decode().strip()
-
-                proc = await asyncio.create_subprocess_exec(
-                    "git", "push", "--force-with-lease", "origin", branch_name,
-                    cwd=wt_path,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                await proc.communicate()
+                # Rebase onto dev and force-push before dispatching reviewer.
+                rebase_error = await _rebase_and_push_worktree(wt_path, agent_run_id)
+                if rebase_error is not None:
+                    return rebase_error
 
                 await release_worktree(
                     worktree_path=wt_path,

--- a/agentception/readers/git.py
+++ b/agentception/readers/git.py
@@ -445,21 +445,32 @@ async def ensure_worktree(
 
 
 def _symlink_frontend_resources(worktree_path: Path) -> None:
-    """Symlink frontend build resources from /app into the new worktree.
+    """Symlink frontend build resources from the main repo into the new worktree.
 
     Agents run npm commands (type-check, test, build:js) from within the
     worktree.  node_modules, package.json, tsconfig.json, and vitest.config.ts
-    live in /app (the main repo mount) and are gitignored, so they are never
-    present in a freshly-created worktree.  Without these symlinks agents waste
-    iterations discovering they must cd to /app before running npm commands.
+    live in the main repo root and are gitignored, so they are never present in
+    a freshly-created worktree.  Without these symlinks agents waste iterations
+    discovering they must cd to the main repo before running npm commands.
 
-    The symlinks are created only when the target in /app actually exists, so
-    this is safe to call in environments where Node is not installed.
+    Uses settings.repo_dir (not a hardcoded /app) so the path is correct in
+    every environment, including tests that override REPO_DIR.
+
+    Symlinks are created only when the target in the main repo actually exists,
+    and are skipped when the destination already exists (real file, real
+    directory, or existing symlink) to avoid clobbering and circular links.
     """
-    app_root = Path("/app")
+    repo_root = settings.repo_dir.resolve()
+
+    # Guard: never symlink if the worktree IS the main repo — that would create
+    # self-referential links (e.g. /app/node_modules → /app/node_modules).
+    if worktree_path.resolve() == repo_root:
+        logger.warning("⚠️ _symlink_frontend_resources: worktree_path == repo_root (%s) — skipping", repo_root)
+        return
+
     resources = ["node_modules", "package.json", "package-lock.json", "tsconfig.json", "vitest.config.ts"]
     for name in resources:
-        src = app_root / name
+        src = repo_root / name
         dst = worktree_path / name
         if not src.exists():
             continue

--- a/agentception/tests/test_mcp_build_commands_pr3.py
+++ b/agentception/tests/test_mcp_build_commands_pr3.py
@@ -451,6 +451,11 @@ async def test_build_complete_run_releases_worktree_before_reviewer() -> None:
             return_value={"worktree_path": "/worktrees/issue-99", "branch": "feat/issue-99"},
         ),
         patch(
+            "agentception.mcp.build_commands._rebase_and_push_worktree",
+            new_callable=AsyncMock,
+            return_value=None,  # None = success
+        ) as mock_rebase,
+        patch(
             "agentception.mcp.build_commands.release_worktree",
             new_callable=AsyncMock,
         ) as mock_release,
@@ -469,8 +474,11 @@ async def test_build_complete_run_releases_worktree_before_reviewer() -> None:
             },
         )
 
+    from agentception.config import settings as _settings
+
     assert json.loads(result["content"][0]["text"])["ok"] is True
+    mock_rebase.assert_awaited_once_with("/worktrees/issue-99", "issue-99")
     mock_release.assert_awaited_once_with(
         worktree_path="/worktrees/issue-99",
-        repo_dir=str(__import__("agentception.config", fromlist=["settings"]).settings.repo_dir),
+        repo_dir=str(_settings.repo_dir),
     )


### PR DESCRIPTION
## Summary

- `_symlink_frontend_resources` in `git.py` had `app_root = Path("/app")` hardcoded. Replaced with `settings.repo_dir.resolve()` to honour `REPO_DIR` overrides and be consistent with the rest of the file.
- Added a guard that returns early when `worktree_path.resolve() == repo_root` — prevents the self-referential `node_modules → /app/node_modules` circular symlink that caused Docker volume mount to fail with "too many levels of symbolic links" (the root cause of the container startup failure in the previous session).
- Extracted the inline `git fetch` / `git rebase` / `git push` block in `build_complete_run` into `_rebase_and_push_worktree`. The existing regression test `test_build_complete_run_releases_worktree_before_reviewer` was failing with `FileNotFoundError` because `asyncio.create_subprocess_exec` was being called with `cwd=/worktrees/issue-99` (doesn't exist) before `release_worktree` was ever reached. The test now mocks `_rebase_and_push_worktree` directly.

## Test plan

- [x] `mypy agentception/ tests/` — 0 errors (264 files)
- [x] `typing_audit.py --max-any 0` — passes
- [x] `pytest agentception/tests/test_mcp_build_commands_pr3.py -v` — 22/22 green (previously 1 failing)
- [x] Full suite — 1947/1948 pass; 1 intermittent flake (`test_dispatch_implementer_uses_origin_dev_as_base`) passes in isolation, fails under full-suite memory pressure; not caused by these changes