### PR TITLE
fix: tool surface audit — 13 bugs, dead code, schema mismatches

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -8,7 +8,6 @@ machine.  Functions are grouped by audience:
 Dispatcher
 ----------
 - ``build_claim_run``       — pending_launch → implementing (was: build_acknowledge_run)
-- ``build_spawn_child_run`` — create child worktree + DB record (was: build_spawn_child)
 
 Engineers
 ---------
@@ -41,7 +40,6 @@ from agentception.db.queries import get_agent_run_role, get_agent_run_teardown
 
 from agentception.services.auto_redispatch import auto_redispatch_after_rejection
 from agentception.services.auto_reviewer import auto_dispatch_reviewer
-from agentception.services.spawn_child import ScopeType, SpawnChildError, Tier, spawn_child
 from agentception.services.teardown import release_worktree, teardown_agent_worktree
 
 logger = logging.getLogger(__name__)
@@ -155,114 +153,6 @@ async def build_claim_run(run_id: str) -> dict[str, object]:
         }
     logger.info("✅ build_claim_run: %r claimed", run_id)
     return {"ok": True, "run_id": run_id, "previous_state": "pending_launch"}
-
-
-async def build_spawn_child_run(
-    parent_run_id: str,
-    role: str,
-    tier: str,
-    scope_type: str,
-    scope_value: str,
-    gh_repo: str,
-    org_domain: str = "",
-    issue_body: str = "",
-    issue_title: str = "",
-    skills_hint: list[str] | None = None,
-    coord_fingerprint: str | None = None,
-    cognitive_arch: str = "",
-) -> dict[str, object]:
-    """Create a child agent node in the tree and return its worktree path.
-
-    Any coordinator agent calls this tool to atomically spawn a child.
-    The tool creates the worktree, persists all task context to the DB row
-    (role, cognitive_arch, tier, scope, parent lineage, and all required fields),
-    and auto-acknowledges the run so the caller can immediately fire a Task call.
-    The child reads its full context via
-    ``ac://runs/{run_id}/context`` and the ``task/briefing`` MCP prompt.
-
-    Was: ``build_spawn_child``.
-
-    Args:
-        parent_run_id:  ``run_id`` of the calling agent (lineage tracking).
-        role:           Child's role slug (e.g. ``"engineering-coordinator"``).
-        tier:           Behavioral execution tier — ``"coordinator"``
-                        or ``"worker"``.
-        scope_type:     ``"label"``, ``"issue"``, or ``"pr"``.
-        scope_value:    Label string, or issue/PR number as a string.
-        gh_repo:        ``"owner/repo"`` string.
-        org_domain:     Organisational slot for UI hierarchy (``"c-suite"``,
-                        ``"engineering"``, ``"qa"``).
-        issue_body:     Issue body for COGNITIVE_ARCH skill extraction.
-        issue_title:    Issue title written to ISSUE_TITLE field.
-        skills_hint:    Explicit skill override list for COGNITIVE_ARCH.
-        coord_fingerprint: The spawning coordinator's fingerprint string.
-        cognitive_arch: When provided, forward this exact arch string to the child.
-
-    Returns:
-        On success: ``{"ok": True, "child_run_id": ..., "worktree_path": ...,
-                       "tier": ..., "org_domain": ..., "role": ..., "cognitive_arch": ...}``
-        On failure: ``{"ok": False, "error": "<reason>"}``
-    """
-    if tier == "coordinator":
-        typed_tier: Tier = "coordinator"
-    elif tier == "worker":
-        typed_tier = "worker"
-    else:
-        return {
-            "ok": False,
-            "error": f"tier must be coordinator/worker, got {tier!r}",
-        }
-
-    if scope_type == "label":
-        scope: ScopeType = "label"
-    elif scope_type == "issue":
-        scope = "issue"
-    elif scope_type == "pr":
-        scope = "pr"
-    else:
-        return {
-            "ok": False,
-            "error": f"scope_type must be label/issue/pr, got {scope_type!r}",
-        }
-
-    domain: str | None = org_domain if org_domain else None
-
-    try:
-        result = await spawn_child(
-            parent_run_id=parent_run_id,
-            role=role,
-            tier=typed_tier,
-            org_domain=domain,
-            scope_type=scope,
-            scope_value=scope_value,
-            gh_repo=gh_repo,
-            issue_body=issue_body,
-            issue_title=issue_title,
-            skills_hint=skills_hint,
-            coord_fingerprint=coord_fingerprint,
-            cognitive_arch=cognitive_arch if cognitive_arch else None,
-        )
-    except SpawnChildError as exc:
-        logger.error("❌ build_spawn_child_run failed: %s", exc)
-        return {"ok": False, "error": str(exc)}
-
-    logger.info(
-        "✅ build_spawn_child_run: spawned child_run_id=%r role=%r tier=%r org_domain=%r scope=%s:%s",
-        result.run_id, result.role, result.tier, result.org_domain,
-        result.scope_type, result.scope_value,
-    )
-    return {
-        "ok": True,
-        "child_run_id": result.run_id,
-        "worktree_path": result.host_worktree_path,
-        "tier": result.tier,
-        "org_domain": result.org_domain,
-        "role": result.role,
-        "cognitive_arch": result.cognitive_arch,
-        "scope_type": result.scope_type,
-        "scope_value": result.scope_value,
-        "status": "implementing",
-    }
 
 
 # Matches https://github.com/<owner>/<repo>/pull/<number>

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -74,8 +74,6 @@ from agentception.mcp.github_tools import (
 from agentception.mcp.prompts import PROMPTS, get_prompt, get_static_prompt
 from agentception.mcp.plan_advance_phase import plan_advance_phase
 from agentception.mcp.plan_tools import (
-    plan_get_cognitive_figures,
-    plan_get_labels,
     plan_validate_manifest,
     plan_validate_spec,
 )
@@ -381,6 +379,21 @@ TOOLS: list[ACToolDef] = [
                         "Your own run ID exactly as it appears in your task briefing "
                         "(e.g. 'issue-858' or 'review-900'). Required — omitting it "
                         "leaves your run stuck in implementing state."
+                    ),
+                },
+                "grade": {
+                    "type": "string",
+                    "description": (
+                        "Reviewer grade (A/B/C/D/F). Required when called by a reviewer "
+                        "agent — A/B merges the PR, C/D/F rejects it with feedback. "
+                        "Omit when called by a developer or other non-reviewer role."
+                    ),
+                },
+                "reviewer_feedback": {
+                    "type": "string",
+                    "description": (
+                        "Detailed feedback posted as an issue comment when the grade is "
+                        "C, D, or F (rejection). Omit for A/B grades and non-reviewer roles."
                     ),
                 },
             },
