### PR TITLE
fix: truncate scoped phase labels to GitHub's 50-char limit

### DIFF
--- a/agentception/readers/issue_creator.py
+++ b/agentception/readers/issue_creator.py
@@ -46,6 +46,20 @@ logger = logging.getLogger(__name__)
 # and any slug convention receives a distinct, deterministic GitHub label color.
 _PHASE_PALETTE: list[str] = ["B60205", "E4E669", "0075CA", "CFD3D7"]
 _INITIATIVE_COLOR = "7057FF"
+# GitHub enforces a 50-character ceiling on label names.
+_GITHUB_LABEL_MAX_LEN = 50
+
+
+def _scoped_label(initiative: str, phase_label: str) -> str:
+    """Return ``initiative/phase_label`` truncated to the GitHub label limit.
+
+    GitHub rejects label names longer than 50 characters with a 422 validation
+    error.  We truncate the combined string rather than either component alone
+    so that the separator ``/`` is always preserved and the result is still
+    human-readable.
+    """
+    full = f"{initiative}/{phase_label}"
+    return full[:_GITHUB_LABEL_MAX_LEN]
 
 
 # ── Event types streamed to the browser ───────────────────────────────────
@@ -212,7 +226,7 @@ async def _bootstrap_labels(spec: PlanSpec) -> None:
     ]
     for idx, phase in enumerate(spec.phases):
         color = _PHASE_PALETTE[idx % len(_PHASE_PALETTE)]
-        scoped_label = f"{spec.initiative}/{phase.label}"
+        scoped_label = _scoped_label(spec.initiative, phase.label)
         # GitHub caps label descriptions at 100 characters.
         desc = phase.description
         if len(desc) > 100:
@@ -326,11 +340,11 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
     for phase_idx, phase in enumerate(spec.phases):
         # Phase 0 is immediately workable; all later phases are phase-gated.
         gate_label = "pipeline/active" if phase_idx == 0 else "pipeline/gated"
-        labels = [spec.initiative, f"{spec.initiative}/{phase.label}", gate_label]
+        labels = [spec.initiative, _scoped_label(spec.initiative, phase.label), gate_label]
         # For phase 1+ embed the blocking phase label into the issue body so
         # agents reading the ticket immediately know what must complete first.
         prev_phase_label = (
-            f"{spec.initiative}/{spec.phases[phase_idx - 1].label}"
+            _scoped_label(spec.initiative, spec.phases[phase_idx - 1].label)
             if phase_idx > 0
             else None
         )

--- a/agentception/tests/test_issue_creator.py
+++ b/agentception/tests/test_issue_creator.py
@@ -28,6 +28,7 @@ from agentception.readers.issue_creator import (
     IssueEvent,
     LabelEvent,
     StartEvent,
+    _scoped_label,
     _embed_cognitive_arch,
     _embed_phase_gate,
     _embed_skills,
@@ -741,3 +742,29 @@ async def test_file_issues_body_edit_failure_is_non_fatal() -> None:
     # Body edit failure must not abort the stream — done event must still arrive.
     done_events = [e for e in events if e["t"] == "done"]
     assert done_events, "done event must be emitted even when body edit fails"
+
+
+# ── _scoped_label truncation ──────────────────────────────────────────────────
+
+
+def test_scoped_label_short_names_unchanged() -> None:
+    """Short initiative+phase combinations are returned verbatim."""
+    assert _scoped_label("ac-build", "phase-0") == "ac-build/phase-0"
+
+
+def test_scoped_label_truncates_to_50_chars() -> None:
+    """Labels longer than 50 characters are truncated to exactly 50.
+
+    Regression test: GitHub rejects label names > 50 chars with 422.
+    e.g. 'context-window-management/2-checkpoint-summarisation' is 52 chars.
+    """
+    result = _scoped_label("context-window-management", "2-checkpoint-summarisation")
+    assert len(result) == 50
+    assert result == "context-window-management/2-checkpoint-summarisati"
+
+
+def test_scoped_label_always_contains_separator() -> None:
+    """The '/' separator is always present in the returned label."""
+    result = _scoped_label("a" * 30, "b" * 30)
+    assert "/" in result
+    assert len(result) == 50


### PR DESCRIPTION
## Summary

- GitHub rejects label names > 50 characters with a `422 Validation Failed` error
- Phase labels like `context-window-management/2-checkpoint-summarisation` (52 chars) were hitting this limit and surfacing as "Label setup failed"
- Introduces `_scoped_label(initiative, phase_label)` which truncates the combined string to 50 chars
- Applied at all three construction sites in `issue_creator.py` so the label name is always consistent

## Test plan
- [x] `test_scoped_label_short_names_unchanged` — short labels returned verbatim
- [x] `test_scoped_label_truncates_to_50_chars` — exact 50-char truncation, regression for the reported name
- [x] `test_scoped_label_always_contains_separator` — `/` always preserved
- [x] `mypy` — zero errors