### PR TITLE
feat: mechanically enforce STOP after pytest exits 0

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -153,6 +153,40 @@ _LOOP_GUARD_THRESHOLD: int = 2
 _FINAL_STRETCH_THRESHOLD: int = 15
 
 # ---------------------------------------------------------------------------
+# Pytest hard-stop — mechanically enforced once pytest exits 0
+# ---------------------------------------------------------------------------
+# When a run_command call containing "pytest" returns exit_code=0, the loop
+# arms a hard-stop interrupt.  On every subsequent iteration, these read-only
+# tools are intercepted and returned as synthetic errors — the same mechanism
+# used by the loop guard — so the agent cannot enter a post-test audit loop.
+# The stop is disarmed if the agent writes new code (file-mutating tools)
+# after the passing test run, because the new code is untested.
+_PYTEST_STOP_BLOCKED_TOOLS: frozenset[str] = frozenset({
+    "read_file",
+    "read_file_lines",
+    "search_text",
+    "search_codebase",
+    "list_directory",
+    "find_call_sites",
+    "read_symbol",
+    "read_window",
+    "update_working_memory",
+})
+
+# Injected every turn once pytest_clean_since is set.
+_PYTEST_STOP_OVERRIDE: str = (
+    "🛑 HARD STOP — pytest exited 0 on iteration {iteration}.\n\n"
+    "Step 3 of your execution contract is now mechanically enforced. "
+    "File reads, searches, and diagnostics are LOCKED.\n\n"
+    "Your only permitted actions:\n"
+    "1. `git_commit_and_push` — commit and push your work.\n"
+    "2. `create_pull_request` — open a PR against dev.\n"
+    "3. `build_complete_run` — mark the run complete.\n\n"
+    "Any read or search tool call will be rejected with a synthetic error. "
+    "Do not audit. Do not re-verify. Commit and ship."
+)
+
+# ---------------------------------------------------------------------------
 # Developer agent — minimal tool surface
 # ---------------------------------------------------------------------------
 # Cursor completes developer tasks in 5–15 tool calls because it has only
