### PR TITLE
feat: add DailyMetrics TypedDict and get_daily_metrics() to db/queries.py

### DIFF
--- a/agentception/db/queries.py
+++ b/agentception/db/queries.py
@@ -3051,3 +3051,200 @@ async def get_file_edit_events(run_id: str) -> list[FileEditEvent]:
         logger.warning("⚠️  get_file_edit_events DB query failed (non-fatal): %s", exc)
         return []
 
+
+# ---------------------------------------------------------------------------
+# Daily metrics
+# ---------------------------------------------------------------------------
+
+_COST_INPUT_PER_MTOK: float = 3.00
+_COST_OUTPUT_PER_MTOK: float = 15.00
+_COST_CACHE_WRITE_PER_MTOK: float = 3.75
+_COST_CACHE_READ_PER_MTOK: float = 0.30
+
+
+class DailyMetrics(TypedDict):
+    """KPI snapshot for a single calendar day."""
+
+    date: str
+    issues_closed: int
+    prs_merged: int
+    reviewer_runs: int
+    grade_a_count: int
+    grade_b_count: int
+    grade_c_count: int
+    grade_d_count: int
+    grade_f_count: int
+    first_pass_rate: float
+    rework_rate: float
+    avg_iterations: float
+    max_iter_hit_count: int
+    avg_cycle_time_seconds: float
+    cost_usd: float
+    cost_per_issue_usd: float
+    redispatch_count: int
+    auto_merge_rate: float
+
+
+async def get_daily_metrics(date: datetime.date) -> DailyMetrics:
+    """Return a KPI snapshot for *date* derived entirely from DB tables.
+
+    Fields:
+    - date: ISO string ("YYYY-MM-DD").
+    - issues_closed: ACIssue rows where closed_at falls on *date* (UTC).
+    - prs_merged: ACAgentRun rows for *date* with pr_number IS NOT NULL and status == "done".
+    - reviewer_runs: ACAgentRun rows for *date* with role == "reviewer".
+    - grade_a/b/c/d/f_count: counts by letter extracted from reviewer done-event payloads.
+    - first_pass_rate: (grade_a + grade_b) / reviewer_runs; 0.0 when reviewer_runs == 0.
+    - rework_rate: developer runs with attempt_number > 0 / total developer runs; 0.0 when 0.
+    - avg_iterations: mean step_start event count per completed developer run; 0.0 when none.
+    - max_iter_hit_count: completed developer runs with step_start count >= 19.
+    - avg_cycle_time_seconds: mean (completed_at - spawned_at).total_seconds() for completed
+      developer runs; 0.0 when none.
+    - cost_usd: sum across all runs of token-weighted cost using module constants.
+    - cost_per_issue_usd: cost_usd / max(issues_closed, 1).
+    - redispatch_count: runs (any role) with attempt_number > 0.
+    - auto_merge_rate: reviewer runs with grade A or B / reviewer_runs; 0.0 when 0.
+    """
+    day_start = datetime.datetime.combine(
+        date, datetime.time.min, tzinfo=datetime.timezone.utc
+    )
+    day_end = datetime.datetime.combine(
+        date + datetime.timedelta(days=1), datetime.time.min, tzinfo=datetime.timezone.utc
+    )
+
+    try:
+        async with get_session() as session:
+            # All runs for the day
+            runs_result = await session.execute(
+                select(ACAgentRun).where(
+                    ACAgentRun.spawned_at >= day_start,
+                    ACAgentRun.spawned_at < day_end,
+                )
+            )
+            runs: list[ACAgentRun] = list(runs_result.scalars().all())
+
+            # issues_closed
+            closed_result = await session.execute(
+                select(func.count()).where(
+                    ACIssue.closed_at >= day_start,
+                    ACIssue.closed_at < day_end,
+                )
+            )
+            issues_closed: int = closed_result.scalar_one() or 0
+
+            # step_start counts per completed developer run
+            dev_runs = [
+                r for r in runs if r.role == "developer" and r.status == "done"
+            ]
+            dev_run_ids = [r.id for r in dev_runs]
+            step_counts: dict[str, int] = {}
+            if dev_run_ids:
+                events_result = await session.execute(
+                    select(ACAgentEvent.agent_run_id, func.count().label("cnt"))
+                    .where(
+                        ACAgentEvent.agent_run_id.in_(dev_run_ids),
+                        ACAgentEvent.event_type == "step_start",
+                    )
+                    .group_by(ACAgentEvent.agent_run_id)
+                )
+                for row in events_result.all():
+                    step_counts[row.agent_run_id] = int(row.cnt)
+
+            # reviewer done-event grades
+            reviewer_runs = [r for r in runs if r.role == "reviewer"]
+            reviewer_run_ids = [r.id for r in reviewer_runs]
+            grade_counts: dict[str, int] = {
+                "A": 0, "B": 0, "C": 0, "D": 0, "F": 0
+            }
+            if reviewer_run_ids:
+                done_result = await session.execute(
+                    select(ACAgentEvent.agent_run_id, ACAgentEvent.payload)
+                    .where(
+                        ACAgentEvent.agent_run_id.in_(reviewer_run_ids),
+                        ACAgentEvent.event_type == "done",
+                    )
+                )
+                for grade_row in done_result.all():
+                    try:
+                        payload = json.loads(grade_row.payload or "{}")
+                        grade = str(payload.get("grade", "")).upper()
+                        if grade in grade_counts:
+                            grade_counts[grade] += 1
+                    except Exception:
+                        pass
+
+    except Exception as exc:
+        logger.warning("⚠️  get_daily_metrics DB query failed: %s", exc)
+        return DailyMetrics(
+            date=date.isoformat(),
+            issues_closed=0, prs_merged=0, reviewer_runs=0,
+            grade_a_count=0, grade_b_count=0, grade_c_count=0,
+            grade_d_count=0, grade_f_count=0,
+            first_pass_rate=0.0, rework_rate=0.0, avg_iterations=0.0,
+            max_iter_hit_count=0, avg_cycle_time_seconds=0.0,
+            cost_usd=0.0, cost_per_issue_usd=0.0,
+            redispatch_count=0, auto_merge_rate=0.0,
+        )
+
+    # --- derived metrics ---
+    prs_merged = sum(
+        1 for r in runs if r.pr_number is not None and r.status == "done"
+    )
+    reviewer_run_count = len(reviewer_runs)
+
+    all_dev_runs = [r for r in runs if r.role == "developer"]
+    rework_dev = sum(1 for r in all_dev_runs if r.attempt_number > 0)
+    rework_rate = rework_dev / max(len(all_dev_runs), 1) if all_dev_runs else 0.0
+
+    iter_counts = [step_counts.get(r.id, 0) for r in dev_runs]
+    avg_iterations = sum(iter_counts) / max(len(iter_counts), 1) if iter_counts else 0.0
+    max_iter_hit_count = sum(1 for c in iter_counts if c >= 19)
+
+    cycle_times = [
+        (r.completed_at - r.spawned_at).total_seconds()
+        for r in dev_runs
+        if r.completed_at is not None
+    ]
+    avg_cycle_time_seconds = sum(cycle_times) / max(len(cycle_times), 1) if cycle_times else 0.0
+
+    cost_usd = sum(
+        (r.total_input_tokens / 1_000_000) * _COST_INPUT_PER_MTOK
+        + (r.total_output_tokens / 1_000_000) * _COST_OUTPUT_PER_MTOK
+        + (r.total_cache_write_tokens / 1_000_000) * _COST_CACHE_WRITE_PER_MTOK
+        + (r.total_cache_read_tokens / 1_000_000) * _COST_CACHE_READ_PER_MTOK
+        for r in runs
+    )
+    cost_per_issue_usd = cost_usd / max(issues_closed, 1)
+
+    redispatch_count = sum(1 for r in runs if r.attempt_number > 0)
+
+    first_pass_rate = (
+        (grade_counts["A"] + grade_counts["B"]) / reviewer_run_count
+        if reviewer_run_count > 0 else 0.0
+    )
+    auto_merge_rate = (
+        (grade_counts["A"] + grade_counts["B"]) / reviewer_run_count
+        if reviewer_run_count > 0 else 0.0
+    )
+
+    return DailyMetrics(
+        date=date.isoformat(),
+        issues_closed=issues_closed,
+        prs_merged=prs_merged,
+        reviewer_runs=reviewer_run_count,
+        grade_a_count=grade_counts["A"],
+        grade_b_count=grade_counts["B"],
+        grade_c_count=grade_counts["C"],
+        grade_d_count=grade_counts["D"],
+        grade_f_count=grade_counts["F"],
+        first_pass_rate=first_pass_rate,
+        rework_rate=rework_rate,
+        avg_iterations=avg_iterations,
+        max_iter_hit_count=max_iter_hit_count,
+        avg_cycle_time_seconds=avg_cycle_time_seconds,
+        cost_usd=cost_usd,
+        cost_per_issue_usd=cost_per_issue_usd,
+        redispatch_count=redispatch_count,
+        auto_merge_rate=auto_merge_rate,
+    )
+

