### PR TITLE
chore: verification pass — semaphore fix mypy and pytest clean

### DIFF
--- a/.agentception/verification-761.md
+++ b/.agentception/verification-761.md
@@ -1,0 +1,44 @@
+# Verification Report — Issue #761
+
+## Semaphore Fix Verification Pass
+
+**Date:** 2026-03-12  
+**Initiative:** worktree-race-fix-p0-001 (PR #831)
+
+## Results
+
+### mypy (files touched by semaphore initiative)
+
+```
+python -m mypy --follow-imports=silent agentception/readers/git.py agentception/tests/test_ensure_helpers.py
+Success: no issues found in 2 source files
+```
+
+✅ Zero errors on files touched by the semaphore initiative.
+
+### pytest agentception/tests/test_ensure_helpers.py -v
+
+```
+32 passed in ~0.5s
+```
+
+✅ All 32 tests pass, including `test_concurrent_worktree_creation_does_not_race`.
+
+### pytest agentception/tests/ -v (full suite)
+
+```
+1 failed, 1928 passed, 1 skipped, 16 warnings in 57.16s
+```
+
+✅ No regressions introduced by the semaphore fix.
+
+## Pre-existing failure (out of scope)
+
+**Test:** `agentception/tests/test_build_commands_rebase.py::test_rebase_conflict_returns_error_and_aborts`
+
+**Root cause:** Introduced by PR #832 (early-return guard in `_rebase_and_push_worktree`
+when worktree directory does not exist). The test uses a non-existent path
+`/worktrees/issue-20`, so it now hits the early-return path instead of the
+rebase conflict path.
+
+**Tracked in:** Issue #833


### PR DESCRIPTION
## Summary

Verification pass confirming the worktree semaphore fix (PR #831) introduced
no regressions in static analysis or the test suite.

## Results

### Static analysis (files touched by semaphore initiative)

```
python -m mypy --follow-imports=silent agentception/readers/git.py agentception/tests/test_ensure_helpers.py
Success: no issues found in 2 source files
```

✅ Zero errors.

### pytest agentception/tests/test_ensure_helpers.py

```
32 passed in ~0.5s
```

✅ All 32 tests pass, including `test_concurrent_worktree_creation_does_not_race`.

### Full suite: pytest agentception/tests/

```
1 failed, 1928 passed, 1 skipped, 16 warnings in 57.16s
```

✅ No regressions from the semaphore fix.

## Pre-existing failure (out of scope)

**Test:** `test_build_commands_rebase.py::test_rebase_conflict_returns_error_and_aborts`

This failure was introduced by PR #832 (early-return guard when worktree
directory does not exist). The test uses a non-existent path `/worktrees/issue-20`,
so it now hits the early-return path instead of the rebase conflict path.

Tracked in issue #833. Not suppressed here — documented per AC.

Closes #761