### PR TITLE
feat: slim inspector header and move events inline into #activity-feed

### DIFF
--- a/agentception/static/js/__tests__/event_card.test.ts
+++ b/agentception/static/js/__tests__/event_card.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { attachEventCardHandler } from '../event_card';
+
+function makeSource(): EventSource {
+  return new EventTarget() as unknown as EventSource;
+}
+
+function dispatch(src: EventTarget, data: object): void {
+  src.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(data) }));
+}
+
+describe('attachEventCardHandler', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="activity-feed"></div>';
+  });
+
+  it('renders step_start card with correct text', () => {
+    const src = makeSource();
+    attachEventCardHandler(src);
+    dispatch(src, { t: 'event', event_type: 'step_start', payload: { step: 'Step 2' }, recorded_at: '' });
+    const card = document.querySelector('.event-card');
+    expect(card).not.toBeNull();
+    expect(card?.getAttribute('data-event-type')).toBe('step_start');
+    expect(card?.querySelector('.event-card__text')?.textContent).toBe('Step 2');
+  });
+
+  it('renders done card with summary text', () => {
+    const src = makeSource();
+    attachEventCardHandler(src);
+    dispatch(src, { t: 'event', event_type: 'done', payload: { summary: 'All green' }, recorded_at: '' });
+    expect(document.querySelector('.event-card__text')?.textContent).toBe('All green');
+  });
+
+  it('renders blocker card with correct data-event-type and icon', () => {
+    const src = makeSource();
+    attachEventCardHandler(src);
+    dispatch(src, { t: 'event', event_type: 'blocker', payload: { description: 'Missing dep' }, recorded_at: '' });
+    const card = document.querySelector('.event-card');
+    expect(card?.getAttribute('data-event-type')).toBe('blocker');
+    expect(card?.querySelector('.event-card__icon')?.textContent).toBe('🚧');
+  });
+
+  it('ignores non-event SSE messages', () => {
+    const src = makeSource();
+    attachEventCardHandler(src);
+    dispatch(src, { t: 'thought', role: 'thinking', content: 'hmm', recorded_at: '' });
+    expect(document.querySelector('.event-card')).toBeNull();
+  });
+
+  it('ignores unknown event_type', () => {
+    const src = makeSource();
+    attachEventCardHandler(src);
+    dispatch(src, { t: 'event', event_type: 'file_edit', payload: {}, recorded_at: '' });
+    expect(document.querySelector('.event-card')).toBeNull();
+  });
+});

--- a/agentception/static/js/build.ts
+++ b/agentception/static/js/build.ts
@@ -15,6 +15,7 @@ import { marked } from 'marked';
 import { attachFileEditHandler } from './file_edit_card';
 import { attachThoughtHandler } from './thought_block';
 import { attachToolCallHandler } from './tool_call_card';
+import { attachEventCardHandler } from './event_card';
 
 // ── Domain types ─────────────────────────────────────────────────────────────
 
