### PR TITLE
fix: treat 422 as already_exists only when GitHub error code confirms it

### DIFF
--- a/agentception/readers/github.py
+++ b/agentception/readers/github.py
@@ -1065,6 +1065,21 @@ async def ensure_label_exists(name: str, color: str, description: str) -> None:
             await _rate_limit_sleep(r, attempt)
             continue
         if r.status_code == 422:
+            # GitHub returns 422 both for "already exists" and for genuine
+            # validation errors (e.g. label name too long).  Only treat it as
+            # "already exists" when the response body confirms this via the
+            # "already_exists" error code; otherwise surface the real error.
+            body: object = r.json()
+            errors: object = body.get("errors", []) if isinstance(body, dict) else []
+            is_already_exists = isinstance(errors, list) and any(
+                isinstance(e, dict) and e.get("code") == "already_exists"
+                for e in errors
+            )
+            if not is_already_exists:
+                raise RuntimeError(
+                    f"GitHub API POST /repos/{repo}/labels failed (422): "
+                    f"{r.text[:400]}"
+                )
             # Label already exists — update it in place via the _api_patch helper
             # which itself handles 429 retries.
             encoded = urllib.parse.quote(name, safe="")

--- a/agentception/tests/test_agentception_github.py
+++ b/agentception/tests/test_agentception_github.py
@@ -721,13 +721,18 @@ async def test_update_issue_patches_only_provided_fields() -> None:
 
 
 @pytest.mark.anyio
-async def test_ensure_label_exists_updates_on_422() -> None:
-    """ensure_label_exists() must PATCH the label when the POST returns 422 (already exists)."""
+async def test_ensure_label_exists_updates_on_422_already_exists() -> None:
+    """ensure_label_exists() must PATCH when the POST returns 422 with already_exists code."""
     from agentception.readers.github import ensure_label_exists
 
-    # POST returns 422 (label exists); PATCH succeeds.
-    resp_422 = _mock_response(None, 422)
+    # POST returns 422 with "already_exists" error code; PATCH succeeds.
+    already_exists_body = {
+        "message": "Validation Failed",
+        "errors": [{"resource": "Label", "code": "already_exists", "field": "name"}],
+    }
+    resp_422 = _mock_response(already_exists_body, 422)
     resp_422.raise_for_status = MagicMock()  # 422 is handled before raise_for_status
+    resp_422.text = ""
     resp_200_patch = _mock_response({"name": "approved"}, 200)
 
     post_client = MagicMock()
@@ -749,4 +754,35 @@ async def test_ensure_label_exists_updates_on_422() -> None:
     # POST was attempted once, then PATCH was called to update.
     assert post_client.post.call_count == 1
     assert patch_client.patch.call_count == 1
+
+
+@pytest.mark.anyio
+async def test_ensure_label_exists_raises_on_422_validation_error() -> None:
+    """ensure_label_exists() must raise RuntimeError when POST 422 is a real validation error.
+
+    GitHub returns 422 both for 'already exists' and for genuine validation
+    failures (e.g. label name too long).  Only the 'already_exists' code
+    should trigger the PATCH fallback — other 422 bodies must surface as errors
+    rather than silently attempting a PATCH that will always 404.
+    """
+    from agentception.readers.github import ensure_label_exists
+
+    validation_error_body = {
+        "message": "Validation Failed",
+        "errors": [{"resource": "Label", "code": "invalid", "field": "name"}],
+    }
+    resp_422 = MagicMock()
+    resp_422.status_code = 422
+    resp_422.json.return_value = validation_error_body
+    resp_422.text = '{"message": "Validation Failed", "errors": [{"code": "invalid"}]}'
+    resp_422.raise_for_status = MagicMock()
+
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.post = AsyncMock(return_value=resp_422)
+
+    with patch("agentception.readers.github.httpx.AsyncClient", return_value=client):
+        with pytest.raises(RuntimeError, match="422"):
+            await ensure_label_exists("x" * 60, "2ea44f", "Too long")
 


### PR DESCRIPTION
## Summary

- `ensure_label_exists()` was blindly treating every 422 from POST as "label already exists" and attempting a PATCH — which 404'd because the label was never created
- GitHub also returns 422 for real validation errors (e.g. label name too long, invalid characters)
- Now inspects the response body for `"code": "already_exists"` before falling through to PATCH; any other 422 raises immediately with the full GitHub error text
- Adds two regression tests: one for the happy-path `already_exists` branch, one asserting `RuntimeError` on a non-`already_exists` 422

## Root cause

The `context-window-management/2-checkpoint-summarisation` label name in the Phase 1A prompt triggered a 422 validation error from GitHub (not an "already exists" conflict). The old code assumed 422 = already exists, PATCH'd a non-existent label URL, got 404, and surfaced it as "Label setup failed".

## Test plan
- [x] `test_ensure_label_exists_updates_on_422_already_exists` — PATCH is called when body has `already_exists`
- [x] `test_ensure_label_exists_raises_on_422_validation_error` — RuntimeError raised when body has other code
- [x] `mypy agentception/readers/github.py agentception/tests/test_agentception_github.py` — zero errors