### PR TITLE
fix: restore sweet-spot developer prompt — STOP on pytest=0, no AC audit loop

### DIFF
--- a/.agentception/roles/developer.md
+++ b/.agentception/roles/developer.md
@@ -23,6 +23,10 @@ If an operation fails (e.g. `old_string` not found), you may run **one**
 `grep` to see the current state of that specific string, then make **one**
 corrective `replace_in_file`. That is it — grep once, fix once, move on.
 
+If your briefing contains a **Reviewer Rejection** section at the top,
+those defects are the highest-priority items. Address every one of them
+before anything else.
+
 ## Definition of Done
 
 Work through this checklist in order. You are not done until every item passes.
@@ -69,40 +73,23 @@ If a required test is missing, write it with `write_file` to the exact path
 named in the AC. If pytest fails, fix the code or the test in one call.
 Re-run pytest once to confirm. Do not read files between fix attempts.
 
-### Step 3 — Acceptance criteria check
+### Step 3 — Ship
 
-Read every AC item from your briefing **one by one**. For each item:
-- If it names a specific file, verify that file was modified or created.
-- If it describes behaviour, verify the code implements it.
-- If it is not satisfied, implement it now in one write call.
-
-**Do not call `build_complete_run` if even one AC item is unmet.** A
-partial PR will be rejected by the reviewer and you will be redispatched
-with the defect list — costing extra compute for both of us.
-
-Also watch for these common code smells before submitting:
-- Using `dir()` to test whether a local variable exists — initialize it
-  before the `try` block instead.
-- Bare `except Exception` without re-raising.
-- Inline SQL strings instead of SQLAlchemy expressions.
-
-If your briefing contains a **Reviewer Rejection** section at the top,
-those defects are the highest-priority items. Address every one of them
-before touching anything else.
+**When pytest exits 0: STOP.** Do not read any more files. Do not write any
+more files. Do not audit. Your implementation is done — trust it and ship.
+Your next and only action is Step 4.
 
 ### Step 4 — Commit, push, PR
-
-Only when Steps 1–3 are all green:
 
 ```bash
 git add -A && git commit -m "feat: <plan summary>"
 git push origin HEAD
 ```
 
-Then:
-- `create_pull_request` — always pass `base: "dev"`, never `main`. Title: concise
-  feat/fix description. Body: `"Closes #<issue_number>"`.
-- `build_complete_run`
+Call `create_pull_request` — always pass `base: "dev"`, never `main`. Title:
+concise feat/fix description. Body: `"Closes #<issue_number>"`.
+
+Then call `build_complete_run` with the PR URL returned by `create_pull_request`.
 
 ## Hard rules
 
@@ -114,19 +101,8 @@ Then:
   is waste.
 - **Never re-read a file you already have in context.** Pre-loaded files and
   prior search results are your source of truth for the current file state.
-- **Do not open a PR until mypy is clean, tests pass, and all AC items are met.**
-  A PR that fails any of these will be rejected by the reviewer.
+- **Do not open a PR until mypy is clean and tests pass.**
+  A PR that fails either will be rejected by the reviewer.
 - Do not introduce features, validators, or files not required by the task or AC.
 - If an operation fails and cannot be fixed in two attempts, call
   `build_cancel_run` with a clear description of what failed and why.
-
-## Tool usage
-
-**`build_complete_run` — only call this when ALL four conditions are met:**
-1. You have written at least one file using `write_file` or `replace_in_file`.
-2. You have run `mypy` and `pytest` locally and both pass.
-3. You have called `git_commit_and_push` and received a success response.
-4. You have an open pull request URL confirmed in the tool response.
-
-Calling `build_complete_run` without a committed PR immediately ends your
-run — the reviewer will see an empty branch and the work will be lost.

--- a/scripts/gen_prompts/templates/roles/developer.md.j2
+++ b/scripts/gen_prompts/templates/roles/developer.md.j2
@@ -22,6 +22,10 @@ If an operation fails (e.g. `old_string` not found), you may run **one**
 `grep` to see the current state of that specific string, then make **one**
 corrective `replace_in_file`. That is it — grep once, fix once, move on.
 
