### PR TITLE
feat: wire enrich_plan_with_codebase_context into plan preview and issue filing

### DIFF
--- a/agentception/readers/issue_creator.py
+++ b/agentception/readers/issue_creator.py
@@ -36,6 +36,7 @@ from agentception.config import settings as _cfg
 from agentception.db.persist import persist_initiative_phases, persist_issue_depends_on
 from agentception.models import PlanIssue, PlanSpec
 from agentception.readers.github import add_label_to_issue, ensure_label_exists
+from agentception.readers.plan_enricher import enrich_plan_with_codebase_context
 
 logger = logging.getLogger(__name__)
 
@@ -314,6 +315,10 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
     The generator never raises; errors are yielded as ``FilingErrorEvent``
     and iteration stops.
     """
+    try:
+        spec = await enrich_plan_with_codebase_context(spec)
+    except Exception as exc:
+        logger.warning("⚠️ plan enrichment failed: %s", exc)
     repo = _cfg.gh_repo
     batch_id = f"batch-{uuid.uuid4().hex[:12]}"
     total_issues = sum(len(p.issues) for p in spec.phases)

--- a/agentception/routes/ui/plan_ui.py
+++ b/agentception/routes/ui/plan_ui.py
@@ -41,6 +41,7 @@ from pydantic import BaseModel
 from starlette.requests import Request
 
 from agentception.readers.llm_phase_planner import _strip_fences
+from agentception.readers.plan_enricher import enrich_plan_with_codebase_context
 from agentception.services.llm import LLMChunk, call_anthropic_stream
 from ._shared import _TEMPLATES
 
@@ -359,6 +360,10 @@ async def plan_preview(body: PlanDraftRequest) -> StreamingResponse:
             parsed = _normalize_plan_dict(parsed)
 
             spec = PlanSpec.model_validate(parsed)
+            try:
+                spec = await enrich_plan_with_codebase_context(spec)
+            except Exception as exc:
+                logger.warning("⚠️ plan enrichment failed: %s", exc)
             canonical = spec.to_yaml()
             total = sum(len(p.issues) for p in spec.phases)
             logger.info(

--- a/agentception/tests/test_plan_enricher_integration.py
+++ b/agentception/tests/test_plan_enricher_integration.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+"""Integration tests for enrich_plan_with_codebase_context wired into file_issues.
+
+Verifies two behaviours:
+1. When enrichment succeeds, the enriched issue bodies (containing
+   '## Relevant codebase locations') are passed to the GitHub issue-creation
+   function.
+2. When enrichment raises, file_issues continues without re-raising — enrichment
+   is best-effort and must never block issue filing.
+"""
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentception.models import PlanIssue, PlanPhase, PlanSpec
+from agentception.readers.issue_creator import IssueFileEvent, file_issues
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_spec(initiative: str = "test-enrich") -> PlanSpec:
+    """Return a single-phase, single-issue PlanSpec for testing."""
+    return PlanSpec(
+        initiative=initiative,
+        phases=[
+            PlanPhase(
+                label="0-foundation",
+                description="Only phase",
+                depends_on=[],
+                issues=[
+                    PlanIssue(
+                        id=f"{initiative}-p0-001",
+                        title="Wire enrichment",
+                        body="Original body without codebase context.",
+                    ),
+                ],
+            )
+        ],
+    )
+
+
+def _mock_proc(returncode: int = 0, stdout: bytes = b"", stderr: bytes = b"") -> MagicMock:
+    """Create a fake asyncio subprocess mock."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    return proc
+
+
+def _issue_url(number: int) -> bytes:
+    """Simulate the plain-text URL that gh issue create prints to stdout."""
+    return f"https://github.com/test/repo/issues/{number}\n".encode()
+
+
+async def _collect(gen: AsyncIterator[IssueFileEvent]) -> list[IssueFileEvent]:
+    """Drain an async generator into a list."""
+    return [event async for event in gen]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_filed_issue_body_contains_codebase_locations() -> None:
+    """Enriched issue bodies (with '## Relevant codebase locations') reach GitHub.
+
+    Patches enrich_plan_with_codebase_context to return a PlanSpec whose issue
+    body contains the codebase-locations heading, then asserts that the body
+    passed to gh issue create contains that heading.
+    """
+    spec = _make_minimal_spec()
+
+    # Build an enriched copy of the spec with the expected heading in the body.
+    # _make_minimal_spec() already uses the correct label format ("0-foundation").
+    enriched_spec = _make_minimal_spec()
+    enriched_spec.phases[0].issues[0].body = (
+        "Original body without codebase context."
+        "\n\n## Relevant codebase locations\n"
+        "- agentception/readers/issue_creator.py lines 1-10 — file_issues"
+    )
+
+    captured_bodies: list[str] = []
+
+    def fake_proc(*args: object, **kwargs: object) -> MagicMock:
+        # Capture the --body argument from the gh CLI command.
+        arg_list = list(args)
+        if "--body" in arg_list:
+            body_idx = arg_list.index("--body")
+            captured_bodies.append(str(arg_list[body_idx + 1]))
+        return _mock_proc(stdout=_issue_url(42))
+
+    with (
+        patch(
+            "agentception.readers.issue_creator.enrich_plan_with_codebase_context",
+            new_callable=AsyncMock,
+            return_value=enriched_spec,
+        ),
+        patch("agentception.readers.issue_creator.ensure_label_exists", new_callable=AsyncMock),
+        patch("asyncio.create_subprocess_exec", side_effect=fake_proc),
+        patch(
+            "agentception.readers.issue_creator.persist_initiative_phases",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.readers.issue_creator.persist_issue_depends_on",
+            new_callable=AsyncMock,
+        ),
+    ):
+        events = await _collect(file_issues(spec))
+
+    # At least one issue event must have been emitted (filing succeeded).
+    issue_events = [e for e in events if e["t"] == "issue"]
+    assert len(issue_events) >= 1, "Expected at least one 'issue' event"
+
+    # The body passed to gh must contain the enrichment heading.
+    assert captured_bodies, "No body was captured — gh issue create was not called"
+    assert any(
+        "## Relevant codebase locations" in body for body in captured_bodies
+    ), f"Enrichment heading not found in captured bodies: {captured_bodies}"
+
+
+@pytest.mark.anyio
+async def test_enrichment_failure_does_not_block_filing() -> None:
+    """A RuntimeError from enrich_plan_with_codebase_context must not stop filing.
+
+    Patches enrich_plan_with_codebase_context to raise RuntimeError("boom"),
+    then asserts that file_issues still yields an 'issue' event and does not
+    re-raise the exception.
+    """
+    spec = _make_minimal_spec()
+
+    gh_called = False
+
+    def fake_proc(*args: object, **kwargs: object) -> MagicMock:
+        nonlocal gh_called
+        gh_called = True
+        return _mock_proc(stdout=_issue_url(99))
+
+    with (
+        patch(
+            "agentception.readers.issue_creator.enrich_plan_with_codebase_context",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ),
+        patch("agentception.readers.issue_creator.ensure_label_exists", new_callable=AsyncMock),
+        patch("asyncio.create_subprocess_exec", side_effect=fake_proc),
+        patch(
+            "agentception.readers.issue_creator.persist_initiative_phases",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.readers.issue_creator.persist_issue_depends_on",
+            new_callable=AsyncMock,
+        ),
+    ):
+        # Must not raise — enrichment failure is swallowed.
+        events = await _collect(file_issues(spec))
+
+    # Filing must have proceeded: at least one 'issue' event expected.
+    issue_events = [e for e in events if e["t"] == "issue"]
+    assert len(issue_events) >= 1, (
+        "Expected at least one 'issue' event even when enrichment fails; "
+        f"got events: {[e['t'] for e in events]}"
+    )
+    assert gh_called, "gh issue create was never called — filing was blocked by enrichment failure"