@@ -982,7 +995,7 @@ async def call_tool_async(
         )
         return ACToolResult(
             content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
-            isError=False,
+            isError=not bool(result.get("ok", True)),
         )
 
     if name == "build_teardown_worktree":

--- a/agentception/routes/api/runs.py
+++ b/agentception/routes/api/runs.py
@@ -10,7 +10,7 @@ UI surfaces retained:
 
 Agent-facing routes (GET /pending, POST /acknowledge, /children, /step,
 /blocker, /decision, /done) have been removed.  Use the MCP equivalents:
-  query_pending_runs, build_claim_run, build_spawn_child_run,
+  query_pending_runs, build_claim_run, build_spawn_adhoc_child,
   log_run_step, log_run_blocker, log_run_decision, build_complete_run.
 """
 from __future__ import annotations

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -179,7 +179,8 @@ _PYTEST_STOP_OVERRIDE: str = (
     "Step 3 of your execution contract is now mechanically enforced. "
     "File reads, searches, and diagnostics are LOCKED.\n\n"
     "Your only permitted actions:\n"
-    "1. `git_commit_and_push` — commit and push your work.\n"
+    "1. Commit and push — use `run_command` with `git add -A && git commit -m '...' && git push origin HEAD` "
+    "(or `git_commit_and_push` if it appears in your tool list).\n"
     "2. `create_pull_request` — open a PR against dev.\n"
     "3. `build_complete_run` — mark the run complete.\n\n"
     "Any read or search tool call will be rejected with a synthetic error. "
@@ -266,9 +267,6 @@ _GUARD_PERMITTED_TOOL_NAMES: frozenset[str] = frozenset({
     "create_pull_request",
     "add_issue_comment",
 })
-
-# Legacy alias kept so existing references compile.
-_READ_ONLY_TOOL_NAMES: frozenset[str] = frozenset()
 
 # System-block text still injected alongside tool narrowing so the model
 # understands WHY its tool palette shrank.
@@ -777,10 +775,10 @@ async def run_agent_loop(
                                 "error": (
                                     f"HARD STOP: pytest exited 0 on iteration "
                                     f"{pytest_clean_since}. Reading, searching, "
-                                    "and diagnostics are locked. Your only "
-                                    "permitted actions are git_commit_and_push, "
-                                    "create_pull_request, and build_complete_run. "
-                                    "Commit and ship now."
+                                    "and diagnostics are locked. Commit via "
+                                    "run_command (git add/commit/push) or "
+                                    "git_commit_and_push if available, then "
+                                    "create_pull_request and build_complete_run."
                                 ),
                             }),
                         })
@@ -2046,7 +2044,6 @@ async def _dispatch_single_tool(
         "write_file": "path",
         "replace_in_file": "path",
         "insert_after_in_file": "path",
-        "create_directory": "path",
         "list_directory": "path",
     }
     _key = _KEY_ARG.get(name)
@@ -2116,7 +2113,7 @@ async def _dispatch_local_tool(
         if not isinstance(new_raw, str):
             return {"ok": False, "error": "replace_in_file: 'new_string' must be a string"}
         allow_raw = args.get("allow_multiple", False)
-        allow = bool(allow_raw) if isinstance(allow_raw, bool) else False
+        allow = bool(allow_raw) if isinstance(allow_raw, (bool, int)) else False
         result = replace_in_file(
             _resolve(path_raw, worktree_path),
             old_raw,

--- a/agentception/tools/definitions.py
+++ b/agentception/tools/definitions.py
@@ -227,7 +227,7 @@ FILE_TOOL_DEFS: list[ToolDefinition] = [
                     },
                     "n_results": {
                         "type": "integer",
-                        "description": "Max matching lines to return (default 30).",
+                        "description": "Max total matching lines to return across all files (default 30).",
                         "default": 30,
                         "minimum": 1,
                         "maximum": 200,
@@ -357,7 +357,7 @@ SEARCH_CODEBASE_TOOL_DEF: ToolDefinition = ToolDefinition(
                     "type": "string",
                     "description": (
                         "Qdrant collection to search. "
-                        "Omit (or leave null) to search the main 'code' collection "
+                        "Omit to search the main 'code' collection "
                         "which indexes the full repository. "
                         "Pass 'worktree-<your-run-id>' to search only the files "
                         "in your worktree (available after the background indexing "
@@ -463,7 +463,7 @@ FIND_CALL_SITES_TOOL_DEF: ToolDefinition = ToolDefinition(
                 },
                 "n_results": {
                     "type": "integer",
-                    "description": "Max matching lines to return (default 30).",
+                    "description": "Max total matching lines to return across all files (default 30).",
                     "default": 30,
                     "minimum": 1,
                     "maximum": 100,

--- a/agentception/tools/file_tools.py
+++ b/agentception/tools/file_tools.py
@@ -17,12 +17,17 @@ logger = logging.getLogger(__name__)
 # Maximum bytes read from a single file before truncation.
 _MAX_READ_BYTES = 131_072  # 128 KiB
 
+# Matches class/def header lines — used by insert_after_in_file to prevent
+# inserting content after a class or function signature (which would break
+# the structure of the class/function body).
+_CLASS_DEF_RE: _re.Pattern[str] = _re.compile(r"^\s*(class|def)\s+\w+")
+
 
 def read_file(path: str | Path) -> dict[str, object]:
     """Return the text content of *path*.
 
     Args:
