### PR TITLE
fix: guard AC pre-loader parent.iterdir() against non-directory paths

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -332,7 +332,7 @@ def _build_ac_file_sections(
             # File doesn't exist — show the parent directory listing so the
             # agent knows the naming convention (e.g. Alembic migration numbers).
             parent = full_path.parent
-            if parent.exists():
+            if parent.is_dir():
                 siblings = sorted(p.name for p in parent.iterdir() if p.is_file())
                 if siblings:
                     listing = "\n".join(siblings[-8:])


### PR DESCRIPTION
## Summary
- `_build_ac_file_sections` called `parent.iterdir()` after checking only `parent.exists()`
- In git worktrees `.git` is a regular file (a gitdir pointer), not a directory
- Issue bodies that mention `.git/config` caused the pre-loader to extract that path, compute parent as `.git`, find it exists, then crash with `NotADirectoryError` on `iterdir()`
- Fix: replace `parent.exists()` with `parent.is_dir()`

## Root cause
Issue #760's body contains `` `.git/config` `` and `` `.git/config.lock` `` — the pre-loader regex extracted them, resolved them relative to the worktree, and tried to list their parent directory which is the `.git` file itself.