@@ -506,6 +540,10 @@ async def run_agent_loop(
     # Write journal: file path → number of mutations applied this session.
     # Injected into extra_blocks every turn so it survives history pruning.
     files_written: dict[str, int] = {}
+    # Set to the iteration number when pytest last exited 0.  None means the
+    # hard-stop interrupt is disarmed.  Reset when new code is written after
+    # the clean run, or when a subsequent pytest run fails.
+    pytest_clean_since: int | None = None
 
     for iteration in range(1, max_iterations + 1):
         await log_run_step(
@@ -614,6 +652,23 @@ async def run_agent_loop(
                 run_id, iteration, remaining,
             )
 
+        # Pytest hard-stop escalation — fires every iteration after pytest
+        # exits 0.  Independent of loop_guard and final_stretch.  Not applied
+        # to reviewers (whose workflow is intentionally read-heavy).
+        _pytest_clean_iter = pytest_clean_since
+        pytest_stop_active: bool = (
+            _pytest_clean_iter is not None and task.role != "reviewer"
+        )
+        if pytest_stop_active and _pytest_clean_iter is not None:
+            extra_blocks.append({
+                "type": "text",
+                "text": _PYTEST_STOP_OVERRIDE.format(iteration=_pytest_clean_iter),
+            })
+            logger.warning(
+                "⚠️ pytest_stop active — run_id=%s current_iter=%d armed_at=%d",
+                run_id, iteration, _pytest_clean_iter,
+            )
+
         try:
             bounded = _prune_history(_truncate_tool_results(messages))
             _active_model = _HAIKU_MODEL if task.role == "reviewer" else _MODEL
@@ -705,6 +760,39 @@ async def run_agent_loop(
             else:
                 tc_to_dispatch = list(response["tool_calls"])
 
+            # Pass 2: pytest hard-stop interception (independent of loop guard).
+            # Any read/search tool that made it past Pass 1 is blocked here when
+            # pytest_stop_active.  This runs on tc_to_dispatch (not the full list)
+            # so guard-intercepted tools are not double-counted.
+            if pytest_stop_active:
+                unblocked: list[ToolCall] = []
+                for tc in tc_to_dispatch:
+                    tc_name = tc["function"]["name"]
+                    if tc_name in _PYTEST_STOP_BLOCKED_TOOLS:
+                        synthetic_errors.append({
+                            "role": "tool",
+                            "tool_call_id": tc["id"],
+                            "content": json.dumps({
+                                "ok": False,
+                                "error": (
+                                    f"HARD STOP: pytest exited 0 on iteration "
+                                    f"{pytest_clean_since}. Reading, searching, "
+                                    "and diagnostics are locked. Your only "
+                                    "permitted actions are git_commit_and_push, "
+                                    "create_pull_request, and build_complete_run. "
+                                    "Commit and ship now."
+                                ),
+                            }),
+                        })
+                    else:
+                        unblocked.append(tc)
+                if len(unblocked) < len(tc_to_dispatch):
+                    logger.warning(
+                        "⚠️ pytest_stop intercepted %d tool call(s) — run_id=%s iteration=%d",
+                        len(tc_to_dispatch) - len(unblocked), run_id, iteration,
+                    )
+                tc_to_dispatch = unblocked
+
             tool_results: list[dict[str, object]] = []
             if tc_to_dispatch:
                 tool_results = await _dispatch_tool_calls(
@@ -781,6 +869,59 @@ async def run_agent_loop(
                         )
                 except (json.JSONDecodeError, AttributeError):
                     pass
+
+            # Pytest hard-stop bookkeeping.
+            #
+            # Arm: if any dispatched run_command call ran pytest and exited 0,
+            # set pytest_clean_since so the hard-stop fires next iteration.
+            # tc_to_dispatch and tool_results are parallel (asyncio.gather order).
+            for tc, tr in zip(tc_to_dispatch, tool_results):
+                if tc["function"]["name"] != "run_command":
+                    continue
+                try:
+                    cmd_args: dict[str, object] = json.loads(tc["function"]["arguments"])
+                    cmd_str = str(cmd_args.get("command", ""))
+                except (json.JSONDecodeError, AttributeError):
+                    continue
+                if "pytest" not in cmd_str:
+                    continue
+                try:
+                    result_data: dict[str, object] = json.loads(
+                        str(tr.get("content", "{}"))
+                    )
+                    exit_code = result_data.get("exit_code")
+                    if exit_code == 0:
+                        pytest_clean_since = iteration
+                        logger.info(
+                            "✅ pytest_stop armed — run_id=%s iteration=%d",
+                            run_id, iteration,
+                        )
+                    elif exit_code is not None and pytest_clean_since is not None:
+                        # A subsequent pytest run failed — disarm so the agent
+                        # can fix the code without being blocked.
+                        logger.info(
+                            "⚠️ pytest_stop disarmed (pytest failed) — run_id=%s"
+                            " iteration=%d exit_code=%s",
+                            run_id, iteration, exit_code,
+                        )
+                        pytest_clean_since = None
+                except (json.JSONDecodeError, AttributeError, ValueError):
+                    pass
+
+            # Disarm if the agent wrote new code after the clean test run.
+            # Only file-mutating tools (not git or run_command) trigger a reset,
+            # and only when the write occurs AFTER the iteration that armed the stop.
+            if (
+                pytest_clean_since is not None
+                and iteration > pytest_clean_since
+                and tool_names_this_iter & _FILE_MUTATING_TOOL_NAMES
+            ):
+                logger.info(
+                    "⚠️ pytest_stop disarmed (new code written) — run_id=%s"
+                    " iteration=%d armed_at=%d",
+                    run_id, iteration, pytest_clean_since,
+                )
+                pytest_clean_since = None
 
             continue
 

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -2944,3 +2944,262 @@ class TestModelSelection:
             f"Expected model='claude-sonnet-4-6' for developer, got {kwargs.get('model')!r}"
         )
 
+
+# ---------------------------------------------------------------------------
+# Pytest hard-stop — mechanically enforced once pytest exits 0
+# ---------------------------------------------------------------------------
+
+
+def _run_command_response(command: str) -> ToolResponse:
+    """Return a ToolResponse simulating the agent calling run_command."""
+    tc = ToolCall(
+        id="call_pytest",
+        type="function",
+        function=ToolCallFunction(name="run_command", arguments=json.dumps({"command": command})),
+    )
+    return ToolResponse(stop_reason="tool_calls", content="", tool_calls=[tc])
+
+
+class TestPytestHardStop:
+    """Pytest hard-stop: reads/searches are intercepted after pytest exits 0.
+
+    The stop arms when run_command runs pytest and exit_code==0.  It is
+    mechanically enforced via synthetic errors on every subsequent iteration
+    for any tool in _PYTEST_STOP_BLOCKED_TOOLS.  It disarms when new code is
+    written after the clean run, or when a later pytest invocation fails.
+    """
+
+    @pytest.mark.anyio
+    async def test_pytest_stop_blocks_reads_after_clean_exit(
+        self, tmp_path: Path
+    ) -> None:
+        """read_file calls are intercepted with a synthetic error after pytest exits 0.
+
+        Sequence:
+          iter 1: run_command("pytest ...") → exit_code=0  (arms stop)
+          iter 2: read_file(...)  → intercepted, synthetic error returned
+          iter 3: stop
+        The LLM must receive the HARD STOP override in extra_system_blocks on
+        iter 2, and read_file must not reach the real dispatcher.
+        """
+        from agentception.services.agent_loop import run_agent_loop
+
+        worktree = tmp_path / "test-pytest-stop"
+        worktree.mkdir()
+        task_spec = _make_task_spec(worktree)
+
+        pytest_cmd_result: dict[str, object] = {
+            "ok": True,
+            "stdout": "1 passed",
+            "stderr": "",
+            "exit_code": 0,
+            "stdout_truncated": False,
+            "stderr_truncated": False,
+        }
+
+        responses = [
+            _run_command_response("pytest agentception/tests/test_foo.py -v"),
+            _tool_response("read_file", {"path": "agentception/models.py"}),
+            _stop_response("Done."),
+        ]
+
+        captured_extra: list[list[dict[str, object]] | None] = []
+
+        async def fake_llm(
+            *args: object,
+            extra_system_blocks: list[dict[str, object]] | None = None,
+            **kwargs: object,
+        ) -> ToolResponse:
+            captured_extra.append(extra_system_blocks)
+            return responses[len(captured_extra) - 1]
+
+        read_file_called = False
+
+        # read_file is synchronous in _dispatch_local_tool — use a plain callable
+        # (not AsyncMock) so the return value is a dict, not a coroutine.
+        def fake_read_file_sync(*args: object, **kwargs: object) -> dict[str, object]:
+            nonlocal read_file_called
+            read_file_called = True
+            return {"ok": True, "content": "stub", "truncated": False}
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
+            patch(
+                "agentception.services.agent_loop.get_run_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic",
+                new_callable=AsyncMock,
+                return_value='{"files": [], "searches": [], "plan": "no-op"}',
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic_with_tools",
+                side_effect=fake_llm,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+            mock_settings.ac_min_turn_delay_secs = 0.0
+
+            from agentception.services import agent_loop as al
+
+            with patch.object(al, "run_command", new=AsyncMock(return_value=pytest_cmd_result)):
+                with patch.object(al, "read_file", side_effect=fake_read_file_sync):
+                    await run_agent_loop("test-pytest-stop")
+
+        # The HARD STOP override must appear in extra_system_blocks on iter 2
+        # (index 1 — the read_file attempt after pytest passed).
+        assert len(captured_extra) >= 2, "Expected at least 2 LLM iterations"
+        iter2_extra = captured_extra[1]
+        assert iter2_extra is not None, "extra_system_blocks must be non-None on iter 2"
+        all_text = " ".join(
+            str(b["text"]) for b in iter2_extra if isinstance(b.get("text"), str)
+        )
+        assert "HARD STOP" in all_text, (
+            "Expected 'HARD STOP' in extra_system_blocks on the iteration after pytest passes"
+        )
+
+        # read_file must NOT have been dispatched — the interception returns a
+        # synthetic error before the real tool is called.
+        assert not read_file_called, (
+            "read_file must be intercepted and not reach the real dispatcher"
+        )
+
+    @pytest.mark.anyio
+    async def test_pytest_stop_disarmed_by_file_write(self, tmp_path: Path) -> None:
+        """Writing a file after pytest passes disarms the hard-stop.
+
+        Sequence:
+          iter 1: run_command("pytest ...") → exit_code=0  (arms stop)
+          iter 2: replace_in_file(...)  (disarms stop — new untested code)
+          iter 3: read_file(...)  → reaches dispatcher normally (stop is disarmed)
+          iter 4: stop
+        """
+        from agentception.services.agent_loop import run_agent_loop
+
+        worktree = tmp_path / "test-pytest-disarm"
+        worktree.mkdir()
+        task_spec = _make_task_spec(worktree)
+
+        pytest_cmd_result: dict[str, object] = {
+            "ok": True,
+            "stdout": "1 passed",
+            "stderr": "",
+            "exit_code": 0,
+            "stdout_truncated": False,
+            "stderr_truncated": False,
+        }
+        replace_result: dict[str, object] = {"ok": True}
+        read_result: dict[str, object] = {"ok": True, "content": "stub", "truncated": False}
+
+        responses = [
+            _run_command_response("pytest agentception/tests/test_foo.py -v"),
+            _tool_response("replace_in_file", {"path": "agentception/foo.py", "old_string": "x", "new_string": "y"}),
+            _tool_response("read_file", {"path": "agentception/models.py"}),
+            _stop_response("Done."),
+        ]
+
+        captured_extra: list[list[dict[str, object]] | None] = []
+
+        async def fake_llm(
+            *args: object,
+            extra_system_blocks: list[dict[str, object]] | None = None,
+            **kwargs: object,
+        ) -> ToolResponse:
+            captured_extra.append(extra_system_blocks)
+            return responses[len(captured_extra) - 1]
+
+        read_file_called = False
+
+        # read_file and replace_in_file are synchronous in _dispatch_local_tool —
+        # use plain MagicMock (not AsyncMock) so the return value is a dict, not
+        # a coroutine.
+        def fake_read_file_sync(*args: object, **kwargs: object) -> dict[str, object]:
+            nonlocal read_file_called
+            read_file_called = True
+            return read_result
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
+            patch(
+                "agentception.services.agent_loop.get_run_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic",
+                new_callable=AsyncMock,
+                return_value='{"files": [], "searches": [], "plan": "no-op"}',
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic_with_tools",
+                side_effect=fake_llm,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+            mock_settings.ac_min_turn_delay_secs = 0.0
+
+            from agentception.services import agent_loop as al
+
+            with patch.object(al, "run_command", new=AsyncMock(return_value=pytest_cmd_result)):
+                with patch.object(al, "replace_in_file", return_value=replace_result):
+                    with patch.object(al, "read_file", side_effect=fake_read_file_sync):
+                        await run_agent_loop("test-pytest-disarm")
+
+        # After the file write on iter 2, the stop is disarmed.
+        # On iter 3, read_file must reach the real dispatcher (not be intercepted).
+        assert read_file_called, (
+            "read_file must be dispatched normally after the stop is disarmed by a file write"
+        )
+
+        # No HARD STOP in extra_system_blocks on iter 3 (index 2).
+        assert len(captured_extra) >= 3, "Expected at least 3 LLM iterations"
+        iter3_extra = captured_extra[2]
+        if iter3_extra is not None:
+            all_text = " ".join(
+                str(b["text"]) for b in iter3_extra if isinstance(b.get("text"), str)
+            )
+            assert "HARD STOP" not in all_text, (
+                "HARD STOP must not appear after disarm"
+            )


### PR DESCRIPTION
## Summary

- Detects `run_command` calls containing `pytest` that return `exit_code=0` and arms a hard-stop interrupt
- On every subsequent iteration, `_PYTEST_STOP_BLOCKED_TOOLS` (read_file, search_text, list_directory, search_codebase, etc.) are intercepted and returned as synthetic errors — same mechanism as the loop guard
- Injects `_PYTEST_STOP_OVERRIDE` into `extra_system_blocks` each turn the stop is active
- Disarms automatically when the agent writes new code (untested) or when a later pytest run fails
- Two regression tests in `TestPytestHardStop` covering arm+block and disarm-by-write

## Test plan
- [x] `mypy agentception/ tests/` — zero errors
- [x] `pytest agentception/tests/test_agent_loop.py::TestPytestHardStop -v` — 2 passed