--- a/agentception/tests/test_queries.py
+++ b/agentception/tests/test_queries.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+"""Smoke tests for agentception.db.queries additions in issue #858.
+
+Full behavioural coverage is deferred to issue #859.  These tests verify
+that the new symbols are importable and that the pure-Python derived-metric
+logic (zero-denominator guards, cost constants) is correct without requiring
+a live database connection.
+"""
+
+import datetime
+
+import pytest
+
+from agentception.db.queries import (
+    DailyMetrics,
+    _COST_CACHE_READ_PER_MTOK,
+    _COST_CACHE_WRITE_PER_MTOK,
+    _COST_INPUT_PER_MTOK,
+    _COST_OUTPUT_PER_MTOK,
+    get_daily_metrics,
+)
+
+
+def test_daily_metrics_importable() -> None:
+    """DailyMetrics TypedDict and get_daily_metrics are importable."""
+    assert DailyMetrics is not None
+    assert callable(get_daily_metrics)
+
+
+def test_cost_constants_match_sonnet_pricing() -> None:
+    """Cost constants must match Claude Sonnet 4.6 pricing."""
+    assert _COST_INPUT_PER_MTOK == pytest.approx(3.00)
+    assert _COST_OUTPUT_PER_MTOK == pytest.approx(15.00)
+    assert _COST_CACHE_WRITE_PER_MTOK == pytest.approx(3.75)
+    assert _COST_CACHE_READ_PER_MTOK == pytest.approx(0.30)
+
+
+def test_daily_metrics_is_typed_dict() -> None:
+    """DailyMetrics must be constructable as a plain dict with the right keys."""
+    m: DailyMetrics = {
+        "date": "2025-01-01",
+        "issues_closed": 0,
+        "prs_merged": 0,
+        "reviewer_runs": 0,
+        "grade_a_count": 0,
+        "grade_b_count": 0,
+        "grade_c_count": 0,
+        "grade_d_count": 0,
+        "grade_f_count": 0,
+        "first_pass_rate": 0.0,
+        "rework_rate": 0.0,
+        "avg_iterations": 0.0,
+        "max_iter_hit_count": 0,
+        "avg_cycle_time_seconds": 0.0,
+        "cost_usd": 0.0,
+        "cost_per_issue_usd": 0.0,
+        "redispatch_count": 0,
+        "auto_merge_rate": 0.0,
+    }
+    assert m["date"] == "2025-01-01"
+    assert m["first_pass_rate"] == 0.0
+    assert m["auto_merge_rate"] == 0.0
+
+
+@pytest.mark.anyio
+async def test_get_daily_metrics_returns_zeros_on_db_error() -> None:
+    """get_daily_metrics must return a zero-filled DailyMetrics when the DB is unavailable."""
+    from unittest.mock import AsyncMock, patch
+
+    today = datetime.date(2025, 1, 15)
+
+    # Patch get_session to raise so the except branch is exercised.
+    with patch(
+        "agentception.db.queries.get_session",
+        side_effect=Exception("no db"),
+    ):
+        result = await get_daily_metrics(today)
+
+    assert result["date"] == "2025-01-15"
+    assert result["issues_closed"] == 0
+    assert result["prs_merged"] == 0
+    assert result["reviewer_runs"] == 0
+    assert result["first_pass_rate"] == 0.0
+    assert result["rework_rate"] == 0.0
+    assert result["avg_iterations"] == 0.0
+    assert result["cost_usd"] == 0.0
+    assert result["cost_per_issue_usd"] == 0.0
+    assert result["redispatch_count"] == 0
+    assert result["auto_merge_rate"] == 0.0


### PR DESCRIPTION
Closes #858

## What

Appends two new exports to `agentception/db/queries.py`:

- `_COST_INPUT_PER_MTOK`, `_COST_OUTPUT_PER_MTOK`, `_COST_CACHE_WRITE_PER_MTOK`, `_COST_CACHE_READ_PER_MTOK` — module-level cost constants matching Claude Sonnet 4.6 pricing.
- `DailyMetrics` — a `TypedDict` capturing a full KPI snapshot for a single calendar day (18 fields).
- `get_daily_metrics(date)` — async function that queries `ac_agent_runs`, `ac_issues`, and `ac_agent_events` to compute all KPIs for the given UTC date, with a safe fallback returning zero-filled metrics on DB error.

## Why

Phase 1 of the daily-metrics pipeline (issue #858). The function and type are consumed by the dashboard route added in phase 2 (issue #859).

## Verification

```
python -m mypy --follow-imports=silent agentception/db/queries.py  # Success: no issues found
python -m pytest agentception/tests/test_queries.py -v             # 4 passed
```