### PR TITLE
fix: add merge=union for _build.scss to reduce parallel-agent conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Append-only SCSS files — agents always add new rule blocks at the end.
+# merge=union includes lines from both sides rather than conflicting, which
+# eliminates spurious merge conflicts when multiple agents land in parallel.
+agentception/static/scss/pages/_build.scss merge=union


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` with `merge=union` for `_build.scss`
- Agents appending SCSS blocks in parallel always conflicted at EOF; `merge=union` includes lines from both sides automatically
- Compiled bundles (`app.js`, `app.css`) are already gitignored so `merge=ours` for them is no longer needed (issue #699 addressed this but those files are now out of git entirely)

## Test plan
- No code changes — git merge strategy only
- Verify `.gitattributes` is present in repo root after merge