### PR TITLE
fix: enforce file-edit and PR pre-flight checks in build_complete_run

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -26,6 +26,10 @@ import asyncio
 import logging
 from pathlib import Path
 
+from sqlalchemy import func, select
+
+from agentception.db.engine import get_session
+from agentception.db.models import ACAgentEvent, ACAgentRun
 from agentception.db.persist import (
     acknowledge_agent_run,
     block_agent_run,
@@ -299,6 +303,55 @@ async def build_complete_run(
     Returns:
         ``{"ok": True, "event": "done", "status": "completed"}``
     """
+    # Pre-flight invariant guards — enforced before any side-effectful code.
+    #
+    # Invariant 1: The agent must have recorded at least one file-edit event
+    # before declaring completion.  Agents that call build_complete_run without
+    # writing any files have produced no artefact; accepting the call would
+    # trigger the auto-reviewer against an empty branch.  We return a
+    # structured dict (not an exception) so the MCP framework serialises it
+    # back to the agent as a normal tool response the agent can act on.
+    #
+    # Invariant 2: A PR number must be recorded on the run row before the
+    # completion call is accepted.  Without a PR the reviewer has nothing to
+    # review, and the auto-dispatch would fail silently.  Again, an early
+    # return (not an exception) is the correct signal — the agent can open
+    # the PR and retry.
+    if agent_run_id:
+        async with get_session() as session:
+            file_edit_count: int = (
+                await session.execute(
+                    select(func.count()).select_from(ACAgentEvent).where(
+                        ACAgentEvent.agent_run_id == agent_run_id,
+                        ACAgentEvent.event_type.in_(["file_edit", "write_file"]),
+                    )
+                )
+            ).scalar_one()
+
+            if file_edit_count == 0:
+                return {
+                    "ok": False,
+                    "error": (
+                        "build_complete_run refused: no file edits recorded for this run. "
+                        "Write and commit your changes first."
+                    ),
+                }
+
+            run_row = (
+                await session.execute(
+                    select(ACAgentRun).where(ACAgentRun.id == agent_run_id)
+                )
+            ).scalar_one_or_none()
+
+            if run_row is None or run_row.pr_number is None:
+                return {
+                    "ok": False,
+                    "error": (
+                        "build_complete_run refused: no PR found. "
+                        "Create and push a branch, then open a pull request first."
+                    ),
+                }
+
     await persist_agent_event(
         issue_number=issue_number,
         event_type="done",

--- a/agentception/tests/test_build_commands.py
+++ b/agentception/tests/test_build_commands.py
@@ -12,7 +12,41 @@ Run targeted:
 """
 
 import pytest
-from unittest.mock import AsyncMock, patch
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _make_mock_session(file_edit_count: int = 1, pr_number: int | None = 42) -> MagicMock:
+    """Build a mock async context-manager session that satisfies the pre-flight guards.
+
+    The pre-flight guards in build_complete_run execute two queries:
+    1. COUNT of ACAgentEvent rows with event_type in ('file_edit', 'write_file').
+    2. SELECT of ACAgentRun row to check pr_number IS NOT NULL.
+
+    This helper returns a mock session whose ``execute`` method returns the
+    appropriate scalar results in call order.
+    """
+    mock_session = MagicMock()
+
+    # First execute call → file_edit count
+    count_result = MagicMock()
+    count_result.scalar_one.return_value = file_edit_count
+
+    # Second execute call → ACAgentRun row
+    run_row = MagicMock()
+    run_row.pr_number = pr_number
+    run_result = MagicMock()
+    run_result.scalar_one_or_none.return_value = run_row
+
+    mock_session.execute = AsyncMock(side_effect=[count_result, run_result])
+
+    from collections.abc import AsyncGenerator
+
+    @asynccontextmanager
+    async def _mock_get_session() -> AsyncGenerator[MagicMock, None]:
+        yield mock_session
+
+    return _mock_get_session  # type: ignore[return-value]
 
 
 @pytest.mark.anyio
@@ -28,6 +62,10 @@ async def test_reviewer_worktree_torn_down_after_failing_grade() -> None:
     reviewer_run_id = "reviewer-issue-42-abc123"
 
     with (
+        patch(
+            "agentception.mcp.build_commands.get_session",
+            new=_make_mock_session(file_edit_count=1, pr_number=99),
+        ),
         patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
@@ -87,6 +125,10 @@ async def test_reviewer_worktree_torn_down_after_passing_grade() -> None:
     reviewer_run_id = "reviewer-issue-55-def456"
 
     with (
+        patch(
+            "agentception.mcp.build_commands.get_session",
+            new=_make_mock_session(file_edit_count=1, pr_number=100),
+        ),
         patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
@@ -148,6 +190,10 @@ async def test_redispatch_fires_after_failing_grade() -> None:
     grade = "F"
 
     with (
+        patch(
+            "agentception.mcp.build_commands.get_session",
+            new=_make_mock_session(file_edit_count=1, pr_number=200),
+        ),
         patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
@@ -219,6 +265,10 @@ async def test_redispatch_skipped_after_passing_grade() -> None:
 
     with (
         patch(
+            "agentception.mcp.build_commands.get_session",
+            new=_make_mock_session(file_edit_count=1, pr_number=300),
+        ),
+        patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
         ),
@@ -281,6 +331,10 @@ async def test_build_complete_run_rejects_empty_grade_from_reviewer() -> None:
 
     with (
         patch(
+            "agentception.mcp.build_commands.get_session",
+            new=_make_mock_session(file_edit_count=1, pr_number=999),
+        ),
+        patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
         ),
@@ -333,6 +387,10 @@ async def test_build_complete_run_rejects_whitespace_grade_from_reviewer() -> No
     reviewer_run_id = "reviewer-issue-99-whitespace"
 
     with (
+        patch(
+            "agentception.mcp.build_commands.get_session",
+            new=_make_mock_session(file_edit_count=1, pr_number=999),
+        ),
         patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,

--- a/tests/test_build_commands.py
+++ b/tests/test_build_commands.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+"""Tests for build_complete_run pre-flight guards.
+
+Coverage:
+- Refused when no file-edit events are recorded for the run.
+- Refused when file-edit events exist but pr_number is NULL on the run row.
+- Allowed (reaches existing completion logic) when both conditions are satisfied.
+
+Run targeted:
+    pytest tests/test_build_commands.py -v
+"""
+
+import pytest
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _make_preflight_session(
+    file_edit_count: int,
+    pr_number: int | None,
+) -> object:
+    """Return a mock async context-manager for get_session.
+
+    Simulates the two sequential queries executed by the pre-flight guards:
+    1. COUNT of ACAgentEvent rows with event_type in ('file_edit', 'write_file').
+    2. SELECT of ACAgentRun row to check pr_number IS NOT NULL.
+    """
+    mock_session = MagicMock()
+
+    count_result = MagicMock()
+    count_result.scalar_one.return_value = file_edit_count
+
+    run_row = MagicMock()
+    run_row.pr_number = pr_number
+    run_result = MagicMock()
+    run_result.scalar_one_or_none.return_value = run_row
+
+    mock_session.execute = AsyncMock(side_effect=[count_result, run_result])
+
+    from collections.abc import AsyncGenerator
+
+    @asynccontextmanager
+    async def _ctx() -> AsyncGenerator[MagicMock, None]:
+        yield mock_session
+
+    return _ctx
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_refused_no_file_edits() -> None:
+    """build_complete_run returns a refusal dict when no file-edit events exist.
+
+    Invariant: an agent that has not written any files cannot declare completion.
+    The handler must return a structured error dict (not raise) so the MCP
+    framework serialises it back to the agent as a retryable tool response.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    agent_run_id = "dev-issue-100-noedits"
+
+    with patch(
+        "agentception.mcp.build_commands.get_session",
+        new=_make_preflight_session(file_edit_count=0, pr_number=None),
+    ):
+        result = await build_complete_run(
+            issue_number=100,
+            pr_url="https://github.com/cgcardona/agentception/pull/500",
+            agent_run_id=agent_run_id,
+        )
+
+    assert result["ok"] is False
+    assert result["error"] == (
+        "build_complete_run refused: no file edits recorded for this run. "
+        "Write and commit your changes first."
+    )
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_refused_no_pr() -> None:
+    """build_complete_run returns a refusal dict when pr_number is NULL on the run row.
+
+    Invariant: a PR must exist before the reviewer can be dispatched.  The
+    handler must return a structured error dict (not raise) so the agent can
+    open the PR and retry.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    agent_run_id = "dev-issue-101-nopr"
+
+    with patch(
+        "agentception.mcp.build_commands.get_session",
+        new=_make_preflight_session(file_edit_count=3, pr_number=None),
+    ):
+        result = await build_complete_run(
+            issue_number=101,
+            pr_url="https://github.com/cgcardona/agentception/pull/501",
+            agent_run_id=agent_run_id,
+        )
+
+    assert result["ok"] is False
+    assert result["error"] == (
+        "build_complete_run refused: no PR found. "
+        "Create and push a branch, then open a pull request first."
+    )
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_allowed_when_checks_pass() -> None:
+    """build_complete_run proceeds to existing completion logic when both guards pass.
+
+    When file-edit count > 0 AND pr_number IS NOT NULL, the handler must reach
+    the persist_agent_event call — the first side-effectful operation in the
+    existing completion path.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    agent_run_id = "dev-issue-102-ok"
+
+    with (
+        patch(
+            "agentception.mcp.build_commands.get_session",
+            new=_make_preflight_session(file_edit_count=5, pr_number=502),
+        ),
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist,
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="developer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_teardown",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+        ),
+    ):
+        result = await build_complete_run(
+            issue_number=102,
+            pr_url="https://github.com/cgcardona/agentception/pull/502",
+            agent_run_id=agent_run_id,
+        )
+
+    # The handler must have reached the existing completion path.
+    mock_persist.assert_called_once()
+    assert result["ok"] is True
+    assert result["status"] == "completed"


### PR DESCRIPTION
Closes #801

## Summary

Adds two sequential pre-flight guards to `build_complete_run` that reject the call with a structured, retryable error dict unless:
1. At least one `file_edit`/`write_file` event exists for the run
2. A PR number has been recorded on the run row

Also fixes the pre-existing tests in `agentception/tests/test_build_commands.py` to mock `get_session` so the new guards pass without hitting the real DB, and adds the three new tests in `tests/test_build_commands.py` as required by the AC.