### PR TITLE
fix: replace dict[str, Any] with DailyMetrics TypedDict in test_metrics_api.py

### DIFF
--- a/agentception/tests/test_metrics_api.py
+++ b/agentception/tests/test_metrics_api.py
@@ -7,17 +7,18 @@ connection is required.
 """
 
 from collections.abc import AsyncGenerator
-from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from agentception.db.queries import DailyMetrics
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
-_METRICS_STUB: dict[str, Any] = {
+_METRICS_STUB: DailyMetrics = {
     "date": "2025-01-15",
     "issues_closed": 3,
     "prs_merged": 2,
@@ -39,7 +40,7 @@ _METRICS_STUB: dict[str, Any] = {
 }
 
 
-def _make_stub(date_str: str) -> dict[str, Any]:
+def _make_stub(date_str: str) -> DailyMetrics:
     """Return a metrics stub with the given date string."""
     return {**_METRICS_STUB, "date": date_str}
 
@@ -141,7 +142,7 @@ async def test_get_metrics_daily_invalid_format_returns_400(client: AsyncClient)
 async def test_get_metrics_daily_range_three_days(client: AsyncClient) -> None:
     """start=2025-01-01&end=2025-01-03 → list of 3 objects, sorted ascending."""
 
-    async def _fake_get_daily_metrics(date: object) -> dict[str, Any]:
+    async def _fake_get_daily_metrics(date: object) -> DailyMetrics:
         import datetime
 
         assert isinstance(date, datetime.date)
@@ -168,7 +169,7 @@ async def test_get_metrics_daily_range_three_days(client: AsyncClient) -> None:
 async def test_get_metrics_daily_range_single_day(client: AsyncClient) -> None:
     """start == end → list of 1 object."""
 
-    async def _fake(date: object) -> dict[str, Any]:
+    async def _fake(date: object) -> DailyMetrics:
         import datetime
 
         assert isinstance(date, datetime.date)


### PR DESCRIPTION
## Summary

- Typing ratchet was failing at 4 `dict[str, Any]` patterns in `test_metrics_api.py`
- `DailyMetrics` TypedDict already exists in `agentception/db/queries/types.py` — the test just wasn't using it
- Replaced all 4 occurrences: `_METRICS_STUB`, `_make_stub` return type, and two inline async fake functions
- Dropped the now-unused `from typing import Any` import

## Result
- `mypy agentception/ tests/` — clean (282 files, 0 errors)
- `typing_audit.py --max-any 0` — ✅ RATCHET OK: 0 Any patterns
- `pytest test_metrics_api.py` — 10/10 passed