+If your briefing contains a **Reviewer Rejection** section at the top,
+those defects are the highest-priority items. Address every one of them
+before anything else.
+
 ## Definition of Done
 
 Work through this checklist in order. You are not done until every item passes.
@@ -68,40 +72,23 @@ If a required test is missing, write it with `write_file` to the exact path
 named in the AC. If pytest fails, fix the code or the test in one call.
 Re-run pytest once to confirm. Do not read files between fix attempts.
 
-### Step 3 — Acceptance criteria check
+### Step 3 — Ship
 
-Read every AC item from your briefing **one by one**. For each item:
-- If it names a specific file, verify that file was modified or created.
-- If it describes behaviour, verify the code implements it.
-- If it is not satisfied, implement it now in one write call.
-
-**Do not call `build_complete_run` if even one AC item is unmet.** A
-partial PR will be rejected by the reviewer and you will be redispatched
-with the defect list — costing extra compute for both of us.
-
-Also watch for these common code smells before submitting:
-- Using `dir()` to test whether a local variable exists — initialize it
-  before the `try` block instead.
-- Bare `except Exception` without re-raising.
-- Inline SQL strings instead of SQLAlchemy expressions.
-
-If your briefing contains a **Reviewer Rejection** section at the top,
-those defects are the highest-priority items. Address every one of them
-before touching anything else.
+**When pytest exits 0: STOP.** Do not read any more files. Do not write any
+more files. Do not audit. Your implementation is done — trust it and ship.
+Your next and only action is Step 4.
 
 ### Step 4 — Commit, push, PR
-
-Only when Steps 1–3 are all green:
 
 ```bash
 git add -A && git commit -m "feat: <plan summary>"
 git push origin HEAD
 ```
 
-Then:
-- `create_pull_request` — always pass `base: "dev"`, never `main`. Title: concise
-  feat/fix description. Body: `"Closes #<issue_number>"`.
-- `build_complete_run`
+Call `create_pull_request` — always pass `base: "dev"`, never `main`. Title:
+concise feat/fix description. Body: `"Closes #<issue_number>"`.
+
+Then call `build_complete_run` with the PR URL returned by `create_pull_request`.
 
 ## Hard rules
 
@@ -113,19 +100,8 @@ Then:
   is waste.
 - **Never re-read a file you already have in context.** Pre-loaded files and
   prior search results are your source of truth for the current file state.
-- **Do not open a PR until mypy is clean, tests pass, and all AC items are met.**
-  A PR that fails any of these will be rejected by the reviewer.
+- **Do not open a PR until mypy is clean and tests pass.**
+  A PR that fails either will be rejected by the reviewer.
 - Do not introduce features, validators, or files not required by the task or AC.
 - If an operation fails and cannot be fixed in two attempts, call
   `build_cancel_run` with a clear description of what failed and why.
-
-## Tool usage
-
-**`build_complete_run` — only call this when ALL four conditions are met:**
-1. You have written at least one file using `write_file` or `replace_in_file`.
-2. You have run `mypy` and `pytest` locally and both pass.
-3. You have called `git_commit_and_push` and received a success response.
-4. You have an open pull request URL confirmed in the tool response.
-
-Calling `build_complete_run` without a committed PR immediately ends your
-run — the reviewer will see an empty branch and the work will be lost.

--- a/tests/test_developer_prompt.py
+++ b/tests/test_developer_prompt.py
@@ -8,32 +8,49 @@ from pathlib import Path
 DEVELOPER_PROMPT = Path(__file__).parent.parent / ".agentception" / "roles" / "developer.md"
 
 
-def test_build_complete_run_checklist_present() -> None:
-    """The four-condition pre-flight checklist must appear verbatim in the compiled prompt."""
+def test_stop_directive_present() -> None:
+    """The hard STOP directive must appear in Step 3 of the compiled prompt."""
     content = DEVELOPER_PROMPT.read_text()
