### PR TITLE
feat: enforce file-edit and PR pre-flight checks in build_complete_run

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -26,6 +26,10 @@ import asyncio
 import logging
 from pathlib import Path
 
+from sqlalchemy import func, select
+
+from agentception.db.engine import get_session
+from agentception.db.models import ACAgentEvent, ACAgentRun
 from agentception.db.persist import (
     acknowledge_agent_run,
     block_agent_run,
@@ -299,6 +303,59 @@ async def build_complete_run(
     Returns:
         ``{"ok": True, "event": "done", "status": "completed"}``
     """
+    # -------------------------------------------------------------------------
+    # Pre-flight invariant guards
+    #
+    # Invariant 1 — file edits must exist before completion is accepted.
+    # Invariant 2 — a PR number must be recorded on the run row.
+    #
+    # These checks enforce the behavioral contract of build_complete_run: the
+    # tool is only meaningful when the agent has actually written code AND
+    # opened a pull request.  Accepting the call without these conditions
+    # produces empty PRs and wastes reviewer cycles.
+    #
+    # We return a structured dict (not raise an exception) so the MCP
+    # framework serialises the refusal back to the agent as a normal tool
+    # response.  The agent can then act on the error — write files, open a PR
+    # — and retry.  An exception would be opaque to the agent and would not
+    # give it actionable guidance.
+    # -------------------------------------------------------------------------
+    if agent_run_id:
+        async with get_session() as _session:
+            file_edit_count: int = (
+                await _session.execute(
+                    select(func.count()).select_from(ACAgentEvent).where(
+                        ACAgentEvent.agent_run_id == agent_run_id,
+                        ACAgentEvent.event_type.in_(["file_edit", "write_file"]),
+                    )
+                )
+            ).scalar_one()
+
+        if file_edit_count == 0:
+            return {
+                "ok": False,
+                "error": (
+                    "build_complete_run refused: no file edits recorded for this run. "
+                    "Write and commit your changes first."
+                ),
+            }
+
+        async with get_session() as _session2:
+            run_row: ACAgentRun | None = (
+                await _session2.execute(
+                    select(ACAgentRun).where(ACAgentRun.id == agent_run_id)
+                )
+            ).scalar_one_or_none()
+
+        if run_row is None or run_row.pr_number is None:
+            return {
+                "ok": False,
+                "error": (
+                    "build_complete_run refused: no PR found. "
+                    "Create and push a branch, then open a pull request first."
+                ),
+            }
+
     await persist_agent_event(
         issue_number=issue_number,
         event_type="done",

--- a/tests/test_build_commands.py
+++ b/tests/test_build_commands.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+"""Tests for build_complete_run pre-flight guards.
+
+Covers the two invariant checks added to build_complete_run:
+  1. At least one file_edit / write_file event must exist for the run.
+  2. The run row must have a non-NULL pr_number.
+
+All tests are fully isolated — no real DB connections are made.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RUN_ID = "test-run-abc123"
+_ISSUE = 42
+_PR_URL = "https://github.com/cgcardona/agentception/pull/99"
+
+
+def _make_scalar_one(value: object) -> MagicMock:
+    """Return a mock whose .scalar_one() returns *value*."""
+    result = MagicMock()
+    result.scalar_one.return_value = value
+    return result
+
+
+def _make_scalar_one_or_none(value: object) -> MagicMock:
+    """Return a mock whose .scalar_one_or_none() returns *value*."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+def _make_session_cm(execute_side_effects: list[object]) -> MagicMock:
+    """Build a mock async context manager for get_session().
+
+    *execute_side_effects* is consumed in order for each ``session.execute``
+    call made inside the ``async with get_session()`` block.
+    """
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=execute_side_effects)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_refused_no_file_edits() -> None:
+    """build_complete_run returns the file-edit refusal dict when count == 0."""
+    from agentception.mcp.build_commands import build_complete_run
+
+    # First get_session call: file-edit count query → 0
+    session_cm_1 = _make_session_cm([_make_scalar_one(0)])
+
+    with patch(
+        "agentception.mcp.build_commands.get_session",
+        side_effect=[session_cm_1],
+    ):
+        result = await build_complete_run(
+            issue_number=_ISSUE,
+            pr_url=_PR_URL,
+            agent_run_id=_RUN_ID,
+        )
+
+    assert result == {
+        "ok": False,
+        "error": (
+            "build_complete_run refused: no file edits recorded for this run. "
+            "Write and commit your changes first."
+        ),
+    }
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_refused_no_pr() -> None:
+    """build_complete_run returns the PR-missing refusal dict when pr_number is None."""
+    from agentception.mcp.build_commands import build_complete_run
+
+    # First get_session call: file-edit count query → 1 (has edits)
+    session_cm_1 = _make_session_cm([_make_scalar_one(1)])
+
+    # Second get_session call: run row query → run with pr_number=None
+    run_mock = MagicMock()
+    run_mock.pr_number = None
+    session_cm_2 = _make_session_cm([_make_scalar_one_or_none(run_mock)])
+
+    with patch(
+        "agentception.mcp.build_commands.get_session",
+        side_effect=[session_cm_1, session_cm_2],
+    ):
+        result = await build_complete_run(
+            issue_number=_ISSUE,
+            pr_url=_PR_URL,
+            agent_run_id=_RUN_ID,
+        )
+
+    assert result == {
+        "ok": False,
+        "error": (
+            "build_complete_run refused: no PR found. "
+            "Create and push a branch, then open a pull request first."
+        ),
+    }
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_allowed_when_checks_pass() -> None:
+    """build_complete_run proceeds to existing completion logic when both checks pass."""
+    from agentception.mcp.build_commands import build_complete_run
+
+    # First get_session call: file-edit count → 3 (has edits)
+    session_cm_1 = _make_session_cm([_make_scalar_one(3)])
+
+    # Second get_session call: run row → run with pr_number set
+    run_mock = MagicMock()
+    run_mock.pr_number = 99
+    session_cm_2 = _make_session_cm([_make_scalar_one_or_none(run_mock)])
+
+    with (
+        patch(
+            "agentception.mcp.build_commands.get_session",
+            side_effect=[session_cm_1, session_cm_2],
+        ),
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist,
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="developer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_teardown",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "agentception.mcp.build_commands.auto_dispatch_reviewer",
+            new_callable=AsyncMock,
+        ),
+        patch("asyncio.create_task"),
+    ):
+        result = await build_complete_run(
+            issue_number=_ISSUE,
+            pr_url=_PR_URL,
+            agent_run_id=_RUN_ID,
+        )
+
+    # persist_agent_event must have been called — proof the handler proceeded
+    mock_persist.assert_awaited_once()
+    assert result == {"ok": True, "event": "done", "status": "completed"}


### PR DESCRIPTION
Closes #801

## Summary

Adds two sequential pre-flight invariant guards to `build_complete_run` that reject the call — with a structured, retryable error dict — unless:

1. At least one `file_edit` or `write_file` event exists for the run (agent has actually written code).
2. The run row has a non-NULL `pr_number` (agent has opened a pull request).

Both checks fire before any side-effectful code (event persistence, state transitions, reviewer dispatch). The refusal is returned as a plain dict so the MCP framework serialises it back to the agent as a normal tool response the agent can act on.

## Changes

- `agentception/mcp/build_commands.py`: Added imports (`get_session`, `ACAgentEvent`, `ACAgentRun`, `func`, `select`) and two guard clauses with a documentation comment block explaining the invariant and the early-return design choice.
- `tests/test_build_commands.py`: New test file with three isolated tests covering both refusal paths and the happy path.

## Tests

```
tests/test_build_commands.py::test_build_complete_run_refused_no_file_edits  PASSED
tests/test_build_commands.py::test_build_complete_run_refused_no_pr          PASSED
tests/test_build_commands.py::test_build_complete_run_allowed_when_checks_pass PASSED
```

All 10 tests in the suite pass. mypy reports zero errors.