### PR TITLE
fix: make agent_run_id required in build_complete_run schema

### DIFF
--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -375,9 +375,16 @@ TOOLS: list[ACToolDef] = [
                     "type": "string",
                     "description": "Optional one-sentence summary of what you did.",
                 },
-                "agent_run_id": {"type": "string"},
+                "agent_run_id": {
+                    "type": "string",
+                    "description": (
+                        "Your own run ID exactly as it appears in your task briefing "
+                        "(e.g. 'issue-858' or 'review-900'). Required — omitting it "
+                        "leaves your run stuck in implementing state."
+                    ),
+                },
             },
-            "required": ["issue_number", "pr_url"],
+            "required": ["issue_number", "pr_url", "agent_run_id"],
             "additionalProperties": False,
         },
     ),

--- a/agentception/tests/test_build_commands.py
+++ b/agentception/tests/test_build_commands.py
@@ -468,16 +468,6 @@ async def test_done_event_payload_includes_grade_for_reviewer() -> None:
 
     with (
         patch(
-            "agentception.mcp.build_commands._has_file_edit_events",
-            new_callable=AsyncMock,
-            return_value=True,
-        ),
-        patch(
-            "agentception.mcp.build_commands._has_pr_recorded",
-            new_callable=AsyncMock,
-            return_value=True,
-        ),
-        patch(
             "agentception.mcp.build_commands.persist_agent_event",
             side_effect=_capture_persist,
         ),
@@ -532,16 +522,6 @@ async def test_done_event_payload_excludes_grade_for_developer() -> None:
             captured_payload.update(payload)
 
     with (
-        patch(
-            "agentception.mcp.build_commands._has_file_edit_events",
-            new_callable=AsyncMock,
-            return_value=True,
-        ),
-        patch(
-            "agentception.mcp.build_commands._has_pr_recorded",
-            new_callable=AsyncMock,
-            return_value=True,
-        ),
         patch(
             "agentception.mcp.build_commands.persist_agent_event",
             side_effect=_capture_persist,


### PR DESCRIPTION
## Summary

- `agent_run_id` was an optional, undescribed field in the `build_complete_run` MCP tool schema — agents never passed it
- `complete_agent_run()` is only called `if agent_run_id:`, so runs stayed `implementing` forever
- `reconcile_stale_runs()` then re-dispatched them as stale, causing the infinite loop seen after PR #900 merged
- Fix: add `agent_run_id` to `required[]` and add a description pointing the agent to its task briefing
- Also removes stale `_has_file_edit_events` / `_has_pr_recorded` patches from two tests — those guards were deleted in PR #880

## Root cause chain

```
agent calls build_complete_run (no agent_run_id)
  → complete_agent_run() skipped
  → run stays 'implementing'
  → reconcile_stale_runs() sees stale run
  → re-dispatches reviewer
  → loop forever
```