### PR TITLE
fix: two reviewer merge bugs — self-approval failure and unmerged-PR teardown

### DIFF
--- a/.agentception/roles/reviewer.md
+++ b/.agentception/roles/reviewer.md
@@ -59,11 +59,8 @@ directories.
 If grade A — merge:
 
 ```
-pull_request_review_write(
-  owner=$OWNER, repo=$REPO, pull_number=$PR_NUMBER,
-  method="create_and_submit",
-  event="APPROVE",
-  body="Grade: A — <one-line summary>")
+# Do NOT call pull_request_review_write(event="APPROVE") — GitHub rejects
+# self-reviews (author and reviewer share the same account).  Skip it entirely.
 
 merge_pull_request(owner=$OWNER, repo=$REPO, pull_number=$PR_NUMBER,
                    merge_method="squash", deleteBranch=true)
@@ -78,6 +75,11 @@ build_complete_run(
   grade="A",                               ← REQUIRED: always pass "A" for passing reviews
   reviewer_feedback="")
 ```
+
+**`merge_pull_request` MUST succeed before you call `build_complete_run`.** The
+server verifies the PR is merged before accepting a grade-A completion. If you
+call `build_complete_run` without a successful merge, the server returns an error
+and you must merge first.
 
 If grade C/D/F — reject:
 
@@ -107,23 +109,25 @@ Up to 3 attempts are allowed before the loop is abandoned.
 
 ## Handling a branch behind dev
 
-If your warmup step shows the branch cannot be fast-forward merged
-into dev (i.e. mergeable_state is "behind" or "dirty" in the
-GitHub API response), do the following BEFORE reviewing the code:
+If `merge_pull_request` fails because the branch is behind dev, you MUST rebase
+before retrying. Do not give up and call `build_complete_run` without merging —
+the server will reject it.
 
-1. Inside the PR worktree, run:
-   git fetch origin dev
-   git rebase origin/dev
-   If it succeeds: git push --force-with-lease origin <branch>.
-   Then continue your review as normal — the conflict was mechanical,
-   not a code defect.
+Use `run_command` from your worktree directory (the path is shown in your
+briefing as the worktree path):
 
-2. If the rebase produces a genuine merge conflict (exit non-zero):
-   grade the PR C. In your grade comment write exactly:
-     "REBASE CONFLICT: <list of conflicting files>. Rebasing onto
-      dev failed. The developer must resolve these conflicts."
-   Do NOT attempt to fix the conflicts yourself — that is the
-   developer's job.
+```
+run_command("git fetch origin dev && git rebase origin/dev && git push --force-with-lease origin HEAD")
+```
+
+If the rebase exits 0, retry `merge_pull_request` immediately. The branch-behind
+condition is a mechanical artefact of another PR landing while you were reviewing
+— it is not a code defect and must not affect the grade.
+
+If the rebase exits non-zero (genuine merge conflict):
+- Grade the PR C.
+- Set `reviewer_feedback` to: "REBASE CONFLICT on <files>. Developer must resolve before resubmitting."
+- Do NOT attempt to fix the conflicts yourself.
 
 ## Hard Rules
 

--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -26,6 +26,8 @@ import logging
 import re
 from pathlib import Path
 
+import httpx
+
 from agentception.db.persist import (
     acknowledge_agent_run,
     block_agent_run,
@@ -160,6 +162,40 @@ async def build_claim_run(run_id: str) -> dict[str, object]:
 _GITHUB_PR_URL_RE: re.Pattern[str] = re.compile(
     r"https://github\.com/[^/]+/[^/]+/pull/\d+"
 )
+
+
+async def _is_pr_merged(pr_url: str) -> bool:
+    """Return True if the GitHub PR at *pr_url* has been merged.
+
+    Parses the owner, repo, and PR number from the URL and calls the GitHub
+    REST API.  Returns False on any network or auth error so the caller can
+    decide whether to treat the failure as a hard block or a soft warning.
+    """
+    m = re.search(
+        r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)",
+        pr_url,
+    )
+    if not m:
+        return False
+    owner, repo, number = m.group("owner"), m.group("repo"), m.group("number")
+    token = settings.github_token
+    headers: dict[str, str] = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}/merge",
+                headers=headers,
+            )
+        # 204 = merged; 404 = not merged; anything else = uncertain
+        return resp.status_code == 204
+    except Exception:
+        logger.warning("⚠️ _is_pr_merged: GitHub API call failed for %r — assuming not merged", pr_url)
+        return False
 
 
 def _is_valid_pr_url(pr_url: str) -> bool:
@@ -306,8 +342,27 @@ async def build_complete_run(
                 name=f"auto-redispatch-{issue_number}",
             )
         else:
-            # Grade A or B: reviewer already merged — full teardown (delete branch too,
-            # since it is now merged into dev).
+            # Grade A or B: reviewer should have already merged the PR.  Verify
+            # before scheduling teardown — teardown deletes the remote branch,
+            # which causes GitHub to auto-close any open PR pointing to it.  If
+            # the PR is not yet merged, refusing here forces the reviewer to
+            # actually call merge_pull_request before completion is recorded.
+            pr_is_merged = await _is_pr_merged(pr_url)
+            if not pr_is_merged:
+                logger.warning(
+                    "⚠️ build_complete_run: reviewer called with grade=%r but PR %r "
+                    "is not merged — refusing completion to prevent branch deletion",
+                    grade,
+                    pr_url,
+                )
+                return {
+                    "ok": False,
+                    "error": (
+                        f"PR {pr_url!r} has not been merged. "
+                        "Call merge_pull_request first, then call build_complete_run again. "
+                        "Completing without a merge would delete the branch and close the PR."
+                    ),
+                }
             logger.info(
                 "ℹ️ build_complete_run: reviewer approved (grade=%r) — "
                 "scheduling full worktree teardown for run_id=%r",

--- a/agentception/tests/test_build_commands.py
+++ b/agentception/tests/test_build_commands.py
@@ -123,6 +123,11 @@ async def test_reviewer_worktree_torn_down_after_passing_grade() -> None:
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
         ) as mock_create_task,
+        patch(
+            "agentception.mcp.build_commands._is_pr_merged",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
     ):
         result = await build_complete_run(
             issue_number=55,
@@ -273,6 +278,11 @@ async def test_redispatch_skipped_after_passing_grade() -> None:
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
         ) as mock_create_task,
+        patch(
+            "agentception.mcp.build_commands._is_pr_merged",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
     ):
         result = await build_complete_run(
             issue_number=issue_number,
@@ -526,6 +536,11 @@ async def test_done_event_payload_includes_grade_for_reviewer() -> None:
             new_callable=AsyncMock,
         ),
         patch("agentception.mcp.build_commands.asyncio.create_task"),
+        patch(
+            "agentception.mcp.build_commands._is_pr_merged",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
     ):
         await build_complete_run(
             issue_number=42,
@@ -582,4 +597,120 @@ async def test_done_event_payload_excludes_grade_for_developer() -> None:
     assert "grade" not in captured_payload
     assert "reviewer_feedback" not in captured_payload
     assert "pr_url" in captured_payload
+
+
+# ---------------------------------------------------------------------------
+# Regression: reviewer must not trigger teardown when PR is not yet merged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_blocks_grade_a_when_pr_not_merged() -> None:
+    """build_complete_run must refuse a grade-A completion when the PR is not merged.
+
+    Regression for the bug where a reviewer called build_complete_run(grade="A")
+    after merge_pull_request failed (branch behind dev).  The server accepted the
+    completion, scheduled teardown_agent_worktree, which deleted the remote branch,
+    which caused GitHub to auto-close the unmerged PR.
+
+    After this fix, build_complete_run returns an error when _is_pr_merged is False,
+    forcing the reviewer to merge first.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    reviewer_run_id = "reviewer-issue-99-unmerged"
+
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="reviewer",
+        ),
+        patch(
+            "agentception.mcp.build_commands._is_pr_merged",
+            new_callable=AsyncMock,
+            return_value=False,  # PR has NOT been merged
+        ),
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+        ) as mock_create_task,
+    ):
+        result = await build_complete_run(
+            issue_number=99,
+            pr_url="https://github.com/cgcardona/agentception/pull/500",
+            agent_run_id=reviewer_run_id,
+            grade="A",
+            reviewer_feedback="",
+        )
+
+    assert result.get("ok") is False, "Expected error when PR is not merged"
+    assert "not been merged" in str(result.get("error", "")).lower(), (
+        f"Error message should mention unmerged PR; got: {result.get('error')}"
+    )
+    # Teardown must NOT have been scheduled — that would delete the branch.
+    mock_create_task.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_allows_grade_a_when_pr_merged() -> None:
+    """build_complete_run proceeds normally for grade-A when the PR is confirmed merged.
+
+    Complement to the unmerged-PR regression test: when _is_pr_merged returns True,
+    the completion is accepted and teardown is scheduled as normal.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    reviewer_run_id = "reviewer-issue-55-merged"
+
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="reviewer",
+        ),
+        patch(
+            "agentception.mcp.build_commands._is_pr_merged",
+            new_callable=AsyncMock,
+            return_value=True,  # PR has been merged
+        ),
+        patch(
+            "agentception.mcp.build_commands.teardown_agent_worktree",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+        ) as mock_create_task,
+    ):
+        result = await build_complete_run(
+            issue_number=55,
+            pr_url="https://github.com/cgcardona/agentception/pull/501",
+            agent_run_id=reviewer_run_id,
+            grade="A",
+            reviewer_feedback="",
+        )
+
+    assert result.get("ok") is True
+    assert result.get("status") == "completed"
+    task_names = [c.kwargs.get("name", "") for c in mock_create_task.call_args_list]
+    assert f"teardown-{reviewer_run_id}" in task_names, (
+        f"Teardown must be scheduled when PR is merged; got: {task_names}"
+    )
 

