### PR TITLE
feat: audit imports, fix broken tests, document new module structure (#877)

### DIFF
--- a/agentception/tests/test_build_board_partial.py
+++ b/agentception/tests/test_build_board_partial.py
@@ -524,9 +524,9 @@ async def test_get_issues_grouped_by_phase_initiative_scoped_labels() -> None:
     mock_result.scalars.return_value.all.return_value = mock_rows
 
     with (
-        patch("agentception.db.queries.get_session") as mock_session,
+        patch("agentception.db.queries.board.get_session") as mock_session,
         patch(
-            "agentception.db.queries.get_initiative_phase_meta",
+            "agentception.db.queries.board.get_initiative_phase_meta",
             new_callable=AsyncMock,
             return_value=[],  # no DB rows → fall back to lexicographic sort
         ),
@@ -579,9 +579,9 @@ async def test_get_issues_grouped_by_phase_phase_key_initiative_prefix() -> None
     mock_result.scalars.return_value.all.return_value = [row]
 
     with (
-        patch("agentception.db.queries.get_session") as mock_session,
+        patch("agentception.db.queries.board.get_session") as mock_session,
         patch(
-            "agentception.db.queries.get_initiative_phase_meta",
+            "agentception.db.queries.board.get_initiative_phase_meta",
             new_callable=AsyncMock,
             return_value=[],
         ),
@@ -761,9 +761,9 @@ async def test_get_issues_grouped_by_phase_filters_closed_deps() -> None:
     mock_result.scalars.return_value.all.return_value = rows
 
     with (
-        patch("agentception.db.queries.get_session") as mock_session,
+        patch("agentception.db.queries.board.get_session") as mock_session,
         patch(
-            "agentception.db.queries.get_initiative_phase_meta",
+            "agentception.db.queries.board.get_initiative_phase_meta",
             new_callable=AsyncMock,
             return_value=[],
         ),

--- a/agentception/tests/test_queries.py
+++ b/agentception/tests/test_queries.py
@@ -70,9 +70,9 @@ async def test_get_daily_metrics_returns_zeros_on_db_error() -> None:
 
     today = datetime.date(2025, 1, 15)
 
-    # Patch get_session to raise so the except branch is exercised.
+    # Patch get_session where it is locally bound in the metrics submodule.
     with patch(
-        "agentception.db.queries.get_session",
+        "agentception.db.queries.metrics.get_session",
         side_effect=Exception("no db"),
     ):
         result = await get_daily_metrics(today)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -264,6 +264,50 @@ The `TaskRunner` protocol (`agentception/services/task_runner.py`) defines a run
 
 ---
 
+## Query module structure
+
+`agentception/db/queries/` is a Python package. All existing call-sites use
+`from agentception.db.queries import X` and continue to work through the
+re-exporting `__init__.py`. The package is split into focused submodules to
+eliminate parallel-agent merge conflicts on the former 3250-line monolith.
+
+| File | Domain ownership |
+|------|-----------------|
+| `types.py` | All `TypedDict` return-value shapes shared across the package. No query logic. |
+| `board.py` | Board issues, initiative phases, label state, wave summaries, workflow states, and grouped-phase views. |
+| `runs.py` | Agent run lifecycle — run rows, active runs, run detail, tree traversal, teardown, and execution plan loading. |
+| `messages.py` | Agent thought stream queries (`get_agent_thoughts_tail`). |
+| `events.py` | Agent event tail queries and file-edit event hydration. |
+| `metrics.py` | Daily metrics, run status counts, throughput, and cost calculation. |
+
+`__init__.py` re-exports every public symbol (and a small set of test-required
+private helpers) using the `import X as X` pattern so that mypy's strict
+re-export checks are satisfied.
+
+All six files carry `merge=union` in `.gitattributes` to prevent spurious
+conflicts when parallel agents append to different domain files simultaneously.
+
+---
+
+## SCSS partial structure
+
+`agentception/static/scss/pages/_build.scss` is a barrel file that imports six
+focused partials in cascade order. Edit the partial — never the barrel.
+
+| Partial | Rule ownership |
+|---------|---------------|
+| `_inspector-layout.scss` | Inspector chrome, toolbar, header, sidebar layout, and general OD structural rules. |
+| `_thought-block.scss` | `.thought-block` collapsible sections for LLM reasoning display. |
+| `_file-edit-card.scss` | `.file-edit-card` diff viewer cards including `.diff-add`, `.diff-remove`, `.diff-context`. |
+| `_assistant-bubble.scss` | `.assistant-bubble` prose message bubbles. |
+| `_tool-call-card.scss` | `.tool-call-card` expandable tool-call detail cards. |
+| `_event-card.scss` | `.event-card` generic SSE event cards in the event log. |
+
+All six partials carry `merge=union` in `.gitattributes` for the same
+parallel-agent conflict-reduction reason as the query submodules.
+
+---
+
 ## Further Reading
 
 - [Plan Spec format](plan-spec.md)


### PR DESCRIPTION
## Summary

- **Audit:** All three import-path grep checks return zero results — no test imports query functions by direct file path
- **Fix 4 broken tests:** Updated stale `mock.patch` targets to point at the domain submodule where each dependency is locally bound after the queries split:
  - `agentception.db.queries.get_session` → `agentception.db.queries.metrics.get_session` (metrics test)
  - `agentception.db.queries.get_session` → `agentception.db.queries.board.get_session` (3 board tests)
  - `agentception.db.queries.get_initiative_phase_meta` → `agentception.db.queries.board.get_initiative_phase_meta` (3 board tests)
- **Docs:** Added `## Query module structure` and `## SCSS partial structure` sections to `docs/architecture.md` with domain ownership tables, re-export contract note, and `.gitattributes` strategy explanation
- **`.gitattributes`:** Already complete with all 13 `merge=union` entries (7 SCSS + 6 query submodules)

## Verification

- `mypy agentception/ tests/` → zero errors (282 files)
- `pytest test_queries.py test_build_board_partial.py test_build_commands.py test_agent_loop.py` → **104 passed, 0 failed** (all 4 previously broken tests now green)

Closes #877