### PR TITLE
feat: extend SSE stream to emit tool_call and tool_result message rows

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -481,6 +481,7 @@ class AgentThoughtRow(TypedDict):
     seq: int
     role: str
     content: str
+    tool_name: str  # empty string when absent
     recorded_at: str
 
 logger = logging.getLogger(__name__)
@@ -2529,7 +2530,7 @@ async def get_initiative_summary(
 async def get_agent_thoughts_tail(
     run_id: str,
     after_seq: int = -1,
-    roles: tuple[str, ...] = ("thinking", "assistant"),
+    roles: tuple[str, ...] = ("thinking", "assistant", "tool_call", "tool_result"),
 ) -> list[AgentThoughtRow]:
     """Return transcript messages for *run_id* with ``sequence_index > after_seq``.
 
@@ -2555,6 +2556,7 @@ async def get_agent_thoughts_tail(
                 seq=row.sequence_index,
                 role=row.role,
                 content=row.content or "",
+                tool_name=row.tool_name or "",
                 recorded_at=row.recorded_at.isoformat(),
             )
             for row in rows

--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -345,6 +345,16 @@ async def build_board_partial(
 # GET /ship/runs/{run_id}/stream — SSE inspector stream
 # ---------------------------------------------------------------------------
 
+_FILE_EDIT_TOOL_NAMES: frozenset[str] = frozenset(
+    {"write_file", "replace_in_file", "create_file"}
+)
+
+
+def _preview(text: str) -> str:
+    """Collapse newlines and truncate to 120 chars (including the ellipsis)."""
+    flat = " ".join(text.split())
+    return flat[:119] + "…" if len(flat) > 119 else flat
+
 
 async def _inspector_sse(run_id: str) -> AsyncGenerator[str, None]:
     """Yield SSE events for the inspector panel.
@@ -383,14 +393,37 @@ async def _inspector_sse(run_id: str) -> AsyncGenerator[str, None]:
         )
         for thought in thoughts:
             last_thought_seq = max(last_thought_seq, int(thought["seq"]))
-            payload = json.dumps(
-                {
-                    "t": "thought",
-                    "role": thought["role"],
-                    "content": thought["content"],
-                    "recorded_at": thought["recorded_at"],
-                }
-            )
+            role = thought["role"]
+            if role == "tool_call":
+                payload = json.dumps(
+                    {
+                        "t": "tool_call",
+                        "tool_name": thought["tool_name"],
+                        "args_preview": _preview(thought["content"]),
+                        "recorded_at": thought["recorded_at"],
+                    }
+                )
+            elif role == "tool_result":
+                tool_name = thought["tool_name"]
+                if tool_name in _FILE_EDIT_TOOL_NAMES:
+                    continue  # file-edit results already have their own rendering path
+                payload = json.dumps(
+                    {
+                        "t": "tool_result",
+                        "tool_name": tool_name,
+                        "result_preview": _preview(thought["content"]),
+                        "recorded_at": thought["recorded_at"],
+                    }
+                )
+            else:
+                payload = json.dumps(
+                    {
+                        "t": "thought",
+                        "role": role,
+                        "content": thought["content"],
+                        "recorded_at": thought["recorded_at"],
+                    }
+                )
             yield f"data: {payload}\n\n"
 
         ping_counter += 1