@@ -62,18 +63,6 @@ interface TreeTierGroup {
 
 interface ApiErrorBody {
   detail?: string;
-}
-
-interface SseMessage {
-  t: 'ping' | 'event' | 'thought';
-  event_type?: string;
-  payload?: Record<string, string>;
-  role?: string;
-  content?: string;
-}
-
-interface SseEvent extends SseMessage {
-  id: number;
 }
 
 interface SseThought {
@@ -127,7 +116,6 @@ export function buildPage() {
   return {
     // ── inspector state ──────────────────────────────────────────────────
     activeIssue: null as ActiveIssue | null,
-    events: [] as SseEvent[],
     thoughts: [] as SseThought[],
     streamOpen: false,
     _evtSource: null as EventSource | null,
@@ -186,7 +174,6 @@ export function buildPage() {
       if (this.activeIssue?.number === issue.number) return;
       this._closeStream();
       this.activeIssue = issue;
-      this.events = [];
       this.thoughts = [];
       if (issue.run) {
         this._openStream(issue.run.id);
@@ -198,7 +185,6 @@ export function buildPage() {
       this._closeStream();
       this._stopTreePoll();
       this.activeIssue = null;
-      this.events = [];
       this.thoughts = [];
       this.chatMessage = '';
       this.chatError = null;
@@ -259,30 +245,8 @@ export function buildPage() {
       attachFileEditHandler(src);
       attachThoughtHandler(src);
       attachToolCallHandler(src);
+      attachEventCardHandler(src);
       this.streamOpen = true;
-
-      src.onmessage = (e: MessageEvent<string>) => {
-        let msg: SseMessage;
-        try {
-          msg = JSON.parse(e.data) as SseMessage;
-        } catch {
-          return;
-        }
-
-        if (msg.t === 'ping') return;
-
-        if (msg.t === 'event') {
-          this.events.push({ ...msg, id: Date.now() + Math.random() });
-        } else if (msg.t === 'thought') {
-          const last = this.thoughts[this.thoughts.length - 1];
-          if (last && last.role === msg.role) {
-            last.content += '\n' + (msg.content ?? '');
-          } else {
-            this.thoughts.push({ role: msg.role ?? '', content: msg.content ?? '' });
-          }
-          this._scrollCot();
-        }
-      };
 
       src.onerror = () => {
         this.streamOpen = false;
@@ -348,27 +312,6 @@ export function buildPage() {
         });
       } catch {
         return iso;
-      }
-    },
-
-    eventIcon(eventType: string): string {
-      const icons: Record<string, string> = {
-        step_start: '▶',
-        blocker:    '🚧',
-        decision:   '💡',
-        done:       '✅',
-      };
-      return icons[eventType] ?? '•';
-    },
-
-    eventDetail(ev: SseEvent): string {
-      const p = ev.payload ?? {};
-      switch (ev.event_type) {
-        case 'step_start': return p['step'] ?? '';
-        case 'blocker':    return p['description'] ?? '';
-        case 'decision':   return `${p['decision'] ?? ''} — ${p['rationale'] ?? ''}`;
-        case 'done':       return p['summary'] ?? p['pr_url'] ?? '';
-        default:           return JSON.stringify(p);
       }
     },
 

--- a/agentception/static/js/event_card.ts
+++ b/agentception/static/js/event_card.ts
@@ -1,0 +1,64 @@
+interface EventSseMessage {
+  t: 'event';
+  event_type: string;
+  payload: Record<string, string>;
+  recorded_at: string;
+}
+
+type AnySseMessage = EventSseMessage | { t: string };
+
+const EVENT_ICONS: Record<string, string> = {
+  step_start: '▶',
+  blocker:    '🚧',
+  decision:   '💡',
+  done:       '✅',
+};
+
+const RENDERABLE = new Set(['step_start', 'blocker', 'decision', 'done']);
+
+function eventText(msg: EventSseMessage): string {
+  const p = msg.payload ?? {};
+  switch (msg.event_type) {
+    case 'step_start': return p['step'] ?? 'Step';
+    case 'blocker':    return p['description'] ?? 'Blocker';
+    case 'decision':   return `${p['decision'] ?? ''} — ${p['rationale'] ?? ''}`;
+    case 'done':       return p['summary'] ?? p['pr_url'] ?? 'Done';
+    default:           return msg.event_type;
+  }
+}
+
+/** Append a div.event-card to #activity-feed for each step_start/blocker/decision/done SSE event. */
+export function attachEventCardHandler(source: EventSource): void {
+  source.addEventListener('message', (evt: MessageEvent<string>) => {
+    let msg: AnySseMessage;
+    try {
+      msg = JSON.parse(evt.data) as AnySseMessage;
+    } catch {
+      return;
+    }
+    if (msg.t !== 'event') return;
+    const m = msg as EventSseMessage;
+    if (!RENDERABLE.has(m.event_type)) return;
+
+    const feed = document.getElementById('activity-feed');
+    if (!feed) return;
+
+    const card = document.createElement('div');
+    card.className = 'event-card';
+    card.dataset['eventType'] = m.event_type;
+
+    const icon = document.createElement('span');
+    icon.className = 'event-card__icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = EVENT_ICONS[m.event_type] ?? '•';
+
+    const text = document.createElement('span');
+    text.className = 'event-card__text';
+    text.textContent = eventText(m);
+
+    card.appendChild(icon);
+    card.appendChild(text);
+    feed.appendChild(card);
+    card.scrollIntoView?.({ block: 'end', behavior: 'smooth' });
+  });
+}

--- a/agentception/static/scss/pages/_build.scss
+++ b/agentception/static/scss/pages/_build.scss
@@ -886,73 +886,6 @@ body:has(.build-layout) nav.topnav {
   }
 }
 
-// ── Agent event timeline ──────────────────────────────────────────────────────
-
-.build-timeline {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-
-  &__item {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.5rem;
-    padding: 0.3rem 0.5rem;
-    border-radius: var(--radius-xs);
-    background: var(--bg-elevated);
-
-    &--blocker    { border-left: 2px solid var(--danger); }
-    &--decision   { border-left: 2px solid var(--warning); }
-    &--step_start { border-left: 2px solid var(--accent); }
-    &--done       { border-left: 2px solid var(--success); }
-  }
-
-  &__icon { font-size: 0.7rem; line-height: 1.5; flex-shrink: 0; }
-
-  &__body {
-    display: flex;
-    flex-direction: column;
-    gap: 1px;
-    min-width: 0;
-  }
-
-  &__type {
-    font-size: 0.625rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--text-secondary);
-  }
-
-  &__detail {
-    font-size: 0.75rem;
-    color: var(--text-primary);
-    line-height: 1.4;
-    word-break: break-word;
-
-    // Tighten up markdown output so it reads inline in the compact timeline.
-    p        { margin: 0 0 0.25em; &:last-child { margin-bottom: 0; } }
-    ul, ol   { margin: 0.25em 0; padding-left: 1.2em; }
-    li       { margin: 0; }
-    code     { font-family: var(--font-mono); font-size: 0.7rem;
-                background: var(--bg-code, rgba(255,255,255,0.07));
-                border-radius: 3px; padding: 0 0.25em; }
-    strong   { font-weight: 600; }
-    a        { color: var(--accent); text-decoration: underline; }
-    h1,h2,h3 { font-size: 0.75rem; font-weight: 700; margin: 0.2em 0; }
-  }
-
-  &__time {
-    font-size: 0.65rem;
-    color: var(--text-secondary);
-    font-family: var(--font-mono);
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
-  }
-}
 
 // ── Chain of thought ──────────────────────────────────────────────────────────
 
@@ -1237,196 +1170,6 @@ $_sw-gap: 0.5rem;
     border: 1px solid var(--success-border);
   }
 }
-
-// ── Inspector tree section ────────────────────────────────────────────────────
-
-.build-inspector__tree-section {
-  padding: 0.75rem 0.875rem 0;
-  flex-shrink: 0;
-  border-bottom: 1px solid var(--border-subtle);
-  padding-bottom: 0.75rem;
-}
-
-.build-inspector__tree-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0.625rem;
-}
-
-.build-inspector__section-label--tree {
-  margin-bottom: 0;
-}
-
-.agent-tree__batch-id {
-  font-family: var(--font-mono);
-  font-size: 0.6rem;
-  color: var(--text-faint);
-  letter-spacing: 0.04em;
-}
-
-// ── Agent hierarchy tree ──────────────────────────────────────────────────────
-
-.agent-tree {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-// Vertical connector between tier rows
-.agent-tree__connector {
-  width: 1px;
-  height: 14px;
-  background: var(--border-subtle);
-  margin: 0 auto;
-  position: relative;
-
-  &::before,
-  &::after {
-    content: '';
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 5px;
-    height: 5px;
-    border-radius: 50%;
-    background: var(--border-default);
-  }
-  &::before { top: -2px; }
-  &::after  { bottom: -2px; }
-}
-
-// One horizontal tier row
-.agent-tree__tier-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.agent-tree__tier-label {
-  font-size: 0.575rem;
-  font-family: var(--font-mono);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-faint);
-}
-
-// Horizontal row of nodes within a tier
-.agent-tree__tier-nodes {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.375rem;
-}
-
-// Individual agent node card
-.agent-tree__node {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  padding: 0.375rem 0.5rem;
-  border-radius: var(--radius);
-  border: 1px solid var(--border-subtle);
-  background: var(--bg-overlay);
-  min-width: 80px;
-  max-width: 130px;
-  transition: border-color 0.15s, box-shadow 0.15s;
-  cursor: default;
-
-  &--selected {
-    border-color: var(--accent);
-    box-shadow: 0 0 0 1px var(--accent-glow);
-    background: rgba(139, 92, 246, 0.06);
-  }
-
-  // Tier colour accents on the left edge
-  &--coordinator {
-    border-left: 2px solid rgba(139, 92, 246, 0.5);
-  }
-
-  &--engineer {
-    border-left: 2px solid var(--success);
-  }
-
-  &--reviewer {
-    border-left: 2px solid var(--info, #38bdf8);
-  }
-}
-
-.agent-tree__node-header {
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
-}
-
-// Status dot — matches the board card dot colours
-.agent-tree__node-dot {
-  flex-shrink: 0;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--text-faint);
-
-  &--implementing,
-  &--pending_launch {
-    background: var(--accent-bright);
-    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.25);
-    animation: tree-dot-pulse 1.8s ease-in-out infinite;
-  }
-
-  &--reviewing {
-    background: var(--info, #38bdf8);
-    box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
-    animation: tree-dot-pulse 1.8s ease-in-out infinite;
-  }
-
-  &--done {
-    background: var(--success);
-  }
-
-  &--stale {
-    background: var(--warning, #f59e0b);
-  }
-
-  &--unknown {
-    background: var(--border-default);
-  }
-}
-
-@keyframes tree-dot-pulse {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.4; }
-}
-
-.agent-tree__node-role {
-  font-size: 0.6rem;
-  font-weight: 600;
-  color: var(--text-secondary);
-  line-height: 1.2;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.agent-tree__node-scope {
-  font-size: 0.575rem;
-  font-family: var(--font-mono);
-  color: var(--text-muted);
-}
-
-.agent-tree__node-step {
-  font-size: 0.55rem;
-  color: var(--text-faint);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 110px;
-}
-
-// ── Org Designer ──────────────────────────────────────────────────────────────
-// Immersive full-screen canvas.  Feels like opening a separate design tool.
-// Design tokens for this surface use hardcoded near-blacks so the experience
-// is always dark and high-contrast regardless of the app theme.
 
 // Canvas palette (always dark — hardcoded, not theme-dependent)
 $od-bg:          #08080f;   // nearly-black canvas
@@ -2265,3 +2008,28 @@ $preset-accents: (
 }
 
 
+
+// ── Event card ────────────────────────────────────────────────────────────────
+
+.event-card {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.5rem;
+  border-left: 2px solid var(--border-subtle, #444);
+  font-size: 0.75rem;
+  color: var(--text-secondary, #888);
+
+  &[data-event-type='step_start'] { border-left-color: var(--accent,  #6366f1); }
+  &[data-event-type='blocker']    { border-left-color: var(--warning, #f59e0b); }
+  &[data-event-type='decision']   { border-left-color: var(--info,    #3b82f6); }
+  &[data-event-type='done']       { border-left-color: var(--success, #22c55e); }
+
+  &__icon { flex-shrink: 0; }
+
+  &__text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -89,59 +89,6 @@
     {# ── right: inspector panel ─────────────────────────────────────────── #}
     <aside class="build-inspector">
 
-      {# ── Agent hierarchy tree (always shown when there are nodes) ─────── #}
-      <template x-if="treeHasNodes">
-        <div class="build-inspector__tree-section">
-          <div class="build-inspector__tree-header">
-            <h4 class="build-inspector__section-label build-inspector__section-label--tree">Agent Hierarchy</h4>
-            <template x-if="agentTreeBatchId">
-              <span class="agent-tree__batch-id" x-text="agentTreeBatchId.slice(-8)"></span>
-            </template>
-          </div>
-
-          <div class="agent-tree">
-            <template x-for="(tierRow, tIdx) in treeTiers" :key="tierRow.tier">
-              <div>
-                {# connector line between tiers #}
-                <template x-if="tIdx > 0">
-                  <div class="agent-tree__connector"></div>
-                </template>
-
-                <div class="agent-tree__tier-row">
-                  <div class="agent-tree__tier-label" x-text="tierRow.label"></div>
-                  <div class="agent-tree__tier-nodes">
-                    <template x-for="node in tierRow.nodes" :key="node.id">
-                      <div class="agent-tree__node"
-                           :class="['agent-tree__node--' + tierRow.tier, activeIssue && activeIssue.run && activeIssue.run.id === node.id ? 'agent-tree__node--selected' : '']">
-                        <div class="agent-tree__node-header">
-                          <span class="agent-tree__node-dot"
-                                :class="'agent-tree__node-dot--' + node.agent_status"
-                                :title="node.agent_status"></span>
-                          <span class="agent-tree__node-role"
-                                x-text="node.role.replace(/-/g, '\u00a0')"></span>
-                        </div>
-                        <template x-if="node.issue_number">
-                          <span class="agent-tree__node-scope"
-                                x-text="'#' + node.issue_number"></span>
-                        </template>
-                        <template x-if="node.pr_number && !node.issue_number">
-                          <span class="agent-tree__node-scope"
-                                x-text="'PR\u00a0#' + node.pr_number"></span>
-                        </template>
-                        <template x-if="node.current_step">
-                          <span class="agent-tree__node-step"
-                                x-text="node.current_step"></span>
-                        </template>
-                      </div>
-                    </template>
-                  </div>
-                </div>
-              </div>
-            </template>
-          </div>
-        </div>
-      </template>
-
       {# empty state — only shown when no tree nodes AND no issue selected #}
       <template x-if="!treeHasNodes && !activeIssue">
         <div class="build-inspector__empty">
@@ -156,36 +103,17 @@
         <div class="build-inspector__content">
 
           <div class="build-inspector__toolbar">
-            <div class="build-inspector__toolbar-left">
-              <a class="build-inspector__num" :href="activeIssue.url" target="_blank" rel="noopener"
-                 x-text="'#' + activeIssue.number"></a>
-              <span class="build-inspector__title" x-text="activeIssue.title"></span>
-            </div>
+            <a class="build-inspector__num" :href="activeIssue.url" target="_blank" rel="noopener"
+               x-text="'#' + activeIssue.number"></a>
+            <span class="build-inspector__title" x-text="activeIssue.title"></span>
+            <template x-if="activeIssue.run && activeIssue.run.pr_number">
+              <a class="build-inspector__pr-link"
+                 :href="'https://github.com/' + repo + '/pull/' + activeIssue.run.pr_number"
+                 target="_blank" rel="noopener"
+                 x-text="'PR #' + activeIssue.run.pr_number"></a>
+            </template>
             <button class="build-inspector__close" @click="clearInspect()">✕</button>
           </div>
-
-          {# run info or dispatch prompt #}
-          <template x-if="activeIssue.run">
-            <div class="build-inspector__run-meta">
-              <span class="build-inspector__run-role" x-text="activeIssue.run.role"></span>
-              <span class="build-inspector__run-status"
-                    :class="'build-inspector__run-status--' + activeIssue.run.status.toLowerCase()"
-                    x-text="activeIssue.run.status"></span>
-              <template x-if="activeIssue.run.tier">
-                <span class="build-issue__tier"
-                      :class="'build-issue__tier--' + activeIssue.run.tier"
-                      x-text="activeIssue.run.org_domain || activeIssue.run.tier"></span>
-              </template>
-              <span class="build-inspector__run-since"
-                    x-text="'since ' + fmtTime(activeIssue.run.spawned_at)"></span>
-              <template x-if="activeIssue.run.pr_number">
-                <a class="build-inspector__pr-link"
-                   :href="'https://github.com/' + repo + '/pull/' + activeIssue.run.pr_number"
-                   target="_blank" rel="noopener"
-                   x-text="'PR #' + activeIssue.run.pr_number"></a>
-              </template>
-            </div>
-          </template>
 
           <template x-if="!activeIssue.run">
             <div class="build-inspector__no-agent">
@@ -195,22 +123,6 @@
 
           {# structured events timeline #}
           <div id="activity-feed" class="build-inspector__activity" role="log" aria-live="polite" aria-label="Agent activity"></div>
-          <div class="build-inspector__timeline" x-show="events.length > 0">
-            <h4 class="build-inspector__section-label">Timeline</h4>
-            <ul class="build-timeline">
-              <template x-for="ev in events" :key="ev.id">
-                <li class="build-timeline__item"
-                    :class="'build-timeline__item--' + ev.event_type">
-                  <span class="build-timeline__icon" x-text="eventIcon(ev.event_type)"></span>
-                  <div class="build-timeline__body">
-                    <span class="build-timeline__type" x-text="ev.event_type.replace('_', ' ')"></span>
-                    <span class="build-timeline__detail" x-html="renderMd(eventDetail(ev))"></span>
-                    <span class="build-timeline__time" x-text="fmtTime(ev.recorded_at)"></span>
-                  </div>
-                </li>
-              </template>
-            </ul>
-          </div>
 
           <template x-if="activeIssue.run && ['implementing','reviewing','stale','pending_launch'].includes(activeIssue.run.agent_status) && !streamOpen">
             <p class="build-inspector__stream-status">⚪ Stream disconnected</p>


### PR DESCRIPTION
Closes #854

## What changed

- **Removed** `div.build-inspector__tree-section` (agent hierarchy tree) from the inspector panel
- **Removed** `div.build-inspector__run-meta` (run role/status/tier metadata row)
- **Removed** `div.build-inspector__timeline` / `.build-timeline` Alpine-rendered event list
- **Simplified toolbar**: now contains issue number link, title, optional PR link pill, and ✕ close button
- **New `event_card.ts`**: attaches an SSE listener that appends `div.event-card` elements directly into `#activity-feed` for `step_start`, `blocker`, `decision`, and `done` events
- **Removed dead code** from `build.ts`: `SseEvent` interface, `events[]` array, `src.onmessage` block, `eventIcon()` and `eventDetail()` methods
- **Removed SCSS** for `.build-timeline` and `.agent-tree` sections; added `.event-card` styles

## Tests

5 new tests in `agentception/static/js/__tests__/event_card.test.ts` covering all renderable event types and ignored message types.