### PR TITLE
feat: retire query_run_status tool — expose as ac://runs/{run_id}/status resource

### DIFF
--- a/.agentception/roles/ceo.md
+++ b/.agentception/roles/ceo.md
@@ -644,10 +644,10 @@ abort the entire task or skip that subtask. Never silently swallow errors.
 
 ## STEP 3 — Wait for all children to complete
 
-After spawning, poll each child every **30 seconds** using `query_run_status`:
+After spawning, poll each child every **30 seconds** using `resources/read`:
 
 ```
-query_run_status(run_id = <child_run_id>)
+resources/read(uri = "ac://runs/<child_run_id>/status")
 ```
 
 Terminal statuses (stop polling): `completed`, `cancelled`, `stopped`.
@@ -689,7 +689,7 @@ You are done. Do not tear down your own worktree — that is managed by the plat
 - Never call `build_complete_run` for yourself — coordinator runs terminate when you
   reach the end of STEP 4.
 - Never spawn sub-coordinators unless your task briefing explicitly authorises it.
-- Never ignore an error from `build_spawn_adhoc_child` or `query_run_status`.
+- Never ignore an error from `build_spawn_adhoc_child` or `resources/read` (status polling).
 
 ---
 

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -387,10 +387,10 @@ abort the entire task or skip that subtask. Never silently swallow errors.
 
 ## STEP 3 — Wait for all children to complete
 
-After spawning, poll each child every **30 seconds** using `query_run_status`:
+After spawning, poll each child every **30 seconds** using `resources/read` with the status resource:
 
 ```
-query_run_status(run_id = <child_run_id>)
+resources/read uri="ac://runs/<child_run_id>/status"
 ```
 
 Terminal statuses (stop polling): `completed`, `cancelled`, `stopped`.
@@ -432,7 +432,7 @@ You are done. Do not tear down your own worktree — that is managed by the plat
 - Never call `build_complete_run` for yourself — coordinator runs terminate when you
   reach the end of STEP 4.
 - Never spawn sub-coordinators unless your task briefing explicitly authorises it.
-- Never ignore an error from `build_spawn_adhoc_child` or `query_run_status`.
+- Never ignore an error from `build_spawn_adhoc_child` or `resources/read ac://runs/{run_id}/status`.
 
 ---
 

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -144,10 +144,10 @@ abort the entire task or skip that subtask. Never silently swallow errors.
 
 ## STEP 3 — Wait for all children to complete
 
-After spawning, poll each child every **30 seconds** using `query_run_status`:
+After spawning, poll each child every **30 seconds** using `resources/read`:
 
 ```
-query_run_status(run_id = <child_run_id>)
+resources/read(uri = "ac://runs/<child_run_id>/status")
 ```
 
 Terminal statuses (stop polling): `completed`, `cancelled`, `stopped`.
@@ -189,6 +189,6 @@ You are done. Do not tear down your own worktree — that is managed by the plat
 - Never call `build_complete_run` for yourself — coordinator runs terminate when you
   reach the end of STEP 4.
 - Never spawn sub-coordinators unless your task briefing explicitly authorises it.
-- Never ignore an error from `build_spawn_adhoc_child` or `query_run_status`.
+- Never ignore an error from `build_spawn_adhoc_child` or `resources/read` (status polling).
 
 ---

--- a/agentception/mcp/resources.py
+++ b/agentception/mcp/resources.py
@@ -25,8 +25,11 @@ Static resources
 Templated resources (RFC 6570)
     ac://runs/{run_id}                  — lightweight metadata for one run
     ac://runs/{run_id}/children         — child runs spawned by this run
+    ac://runs/{run_id}/context          — full task context (RunContextRow)
     ac://runs/{run_id}/events           — full structured event log
     ac://runs/{run_id}/events?after_id={n} — paginated event log (n > 0)
+    ac://runs/{run_id}/status           — current status and completed_at timestamp
+    ac://runs/{run_id}/task             — task_description field for the run
 
     ac://batches/{batch_id}/tree        — all runs in a batch, flat list
     ac://plan/figures/{role}            — cognitive-arch figures for a role
@@ -54,6 +57,7 @@ from agentception.mcp.query_tools import (
     query_run,
     query_run_context,
     query_run_events,
+    query_run_status,
     query_run_tree,
     query_system_health,
 )
@@ -235,6 +239,12 @@ RESOURCE_TEMPLATES: list[ACResourceTemplate] = [
             "spawned_at, last_activity_at, completed_at. "
             "Returns ok=false when the run does not exist."
         ),
+        mimeType=_MIME,
+    ),
+    ACResourceTemplate(
+        uriTemplate="ac://runs/{run_id}/status",
+        name="Run status",
+        description="Current status and completed_at timestamp for a single run",
         mimeType=_MIME,
     ),
 