--- a/agentception/tests/test_build_ui_sse.py
+++ b/agentception/tests/test_build_ui_sse.py
@@ -1,0 +1,131 @@
+"""Tests for the new tool_call / tool_result SSE event shapes in _inspector_sse.
+
+Covers issue #851: extend the inspector SSE stream to emit tool_call and
+tool_result message rows.
+
+Run targeted:
+    pytest agentception/tests/test_build_ui_sse.py -v
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentception.db.queries import AgentThoughtRow
+from agentception.routes.ui.build_ui import _inspector_sse
+
+
+def _make_thought(
+    seq: int,
+    role: str,
+    content: str,
+    tool_name: str = "",
+    recorded_at: str = "2026-01-01T00:00:00",
+) -> AgentThoughtRow:
+    return AgentThoughtRow(
+        seq=seq,
+        role=role,
+        content=content,
+        tool_name=tool_name,
+        recorded_at=recorded_at,
+    )
+
+
+@pytest.mark.anyio
+async def test_tool_call_emitted() -> None:
+    with (
+        patch(
+            "agentception.routes.ui.build_ui.get_agent_events_tail",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_agent_thoughts_tail",
+            new_callable=AsyncMock,
+            side_effect=[
+                [_make_thought(0, "tool_call", '{"foo": 1}', tool_name="bash")],
+                Exception("stop"),
+            ],
+        ),
+    ):
+        gen = _inspector_sse("run-1")
+        events = []
+        try:
+            async for chunk in gen:
+                if chunk.startswith("data:"):
+                    events.append(json.loads(chunk.removeprefix("data: ").strip()))
+        except Exception:
+            pass
+    tc = [e for e in events if e.get("t") == "tool_call"]
+    assert len(tc) == 1
+    assert tc[0]["tool_name"] == "bash"
+    assert len(tc[0]["args_preview"]) <= 120
+
+
+@pytest.mark.anyio
+async def test_tool_result_emitted() -> None:
+    with (
+        patch(
+            "agentception.routes.ui.build_ui.get_agent_events_tail",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_agent_thoughts_tail",
+            new_callable=AsyncMock,
+            side_effect=[
+                [_make_thought(0, "tool_result", "ok output", tool_name="bash")],
+                Exception("stop"),
+            ],
+        ),
+    ):
+        gen = _inspector_sse("run-1")
+        events = []
+        try:
+            async for chunk in gen:
+                if chunk.startswith("data:"):
+                    events.append(json.loads(chunk.removeprefix("data: ").strip()))
+        except Exception:
+            pass
+    tr = [e for e in events if e.get("t") == "tool_result"]
+    assert len(tr) == 1
+    assert tr[0]["tool_name"] == "bash"
+
+
+@pytest.mark.anyio
+async def test_file_edit_tool_result_suppressed() -> None:
+    with (
+        patch(
+            "agentception.routes.ui.build_ui.get_agent_events_tail",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "agentception.routes.ui.build_ui.get_agent_thoughts_tail",
+            new_callable=AsyncMock,
+            side_effect=[
+                [_make_thought(0, "tool_result", "wrote ok", tool_name="write_file")],
+                Exception("stop"),
+            ],
+        ),
+    ):
+        gen = _inspector_sse("run-1")
+        events = []
+        try:
+            async for chunk in gen:
+                if chunk.startswith("data:"):
+                    events.append(json.loads(chunk.removeprefix("data: ").strip()))
+        except Exception:
+            pass
+    assert not any(e.get("t") == "tool_result" for e in events)
+
+
+@pytest.mark.anyio
+async def test_args_preview_truncated() -> None:
+    long_content = "x" * 200
+    from agentception.routes.ui.build_ui import _preview
+    result = _preview(long_content)
+    assert result.endswith("…")
+    assert len(result) <= 120


### PR DESCRIPTION
Closes #851

## Changes

### `agentception/db/queries.py`
- Added `tool_name: str` field to `AgentThoughtRow` TypedDict
- Updated `get_agent_thoughts_tail()` default `roles` tuple to include `"tool_call"` and `"tool_result"`
- Updated `AgentThoughtRow()` constructor call to populate `tool_name` from `row.tool_name or ""`

### `agentception/routes/ui/build_ui.py`
- Added `_FILE_EDIT_TOOL_NAMES` frozenset at module level (`write_file`, `replace_in_file`, `create_file`)
- Added `_preview()` helper that collapses newlines and truncates to 120 chars with `…` suffix
- Updated `_inspector_sse()` thought loop to emit `{"t":"tool_call", ...}` for `tool_call` rows, `{"t":"tool_result", ...}` for non-file-edit `tool_result` rows, and suppress file-edit tool results

### `agentception/tests/test_build_ui_sse.py` (new file)
- `test_tool_call_emitted` — verifies `tool_call` rows produce `{"t":"tool_call"}` SSE events
- `test_tool_result_emitted` — verifies non-file-edit `tool_result` rows produce `{"t":"tool_result"}` SSE events
- `test_file_edit_tool_result_suppressed` — verifies `write_file` tool results are suppressed
- `test_args_preview_truncated` — verifies `_preview()` truncates to ≤120 chars with `…` suffix