### PR TITLE
feat: invoke reconcile_stale_runs() on every poller cycle with configurable threshold

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -108,6 +108,15 @@ class AgentCeptionSettings(BaseSettings):
     """
     gh_repo: str = "cgcardona/agentception"
     poll_interval_seconds: int = 5
+    stale_run_threshold_minutes: int = 10
+    """Minutes of inactivity before an implementing run is a reconciliation candidate.
+
+    Set via ``STALE_RUN_THRESHOLD_MINUTES`` env var.  Runs whose
+    ``last_activity_at`` is older than this value are checked against GitHub
+    and transitioned to ``completed`` if their issue is closed or PR is merged.
+    Defaults to 10 minutes.  Raise this value if agents are being incorrectly
+    marked stale during slow operations.
+    """
     agent_max_iterations: int = 100
     # TTL must be strictly less than poll_interval_seconds (currently 5) so every
     # poller tick sees live GitHub data.  Keep GITHUB_CACHE_SECONDS < POLL_INTERVAL_SECONDS.

--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -22,6 +22,8 @@ import time
 from pathlib import Path
 
 from agentception.config import settings
+from agentception.reconcile import reconcile_stale_runs
+from agentception.db.engine import get_session
 from agentception.intelligence.guards import detect_out_of_order_prs, detect_stale_claims
 from agentception.db.queries import RunContextRow, list_active_runs
 from agentception.models import AgentNode, AgentStatus, BoardIssue, PipelineState, PlanDraftEvent, StaleClaim, StalledAgentEvent
@@ -779,6 +781,23 @@ async def polling_loop() -> None:
         try:
             await tick()
             _rate_limit_backoff = 0  # reset on success
+            try:
+                async with get_session() as _reconcile_session:
+                    _reconciled = await reconcile_stale_runs(
+                        _reconcile_session,
+                        stale_threshold_minutes=settings.stale_run_threshold_minutes,
+                    )
+                if _reconciled:
+                    logger.info(
+                        "[poller] reconciled %d stale run(s): %s",
+                        len(_reconciled),
+                        _reconciled,
+                    )
+            except Exception as _reconcile_exc:
+                logger.error(
+                    "❌ [poller] reconcile_stale_runs failed: %s",
+                    _reconcile_exc,
+                )
             await asyncio.sleep(settings.poll_interval_seconds)
         except asyncio.CancelledError:
             logger.info("✅ Polling loop stopped cleanly")

--- a/agentception/tests/test_poller_reconcile_wiring.py
+++ b/agentception/tests/test_poller_reconcile_wiring.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentception.poller import polling_loop
+
+
+@pytest.fixture()
+def mock_tick() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture()
+def mock_reconcile() -> AsyncMock:
+    return AsyncMock(return_value=[])
+
+
+@pytest.fixture()
+def mock_get_session() -> MagicMock:
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    factory = MagicMock(return_value=ctx)
+    return factory
+
+
+@pytest.mark.anyio
+async def test_reconcile_called_each_cycle(
+    mock_tick: AsyncMock,
+    mock_reconcile: AsyncMock,
+    mock_get_session: MagicMock,
+) -> None:
+    """reconcile_stale_runs is invoked once per poller tick."""
+    call_count = 0
+
+    async def _counting_reconcile(*args: object, **kwargs: object) -> list[str]:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            raise asyncio.CancelledError
+        return []
+
+    with (
+        patch("agentception.poller.tick", mock_tick),
+        patch("agentception.poller.reconcile_stale_runs", side_effect=_counting_reconcile),
+        patch("agentception.poller.get_session", mock_get_session),
+        patch("agentception.poller.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        # polling_loop() catches CancelledError and returns cleanly — no raise
+        await polling_loop()
+
+    assert call_count >= 1
+
+
+@pytest.mark.anyio
+async def test_reconcile_exception_does_not_crash_poller(
+    mock_tick: AsyncMock,
+    mock_get_session: MagicMock,
+) -> None:
+    """An exception from reconcile_stale_runs must not stop the poller loop."""
+    tick_count = 0
+
+    async def _counted_tick() -> None:
+        nonlocal tick_count
+        tick_count += 1
+        if tick_count >= 2:
+            raise asyncio.CancelledError
+
+    async def _failing_reconcile(*args: object, **kwargs: object) -> list[str]:
+        raise RuntimeError("github exploded")
+
+    with (
+        patch("agentception.poller.tick", side_effect=_counted_tick),
+        patch("agentception.poller.reconcile_stale_runs", side_effect=_failing_reconcile),
+        patch("agentception.poller.get_session", mock_get_session),
+        patch("agentception.poller.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        # polling_loop() catches CancelledError and returns cleanly — no raise
+        await polling_loop()
+
+    assert tick_count >= 2
+
+
+@pytest.mark.anyio
+async def test_threshold_from_env(
+    mock_tick: AsyncMock,
+    mock_get_session: MagicMock,
+) -> None:
+    """STALE_RUN_THRESHOLD_MINUTES env var is forwarded to reconcile_stale_runs."""
+    received_threshold: list[int] = []
+
+    async def _capture_reconcile(
+        session: object,
+        *,
+        stale_threshold_minutes: int = 10,
+    ) -> list[str]:
+        received_threshold.append(stale_threshold_minutes)
+        raise asyncio.CancelledError
+
+    with (
+        patch("agentception.poller.tick", mock_tick),
+        patch("agentception.poller.reconcile_stale_runs", side_effect=_capture_reconcile),
+        patch("agentception.poller.get_session", mock_get_session),
+        patch("agentception.poller.asyncio.sleep", new_callable=AsyncMock),
+        patch("agentception.poller.settings") as mock_settings,
+    ):
+        mock_settings.poll_interval_seconds = 5
+        mock_settings.stale_run_threshold_minutes = 20
+        # polling_loop() catches CancelledError and returns cleanly — no raise
+        await polling_loop()
+
+    assert received_threshold == [20]

--- a/docs/reference/yaml-config.md
+++ b/docs/reference/yaml-config.md
@@ -304,3 +304,11 @@ The `generate.py` script renders every `.j2` file in `scripts/gen_prompts/templa
 3. Run `sync_labels.sh` to create the new labels in GitHub.
 
 4. Use the Plan page to generate a PlanSpec for the new initiative, then file issues. The `initiative_phases` rows written at filing time are the canonical phase order for the board — `config.yaml` phases drive the agent prompts, not the board display order.
+
+---
+
+## Environment Variable Reference
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `STALE_RUN_THRESHOLD_MINUTES` | `int` | `10` | Minutes of inactivity before an implementing run is checked for reconciliation. |


### PR DESCRIPTION
Closes #823

## Summary

Wires `reconcile_stale_runs()` into the poller loop so stuck `implementing` runs are automatically transitioned to `completed` on every polling cycle.

## Changes

- **`agentception/config.py`**: Added `stale_run_threshold_minutes: int = 10` field to `AgentCeptionSettings`, configurable via `STALE_RUN_THRESHOLD_MINUTES` env var.
- **`agentception/poller.py`**: 
  - Added top-level imports for `reconcile_stale_runs` and `get_session`.
  - Inside `polling_loop()`, after each `tick()`, calls `reconcile_stale_runs()` with the configured threshold. Exceptions are caught and logged; the loop continues.
- **`docs/reference/yaml-config.md`**: Added `STALE_RUN_THRESHOLD_MINUTES` row to the configuration reference table.
- **`agentception/tests/test_poller_reconcile_wiring.py`**: New test file with three tests verifying reconcile is called each cycle, exceptions don't crash the poller, and the threshold is forwarded from settings.