### PR TITLE
fix: enforce file-edit and PR pre-flight checks in build_complete_run

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -26,6 +26,10 @@ import asyncio
 import logging
 from pathlib import Path
 
+from sqlalchemy import func, select
+
+from agentception.db.engine import get_session
+from agentception.db.models import ACAgentEvent, ACAgentRun
 from agentception.db.persist import (
     acknowledge_agent_run,
     block_agent_run,
@@ -264,6 +268,37 @@ async def build_spawn_child_run(
     }
 
 
+async def _has_file_edit_events(run_id: str) -> bool:
+    """Return True if at least one file_edit or write_file event exists for the run.
+
+    Used as a pre-flight guard inside build_complete_run to prevent agents from
+    signalling completion before writing any code.
+    """
+    async with get_session() as session:
+        result = await session.execute(
+            select(func.count(ACAgentEvent.id)).where(
+                ACAgentEvent.agent_run_id == run_id,
+                ACAgentEvent.event_type.in_(["file_edit", "write_file"]),
+            )
+        )
+        count: int = result.scalar_one()
+    return count > 0
+
+
+async def _has_pr_recorded(run_id: str) -> bool:
+    """Return True if a PR number has been recorded on the run row.
+
+    Used as a pre-flight guard inside build_complete_run to prevent agents from
+    signalling completion before opening a pull request.
+    """
+    async with get_session() as session:
+        result = await session.execute(
+            select(ACAgentRun.pr_number).where(ACAgentRun.id == run_id)
+        )
+        row = result.one_or_none()
+    return row is not None and row[0] is not None
+
+
 async def build_complete_run(
     issue_number: int,
     pr_url: str,
@@ -299,6 +334,30 @@ async def build_complete_run(
     Returns:
         ``{"ok": True, "event": "done", "status": "completed"}``
     """
+    # --- Pre-flight guards ---
+    # These invariants must hold before any side-effectful completion logic runs.
+    # We return a structured error dict (not an exception) so the MCP framework
+    # serialises it back to the agent as a normal tool response the agent can
+    # act on — retry after completing the missing step.
+    if agent_run_id:
+        if not await _has_file_edit_events(agent_run_id):
+            return {
+                "ok": False,
+                "error": (
+                    "build_complete_run refused: no file edits recorded for this run. "
+                    "Write and commit your changes first."
+                ),
+            }
+        if not await _has_pr_recorded(agent_run_id):
+            return {
+                "ok": False,
+                "error": (
+                    "build_complete_run refused: no PR found. "
+                    "Create and push a branch, then open a pull request first."
+                ),
+            }
+    # -------------------------
+
     await persist_agent_event(
         issue_number=issue_number,
         event_type="done",

--- a/agentception/tests/test_build_board_partial.py
+++ b/agentception/tests/test_build_board_partial.py
@@ -671,6 +671,8 @@ async def test_build_complete_run_does_not_teardown_worktree() -> None:
     from agentception.mcp.build_commands import build_complete_run
 
     with (
+        patch("agentception.mcp.build_commands._has_file_edit_events", new_callable=AsyncMock, return_value=True),
+        patch("agentception.mcp.build_commands._has_pr_recorded", new_callable=AsyncMock, return_value=True),
         patch("agentception.mcp.build_commands.persist_agent_event", new_callable=AsyncMock),
         patch("agentception.mcp.build_commands.complete_agent_run", new_callable=AsyncMock, return_value=True),
         patch("agentception.mcp.build_commands.auto_dispatch_reviewer", new_callable=AsyncMock),

--- a/agentception/tests/test_build_commands.py
+++ b/agentception/tests/test_build_commands.py
@@ -29,6 +29,16 @@ async def test_reviewer_worktree_torn_down_after_failing_grade() -> None:
 
     with (
         patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
         ),
@@ -87,6 +97,16 @@ async def test_reviewer_worktree_torn_down_after_passing_grade() -> None:
     reviewer_run_id = "reviewer-issue-55-def456"
 
     with (
+        patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
         patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
@@ -148,6 +168,16 @@ async def test_redispatch_fires_after_failing_grade() -> None:
     grade = "F"
 
     with (
+        patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
         patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
@@ -219,6 +249,16 @@ async def test_redispatch_skipped_after_passing_grade() -> None:
 
     with (
         patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
         ),
@@ -281,6 +321,16 @@ async def test_build_complete_run_rejects_empty_grade_from_reviewer() -> None:
 
     with (
         patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
         ),
@@ -322,6 +372,138 @@ async def test_build_complete_run_rejects_empty_grade_from_reviewer() -> None:
 
 
 @pytest.mark.anyio
+async def test_build_complete_run_refused_no_file_edits() -> None:
+    """build_complete_run returns a refusal dict when no file_edit/write_file events exist.
+
+    Pre-flight guard: prevents agents from signalling completion before writing any code.
+    The guard must fire before any side-effectful completion logic runs.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    run_id = "issue-999-no-edits"
+
+    with (
+        patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist,
+    ):
+        result = await build_complete_run(
+            issue_number=999,
+            pr_url="https://github.com/cgcardona/agentception/pull/1",
+            agent_run_id=run_id,
+        )
+
+    assert result["ok"] is False
+    assert "no file edits recorded" in str(result["error"])
+    mock_persist.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_refused_no_pr() -> None:
+    """build_complete_run returns a refusal dict when pr_number is not recorded on the run.
+
+    Pre-flight guard: file-edit events exist but no PR has been created yet.
+    The guard must fire before any side-effectful completion logic runs.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    run_id = "issue-998-no-pr"
+
+    with (
+        patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist,
+    ):
+        result = await build_complete_run(
+            issue_number=998,
+            pr_url="https://github.com/cgcardona/agentception/pull/2",
+            agent_run_id=run_id,
+        )
+
+    assert result["ok"] is False
+    assert "no PR found" in str(result["error"])
+    mock_persist.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_allowed_when_checks_pass() -> None:
+    """build_complete_run proceeds to completion logic when both pre-flight checks pass.
+
+    With file-edit events recorded and a PR number on the run, the handler must
+    reach the existing completion path (persist_agent_event is called).
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    run_id = "issue-997-all-good"
+
+    with (
+        patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ) as mock_persist,
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="developer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_teardown",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+        ),
+    ):
+        result = await build_complete_run(
+            issue_number=997,
+            pr_url="https://github.com/cgcardona/agentception/pull/3",
+            agent_run_id=run_id,
+        )
+
+    assert result["ok"] is True
+    assert result["status"] == "completed"
+    mock_persist.assert_called_once()
+
+
+@pytest.mark.anyio
 async def test_build_complete_run_rejects_whitespace_grade_from_reviewer() -> None:
     """build_complete_run returns an error dict when reviewer passes grade='   '.
 
@@ -333,6 +515,16 @@ async def test_build_complete_run_rejects_whitespace_grade_from_reviewer() -> No
     reviewer_run_id = "reviewer-issue-99-whitespace"
 
     with (
+        patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
         patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
@@ -372,4 +564,3 @@ async def test_build_complete_run_rejects_whitespace_grade_from_reviewer() -> No
     mock_redispatch.assert_not_called()
     mock_teardown.assert_not_called()
     mock_create_task.assert_not_called()
-

--- a/agentception/tests/test_build_commands_rebase.py
+++ b/agentception/tests/test_build_commands_rebase.py
@@ -79,6 +79,16 @@ async def test_rebase_succeeds_force_pushes_and_dispatches_reviewer() -> None:
 
     with (
         patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
         ),
@@ -162,6 +172,16 @@ async def test_rebase_conflict_returns_error_and_aborts() -> None:
 
     with (
         patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
         ),
@@ -240,6 +260,16 @@ async def test_no_worktree_path_skips_rebase_and_dispatches_reviewer() -> None:
 
     with (
         patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
         ),
@@ -307,6 +337,16 @@ async def test_rebase_succeeds_with_empty_worktree_path_dict() -> None:
     agent_run_id = "dev-issue-40-null-wt"
 
     with (
+        patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
         patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,

--- a/agentception/tests/test_mcp_build_commands_pr3.py
+++ b/agentception/tests/test_mcp_build_commands_pr3.py
@@ -344,6 +344,16 @@ async def test_build_complete_run_reviewer_does_not_redispatch_reviewer() -> Non
     """
     with (
         patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
         ),
@@ -382,6 +392,16 @@ async def test_build_complete_run_reviewer_does_not_redispatch_reviewer() -> Non
 async def test_build_complete_run_implementer_does_redispatch_reviewer() -> None:
     """When a developer calls build_complete_run, reviewer IS dispatched."""
     with (
+        patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
         patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,
@@ -431,6 +451,16 @@ async def test_build_complete_run_releases_worktree_before_reviewer() -> None:
     release_worktree (remove dir + prune refs) first.
     """
     with (
+        patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
         patch(
             "agentception.mcp.build_commands.persist_agent_event",
             new_callable=AsyncMock,


### PR DESCRIPTION
Closes #801

## Summary

- Adds `_has_file_edit_events` and `_has_pr_recorded` private helpers to `agentception/mcp/build_commands.py`
- Inserts two sequential pre-flight guards in `build_complete_run` that reject the call (structured error dict, not exception) unless: (1) at least one `file_edit`/`write_file` event exists for the run, and (2) a PR number is recorded on the run row
- Both guards fire before `persist_agent_event` — no side effects occur on refusal
- Adds 3 required acceptance-criteria tests directly in `agentception/tests/test_build_commands.py` where pytest collects them
- Updates all pre-existing `build_complete_run` tests in 4 test files to mock the new pre-flight helpers

## Test plan
- [x] `mypy agentception/ tests/` — zero errors
- [x] `typing_audit --max-any 0` — passes
- [x] `pytest agentception/tests/test_build_commands.py -v` — 9/9 passed
- [x] `pytest agentception/tests/test_build_board_partial.py agentception/tests/test_build_commands_rebase.py agentception/tests/test_mcp_build_commands_pr3.py -v` — 8/8 passed
- [x] `pytest agentception/tests/ -v` — 1933+8 = all green (previously 8 failing)