### PR TITLE
feat: persist grade and reviewer_feedback in done-event payload for reviewer runs

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -358,10 +358,18 @@ async def build_complete_run(
             }
     # -------------------------
 
+    # ── Determine caller role before persisting so the done-event payload
+    # can include grade/feedback for reviewer runs.
+    caller_role = await get_agent_run_role(agent_run_id) if agent_run_id else None
+    _done_payload: dict[str, object] = {"pr_url": pr_url, "summary": summary}
+    if caller_role == "reviewer":
+        _done_payload["grade"] = grade.strip().upper()
+        _done_payload["reviewer_feedback"] = reviewer_feedback
+
     await persist_agent_event(
         issue_number=issue_number,
         event_type="done",
-        payload={"pr_url": pr_url, "summary": summary},
+        payload=_done_payload,
         agent_run_id=agent_run_id,
     )
 
@@ -381,11 +389,10 @@ async def build_complete_run(
 
     # Reviewer path: grade determines whether to merge (handled by reviewer) or
     # redispatch a corrected developer run.
-    caller_role = await get_agent_run_role(agent_run_id) if agent_run_id else None
     if caller_role == "reviewer":
         VALID_REVIEWER_GRADES: frozenset[str] = frozenset({"A", "B", "C", "D", "F"})
         _FAILING_GRADES: frozenset[str] = frozenset({"C", "D", "F"})
-        normalised_grade = grade.strip().upper()
+        normalised_grade = str(_done_payload["grade"])
         # Reviewer must commit to a valid grade before merge/redispatch logic runs.
         if normalised_grade not in VALID_REVIEWER_GRADES:
             return {

--- a/agentception/tests/test_build_commands.py
+++ b/agentception/tests/test_build_commands.py
@@ -564,3 +564,123 @@ async def test_build_complete_run_rejects_whitespace_grade_from_reviewer() -> No
     mock_redispatch.assert_not_called()
     mock_teardown.assert_not_called()
     mock_create_task.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_done_event_payload_includes_grade_for_reviewer() -> None:
+    """Reviewer done-event payload must include grade and reviewer_feedback."""
+    from agentception.mcp.build_commands import build_complete_run
+
+    captured_payload: dict[str, str] = {}
+
+    async def _capture_persist(
+        *,
+        issue_number: int,
+        event_type: str,
+        payload: dict[str, str],
+        agent_run_id: str | None = None,
+    ) -> None:
+        if event_type == "done":
+            captured_payload.update(payload)
+
+    with (
+        patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            side_effect=_capture_persist,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="reviewer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.auto_redispatch_after_rejection",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.teardown_agent_worktree",
+            new_callable=AsyncMock,
+        ),
+        patch("agentception.mcp.build_commands.asyncio.create_task"),
+    ):
+        await build_complete_run(
+            issue_number=42,
+            pr_url="https://github.com/cgcardona/agentception/pull/99",
+            agent_run_id="review-issue-42-abc",
+            grade="b",                          # lower-case — must be normalised
+            reviewer_feedback="Looks good overall.",
+        )
+
+    assert captured_payload.get("grade") == "B"
+    assert captured_payload.get("reviewer_feedback") == "Looks good overall."
+    assert "pr_url" in captured_payload
+
+
+@pytest.mark.anyio
+async def test_done_event_payload_excludes_grade_for_developer() -> None:
+    """Developer done-event payload must NOT contain grade or reviewer_feedback."""
+    from agentception.mcp.build_commands import build_complete_run
+
+    captured_payload: dict[str, str] = {}
+
+    async def _capture_persist(
+        *,
+        issue_number: int,
+        event_type: str,
+        payload: dict[str, str],
+        agent_run_id: str | None = None,
+    ) -> None:
+        if event_type == "done":
+            captured_payload.update(payload)
+
+    with (
+        patch(
+            "agentception.mcp.build_commands._has_file_edit_events",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands._has_pr_recorded",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            side_effect=_capture_persist,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="developer",
+        ),
+    ):
+        await build_complete_run(
+            issue_number=99,
+            pr_url="https://github.com/cgcardona/agentception/pull/200",
+            agent_run_id="issue-99-xyz",
+        )
+
+    assert "grade" not in captured_payload
+    assert "reviewer_feedback" not in captured_payload
+    assert "pr_url" in captured_payload
+


### PR DESCRIPTION
Closes #857

## Summary

Moves `get_agent_run_role` call to **before** `persist_agent_event` in `build_complete_run` so the `done` event payload can include `grade` and `reviewer_feedback` for reviewer runs.

### Changes

**`agentception/mcp/build_commands.py`**
- Determine `caller_role` before building the done-event payload
- Build `_done_payload` dict and conditionally add `grade` (upper-cased) and `reviewer_feedback` when `caller_role == "reviewer"`
- Reuse `_done_payload["grade"]` as `normalised_grade` in the reviewer block (avoids duplicate `.strip().upper()`)
- Remove the now-duplicate `caller_role = await get_agent_run_role(...)` line that was after the persist call

**`agentception/tests/test_build_commands.py`**
- `test_done_event_payload_includes_grade_for_reviewer` — verifies reviewer done-event payload contains `grade` (normalised to uppercase) and `reviewer_feedback`
- `test_done_event_payload_excludes_grade_for_developer` — verifies developer done-event payload does NOT contain `grade` or `reviewer_feedback`