### PR TITLE
feat: add AssistantBubble component for role=assistant SSE messages

### DIFF
--- a/agentception/static/js/__tests__/thought_block.test.ts
+++ b/agentception/static/js/__tests__/thought_block.test.ts
@@ -49,4 +49,30 @@ describe("attachThoughtHandler", () => {
     const btn = document.querySelector(".thought-block__header");
     expect(btn?.getAttribute("aria-expanded")).toBe("false");
   });
+
+  it("renders assistant-bubble for role=assistant event", () => {
+    const src = makeSource();
+    attachThoughtHandler(src);
+    dispatch(src, { t: "thought", role: "assistant", content: "Here is my answer.", recorded_at: "" });
+    const bubble = document.querySelector(".assistant-bubble");
+    expect(bubble).not.toBeNull();
+    expect(bubble?.textContent).toBe("Here is my answer.");
+  });
+
+  it("renders thought-block for role=thinking event (existing behaviour unchanged)", () => {
+    const src = makeSource();
+    attachThoughtHandler(src);
+    dispatch(src, { t: "thought", role: "thinking", content: "thinking...", recorded_at: "" });
+    expect(document.querySelector(".thought-block")).not.toBeNull();
+    expect(document.querySelector(".assistant-bubble")).toBeNull();
+  });
+
+  it("assistant-bubble has no collapse button", () => {
+    const src = makeSource();
+    attachThoughtHandler(src);
+    dispatch(src, { t: "thought", role: "assistant", content: "answer", recorded_at: "" });
+    // No button inside the bubble.
+    expect(document.querySelector(".assistant-bubble button")).toBeNull();
+    expect(document.querySelector(".assistant-bubble .thought-block__header")).toBeNull();
+  });
 });

--- a/agentception/static/js/thought_block.ts
+++ b/agentception/static/js/thought_block.ts
@@ -129,6 +129,20 @@ export function attachThoughtHandler(source: EventSource): void {
       return;
     }
 
+    if (msg.t === "thought" && msg.role === "assistant") {
+      closeActive(); // collapse any open thinking block first
+      const bubble = document.createElement("div");
+      bubble.className = "assistant-bubble";
+      bubble.setAttribute("role", "note");
+      bubble.setAttribute("aria-label", "Agent response");
+      bubble.textContent = msg.content;
+      feed.appendChild(bubble);
+      if (typeof bubble.scrollIntoView === "function") {
+        bubble.scrollIntoView({ block: "end", behavior: "smooth" });
+      }
+      return;
+    }
+
     if (msg.t === "event") {
       if (msg.event_type === "step_start" || msg.event_type === "done") {
         closeActive();

--- a/agentception/static/scss/pages/_build.scss
+++ b/agentception/static/scss/pages/_build.scss
@@ -2213,3 +2213,14 @@ $preset-accents: (
 .diff-remove  { display: block; background: rgba(255, 60, 60, 0.10); color: #f97583; }
 .diff-context { display: block; color: var(--color-text-muted, #888); }
 
+// ── Assistant bubble ──────────────────────────────────────────────────────────
+
+.assistant-bubble {
+  border-left: 2px solid var(--color-text, #eee);
+  padding: 0.35rem 0.5rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-text, #eee);
+  line-height: 1.5;
+}
+


### PR DESCRIPTION
Closes #853

## Changes

- **`thought_block.ts`**: Added handler for `{t:"thought", role:"assistant"}` SSE messages — renders a `div.assistant-bubble` in `#activity-feed` with no collapse toggle or button children. Calls `closeActive()` first to collapse any open thinking block.
- **`_build.scss`**: Appended `.assistant-bubble` styles with `border-left`, `white-space: pre-wrap`, `color`, `padding`, `word-break`, and `line-height`.
- **`thought_block.test.ts`**: Extended with 3 new tests covering assistant-bubble rendering, no-regression for thinking blocks, and absence of collapse button.

## Verification

- `npm run type-check` → 0 errors
- `npm test` → 62/62 tests pass (7 thought_block tests: 4 existing + 3 new)
- `npm run build:js` + `npm run build:css` → both succeed