### PR TITLE
feat: re-dispatch developer onto existing PR branch after reviewer rejection

### DIFF
--- a/.agentception/roles/ceo.md
+++ b/.agentception/roles/ceo.md
@@ -644,7 +644,8 @@ abort the entire task or skip that subtask. Never silently swallow errors.
 
 ## STEP 3 — Wait for all children to complete
 
-After spawning, poll each child every **30 seconds** using `resources/read`:
+After spawning, poll each child every **30 seconds** using `resources/read` with the
+`ac://runs/{run_id}/status` resource:
 
 ```
 resources/read(uri = "ac://runs/<child_run_id>/status")
@@ -689,7 +690,7 @@ You are done. Do not tear down your own worktree — that is managed by the plat
 - Never call `build_complete_run` for yourself — coordinator runs terminate when you
   reach the end of STEP 4.
 - Never spawn sub-coordinators unless your task briefing explicitly authorises it.
-- Never ignore an error from `build_spawn_adhoc_child` or `resources/read` (status polling).
+- Never ignore an error from `build_spawn_adhoc_child` or `resources/read ac://runs/{run_id}/status`.
 
 ---
 

--- a/.agentception/roles/cto.md
+++ b/.agentception/roles/cto.md
@@ -387,10 +387,11 @@ abort the entire task or skip that subtask. Never silently swallow errors.
 
 ## STEP 3 — Wait for all children to complete
 
-After spawning, poll each child every **30 seconds** using `resources/read` with the status resource:
+After spawning, poll each child every **30 seconds** using `resources/read` with the
+`ac://runs/{run_id}/status` resource:
 
 ```
-resources/read uri="ac://runs/<child_run_id>/status"
+resources/read(uri = "ac://runs/<child_run_id>/status")
 ```
 
 Terminal statuses (stop polling): `completed`, `cancelled`, `stopped`.

--- a/.agentception/roles/engineering-coordinator.md
+++ b/.agentception/roles/engineering-coordinator.md
@@ -144,7 +144,8 @@ abort the entire task or skip that subtask. Never silently swallow errors.
 
 ## STEP 3 — Wait for all children to complete
 
-After spawning, poll each child every **30 seconds** using `resources/read`:
+After spawning, poll each child every **30 seconds** using `resources/read` with the
+`ac://runs/{run_id}/status` resource:
 
 ```
 resources/read(uri = "ac://runs/<child_run_id>/status")
@@ -189,6 +190,6 @@ You are done. Do not tear down your own worktree — that is managed by the plat
 - Never call `build_complete_run` for yourself — coordinator runs terminate when you
   reach the end of STEP 4.
 - Never spawn sub-coordinators unless your task briefing explicitly authorises it.
-- Never ignore an error from `build_spawn_adhoc_child` or `resources/read` (status polling).
+- Never ignore an error from `build_spawn_adhoc_child` or `resources/read ac://runs/{run_id}/status`.
 
 ---