-        path: File to read.  Relative paths are resolved from the caller's cwd.
+        path: File to read.  Pre-resolved to the worktree root by the dispatcher.
 
     Returns:
         ``{"ok": True, "content": str, "truncated": bool}`` on success, or
@@ -289,7 +294,6 @@ def insert_after_in_file(
     # indented — inserting between them detaches the body from its header and
     # produces a SyntaxError.  The caller must use an anchor that ends inside
     # the body (e.g. the last method's closing line) rather than on the header.
-    _CLASS_DEF_RE = _re.compile(r"^\s*(class|def)\s+\w+")
     anchor_end_line = original[:insert_pos].rpartition("\n")[2]
     stripped_header = anchor_end_line.rstrip()
     if stripped_header.endswith(":") and _CLASS_DEF_RE.match(stripped_header):
@@ -326,6 +330,29 @@ def insert_after_in_file(
     return {"ok": True, "inserted_at": insert_pos}
 
 
+def _truncate_rg_output(output: str, n_results: int) -> str:
+    """Truncate ripgrep ``--heading`` output to at most *n_results* match lines.
+
+    In ``--heading`` mode rg emits a file-path header line, then numbered
+    match lines (``<lineno>:<content>``), then a blank separator between
+    file groups.  This function counts only the numbered match lines and
+    stops (dropping trailing headers/blanks) once the limit is reached so
+    the total returned is bounded regardless of how many files matched.
+    """
+    kept: list[str] = []
+    match_count = 0
+    for line in output.split("\n"):
+        # Numbered match lines in --heading mode start with digits followed
+        # by ":" (e.g. "42:def foo():").  File headers and blank separators
+        # do not match this pattern.
+        if line and line[0].isdigit() and ":" in line:
+            if match_count >= n_results:
+                break
+            match_count += 1
+        kept.append(line)
+    return "\n".join(kept).rstrip()
+
+
 async def search_text(
     pattern: str,
     directory: str | Path,
@@ -340,11 +367,11 @@ async def search_text(
     Args:
         pattern: Regex or literal pattern forwarded verbatim to ``rg``.
         directory: Root directory to search.
-        n_results: Maximum number of matching lines to return.
+        n_results: Maximum total matching lines to return across all files.
 
     Returns:
         ``{"ok": True, "matches": str}`` — rg output (at most *n_results*
-        lines) — or ``{"ok": False, "error": str}`` on failure.
+        total match lines) — or ``{"ok": False, "error": str}`` on failure.
     """
     import asyncio
 
@@ -357,8 +384,6 @@ async def search_text(
             "rg",
             "--heading",
             "--line-number",
-            "--max-count",
-            str(n_results),
             pattern,
             str(d),
             stdout=asyncio.subprocess.PIPE,
@@ -378,7 +403,8 @@ async def search_text(
         err_text = stderr.decode("utf-8", errors="replace").strip()
         return {"ok": False, "error": f"rg failed (exit {proc.returncode}): {err_text}"}
 
-    return {"ok": True, "matches": output or "(no matches)"}
+    truncated = _truncate_rg_output(output, n_results)
+    return {"ok": True, "matches": truncated or "(no matches)"}
 
 
 # ---------------------------------------------------------------------------
@@ -560,7 +586,7 @@ async def find_call_sites(
     Args:
         symbol_name: Function or class name to search for.
         directory: Root directory to search (defaults to worktree root).
-        n_results: Maximum matching lines to return.
+        n_results: Maximum total matching lines to return across all files.
 
     Returns:
         ``{"ok": True, "matches": str}`` — ripgrep-formatted output — or
@@ -580,8 +606,6 @@ async def find_call_sites(
             "rg",
             "--heading",
             "--line-number",
-            "--max-count",
-            str(n_results),
             "-e",
             pattern,
             str(d),
@@ -601,5 +625,6 @@ async def find_call_sites(
         err_text = stderr.decode("utf-8", errors="replace").strip()
         return {"ok": False, "error": f"rg failed (exit {proc.returncode}): {err_text}"}
 
+    truncated = _truncate_rg_output(output, n_results)
     logger.info("✅ find_call_sites — %s in %s", symbol_name, d)
-    return {"ok": True, "matches": output or "(no call sites found)"}
+    return {"ok": True, "matches": truncated or "(no call sites found)"}

--- a/agentception/tools/shell_tools.py
+++ b/agentception/tools/shell_tools.py
@@ -276,7 +276,7 @@ async def git_commit_and_push(
             if code2 != 0:
                 return {
                     "ok": False,
-                    "error": f"git_commit_and_push: checkout failed",
+                    "error": "git_commit_and_push: checkout failed",
                     "stderr": err + "\n" + err2,
                 }
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -205,7 +205,7 @@ starting agents, advancing phase gates) always require an explicit human confirm
 | **Auto — tools** | `log_run_step`, `log_run_blocker`, `log_run_decision`, `log_run_message`, `log_run_error` | Append-only DB writes — no external effects. |
 | **Prompt** | `build_claim_run`, `build_complete_run`, `build_cancel_run`, `build_stop_run`, `build_block_run`, `build_resume_run` | Pipeline state transitions in the DB — recoverable but worth confirming. |
 | **Prompt** | `github_add_label`, `github_remove_label`, `github_claim_issue`, `github_unclaim_issue`, `github_add_comment` | External GitHub API mutations. |
-| **Always prompt** | `build_spawn_child`, `plan_advance_phase`, `build_spawn_child_run`, `build_teardown_worktree` | Create real GitHub issues, git worktrees, and live agents — irreversible side effects. |
+| **Always prompt** | `build_spawn_adhoc_child`, `plan_advance_phase`, `build_teardown_worktree` | Create real GitHub issues, git worktrees, and live agents — irreversible side effects. |
 
 **What this means for you:**
 


### PR DESCRIPTION
## Summary

- **Critical:** `build_complete_run` schema blocked `grade`/`reviewer_feedback` via `additionalProperties: False` — reviewer pathway was unreachable through any spec-compliant MCP client. Both fields now declared as optional properties. Also fixed `isError=False` hardcode (was inconsistent with every other `build_*` tool).
- **High:** `search_text` and `find_call_sites` used rg `--max-count N` which limits per-file, not total — replaced with `_truncate_rg_output()` that counts numbered match lines and stops at `n_results` across all files. Schema descriptions updated.
- **Medium:** Pytest hard-stop message told developer agents to use `git_commit_and_push` which isn't in their allowlist — updated to `run_command`. Fixed `allow_multiple` bool coercion narrowness (`isinstance(bool)` → `isinstance((bool, int))`).
- **Dead code:** `_READ_ONLY_TOOL_NAMES` legacy alias, `build_spawn_child_run` orphaned function (106 lines), dead `plan_get_*` imports in server.py, `create_directory` ghost in `_KEY_ARG` — all deleted.
- **Style:** `_CLASS_DEF_RE` moved to module level, spurious `f`-string removed, schema doc corrections.

## Test plan
- [x] `mypy agentception/ tests/` — 0 errors (276 files)
- [x] `pytest test_agent_loop.py test_build_commands.py -v` — 70 passed
- [x] `generate.py --check` — 0 drift