-    assert '"build_complete_run" — only call this when ALL four conditions are met' not in content or \
-        "`build_complete_run` — only call this when ALL four conditions are met" in content, \
-        "Checklist header not found in developer.md"
-    assert "`build_complete_run` — only call this when ALL four conditions are met" in content, \
-        f"Pre-flight checklist missing from {DEVELOPER_PROMPT}"
+    assert "When pytest exits 0: STOP." in content, (
+        f"STOP directive missing from {DEVELOPER_PROMPT}"
+    )
 
 
-def test_tool_usage_section_present() -> None:
-    """The 'Tool usage' section must exist in the compiled developer prompt."""
+def test_step3_ship_present() -> None:
+    """Step 3 must be titled 'Ship', not the old AC audit loop."""
     content = DEVELOPER_PROMPT.read_text()
-    assert "## Tool usage" in content, f"'## Tool usage' section missing from {DEVELOPER_PROMPT}"
+    assert "### Step 3 — Ship" in content, (
+        f"'Step 3 — Ship' heading missing from {DEVELOPER_PROMPT}"
+    )
+    assert "### Step 3 — Acceptance criteria check" not in content, (
+        "Old AC audit loop heading still present — should be removed"
+    )
 
 
-def test_four_conditions_present() -> None:
-    """All four pre-flight conditions must appear in the compiled developer prompt."""
+def test_build_complete_run_in_step4() -> None:
+    """build_complete_run must be called in Step 4 with the PR URL."""
     content = DEVELOPER_PROMPT.read_text()
-    assert "You have written at least one file using `write_file` or `replace_in_file`." in content
-    assert "You have run `mypy` and `pytest` locally and both pass." in content
-    assert "You have called `git_commit_and_push` and received a success response." in content
-    assert "You have an open pull request URL confirmed in the tool response." in content
+    assert "build_complete_run` with the PR URL returned by `create_pull_request`" in content, (
+        f"build_complete_run PR-URL call missing from Step 4 in {DEVELOPER_PROMPT}"
+    )
 
 
-def test_warning_text_present() -> None:
-    """The warning about premature build_complete_run calls must be present."""
+def test_reviewer_rejection_in_execution_contract() -> None:
+    """The Reviewer Rejection priority note must appear before the Definition of Done."""
     content = DEVELOPER_PROMPT.read_text()
-    assert "Calling `build_complete_run` without a committed PR immediately ends your" in content
+    rejection_pos = content.find("Reviewer Rejection")
+    dod_pos = content.find("## Definition of Done")
+    assert rejection_pos != -1, "Reviewer Rejection note missing from developer.md"
+    assert dod_pos != -1, "Definition of Done section missing from developer.md"
+    assert rejection_pos < dod_pos, (
+        "Reviewer Rejection note must appear before Definition of Done"
+    )
+
+
+def test_no_verbose_tool_usage_gate() -> None:
+    """The verbose 4-condition Tool usage gate must not be present."""
+    content = DEVELOPER_PROMPT.read_text()
+    assert "only call this when ALL four conditions are met" not in content, (
+        "Old 4-condition gate is still present — it was removed to restore the sweet-spot "
+        "iteration budget"
+    )


### PR DESCRIPTION
## Summary

- Replaces Step 3 'Acceptance criteria check' (AC audit loop) with Step 3 'Ship' — a hard `STOP` directive that fires immediately when pytest exits 0
- Removes the standalone 'Tool usage' 4-condition gate; `build_complete_run` call is folded into Step 4 as a single concise line
- Moves the Reviewer Rejection priority note into the Execution contract section so it is seen before any work begins
- Updates `tests/test_developer_prompt.py` to assert the new shape

## Root cause

The executor role merge (`eabec3f`, PR #794, Mar 12 10:47) added Step 3 'Acceptance criteria check', which told agents to re-read every AC item one-by-one after pytest passed. That explicit audit loop gave agents permission to keep iterating post-test, pushing average completion from ~15 to ~20 iterations. The sweet-spot prompt from `9faf788` (Mar 11 16:28) had a hard 'When pytest exits 0: STOP' cutoff — this PR restores that contract.

## Test plan
- [x] `mypy agentception/ tests/` — zero errors
- [x] `pytest tests/test_developer_prompt.py -v` — 5/5 pass
- [x] `generate.py --check` — no drift