--- a/scripts/gen_prompts/templates/roles/reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/reviewer.md.j2
@@ -58,11 +58,8 @@ directories.
 If grade A — merge:
 
 ```
-pull_request_review_write(
-  owner=$OWNER, repo=$REPO, pull_number=$PR_NUMBER,
-  method="create_and_submit",
-  event="APPROVE",
-  body="Grade: A — <one-line summary>")
+# Do NOT call pull_request_review_write(event="APPROVE") — GitHub rejects
+# self-reviews (author and reviewer share the same account).  Skip it entirely.
 
 merge_pull_request(owner=$OWNER, repo=$REPO, pull_number=$PR_NUMBER,
                    merge_method="squash", deleteBranch=true)
@@ -77,6 +74,11 @@ build_complete_run(
   grade="A",                               ← REQUIRED: always pass "A" for passing reviews
   reviewer_feedback="")
 ```
+
+**`merge_pull_request` MUST succeed before you call `build_complete_run`.** The
+server verifies the PR is merged before accepting a grade-A completion. If you
+call `build_complete_run` without a successful merge, the server returns an error
+and you must merge first.
 
 If grade C/D/F — reject:
 
@@ -106,23 +108,25 @@ Up to 3 attempts are allowed before the loop is abandoned.
 
 ## Handling a branch behind dev
 
-If your warmup step shows the branch cannot be fast-forward merged
-into dev (i.e. mergeable_state is "behind" or "dirty" in the
-GitHub API response), do the following BEFORE reviewing the code:
+If `merge_pull_request` fails because the branch is behind dev, you MUST rebase
+before retrying. Do not give up and call `build_complete_run` without merging —
+the server will reject it.
 
-1. Inside the PR worktree, run:
-   git fetch origin dev
-   git rebase origin/dev
-   If it succeeds: git push --force-with-lease origin <branch>.
-   Then continue your review as normal — the conflict was mechanical,
-   not a code defect.
+Use `run_command` from your worktree directory (the path is shown in your
+briefing as the worktree path):
 
-2. If the rebase produces a genuine merge conflict (exit non-zero):
-   grade the PR C. In your grade comment write exactly:
-     "REBASE CONFLICT: <list of conflicting files>. Rebasing onto
-      dev failed. The developer must resolve these conflicts."
-   Do NOT attempt to fix the conflicts yourself — that is the
-   developer's job.
+```
+run_command("git fetch origin dev && git rebase origin/dev && git push --force-with-lease origin HEAD")
+```
+
+If the rebase exits 0, retry `merge_pull_request` immediately. The branch-behind
+condition is a mechanical artefact of another PR landing while you were reviewing
+— it is not a code defect and must not affect the grade.
+
+If the rebase exits non-zero (genuine merge conflict):
+- Grade the PR C.
+- Set `reviewer_feedback` to: "REBASE CONFLICT on <files>. Developer must resolve before resubmitting."
+- Do NOT attempt to fix the conflicts yourself.
 
 ## Hard Rules
 


### PR DESCRIPTION
## Summary

- **Bug 1 (prompt):** Reviewer was calling `pull_request_review_write(event="APPROVE")` before `merge_pull_request`. GitHub rejects self-reviews (author and reviewer share the same account) with 422. This wasted an iteration, confused the model into giving up on the merge, and caused the reviewer to call `build_complete_run` without having merged.
- **Bug 2 (server):** When `merge_pull_request` failed (branch behind dev), the reviewer called `build_complete_run(grade="A")` without merging. `build_complete_run` accepted this and scheduled `teardown_agent_worktree`, which deleted the remote branch, which caused GitHub to **auto-close the unmerged PR**.

## Fixes

1. **`reviewer.md.j2`:** Remove `pull_request_review_write(event="APPROVE")` from the grade-A flow entirely. Go straight to `merge_pull_request`. Strengthen the "branch behind dev" rebase instructions to make the mandatory retry path unambiguous. Add explicit warning that `build_complete_run` must not be called before `merge_pull_request` succeeds.

2. **`build_commands.py`:** Add `_is_pr_merged(pr_url)` helper that calls the GitHub REST API (`GET /repos/{owner}/{repo}/pulls/{number}/merge`, 204 = merged). In `build_complete_run`, for reviewer grade-A/B completions, call `_is_pr_merged` before scheduling teardown. If the PR is not merged, return an error — the reviewer must merge first.

## Test plan

- [x] `mypy agentception/ tests/` — zero errors
- [x] `pytest agentception/tests/test_build_commands.py -v` — 12 passed
- [x] `generate.py --check` — no drift
- [x] Regression: `test_build_complete_run_blocks_grade_a_when_pr_not_merged` — server rejects completion when PR not merged
- [x] Regression: `test_build_complete_run_allows_grade_a_when_pr_merged` — server accepts and schedules teardown when PR is merged