--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -381,42 +381,58 @@ async def build_complete_run(
         if normalised_grade in _FAILING_GRADES:
             logger.info(
                 "ℹ️ build_complete_run: reviewer rejected (grade=%r) — "
-                "scheduling auto-redispatch for issue #%d run_id=%r",
+                "releasing worktree and scheduling redispatch for issue #%d run_id=%r",
                 grade,
                 issue_number,
                 agent_run_id,
             )
+            # Resolve the PR branch name and worktree path from DB before releasing.
+            pr_branch: str | None = None
+            if agent_run_id:
+                teardown_info = await get_agent_run_teardown(agent_run_id)
+                wt_path = teardown_info.get("worktree_path") if teardown_info else None
+                pr_branch = teardown_info.get("branch") if teardown_info else None
+                if wt_path:
+                    # Release the reviewer's worktree synchronously BEFORE scheduling
+                    # redispatch.  release_worktree removes the worktree directory and
+                    # prunes refs but does NOT delete the branch — the developer
+                    # continuation dispatch needs the branch to be alive.
+                    # This sequencing guarantees git will never see the branch checked
+                    # out in two worktrees simultaneously.
+                    await release_worktree(wt_path, str(settings.repo_dir))
+                    logger.info(
+                        "🧹 build_complete_run: reviewer worktree released (branch kept) for run_id=%r",
+                        agent_run_id,
+                    )
+
             asyncio.create_task(
                 auto_redispatch_after_rejection(
                     issue_number=issue_number,
                     pr_url=pr_url,
                     reviewer_feedback=reviewer_feedback,
                     grade=normalised_grade,
+                    pr_branch=pr_branch,
                 ),
                 name=f"auto-redispatch-{issue_number}",
             )
         else:
-            # Grade A or B: reviewer already merged — nothing else to do.
+            # Grade A or B: reviewer already merged — full teardown (delete branch too,
+            # since it is now merged into dev).
             logger.info(
                 "ℹ️ build_complete_run: reviewer approved (grade=%r) — "
-                "no redispatch needed run_id=%r",
+                "scheduling full worktree teardown for run_id=%r",
                 grade,
                 agent_run_id,
             )
-
-        # Always tear down the reviewer's own worktree regardless of grade.
-        # Leaving the reviewer worktree on disk blocks re-dispatch of the same
-        # issue because git worktree add refuses to check out a branch that is
-        # already active in another worktree.
-        if agent_run_id:
-            asyncio.create_task(
-                teardown_agent_worktree(agent_run_id),
-                name=f"teardown-{agent_run_id}",
-            )
-            logger.info(
-                "🧹 build_complete_run: reviewer worktree teardown queued for run_id=%r",
-                agent_run_id,
-            )
+            if agent_run_id:
+                asyncio.create_task(
+                    teardown_agent_worktree(agent_run_id),
+                    name=f"teardown-{agent_run_id}",
+                )
+                logger.info(
+                    "🧹 build_complete_run: reviewer worktree teardown queued for run_id=%r",
+                    agent_run_id,
+                )
     else:
         # Non-reviewer (implementer) completed: release worktree and dispatch reviewer.
         # Release the developer's worktree before dispatching the reviewer.

--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -488,6 +488,18 @@ class DispatchRequest(BaseModel):
     The ``run_id`` and worktree slug are always derived from ``issue_number``
     regardless of what ``pr_branch`` is set to.
     """
+    continuation_branch: str | None = None
+    """Existing remote branch for a rework (C/D/F rejection) developer dispatch.
+
+    For ``developer`` rework dispatches only.  When set, the endpoint reattaches
+    the worktree to this branch (fetching from remote first) instead of branching
+    fresh from ``origin/dev``.  The developer inherits the previous attempt's
+    code and only needs to fix the specific defects listed in the rejection
+    section of the issue body.
+
+    Populated automatically by ``auto_redispatch_after_rejection``.  Do not
+    set this when dispatching a brand-new developer run.
+    """
 
 
 class DispatchResponse(BaseModel):
@@ -678,20 +690,31 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
         slug = f"issue-{req.issue_number}"
         run_id = f"issue-{req.issue_number}"
 
-    # For reviewer dispatches the PR branch may not follow feat/issue-{N} naming
-    # (e.g. feat/reviewer-branch-orientation).  pr_branch overrides the default.
-    branch = req.pr_branch if req.pr_branch else f"feat/issue-{req.issue_number}"
+    # Branch name resolution:
+    # - reviewer: pr_branch override or feat/issue-{N} (the implementer's branch)
+    # - developer continuation (rework after C/D/F): continuation_branch (existing PR branch)
+    # - developer fresh: feat/issue-{N}
+    if is_reviewer:
+        branch = req.pr_branch if req.pr_branch else f"feat/issue-{req.issue_number}"
+        is_continuation = False
+    elif req.continuation_branch is not None:
+        branch = req.continuation_branch
+        is_continuation = True
+    else:
+        branch = f"feat/issue-{req.issue_number}"
+        is_continuation = False
     batch_id = _make_batch_id(req.issue_number)
     worktree_path = str(Path(settings.worktrees_dir) / slug)
     host_worktree_path = str(Path(settings.host_worktrees_dir) / slug)
 
     from agentception.readers.git import ensure_worktree  # noqa: PLC0415
 
-    if is_reviewer:
-        # For reviewers the relevant code lives on the implementer's branch, not
-        # dev.  Fetch the remote branch so `origin/<branch>` is up to date, then
-        # create the worktree from that ref.  The agent is on the correct branch
-        # from its very first turn — no wasted turns detecting the wrong branch.
+    if is_reviewer or is_continuation:
+        # For reviewers: the relevant code lives on the implementer's branch, not dev.
+        # For continuation dispatches: the developer re-attaches to the existing PR
+        # branch and only fixes the specific defects — no from-scratch re-implementation.
+        # Fetch the remote branch so `origin/<branch>` is up to date, then create the
+        # worktree from that ref.
         fetch_proc = await asyncio.create_subprocess_exec(
             "git", "fetch", "origin", branch,
             cwd=str(settings.repo_dir),
@@ -702,27 +725,44 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
         if fetch_proc.returncode != 0:
             err_msg = _fetch_err.decode(errors="replace").strip()
             logger.error("❌ dispatch: fetch of %s failed — %s", branch, err_msg)
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    f"Remote branch '{branch}' not found. "
-                    "If the PR was already merged and the branch deleted, reviewers "
-                    "must be dispatched before merge. "
-                    "If the branch uses a non-standard name, pass it in 'pr_branch'. "
-                    f"git error: {err_msg}"
-                ),
-            )
+            if is_reviewer:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Remote branch '{branch}' not found. "
+                        "If the PR was already merged and the branch deleted, reviewers "
+                        "must be dispatched before merge. "
+                        "If the branch uses a non-standard name, pass it in 'pr_branch'. "
+                        f"git error: {err_msg}"
+                    ),
+                )
+            else:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Continuation branch '{branch}' not found on remote. "
+                        f"git error: {err_msg}"
+                    ),
+                )
         worktree_base = f"origin/{branch}"
-        logger.info("✅ dispatch: fetched %s for reviewer worktree", branch)
+        logger.info(
+            "✅ dispatch: fetched %s for %s worktree",
+            branch,
+            "reviewer" if is_reviewer else "continuation-developer",
+        )
     else:
         worktree_base = "origin/dev"
 
     try:
-        # reset=True for implementers: if a stale worktree/branch exists from a
-        # prior run, tear it down first so the developer always starts from a
-        # clean origin/dev.  Reviewers use reset=False — they reuse the branch
-        # the implementer already pushed.
-        await ensure_worktree(Path(worktree_path), branch, worktree_base, reset=not is_reviewer)
+        # reset=True for fresh developer dispatches: if a stale worktree/branch exists
+        # from a prior run, tear it down first so the developer always starts from a
+        # clean origin/dev.
+        # reset=False for reviewers and continuation dispatches: they reuse the branch
+        # the implementer already pushed — no teardown, just reattach.
+        await ensure_worktree(
+            Path(worktree_path), branch, worktree_base,
+            reset=not is_reviewer and not is_continuation,
+        )
         logger.info("✅ dispatch: worktree created at %s (base=%s)", worktree_path, worktree_base)
     except RuntimeError as exc:
         logger.error("❌ dispatch: worktree creation failed — %s", exc)

--- a/agentception/services/auto_redispatch.py
+++ b/agentception/services/auto_redispatch.py
@@ -3,11 +3,16 @@
 When the reviewer calls build_complete_run with a failing grade (C/D/F),
 this service:
 
-1. Closes the rejected PR.
-2. Fetches the original issue details from GitHub.
-3. Builds an enhanced issue body injecting the reviewer's defect list at the top.
-4. Redispatches a developer run with the enriched briefing so the executor
-   sees the full defect list before writing a single line of code.
+1. Posts a rejection comment on the existing (still-open) PR with the
+   full defect list.
+2. Fetches the original issue details from GitHub for the enhanced body.
+3. Dispatches a developer run configured to *continue from the same branch*
+   rather than starting from origin/dev — so the agent only needs to fix
+   the specific defects, not re-implement everything from scratch.
+
+The reviewer's worktree must be released (via release_worktree) by the
+caller *before* this coroutine is awaited, so that the branch is free for
+the new developer worktree to reattach.
 
 Maximum 3 attempts. After the third rejection the run is abandoned and an
 error is logged — no further redispatch occurs.
@@ -22,16 +27,16 @@ import httpx
 
 from agentception.config import settings
 from agentception.db.queries import get_agent_run_task_description
-from agentception.readers.github import close_pr, get_issue
+from agentception.readers.github import add_comment_to_issue, get_issue
 
 logger = logging.getLogger(__name__)
 
 _PR_URL_RE = re.compile(r"/pull/(\d+)")
 _SERVICE_URL = "http://localhost:10003/api/dispatch/issue"
 
-# Seconds to wait before redispatching — gives GitHub time to process
-# the PR close before the new worktree fetch starts.
-_REDISPATCH_DELAY_SECS: float = 3.0
+# Brief pause after worktree release before touching git/GitHub so git prune
+# has time to flush its ref locks.
+_REDISPATCH_DELAY_SECS: float = 1.0
 
 # Maximum number of reviewer-rejected attempts before giving up.
 _MAX_ATTEMPTS: int = 3
@@ -73,19 +78,31 @@ async def auto_redispatch_after_rejection(
     pr_url: str,
     reviewer_feedback: str,
     grade: str,
+    pr_branch: str | None = None,
 ) -> None:
-    """Close a rejected PR and redispatch the developer for a new attempt.
+    """Post a rejection comment and redispatch the developer for a new attempt.
 
     Called as a fire-and-forget background task from build_complete_run when
     the reviewer signals a failing grade.  Never raises — all errors are
     logged at ERROR level and swallowed so the reviewer's completed state is
     not disturbed.
 
+    The PR is kept open and the branch is kept alive.  The new developer run
+    is dispatched with ``continuation_branch`` set to *pr_branch* so it
+    reattaches to the existing branch and only has to fix the specific
+    defects identified by the reviewer.
+
+    The caller must have already called ``release_worktree`` on the
+    reviewer's worktree before scheduling this task so the branch is free.
+
     Args:
         issue_number: GitHub issue number the implementer worked on.
-        pr_url: Full URL of the rejected pull request.
+        pr_url: Full URL of the (still-open) pull request.
         reviewer_feedback: Full defect list from the reviewer (plain text).
         grade: Single letter grade from the reviewer (e.g. "C", "D", "F").
+        pr_branch: Name of the existing PR branch (e.g. "feat/issue-869").
+            When provided the re-dispatched developer will reattach to this
+            branch instead of branching fresh from origin/dev.
     """
     run_id = f"issue-{issue_number}"
 
@@ -118,25 +135,27 @@ async def auto_redispatch_after_rejection(
 
     await asyncio.sleep(_REDISPATCH_DELAY_SECS)
 
-    # Close the rejected PR so the branch can be recreated clean.
+    # Post a rejection comment on the open PR so the history is visible on
+    # GitHub — the PR itself stays open for the developer to push a fix onto
+    # the same branch.
     try:
-        await close_pr(
+        await add_comment_to_issue(
             pr_number,
-            comment=(
-                f"**Grade {grade} — Attempt {attempt} rejected.** "
-                f"Closing for rework. Defects:\n\n{reviewer_feedback}"
+            body=(
+                f"**Grade {grade} — Attempt {attempt} needs rework.**\n\n"
+                f"The implementation has been sent back for corrections. "
+                f"Defects to resolve:\n\n{reviewer_feedback}"
             ),
         )
         logger.info(
-            "✅ auto_redispatch: closed PR #%d for issue #%d (attempt %d, grade %s)",
+            "✅ auto_redispatch: posted rejection comment on PR #%d (attempt %d, grade %s)",
             pr_number,
             issue_number,
             attempt,
-            grade,
         )
     except Exception as exc:  # noqa: BLE001
         logger.error(
-            "❌ auto_redispatch: failed to close PR #%d — %s (continuing)",
+            "❌ auto_redispatch: failed to comment on PR #%d — %s (continuing)",
             pr_number,
             exc,
         )
@@ -163,6 +182,13 @@ async def auto_redispatch_after_rejection(
         "role": "developer",
         "repo": settings.gh_repo,
     }
+    # When the PR branch is known, tell the dispatch endpoint to reattach the
+    # developer worktree to the existing branch instead of starting fresh from
+    # origin/dev.  This means the agent only patches the specific defects —
+    # it does not have to re-implement from scratch.
+    if pr_branch:
+        payload["continuation_branch"] = pr_branch
+
     headers = {
         "X-API-Key": settings.ac_api_key,
         "Content-Type": "application/json",
@@ -178,10 +204,11 @@ async def auto_redispatch_after_rejection(
             )
             resp.raise_for_status()
         logger.info(
-            "✅ auto_redispatch: developer dispatched for issue #%d (attempt %d/%d)",
+            "✅ auto_redispatch: developer dispatched for issue #%d (attempt %d/%d, branch=%r)",
             issue_number,
             attempt,
             _MAX_ATTEMPTS,
+            pr_branch,
         )
     except httpx.HTTPStatusError as exc:
         logger.error(

--- a/agentception/tests/test_auto_redispatch.py
+++ b/agentception/tests/test_auto_redispatch.py
@@ -4,11 +4,12 @@ Covers:
 - _count_prior_rejections: zero, one, multiple rejections in task_description
 - _build_enhanced_body: correct structure and ordering
 - auto_redispatch_after_rejection:
-    - max attempts guard
-    - bad PR URL guard
-    - happy path: closes PR, fetches issue, dispatches developer
-    - close_pr failure is non-fatal (continues to dispatch)
+    - max attempts guard (no comment posted, no dispatch)
+    - bad PR URL guard (no comment posted, no dispatch)
+    - happy path: posts rejection comment, fetches issue, dispatches developer
+    - comment failure is non-fatal (continues to dispatch)
     - dispatch HTTP error is logged and swallowed
+    - pr_branch forwarded as continuation_branch in dispatch payload
 
 Run targeted:
     pytest agentception/tests/test_auto_redispatch.py -v
@@ -115,11 +116,12 @@ _ISSUE_NUMBER = 37
 _PR_URL = "https://github.com/cgcardona/agentception/pull/569"
 _GRADE = "C"
 _FEEDBACK = "1. dir() smell\n2. SCSS not moved\n3. No regression test"
+_PR_BRANCH = "feat/issue-37"
 
 
 @pytest.mark.anyio
 async def test_auto_redispatch_max_attempts_guard() -> None:
-    """No dispatch or PR-close occurs when max attempts is reached."""
+    """No dispatch or comment occurs when max attempts is reached."""
     with (
         patch(
             "agentception.services.auto_redispatch.get_agent_run_task_description",
@@ -132,9 +134,9 @@ async def test_auto_redispatch_max_attempts_guard() -> None:
             ),
         ),
         patch(
-            "agentception.services.auto_redispatch.close_pr",
+            "agentception.services.auto_redispatch.add_comment_to_issue",
             new_callable=AsyncMock,
-        ) as mock_close,
+        ) as mock_comment,
         patch(
             "agentception.services.auto_redispatch.get_issue",
             new_callable=AsyncMock,
@@ -146,7 +148,7 @@ async def test_auto_redispatch_max_attempts_guard() -> None:
             reviewer_feedback=_FEEDBACK,
             grade=_GRADE,
         )
-    mock_close.assert_not_called()
+    mock_comment.assert_not_called()
     mock_get_issue.assert_not_called()
 
 
@@ -160,9 +162,9 @@ async def test_auto_redispatch_bad_pr_url_guard() -> None:
             return_value=None,
         ),
         patch(
-            "agentception.services.auto_redispatch.close_pr",
+            "agentception.services.auto_redispatch.add_comment_to_issue",
             new_callable=AsyncMock,
-        ) as mock_close,
+        ) as mock_comment,
         patch("agentception.services.auto_redispatch.asyncio.sleep", new_callable=AsyncMock),
     ):
         await auto_redispatch_after_rejection(
@@ -171,12 +173,12 @@ async def test_auto_redispatch_bad_pr_url_guard() -> None:
             reviewer_feedback=_FEEDBACK,
             grade=_GRADE,
         )
-    mock_close.assert_not_called()
+    mock_comment.assert_not_called()
 
 
 @pytest.mark.anyio
 async def test_auto_redispatch_happy_path() -> None:
-    """Closes PR, fetches issue, dispatches developer on the happy path."""
+    """Posts rejection comment, fetches issue, dispatches developer on the happy path."""
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
 
@@ -187,9 +189,10 @@ async def test_auto_redispatch_happy_path() -> None:
             return_value=None,  # first attempt
         ),
         patch(
-            "agentception.services.auto_redispatch.close_pr",
+            "agentception.services.auto_redispatch.add_comment_to_issue",
             new_callable=AsyncMock,
-        ) as mock_close,
+            return_value="https://github.com/comment/1",
+        ) as mock_comment,
         patch(
             "agentception.services.auto_redispatch.get_issue",
             new_callable=AsyncMock,
@@ -211,9 +214,14 @@ async def test_auto_redispatch_happy_path() -> None:
             pr_url=_PR_URL,
             reviewer_feedback=_FEEDBACK,
             grade=_GRADE,
+            pr_branch=_PR_BRANCH,
         )
 
