### PR TITLE
feat: add reconcile_stale_runs() sweep function with GitHub signal detection

### DIFF
--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -812,6 +812,50 @@ async def get_issue(number: int) -> dict[str, object]:
     }
 
 
+async def is_branch_merged_into(branch: str, base: str = "dev") -> bool:
+    """Return ``True`` when *branch* has been fully merged into *base*.
+
+    Uses the GitHub compare API (``GET /repos/{owner}/{repo}/compare/{base}...{head}``).
+    The response ``"status"`` field is:
+
+    - ``"identical"`` — the branches point to the same commit (already merged).
+    - ``"behind"``    — *head* is behind *base*, meaning all commits from *head*
+      are already in *base* (merged).
+    - ``"ahead"``     — *head* has commits not in *base* (not yet merged).
+    - ``"diverged"``  — branches have diverged (not merged).
+
+    Parameters
+    ----------
+    branch:
+        The head branch name to check (e.g. ``"feat/issue-822"``).
+    base:
+        The base branch to compare against (default ``"dev"``).
+
+    Returns
+    -------
+    bool
+        ``True`` if *branch* is merged into *base*, ``False`` otherwise.
+
+    Raises
+    ------
+    RuntimeError
+        On any non-2xx GitHub API response.
+    """
+    repo = settings.gh_repo
+    encoded_base = urllib.parse.quote(base, safe="")
+    encoded_head = urllib.parse.quote(branch, safe="")
+    cache_key = f"is_branch_merged_into:{base}:{branch}"
+    result = await _api_get(
+        f"repos/{repo}/compare/{encoded_base}...{encoded_head}",
+        {},
+        cache_key,
+    )
+    if not isinstance(result, dict):
+        return False
+    status: object = result.get("status")
+    return status in ("identical", "behind")
+
+
 async def get_repo_labels(limit: int = 100) -> list[dict[str, object]]:
     """Return all labels defined in the repository.
 

--- a/agentception/reconcile.py
+++ b/agentception/reconcile.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+"""Stale-run reconciliation — detect and complete implementing runs that are stuck.
+
+Agent runs that crash, hit the iteration limit, or skip ``build_complete_run``
+leave their DB row permanently at ``implementing``.  This module provides
+``reconcile_stale_runs()``, which detects those runs and transitions them to
+``completed`` based on two GitHub signals:
+
+1. **issue_closed** — the linked GitHub issue is in ``closed`` state.
+2. **pr_merged**    — the agent's branch has been merged into ``dev``.
+
+Safety contract
+---------------
+Only runs whose ``last_activity_at`` is older than ``stale_threshold_minutes``
+are considered.  Runs with a recent heartbeat are left untouched — those agents
+may still be active.
+
+Each row is committed independently so a GitHub API failure on one candidate
+does not roll back mutations already applied to earlier candidates.
+"""
+
+import datetime
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agentception.db.models import ACAgentRun
+from agentception.readers.github import get_issue, is_branch_merged_into
+
+logger = logging.getLogger(__name__)
+
+_UTC = datetime.timezone.utc
+
+
+def _utcnow() -> datetime.datetime:
+    return datetime.datetime.now(_UTC)
+
+
+async def reconcile_stale_runs(
+    session: AsyncSession,
+    *,
+    stale_threshold_minutes: int = 10,
+) -> list[str]:
+    """Detect and complete runs stuck at implementing.
+
+    Queries for ``ACAgentRun`` rows with ``status = 'implementing'`` whose
+    ``last_activity_at`` is older than *stale_threshold_minutes*.  For each
+    candidate the function checks GitHub in priority order:
+
+    1. If ``issue_number`` is set, calls :func:`get_issue` — marks stale when
+       ``state == 'closed'`` (signal ``"issue_closed"``).
+    2. If ``branch`` is set, calls :func:`is_branch_merged_into` with
+       ``base="dev"`` — marks stale when the branch has been merged (signal
+       ``"pr_merged"``).
+
+    Runs that have neither ``issue_number`` nor ``branch`` are skipped entirely
+    (no GitHub call, no mutation).
+
+    Parameters
+    ----------
+    session:
+        An open :class:`~sqlalchemy.ext.asyncio.AsyncSession`.  The caller is
+        responsible for its lifecycle; this function does **not** close it.
+    stale_threshold_minutes:
+        Minimum age (in minutes) of ``last_activity_at`` before a run is
+        considered a reconciliation candidate.  Defaults to 10 minutes.
+        Set to a higher value in production to avoid racing active agents.
+
+    Returns
+    -------
+    list[str]
+        Run IDs that were transitioned to ``completed`` during this call.
+
+    Safety contract
+    ---------------
+    Runs with ``last_activity_at`` within *stale_threshold_minutes* of now are
+    **never** touched.  Each reconciled row is committed independently so a
+    GitHub API error on row N does not roll back row N-1.
+    """
+    cutoff = _utcnow() - datetime.timedelta(minutes=stale_threshold_minutes)
+
+    result = await session.execute(
+        select(ACAgentRun).where(
+            ACAgentRun.status == "implementing",
+            ACAgentRun.last_activity_at < cutoff,
+        )
+    )
+    candidates: list[ACAgentRun] = list(result.scalars().all())
+
+    reconciled: list[str] = []
+
+    for run in candidates:
+        # Skip runs with no GitHub signals — nothing to check.
+        if run.issue_number is None and run.branch is None:
+            continue
+
+        signal: str | None = None
+
+        # Signal 1: linked issue is closed.
+        if run.issue_number is not None:
+            try:
+                issue_data = await get_issue(run.issue_number)
+                if issue_data.get("state") == "closed":
+                    signal = "issue_closed"
+            except Exception as exc:
+                logger.warning(
+                    "[reconcile] run_id=%s issue_number=%s get_issue failed: %s",
+                    run.id,
+                    run.issue_number,
+                    exc,
+                )
+
+        # Signal 2: PR branch has been merged into dev (only if signal 1 not triggered).
+        if signal is None and run.branch is not None:
+            try:
+                merged = await is_branch_merged_into(run.branch, base="dev")
+                if merged:
+                    signal = "pr_merged"
+            except Exception as exc:
+                logger.warning(
+                    "[reconcile] run_id=%s branch=%r is_branch_merged_into failed: %s",
+                    run.id,
+                    run.branch,
+                    exc,
+                )
+
+        if signal is None:
+            # Neither signal fired — leave the run alone.
+            continue
+
+        # Mutate and commit independently so failures on later rows don't
+        # roll back this row.
+        run.status = "completed"
+        run.last_activity_at = _utcnow()
+        try:
+            await session.commit()
+            logger.info(
+                "[reconcile] run_id=%s signal=%s -> completed",
+                run.id,
+                signal,
+            )
+            reconciled.append(run.id)
+        except Exception as exc:
+            logger.warning(
+                "[reconcile] run_id=%s commit failed: %s",
+                run.id,
+                exc,
+            )
+            await session.rollback()
+
+    return reconciled

--- a/agentception/tests/test_reconcile.py
+++ b/agentception/tests/test_reconcile.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+"""Tests for agentception.reconcile — stale-run reconciliation."""
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agentception.db.models import ACAgentRun
+from agentception.reconcile import reconcile_stale_runs
+
+_UTC = datetime.timezone.utc
+
+
+def _make_run(
+    run_id: str = "issue-999",
+    status: str = "implementing",
+    issue_number: int | None = None,
+    branch: str | None = None,
+    last_activity_at: datetime.datetime | None = None,
+) -> MagicMock:
+    """Build a minimal ACAgentRun-like mock for testing."""
+    run = MagicMock(spec=ACAgentRun)
+    run.id = run_id
+    run.status = status
+    run.issue_number = issue_number
+    run.branch = branch
+    run.last_activity_at = last_activity_at or (
+        datetime.datetime.now(_UTC) - datetime.timedelta(minutes=30)
+    )
+    return run
+
+
+def _make_session(candidates: list[MagicMock]) -> MagicMock:
+    """Return a mock AsyncSession whose execute() returns *candidates*."""
+    scalars_mock = MagicMock()
+    scalars_mock.all.return_value = candidates
+
+    result_mock = MagicMock()
+    result_mock.scalars.return_value = scalars_mock
+
+    session = MagicMock(spec=AsyncSession)
+    session.execute = AsyncMock(return_value=result_mock)
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# test_skips_recent_run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_skips_recent_run() -> None:
+    """A run with last_activity_at = utcnow() must not be mutated.
+
+    The query filters by cutoff time; we simulate this by returning an empty
+    candidate list (the DB would exclude the recent run).
+    """
+    # The session returns no candidates — simulating the WHERE clause filtering
+    # out the recent run.
+    session = _make_session([])
+
+    reconciled = await reconcile_stale_runs(session, stale_threshold_minutes=10)
+
+    assert reconciled == []
+    session.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# test_reconciles_on_closed_issue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_reconciles_on_closed_issue(caplog: pytest.LogCaptureFixture) -> None:
+    """A stale run whose linked issue is closed must be set to completed."""
+    run = _make_run(run_id="issue-100", issue_number=100)
+    session = _make_session([run])
+
+    with patch(
+        "agentception.reconcile.get_issue",
+        new=AsyncMock(return_value={"state": "closed", "number": 100}),
+    ), patch(
+        "agentception.reconcile.is_branch_merged_into",
+        new=AsyncMock(return_value=False),
+    ):
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="agentception.reconcile"):
+            reconciled = await reconcile_stale_runs(session, stale_threshold_minutes=10)
+
+    assert reconciled == ["issue-100"]
+    assert run.status == "completed"
+    session.commit.assert_called_once()
+    assert "signal=issue_closed" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# test_reconciles_on_merged_pr
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_reconciles_on_merged_pr(caplog: pytest.LogCaptureFixture) -> None:
+    """A stale run whose branch is merged into dev must be set to completed."""
+    run = _make_run(run_id="issue-200", branch="feat/issue-200")
+    session = _make_session([run])
+
+    with patch(
+        "agentception.reconcile.get_issue",
+        new=AsyncMock(return_value={"state": "open", "number": None}),
+    ), patch(
+        "agentception.reconcile.is_branch_merged_into",
+        new=AsyncMock(return_value=True),
+    ):
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="agentception.reconcile"):
+            reconciled = await reconcile_stale_runs(session, stale_threshold_minutes=10)
+
+    assert reconciled == ["issue-200"]
+    assert run.status == "completed"
+    session.commit.assert_called_once()
+    assert "signal=pr_merged" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# test_skips_run_with_no_signals
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_skips_run_with_no_signals() -> None:
+    """A stale run with no issue_number and no branch must not be mutated."""
+    run = _make_run(run_id="issue-300", issue_number=None, branch=None)
+    session = _make_session([run])
+
+    with patch(
+        "agentception.reconcile.get_issue",
+        new=AsyncMock(side_effect=AssertionError("should not be called")),
+    ), patch(
+        "agentception.reconcile.is_branch_merged_into",
+        new=AsyncMock(side_effect=AssertionError("should not be called")),
+    ):
+        reconciled = await reconcile_stale_runs(session, stale_threshold_minutes=10)
+
+    assert reconciled == []
+    assert run.status == "implementing"
+    session.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# test_partial_github_failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_partial_github_failure() -> None:
+    """A GitHub API error on the second run must not prevent the first from committing.
+
+    The first run has a closed issue and should be committed.
+    The second run raises an exception from get_issue — it should be skipped
+    but the first run's commit must already have happened.
+    """
+    run1 = _make_run(run_id="issue-401", issue_number=401)
+    run2 = _make_run(run_id="issue-402", issue_number=402)
+    session = _make_session([run1, run2])
+
+    call_count = 0
+
+    async def _get_issue_side_effect(number: int) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        if number == 401:
+            return {"state": "closed", "number": 401}
+        raise RuntimeError("GitHub API timeout")
+
+    with patch(
+        "agentception.reconcile.get_issue",
+        new=AsyncMock(side_effect=_get_issue_side_effect),
+    ), patch(
+        "agentception.reconcile.is_branch_merged_into",
+        new=AsyncMock(return_value=False),
+    ):
+        reconciled = await reconcile_stale_runs(session, stale_threshold_minutes=10)
+
+    # Only run1 should be reconciled.
+    assert reconciled == ["issue-401"]
+    assert run1.status == "completed"
+    # run2 had a GitHub error — no signal fired, so it stays implementing.
+    assert run2.status == "implementing"
+    # commit was called exactly once (for run1).
+    assert session.commit.call_count == 1


### PR DESCRIPTION
Closes #822

## Summary

Implements `reconcile_stale_runs()` in `agentception/reconcile.py` — a sweep function that detects agent runs stuck at `implementing` and transitions them to `completed` based on two GitHub signals:

1. **`issue_closed`** — the linked GitHub issue is in `closed` state
2. **`pr_merged`** — the agent's branch has been merged into `dev`

Also adds `is_branch_merged_into(branch, base)` to `agentception/readers/github.py` using the GitHub compare API.

## Key design decisions

- **Safety threshold guard**: only runs with `last_activity_at` older than `stale_threshold_minutes` (default 10) are considered — active agents are never touched
- **Per-row independent commits**: each reconciled row is committed independently so a GitHub API failure on row N does not roll back row N-1
- **Skip runs with no signals**: runs with neither `issue_number` nor `branch` are skipped entirely (no GitHub calls, no mutations)
- **Signal priority**: `issue_closed` is checked first; `pr_merged` is only checked if the issue signal did not fire

## Files changed

- `agentception/reconcile.py` — new file with `reconcile_stale_runs()`
- `agentception/readers/github.py` — added `is_branch_merged_into()`
- `agentception/tests/test_reconcile.py` — 5 tests covering all AC scenarios