@@ -552,6 +562,9 @@ async def _dispatch(
 
             if sub == "context" and len(path_parts) == 2:
                 return _content(uri, await query_run_context(run_id))
+
+            if sub == "status" and len(path_parts) == 2:
+                return _content(uri, await query_run_status(run_id))
 
             if sub == "task" and len(path_parts) == 2:
                 return await _handle_run_task(uri, run_id)

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -22,6 +22,14 @@ Tool vs Resource design
   Actions that mutate state (build_*, log_*, github_*, plan mutations) remain Tools.
   See :mod:`agentception.mcp.resources` for the full URI catalogue.
 
+Run-level resource templates (ac://runs/{run_id}/*)
+  ac://runs/{run_id}          — lightweight metadata for one run
+  ac://runs/{run_id}/children — child runs spawned by this run
+  ac://runs/{run_id}/context  — full task context (RunContextRow)
+  ac://runs/{run_id}/events   — structured event log (paginated via ?after_id=N)
+  ac://runs/{run_id}/status   — current status and completed_at timestamp
+  ac://runs/{run_id}/task     — task_description field for the run
+
 Error handling follows the JSON-RPC 2.0 specification:
   - Parse errors     → code -32700 (never raised here; caller parses JSON)
   - Invalid Request  → code -32600 (missing required fields)
@@ -46,7 +54,6 @@ from agentception.mcp.build_commands import (
     build_stop_run,
     build_teardown_worktree,
 )
-from agentception.mcp.query_tools import query_run_status
 from agentception.mcp.log_tools import (
     log_run_blocker,
     log_run_decision,
@@ -122,6 +129,7 @@ _RETIRED_TOOL_URIS: dict[str, str] = {
     "plan_get_schema": "ac://plan/schema",
     "plan_get_labels": "ac://plan/labels",
     "plan_get_cognitive_figures": "ac://plan/figures/{role}",
+    "query_run_status": "ac://runs/{run_id}/status",
 }
 
 # ---------------------------------------------------------------------------
@@ -312,7 +320,7 @@ TOOLS: list[ACToolDef] = [
             "The child receives its context entirely "
             "via the task/briefing MCP prompt and ac://runs/{run_id}/context resource. "
             "Returns {ok, child_run_id, worktree_path, cognitive_arch}. "
-            "After calling this tool, use query_run_status to poll for completion."
+            "After calling this tool, use resources/read with ac://runs/{run_id}/status to poll for completion."
         ),
         inputSchema={
             "type": "object",
@@ -343,28 +351,6 @@ TOOLS: list[ACToolDef] = [
                 },
             },
             "required": ["parent_run_id", "role", "task_description"],
-            "additionalProperties": False,
-        },
-    ),
-    ACToolDef(
-        name="query_run_status",
-        description=(
-            "Return the current status of a run. "
-            "Coordinators use this to poll child runs spawned with build_spawn_adhoc_child. "
-            "Poll every 30–60 seconds until status is a terminal value. "
-            "Terminal statuses: 'completed', 'cancelled', 'stopped'. "
-            "Active statuses: 'implementing', 'reviewing', 'pending_launch'. "
-            "Returns {ok, run_id, status, completed_at}."
-        ),
-        inputSchema={
-            "type": "object",
-            "properties": {
-                "run_id": {
-                    "type": "string",
-                    "description": "The child_run_id returned by build_spawn_adhoc_child.",
-                },
-            },
-            "required": ["run_id"],
             "additionalProperties": False,
         },
     ),
@@ -845,8 +831,6 @@ def call_tool(name: str, arguments: dict[str, object]) -> ACToolResult:
         "build_resume_run",
         "build_cancel_run",
         "build_stop_run",
-        # Query tools
-        "query_run_status",
         # Log tools
         "log_run_step",
         "log_run_blocker",
@@ -963,23 +947,6 @@ async def call_tool_async(
             figure=figure,
             base_branch=base_branch,
         )
-        is_error = not bool(result.get("ok", False))
-        return ACToolResult(
-            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=is_error,
-        )
-
-    if name == "query_run_status":
-        run_id_arg = arguments.get("run_id")
-        if not isinstance(run_id_arg, str) or not run_id_arg:
-            err_text = _tool_result_to_text(
-                {"error": "query_run_status requires a non-empty run_id string"}
-            )
-            return ACToolResult(
-                content=[ACToolContent(type="text", text=err_text)],
-                isError=True,
-            )
-        result = await query_run_status(run_id_arg)
         is_error = not bool(result.get("ok", False))
         return ACToolResult(
             content=[ACToolContent(type="text", text=_tool_result_to_text(result))],

--- a/agentception/tests/test_lineage_fields.py
+++ b/agentception/tests/test_lineage_fields.py
@@ -200,15 +200,15 @@ def test_engineering_coordinator_uses_build_spawn_adhoc_child() -> None:
 
 
 def test_engineering_coordinator_uses_query_run_status() -> None:
-    """The engineering-coordinator role uses query_run_status to poll child runs."""
+    """The engineering-coordinator role uses ac://runs/{run_id}/status to poll child runs."""
     role_path = (
         Path(__file__).parent.parent.parent
         / ".agentception" / "roles" / "engineering-coordinator.md"
     )
     assert role_path.exists(), f"Role file missing: {role_path}"
     content = role_path.read_text()
-    assert re.search(r"query_run_status", content), (
-        "engineering-coordinator must use query_run_status to poll child run completion"
+    assert re.search(r"ac://runs/.*status", content), (
+        "engineering-coordinator must use ac://runs/{run_id}/status to poll child run completion"
     )
 
 

--- a/agentception/tests/test_mcp_resources.py
+++ b/agentception/tests/test_mcp_resources.py
@@ -805,3 +805,43 @@ async def test_read_resource_empty_uri_returns_error() -> None:
     result = await read_resource("")
     payload = _content(result)
     assert "error" in payload
+
+# ---------------------------------------------------------------------------
+# ac://runs/{run_id}/status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_read_run_status_resource() -> None:
+    """ac://runs/{run_id}/status returns ok, run_id, status, and completed_at."""
+    mock_result = {
+        "ok": True,
+        "run_id": "issue-42",
+        "status": "implementing",
+        "completed_at": None,
+    }
+    with patch(
+        "agentception.mcp.resources.query_run_status",
+        new_callable=AsyncMock,
+        return_value=mock_result,
+    ):
+        result = await read_resource("ac://runs/issue-42/status")
+
+    payload = _content(result)
+    assert "ok" in payload
+    assert "run_id" in payload
+    assert "status" in payload
+    assert "completed_at" in payload
+    assert payload["run_id"] == "issue-42"
+    assert payload["status"] == "implementing"
+
+
+@pytest.mark.anyio
+async def test_retired_query_run_status_tool() -> None:
+    """tools/call query_run_status returns the retired-tool redirect error."""
+    result = await call_tool_async("query_run_status", {"run_id": "issue-42"})
+    assert result["isError"] is True
+    payload = json.loads(result["content"][0]["text"])
+    assert "resources/read" in payload["error"]
+    assert "ac://runs/{run_id}/status" in payload["error"]
+

--- a/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2
@@ -106,10 +106,11 @@ abort the entire task or skip that subtask. Never silently swallow errors.
 
 ## STEP 3 — Wait for all children to complete
 
-After spawning, poll each child every **30 seconds** using `query_run_status`:
+After spawning, poll each child every **30 seconds** using `resources/read` with the
+`ac://runs/{run_id}/status` resource:
 
 ```
-query_run_status(run_id = <child_run_id>)
+resources/read(uri = "ac://runs/<child_run_id>/status")
 ```
 
 Terminal statuses (stop polling): `completed`, `cancelled`, `stopped`.
@@ -151,6 +152,6 @@ You are done. Do not tear down your own worktree — that is managed by the plat
 - Never call `build_complete_run` for yourself — coordinator runs terminate when you
   reach the end of STEP 4.
 - Never spawn sub-coordinators unless your task briefing explicitly authorises it.
-- Never ignore an error from `build_spawn_adhoc_child` or `query_run_status`.
+- Never ignore an error from `build_spawn_adhoc_child` or `resources/read ac://runs/{run_id}/status`.
 
 ---


### PR DESCRIPTION
Closes #810

## Summary

Migrates `query_run_status` from a Tool to an MCP Resource, completing the run-resource surface alongside `ac://runs/{run_id}`, `/context`, `/events`, and `/children`.

## Changes

### `agentception/mcp/resources.py`
- Added `ACResourceTemplate` for `ac://runs/{run_id}/status`
- Added `query_run_status` import from `query_tools`
- Added `status` handler branch in `_dispatch()` under `ac://runs/{run_id}/*`
- Updated module docstring to list the new template

### `agentception/mcp/server.py`
- Removed `ACToolDef` entry for `query_run_status` from `TOOLS`
- Removed `"query_run_status"` dispatch branch from `call_tool_async()`
- Added `"query_run_status": "ac://runs/{run_id}/status"` to `_RETIRED_TOOLS`
- Updated module docstring

### Agent prompts updated
- `.agentception/roles/ceo.md` — replaced `query_run_status` tool call with `resources/read ac://runs/{run_id}/status`
- `.agentception/roles/engineering-coordinator.md` — same
- `.agentception/roles/cto.md` — same
- `scripts/gen_prompts/templates/roles/engineering-coordinator.md.j2` — same

### Tests
- `test_read_run_status_resource` — verifies `ac://runs/{run_id}/status` returns `ok`, `run_id`, `status`, `completed_at`
- `test_retired_query_run_status_tool` — verifies `tools/call query_run_status` returns the retired-tool redirect error containing `ac://runs/{run_id}/status`
- `test_retired_query_tools_not_in_tools_list` — updated to include `query_run_status`