-    mock_close.assert_called_once_with(569, comment=mock_close.call_args[1]["comment"])
+    # Comment posted on the PR number (569), not the issue number (37).
+    mock_comment.assert_called_once_with(
+        569,
+        body=mock_comment.call_args[1]["body"],
+    )
     mock_get_issue.assert_called_once_with(_ISSUE_NUMBER)
     mock_client.post.assert_called_once()
     payload = mock_client.post.call_args[1]["json"]
@@ -221,11 +229,13 @@ async def test_auto_redispatch_happy_path() -> None:
     assert payload["issue_number"] == _ISSUE_NUMBER
     assert _REJECTION_MARKER in payload["issue_body"]
     assert _FEEDBACK in payload["issue_body"]
+    # Continuation branch must be forwarded so the developer reattaches.
+    assert payload["continuation_branch"] == _PR_BRANCH
 
 
 @pytest.mark.anyio
-async def test_auto_redispatch_close_pr_failure_is_nonfatal() -> None:
-    """A close_pr failure must not prevent the developer dispatch."""
+async def test_auto_redispatch_no_pr_branch_omits_continuation_field() -> None:
+    """When pr_branch is omitted, continuation_branch is not included in the payload."""
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
 
@@ -236,7 +246,52 @@ async def test_auto_redispatch_close_pr_failure_is_nonfatal() -> None:
             return_value=None,
         ),
         patch(
-            "agentception.services.auto_redispatch.close_pr",
+            "agentception.services.auto_redispatch.add_comment_to_issue",
+            new_callable=AsyncMock,
+            return_value="https://github.com/comment/1",
+        ),
+        patch(
+            "agentception.services.auto_redispatch.get_issue",
+            new_callable=AsyncMock,
+            return_value={"title": "Fix", "body": "body"},
+        ),
+        patch("agentception.services.auto_redispatch.asyncio.sleep", new_callable=AsyncMock),
+        patch("agentception.services.auto_redispatch.settings") as mock_settings,
+        patch("agentception.services.auto_redispatch.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_settings.gh_repo = "cgcardona/agentception"
+        mock_settings.ac_api_key = "test-key"
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await auto_redispatch_after_rejection(
+            issue_number=_ISSUE_NUMBER,
+            pr_url=_PR_URL,
+            reviewer_feedback=_FEEDBACK,
+            grade=_GRADE,
+            # pr_branch omitted — fallback to original behaviour (fresh dispatch)
+        )
+
+    payload = mock_client.post.call_args[1]["json"]
+    assert "continuation_branch" not in payload
+
+
+@pytest.mark.anyio
+async def test_auto_redispatch_comment_failure_is_nonfatal() -> None:
+    """A comment failure must not prevent the developer dispatch."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with (
+        patch(
+            "agentception.services.auto_redispatch.get_agent_run_task_description",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "agentception.services.auto_redispatch.add_comment_to_issue",
             new_callable=AsyncMock,
             side_effect=RuntimeError("GitHub unavailable"),
         ),
@@ -263,7 +318,7 @@ async def test_auto_redispatch_close_pr_failure_is_nonfatal() -> None:
             grade=_GRADE,
         )
 
-    # Dispatch must still have been called despite close_pr raising.
+    # Dispatch must still have been called despite comment failure.
     mock_client.post.assert_called_once()
 
 
@@ -276,7 +331,11 @@ async def test_auto_redispatch_http_error_is_swallowed() -> None:
             new_callable=AsyncMock,
             return_value=None,
         ),
-        patch("agentception.services.auto_redispatch.close_pr", new_callable=AsyncMock),
+        patch(
+            "agentception.services.auto_redispatch.add_comment_to_issue",
+            new_callable=AsyncMock,
+            return_value="https://github.com/comment/1",
+        ),
         patch(
             "agentception.services.auto_redispatch.get_issue",
             new_callable=AsyncMock,

--- a/agentception/tests/test_build_commands.py
+++ b/agentception/tests/test_build_commands.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-"""Tests for build_complete_run reviewer worktree teardown behaviour.
+"""Tests for build_complete_run reviewer worktree teardown / release behaviour.
 
 Coverage:
-- Reviewer worktree is torn down after a failing grade (C/D/F).
-- Reviewer worktree is torn down after a passing grade (A/B).
+- C/D/F grade: reviewer worktree is *released* (branch kept) before redispatch.
+- A/B grade: reviewer worktree is fully torn down (branch deleted, PR merged).
 - Teardown task name follows the expected convention.
 
 Run targeted:
@@ -16,16 +16,19 @@ from unittest.mock import AsyncMock, patch
 
 
 @pytest.mark.anyio
-async def test_reviewer_worktree_torn_down_after_failing_grade() -> None:
-    """build_complete_run schedules reviewer worktree teardown on a failing grade (C).
+async def test_reviewer_worktree_released_after_failing_grade() -> None:
+    """build_complete_run releases (not full-tears-down) the reviewer worktree for C/D/F.
 
-    Regression: the reviewer worktree was left on disk after a C/D/F grade,
-    blocking re-dispatch of the same issue because git worktree add refuses to
-    check out a branch already active in another worktree.
+    For a failing grade, the PR branch must be kept alive so the re-dispatched
+    developer can continue from the existing branch.  release_worktree removes
+    the worktree directory without deleting the branch, while teardown_agent_worktree
+    (which would delete the branch) must NOT be called for C/D/F grades.
     """
     from agentception.mcp.build_commands import build_complete_run
 
     reviewer_run_id = "reviewer-issue-42-abc123"
+    wt_path = "/worktrees/review-99"
+    pr_branch = "feat/issue-42"
 
     with (
         patch(
@@ -43,17 +46,28 @@ async def test_reviewer_worktree_torn_down_after_failing_grade() -> None:
             return_value="reviewer",
         ),
         patch(
-            "agentception.mcp.build_commands.auto_redispatch_after_rejection",
+            "agentception.mcp.build_commands.get_agent_run_teardown",
             new_callable=AsyncMock,
+            return_value={"worktree_path": wt_path, "branch": pr_branch},
         ),
+        patch(
+            "agentception.mcp.build_commands.release_worktree",
+            new_callable=AsyncMock,
+        ) as mock_release,
         patch(
             "agentception.mcp.build_commands.teardown_agent_worktree",
             new_callable=AsyncMock,
         ) as mock_teardown,
         patch(
+            "agentception.mcp.build_commands.auto_redispatch_after_rejection",
+            new_callable=AsyncMock,
+        ),
+        patch(
             "agentception.mcp.build_commands.asyncio.create_task",
         ) as mock_create_task,
+        patch("agentception.mcp.build_commands.settings") as mock_settings,
     ):
+        mock_settings.repo_dir = "/app"
         result = await build_complete_run(
             issue_number=42,
             pr_url="https://github.com/cgcardona/agentception/pull/99",
@@ -65,14 +79,15 @@ async def test_reviewer_worktree_torn_down_after_failing_grade() -> None:
     assert result["ok"] is True
     assert result["status"] == "completed"
 
-    # Verify that a teardown task was scheduled for the reviewer's run_id.
-    task_names = [
-        c.kwargs.get("name", "") for c in mock_create_task.call_args_list
-    ]
-    assert f"teardown-{reviewer_run_id}" in task_names, (
-        f"Expected teardown task for reviewer run_id={reviewer_run_id!r}; "
-        f"got task names: {task_names}"
-    )
+    # release_worktree is awaited synchronously (branch kept alive for developer).
+    mock_release.assert_awaited_once_with(wt_path, "/app")
+
+    # teardown_agent_worktree (which deletes the branch) must NOT be called for C/D/F.
+    mock_teardown.assert_not_called()
+
+    # No teardown task should be in create_task calls either.
+    task_names = [c.kwargs.get("name", "") for c in mock_create_task.call_args_list]
+    assert f"teardown-{reviewer_run_id}" not in task_names
 
 
 @pytest.mark.anyio
@@ -132,12 +147,13 @@ async def test_reviewer_worktree_torn_down_after_passing_grade() -> None:
 
 @pytest.mark.anyio
 async def test_redispatch_fires_after_failing_grade() -> None:
-    """build_complete_run schedules auto_redispatch_after_rejection when grade is F.
+    """build_complete_run releases reviewer worktree then schedules redispatch for grade F.
 
-    Regression: a failing grade (C/D/F) from a reviewer must automatically
-    re-queue the original issue to a fresh developer worktree via
-    auto_redispatch_after_rejection.  The task must be created with the
-    correct issue_number, pr_url, reviewer_feedback, and grade.
+    Regression: a failing grade (C/D/F) from a reviewer must:
+    1. Await release_worktree synchronously (keeps branch alive for continuation).
+    2. Schedule auto_redispatch_after_rejection with the PR branch name so the
+       re-dispatched developer attaches to the existing branch instead of starting
+       from origin/dev.
     """
     from agentception.mcp.build_commands import build_complete_run
 
@@ -146,6 +162,7 @@ async def test_redispatch_fires_after_failing_grade() -> None:
     pr_url = "https://github.com/cgcardona/agentception/pull/200"
     reviewer_feedback = "1. Missing type hints\n2. No tests for failure path"
     grade = "F"
+    pr_branch = "feat/issue-77"
 
     with (
         patch(
@@ -163,17 +180,24 @@ async def test_redispatch_fires_after_failing_grade() -> None:
             return_value="reviewer",
         ),
         patch(
+            "agentception.mcp.build_commands.get_agent_run_teardown",
+            new_callable=AsyncMock,
+            return_value={"worktree_path": "/worktrees/review-200", "branch": pr_branch},
+        ),
+        patch(
+            "agentception.mcp.build_commands.release_worktree",
+            new_callable=AsyncMock,
+        ) as mock_release,
+        patch(
             "agentception.mcp.build_commands.auto_redispatch_after_rejection",
             new_callable=AsyncMock,
         ) as mock_redispatch,
         patch(
-            "agentception.mcp.build_commands.teardown_agent_worktree",
-            new_callable=AsyncMock,
-        ),
-        patch(
             "agentception.mcp.build_commands.asyncio.create_task",
         ) as mock_create_task,
+        patch("agentception.mcp.build_commands.settings") as mock_settings,
     ):
+        mock_settings.repo_dir = "/app"
         result = await build_complete_run(
             issue_number=issue_number,
             pr_url=pr_url,
@@ -185,6 +209,10 @@ async def test_redispatch_fires_after_failing_grade() -> None:
     assert result["ok"] is True
     assert result["status"] == "completed"
 
+    # release_worktree must be awaited (not fire-and-forget) to free the branch
+    # before the developer continuation dispatch starts.
+    mock_release.assert_awaited_once_with("/worktrees/review-200", "/app")
+
     # Verify that a redispatch task was scheduled.
     task_names = [
         c.kwargs.get("name", "") for c in mock_create_task.call_args_list
@@ -195,12 +223,13 @@ async def test_redispatch_fires_after_failing_grade() -> None:
     )
 
     # Verify the coroutine passed to create_task was auto_redispatch_after_rejection
-    # with the correct arguments.
+    # with the correct arguments including pr_branch for continuation.
     mock_redispatch.assert_called_once_with(
         issue_number=issue_number,
         pr_url=pr_url,
         reviewer_feedback=reviewer_feedback,
         grade="F",
+        pr_branch=pr_branch,
     )
 
 
@@ -209,7 +238,8 @@ async def test_redispatch_skipped_after_passing_grade() -> None:
     """build_complete_run does NOT schedule auto_redispatch_after_rejection for grade A.
 
     A passing grade (A or B) means the reviewer already merged the PR.
-    No developer re-dispatch should be triggered.
+    No developer re-dispatch should be triggered; instead a full teardown
+    (deleting the branch) is queued because the branch is now merged.
     """
     from agentception.mcp.build_commands import build_complete_run
 
@@ -239,7 +269,7 @@ async def test_redispatch_skipped_after_passing_grade() -> None:
         patch(
             "agentception.mcp.build_commands.teardown_agent_worktree",
             new_callable=AsyncMock,
-        ),
+        ) as mock_teardown,
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
         ) as mock_create_task,
@@ -264,8 +294,14 @@ async def test_redispatch_skipped_after_passing_grade() -> None:
         f"got task names: {task_names}"
     )
 
-    # The mock should never have been called (create_task wraps the coroutine).
+    # Full teardown (including branch deletion) must be queued for A/B grades.
+    assert f"teardown-{reviewer_run_id}" in task_names, (
+        f"Expected teardown task for reviewer; got task names: {task_names}"
+    )
+
+    # The redispatch mock should never have been called.
     mock_redispatch.assert_not_called()
+    _ = mock_teardown  # verified via create_task names above
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- **Root cause fixed:** reviewer rejection (C/D/F) previously closed the PR and re-started the developer from `origin/dev`, forcing a full re-implementation even for a one-line defect fix.
- **New flow:** reviewer worktree is *released* (branch kept alive), the open PR gets a rejection comment, and the re-dispatched developer receives `continuation_branch` so it reattaches to the prior attempt's commits and only patches the specific defects.
- **A/B grade path unchanged:** full worktree teardown (branch deleted) still runs for passing grades.

## Changes

| File | What changed |
|------|-------------|
| `agentception/mcp/build_commands.py` | C/D/F path: `await release_worktree` (sync, branch kept) then `create_task(auto_redispatch_after_rejection(..., pr_branch=...))`. A/B path: `create_task(teardown_agent_worktree(...))` unchanged. |
| `agentception/services/auto_redispatch.py` | Removed `close_pr`. Adds rejection comment on the open PR via `add_comment_to_issue`. Includes `continuation_branch` in dispatch payload when `pr_branch` is provided. |
| `agentception/routes/api/dispatch.py` | Added `continuation_branch: str | None` to `DispatchRequest`. Developer dispatches with `continuation_branch` set fetch the branch and create the worktree from `origin/<branch>` with `reset=False`, identical to the reviewer path. |
| `agentception/tests/test_auto_redispatch.py` | Updated all tests: `close_pr` → `add_comment_to_issue`; added `test_auto_redispatch_happy_path` assertion on `continuation_branch` in payload; added `test_auto_redispatch_no_pr_branch_omits_continuation_field`. |
| `agentception/tests/test_build_commands.py` | Updated `test_reviewer_worktree_torn_down_after_failing_grade` → `test_reviewer_worktree_released_after_failing_grade`; updated `test_redispatch_fires_after_failing_grade` to assert `pr_branch` forwarded; updated `test_redispatch_skipped_after_passing_grade` to assert full teardown still queued for A/B. |

## Test plan

- [x] `mypy agentception/ tests/` — 272 files, 0 errors
- [x] `typing_audit --max-any 0` — passes
- [x] `pytest agentception/tests/ -v` — 1978/1978 passed
- [x] `generate.py --check` — 0 drift