### PR TITLE
feat: add plan_enricher.py with enrich_plan_with_codebase_context()

### DIFF
--- a/agentception/readers/plan_enricher.py
+++ b/agentception/readers/plan_enricher.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Enrich a PlanSpec with codebase context from the semantic search index.
+
+Called after Phase 1A LLM generation and before Phase 1B review.  Appends
+a '## Relevant codebase locations' section to each PlanIssue body so that
+developer agents have file/line grounding without needing to guess.
+"""
+
+import asyncio
+import logging
+import re
+
+from agentception.models import PlanIssue, PlanSpec
+from agentception.services.code_indexer import SearchMatch, search_codebase
+
+logger = logging.getLogger(__name__)
+
+_SYMBOL_RE = re.compile(r"^#\s+(?:def|class)\s+(\w+)")
+
+
+def _symbol_name(match: SearchMatch) -> str:
+    """Extract the first def/class name from a chunk, or fall back to file path."""
+    for line in match["chunk"].splitlines():
+        m = _SYMBOL_RE.match(line)
+        if m:
+            return m.group(1)
+    return match["file"]
+
+
+def _format_location(match: SearchMatch) -> str:
+    symbol = _symbol_name(match)
+    return (
+        f"- {match['file']} "
+        f"lines {match['start_line']}-{match['end_line']} "
+        f"\u2014 {symbol}"
+    )
+
+
+async def _enrich_issue(issue: PlanIssue) -> None:
+    """Append a codebase locations section to issue.body if search returns results."""
+    try:
+        results: list[SearchMatch] = await search_codebase(issue.title, n_results=5)
+    except Exception:
+        logger.debug("⚠️ plan_enricher: search failed for %r, skipping", issue.title)
+        return
+    if not results:
+        return
+    lines = ["\n\n## Relevant codebase locations"]
+    for match in results:
+        lines.append(_format_location(match))
+    issue.body += "\n".join(lines)
+
+
+async def enrich_plan_with_codebase_context(spec: PlanSpec) -> PlanSpec:
+    """Enrich every PlanIssue in spec with semantic codebase search results.
+
+    Runs all enrichments concurrently via asyncio.gather.  Individual
+    enrichment failures are swallowed — this function never raises.
+    """
+    all_issues: list[PlanIssue] = [
+        issue for phase in spec.phases for issue in phase.issues
+    ]
+    await asyncio.gather(
+        *[_enrich_issue(issue) for issue in all_issues],
+        return_exceptions=True,
+    )
+    return spec

--- a/agentception/tests/test_plan_enricher.py
+++ b/agentception/tests/test_plan_enricher.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""Unit tests for agentception.readers.plan_enricher."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentception.models import PlanIssue, PlanPhase, PlanSpec
+from agentception.readers.plan_enricher import enrich_plan_with_codebase_context
+from agentception.services.code_indexer import SearchMatch
+
+
+def _make_spec(body: str = "Do the thing.") -> PlanSpec:
+    return PlanSpec(
+        initiative="test-plan",
+        phases=[
+            PlanPhase(
+                label="0-foundation",
+                description="Foundation phase.",
+                issues=[
+                    PlanIssue(id="issue-1", title="Add foo", body=body),
+                ],
+            )
+        ],
+    )
+
+
+def _make_match(file: str = "agentception/foo.py", chunk: str = "# def my_func\nx = 1") -> SearchMatch:
+    return SearchMatch(
+        file=file,
+        chunk=chunk,
+        score=0.9,
+        start_line=10,
+        end_line=20,
+    )
+
+
+@pytest.mark.anyio
+async def test_enrich_appends_locations_section() -> None:
+    """When search returns results, body contains '## Relevant codebase locations'."""
+    spec = _make_spec()
+    matches = [_make_match(), _make_match(file="agentception/bar.py", chunk="# class MyClass\n")]
+
+    with patch(
+        "agentception.readers.plan_enricher.search_codebase",
+        new=AsyncMock(return_value=matches),
+    ):
+        result = await enrich_plan_with_codebase_context(spec)
+
+    body = result.phases[0].issues[0].body
+    assert "## Relevant codebase locations" in body
+    assert "agentception/foo.py" in body
+    assert "agentception/bar.py" in body
+
+
+@pytest.mark.anyio
+async def test_enrich_empty_results_leaves_body_unchanged() -> None:
+    """When search returns [], body is identical to the original."""
+    original_body = "Do the thing."
+    spec = _make_spec(original_body)
+
+    with patch(
+        "agentception.readers.plan_enricher.search_codebase",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await enrich_plan_with_codebase_context(spec)
+
+    assert result.phases[0].issues[0].body == original_body
+
+
+@pytest.mark.anyio
+async def test_enrich_search_raises_leaves_body_unchanged() -> None:
+    """When search raises, body is unchanged and no exception propagates."""
+    original_body = "Do the thing."
+    spec = _make_spec(original_body)
+
+    with patch(
+        "agentception.readers.plan_enricher.search_codebase",
+        new=AsyncMock(side_effect=RuntimeError("qdrant unavailable")),
+    ):
+        result = await enrich_plan_with_codebase_context(spec)  # must not raise
+
+    assert result.phases[0].issues[0].body == original_body
+
+
+@pytest.mark.anyio
+async def test_enrich_extracts_symbol_name_from_chunk() -> None:
+    """Label ends with '\u2014 my_func' when chunk starts with '# def my_func'."""
+    spec = _make_spec()
+    match = _make_match(chunk="# def my_func\nx = 1")
+
+    with patch(
+        "agentception.readers.plan_enricher.search_codebase",
+        new=AsyncMock(return_value=[match]),
+    ):
+        result = await enrich_plan_with_codebase_context(spec)
+
+    body = result.phases[0].issues[0].body
+    assert "— my_func" in body


### PR DESCRIPTION
Closes #868

Adds `agentception/readers/plan_enricher.py` with `enrich_plan_with_codebase_context(spec: PlanSpec) -> PlanSpec`.

Called between Phase 1A (LLM planning) and Phase 1B (issue filing), this function enriches every `PlanIssue.body` with a `## Relevant codebase locations` section sourced from the Qdrant semantic search index. All enrichments run concurrently via `asyncio.gather`; individual search failures are swallowed so the function never raises.

- mypy: zero errors
- pytest: 4/4 tests pass
- typing_audit: 0 Any patterns (threshold 0)