### PR TITLE
fix: add missing recorded_at to ACAgentEvent inserts — status stuck on implementing

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -937,6 +937,7 @@ async def _upsert_agent_runs(
                         issue_number=orphan.issue_number,
                         event_type="orphan_failed",
                         payload=json.dumps({"reason": "worktree_gone_no_build_complete"}),
+                        recorded_at=now,
                     ))
                     logger.warning(
                         "🧹 Orphan run %s → failed (worktree gone, no build_complete_run event)",
@@ -1197,6 +1198,7 @@ async def complete_agent_run(run_id: str) -> bool:
                 agent_run_id=run_id,
                 event_type="build_complete_run",
                 payload="{}",
+                recorded_at=_now(),
             ))
             await session.commit()
         logger.info("✅ complete_agent_run: %s → completed", run_id)


### PR DESCRIPTION
## Summary

- Two `ACAgentEvent` creation sites in `persist.py` were missing the required `recorded_at` field (`NOT NULL`, no server default)
- The constraint violation rolled back the entire DB transaction — so `complete_agent_run` silently returned `False` and the run's status was never updated from `implementing`
- Every successfully-completed agent run left its DB row stuck on `implementing` despite its PR being merged

## Root cause

`complete_agent_run` (build_complete_run event) and the orphan sweep (orphan_failed event) both constructed `ACAgentEvent(...)` without `recorded_at`. The exception was caught and swallowed, masking the failure.

## Fix

Pass `recorded_at=_now()` in `complete_agent_run` and `recorded_at=now` in the orphan sweep (which already has `now` in scope). The third creation site at line 1747 was already correct.

Also manually corrected issue-884's stuck row to `status=done`.

## Test plan
- [x] `mypy agentception/db/persist.py` — clean
- [x] `pytest agentception/tests/test_persist.py` — 6/6 passed