### PR TITLE
feat: update MCP protocol version constant to 2025-03-26

### DIFF
--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -97,7 +97,7 @@ from agentception.mcp.types import (
 logger = logging.getLogger(__name__)
 
 #: MCP protocol version this server implements.
-_MCP_PROTOCOL_VERSION = "2024-11-05"
+_MCP_PROTOCOL_VERSION = "2025-03-26"
 
 #: Server identity advertised in the ``initialize`` response.
 class _ServerInfo(TypedDict):

--- a/agentception/services/github_mcp_client.py
+++ b/agentception/services/github_mcp_client.py
@@ -29,7 +29,7 @@ from agentception.services.llm import ToolDefinition, ToolFunction
 logger = logging.getLogger(__name__)
 
 _GH_MCP_BINARY = "github-mcp-server"
-_MCP_PROTOCOL_VERSION = "2024-11-05"
+_MCP_PROTOCOL_VERSION = "2025-03-26"
 _READ_TIMEOUT_SECS = 30.0
 # GitHub MCP tools/list response can exceed asyncio's default 64 KB readline
 # buffer.  Set a generous limit (16 MB) to accommodate it.

--- a/agentception/tests/test_mcp_resources.py
+++ b/agentception/tests/test_mcp_resources.py
@@ -261,7 +261,7 @@ async def test_initialize_declares_resources_capability() -> None:
         "jsonrpc": "2.0",
         "id": 0,
         "method": "initialize",
-        "params": {"protocolVersion": "2024-11-05", "capabilities": {}},
+        "params": {"protocolVersion": "2025-03-26", "capabilities": {}},
     })
     result = _rpc_result(resp)
     caps = result["capabilities"]


### PR DESCRIPTION
Closes #809

Updates `_MCP_PROTOCOL_VERSION` from `"2024-11-05"` to `"2025-03-26"` in both `agentception/mcp/server.py` and `agentception/services/github_mcp_client.py`, and updates the matching fixture in `agentception/tests/test_mcp_resources.py`. Zero occurrences of the old version string remain.