### PR TITLE
feat: log per-turn token counts and track last_input_tokens in agent loop

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -550,6 +550,7 @@ async def run_agent_loop(
     # hard-stop interrupt is disarmed.  Reset when new code is written after
     # the clean run, or when a subsequent pytest run fails.
     pytest_clean_since: int | None = None
+    last_input_tokens: int = 0
 
     for iteration in range(1, max_iterations + 1):
         await log_run_step(
@@ -706,6 +707,15 @@ async def run_agent_loop(
                 cache_read_tokens=response.get("cache_read_input_tokens", 0),
             ),
             name=f"token-accum-{run_id}-{iteration}",
+        )
+
+        last_input_tokens = response.get("input_tokens", 0)
+        logger.info(
+            "📊 context: iter=%d input_tokens=%d output_tokens=%d cache_hit=%d",
+            iteration,
+            last_input_tokens,
+            response.get("output_tokens", 0),
+            response.get("cache_read_input_tokens", 0),
         )
 
         # Append assistant message to history before persisting so the full


### PR DESCRIPTION
Closes #884

## Changes

- Initialises `last_input_tokens: int = 0` before the `for iteration` loop in `run_agent_loop` (alongside `pytest_clean_since`).
- After each `accumulate_token_usage` fire-and-forget task, assigns `last_input_tokens = response.get("input_tokens", 0)` and emits an INFO log line:
  ```
  📊 context: iter=N input_tokens=X output_tokens=Y cache_hit=Z
  ```
- Purely additive — no behaviour change, no existing logic touched.
- mypy clean, all 61 existing tests pass.