### PR DESCRIPTION
## Summary

Wires `enrich_plan_with_codebase_context` (already implemented in `plan_enricher.py`) into the two call sites where it was always intended to run but was never called.

## What changed

### `agentception/routes/ui/plan_ui.py`
- Added top-level import: `from agentception.readers.plan_enricher import enrich_plan_with_codebase_context`
- In `_llm_stream()` (the inner async generator inside `plan_preview`), inserted a `try/except` block between `PlanSpec.model_validate(parsed)` and `spec.to_yaml()` that calls the enricher. On failure, logs a warning and continues with the original `spec`.

### `agentception/readers/issue_creator.py`
- Added top-level import: `from agentception.readers.plan_enricher import enrich_plan_with_codebase_context`
- At the very top of `file_issues()`, before `repo = _cfg.gh_repo`, inserted a `try/except` block that calls the enricher. On failure, logs a warning and continues with the original `spec`. This means `id_to_body` is built from enriched issue bodies.

### `agentception/tests/test_plan_enricher_integration.py` (new file)
Two `@pytest.mark.anyio` integration tests:
1. **`test_filed_issue_body_contains_codebase_locations`** — patches `agentception.readers.issue_creator.enrich_plan_with_codebase_context` to return a `PlanSpec` with `## Relevant codebase locations` in issue bodies; asserts the body passed to `_gh_create_issue` contains that heading.
2. **`test_enrichment_failure_does_not_block_filing`** — patches the enricher to raise `RuntimeError("boom")`; asserts `file_issues` still calls the GitHub issue-creation function and does not re-raise.

## Design decisions

**Enrichment is best-effort.** The `try/except Exception` pattern with `logger.warning` ensures a Qdrant outage, a timeout, or any other enrichment failure never blocks issue filing. The user's plan always goes through — enrichment is additive, not gating.

**Patch the already-imported name.** Tests patch `agentception.readers.issue_creator.enrich_plan_with_codebase_context` (not the original module), which is the correct pattern for mocking module-level imports in Python.

**No SSE event shapes changed.** The enrichment is transparent to the browser — it only affects the YAML content that flows into the editor and the issue bodies that get filed.

## Test results

```
58 passed in 76.97s
```

All existing tests pass. The two new integration tests also pass.

Closes #870