### PR TITLE
fix: skip rebase in _rebase_and_push_worktree when worktree already removed

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -24,6 +24,7 @@ Rules
 
 import asyncio
 import logging
+from pathlib import Path
 
 from agentception.db.persist import (
     acknowledge_agent_run,
@@ -53,7 +54,19 @@ async def _rebase_and_push_worktree(wt_path: str, agent_run_id: str | None) -> d
 
     Extracted into its own function so tests can mock it cleanly without
     spawning real git subprocesses against non-existent paths.
+
+    If the worktree directory no longer exists (e.g. the agent called
+    build_complete_run explicitly as a tool and the loop's stop-path
+    calls it again as a safety net) the function skips the rebase and
+    returns ``None`` — the branch was already pushed by the first call.
     """
+    if not Path(wt_path).exists():
+        logger.info(
+            "ℹ️  _rebase_and_push_worktree: worktree %r already removed — skipping rebase",
+            wt_path,
+        )
+        return None
+
     proc = await asyncio.create_subprocess_exec(
         "git", "fetch", "origin", "dev",
         cwd=wt_path,


### PR DESCRIPTION
## Summary
- When an agent explicitly calls `build_complete_run` as an MCP tool, the developer worktree is released and the reviewer is dispatched
- `agent_loop.py` then **also** calls `build_complete_run` when `stop_reason='stop'` as a safety net — but by then `wt_path` no longer exists
- `asyncio.create_subprocess_exec(cwd=<deleted path>)` raises `FileNotFoundError`, which escapes the fire-and-forget `run_agent_loop` task
- Result: "❌ Task exception was never retrieved" logged on every run after the developer completes

## Fix
Guard at the top of `_rebase_and_push_worktree`: if `Path(wt_path)` does not exist, log and return `None` — the branch was already pushed and rebased by the first `build_complete_run` call.

## Test plan
- Reviewer dispatch still works (the guard is a no-op when the worktree exists — first call path)
- The "Task exception was never retrieved" error should no longer appear between developer stop and reviewer start