### PR TITLE
feat: add build_complete_run pre-flight checklist to developer role prompt

### DIFF
--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -110,3 +110,15 @@ Then:
   `build_cancel_run` with a clear description of what failed and why.
 - The plan operations are immutable in order and content. Adding operations to
   satisfy AC items (missing tests, type fixes) is allowed and expected.
+
+## Tool usage
+
+**`build_complete_run` — only call this when ALL four conditions are met:**
+1. You have written at least one file using `write_file` or `replace_in_file`.
+2. You have run `mypy` and `pytest` locally and both pass.
+3. You have called `git_commit_and_push` and received a success response.
+4. You have an open pull request URL confirmed in the tool response.
+
+Calling `build_complete_run` without a committed PR immediately ends your
+run — the reviewer will see an empty branch and the work will be lost.
+

--- a/scripts/gen_prompts/templates/roles/developer.md.j2
+++ b/scripts/gen_prompts/templates/roles/developer.md.j2
@@ -109,3 +109,14 @@ Then:
   `build_cancel_run` with a clear description of what failed and why.
 - The plan operations are immutable in order and content. Adding operations to
   satisfy AC items (missing tests, type fixes) is allowed and expected.
+
+## Tool usage
+
+**`build_complete_run` — only call this when ALL four conditions are met:**
+1. You have written at least one file using `write_file` or `replace_in_file`.
+2. You have run `mypy` and `pytest` locally and both pass.
+3. You have called `git_commit_and_push` and received a success response.
+4. You have an open pull request URL confirmed in the tool response.
+
+Calling `build_complete_run` without a committed PR immediately ends your
+run — the reviewer will see an empty branch and the work will be lost.

--- a/tests/test_developer_prompt.py
+++ b/tests/test_developer_prompt.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+COMPILED_PROMPT = Path(__file__).parent.parent / ".agentception" / "roles" / "developer.md"
+
+
+def test_build_complete_run_checklist_present() -> None:
+    """Compiled developer role prompt must contain the build_complete_run pre-flight checklist."""
+    content = COMPILED_PROMPT.read_text()
+    assert '`build_complete_run` — only call this when ALL four conditions are met' in content, (
+        f"Pre-flight checklist not found in {COMPILED_PROMPT}"
+    )


### PR DESCRIPTION
Closes #800

Adds an explicit four-condition pre-flight checklist under a new "Tool usage" section in the developer role prompt template (`scripts/gen_prompts/templates/roles/developer.md.j2`) and its compiled output (`.agentception/roles/developer.md`). The checklist prevents agents from calling `build_complete_run` before they have written files, run mypy+pytest, committed, and opened a PR.

Also adds `tests/test_developer_prompt.py::test_build_complete_run_checklist_present` to assert the checklist string is present in the compiled prompt.