### PR TITLE
fix: address three deferred tool-surface audit items

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -256,12 +256,20 @@ _REVIEWER_TOOL_ALLOWLIST: frozenset[str] = frozenset({
 # cases where the reviewer needs to request changes and wait for context.
 _REVIEWER_MAX_ITERATIONS = 20
 
-# When the loop guard fires, the tool palette switches to an ALLOWLIST:
-# only write tools and a minimal set of essential non-read tools remain.
+# When the loop guard fires, these tools remain available.  The set must
+# include run_command and git_commit_and_push so a guarded agent can still
+# run mypy/pytest to verify its own writes and then commit and push to ship.
+# Without them, a guarded agent writes code with no path to verify or deliver
+# it — the guard would correctly fire, force a write, then fire again forever.
 _GUARD_PERMITTED_TOOL_NAMES: frozenset[str] = frozenset({
+    # Code-mutation tools — the primary target of the guard.
     "write_file",
     "replace_in_file",
     "insert_after_in_file",
+    # Shell — needed to run mypy/pytest (verification) and git (delivery).
+    "run_command",
+    "git_commit_and_push",
+    # Completion — the only way to close the loop.
     "build_complete_run",
     "build_cancel_run",
     "create_pull_request",

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -1292,6 +1292,25 @@ class TestLoopGuard:
             )
 
 
+    def test_guard_allowlist_includes_shell_tools(self) -> None:
+        """run_command and git_commit_and_push must always be in the guard allowlist.
+
+        Without these a guarded agent can write code but has no way to run
+        verification (mypy/pytest) or deliver the work (git push) — the guard
+        would re-fire on every iteration, trapping the agent permanently.
+        """
+        from agentception.services.agent_loop import _GUARD_PERMITTED_TOOL_NAMES
+
+        assert "run_command" in _GUARD_PERMITTED_TOOL_NAMES, (
+            "run_command must be in _GUARD_PERMITTED_TOOL_NAMES so a guarded "
+            "agent can still run mypy/pytest to verify its writes."
+        )
+        assert "git_commit_and_push" in _GUARD_PERMITTED_TOOL_NAMES, (
+            "git_commit_and_push must be in _GUARD_PERMITTED_TOOL_NAMES so a "
+            "guarded agent can still commit and push after writing code."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Loop guard disabled for reviewer
 # ---------------------------------------------------------------------------

--- a/agentception/tools/file_tools.py
+++ b/agentception/tools/file_tools.py
@@ -488,6 +488,12 @@ def read_symbol(path: str | Path, symbol_name: str) -> dict[str, object]:
         # AST found nothing — fall through to string scan below.
 
     # Non-Python or AST miss: scan for `def name` / `class name`.
+    # LIMITATION: this heuristic uses indentation-based end-detection, which
+    # works for Python-style files but NOT for brace-delimited languages such
+    # as TypeScript or JavaScript.  For .ts/.js files the heuristic returns
+    # only the opening line (the `{` body is not indented relative to the
+    # header).  If a TypeScript agent role is added, replace this path with
+    # a tree-sitter or AST-based extractor for those file types.
     for i, line in enumerate(lines, 1):
         stripped = line.lstrip()
         if stripped.startswith(f"def {symbol_name}(") or stripped.startswith(
@@ -598,8 +604,18 @@ async def find_call_sites(
     if not d.exists():
         return {"ok": False, "error": f"Directory does not exist: {d}"}
 
-    # Match call sites `name(` AND import lines `import name` / `from x import name`.
-    pattern = rf"\b{symbol_name}[\(\s]|import\s+{symbol_name}"
+    # Four patterns cover the main usage forms:
+    # 1. Call sites:   symbol_name( or symbol_name  (followed by whitespace)
+    # 2. Bare import:  import symbol_name
+    # 3. From-import:  from x import symbol_name  (including multi-symbol lines)
+    # 4. Type context: symbol_name: / symbol_name[ / symbol_name, / symbol_name)
+    #    — covers annotations, generic parameters, and tuple positions
+    pattern = (
+        rf"\b{symbol_name}[\(\s]"
+        rf"|import\s+{symbol_name}\b"
+        rf"|from\s+\S+\s+import\b[^#\n]*\b{symbol_name}\b"
+        rf"|\b{symbol_name}[:\[,\)]"
+    )
 
     try:
         proc = await asyncio.create_subprocess_exec(


### PR DESCRIPTION
## Summary

- **`_GUARD_PERMITTED_TOOL_NAMES`** — add `run_command` and `git_commit_and_push` to the loop-guard allowlist. Without them a guarded agent can write code but has no path to verify it (mypy/pytest) or deliver it (git push), trapping it in a permanent guard loop. Regression guard `test_guard_allowlist_includes_shell_tools` prevents silent regressions.
- **`find_call_sites` regex** — expand match pattern to cover `from x import symbol` lines and type-annotation contexts (`symbol:`, `symbol[`, `symbol,`, `symbol)`). Previously only call-sites (`symbol(`) and bare `import symbol` lines were matched.
- **`read_symbol` heuristic** — document inline that the indentation-based fallback does NOT work for brace-delimited languages (TypeScript/JavaScript). If a TS agent role is ever added, the heuristic must be replaced with a tree-sitter extractor.

## Test plan

- [x] `mypy agentception/ tests/` — zero errors
- [x] `pytest agentception/tests/test_agent_loop.py::TestLoopGuard -v` — all pass including new `test_guard_allowlist_includes_shell_tools`
- [x] `pytest agentception/tests/test_agent_loop.py::TestPytestHardStop -v` — all pass
