### PR TITLE
feat: inject _CONTEXT_PRESSURE_WARNING into extra_blocks when input tokens exceed threshold

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -318,6 +318,19 @@ _FINAL_STRETCH_WARNING: str = (
     "search_codebase. Only write/fix/commit/push/PR tools are permitted."
 )
 
+# Injected on every iteration where last_input_tokens exceeds
+# _CONTEXT_PRESSURE_THRESHOLD.  Tells the agent the context window is filling
+# and to avoid expensive reads that accelerate truncation.
+_CONTEXT_PRESSURE_WARNING: str = (
+    "⚠️ CONTEXT PRESSURE — {tokens_k}K input tokens consumed this turn.\n\n"
+    "The context window is filling. To avoid truncation:\n"
+    "- Do NOT read large files. Read only specific line ranges.\n"
+    "- Do NOT repeat searches you have already run.\n"
+    "- Prefer replace_in_file over write_file (smaller diffs).\n"
+    "- Complete your remaining work and call build_complete_run soon.\n"
+    "Remaining context budget: approximately {remaining_k}K tokens."
+)
+
 # Injected when the agent has searched for the same query twice.
 _SYMBOL_ABSENCE_OVERRIDE = """\
 ⚠️  SYMBOL ABSENCE — "{query}" NOT FOUND AFTER REPEATED SEARCH
@@ -661,6 +674,26 @@ async def run_agent_loop(
             logger.warning(
                 "⚠️ final_stretch — run_id=%s iteration=%d remaining=%d",
                 run_id, iteration, remaining,
+            )
+
+        # Context-pressure warning — fires on every iteration where the previous
+        # turn consumed more than _CONTEXT_PRESSURE_THRESHOLD input tokens.
+        # last_input_tokens is 0 on the first iteration (before any LLM call),
+        # so the condition is naturally False and the warning is never shown then.
+        if last_input_tokens > _CONTEXT_PRESSURE_THRESHOLD:
+            tokens_k = last_input_tokens // 1000
+            remaining_k = max(0, (200_000 - last_input_tokens) // 1000)
+            extra_blocks.append({
+                "type": "text",
+                "text": _CONTEXT_PRESSURE_WARNING.format(
+                    tokens_k=tokens_k, remaining_k=remaining_k
+                ),
+            })
+            logger.warning(
+                "⚠️ context_pressure — run_id=%s iter=%d input_tokens=%d",
+                run_id,
+                iteration,
+                last_input_tokens,
             )
 
         # Pytest hard-stop escalation — fires every iteration after pytest

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -3283,3 +3283,226 @@ class TestPruneHistoryTokenBudget:
         estimated = sum(len(json.dumps(m)) // 4 for m in result)
         assert estimated <= _MAX_INPUT_TOKEN_ESTIMATE
 
+
+# ---------------------------------------------------------------------------
+# TestContextPressureWarning
+# ---------------------------------------------------------------------------
+
+
+class TestContextPressureWarning:
+    """_CONTEXT_PRESSURE_WARNING is injected into extra_blocks when
+    last_input_tokens > _CONTEXT_PRESSURE_THRESHOLD.
+
+    The warning must NOT appear on the first iteration (last_input_tokens==0)
+    and must NOT appear when the previous turn consumed fewer tokens than the
+    threshold.
+    """
+
+    @pytest.mark.anyio
+    async def test_context_pressure_warning_injected_above_threshold(
+        self, tmp_path: Path
+    ) -> None:
+        """Warning appears on iteration 2 when iteration 1 returned 110K tokens."""
+        from agentception.services.agent_loop import (
+            _CONTEXT_PRESSURE_THRESHOLD,
+            _CONTEXT_PRESSURE_WARNING,
+            run_agent_loop,
+        )
+
+        worktree = tmp_path / "test-run-ctx-pressure-above"
+        worktree.mkdir()
+        task_spec = _make_task_spec(worktree)
+
+        # Iteration 1: read_file tool call with input_tokens=110_000 (above threshold).
+        # Iteration 2: stop.
+        first_response: ToolResponse = {
+            **_tool_response("read_file", {"path": "agentception/models.py"}),
+            "input_tokens": 110_000,
+        }
+        all_responses: list[ToolResponse] = [
+            first_response,
+            _stop_response("Done."),
+        ]
+
+        captured_extra: list[list[dict[str, object]] | None] = []
+
+        async def fake_llm(
+            *args: object,
+            extra_system_blocks: list[dict[str, object]] | None = None,
+            **kwargs: object,
+        ) -> ToolResponse:
+            captured_extra.append(extra_system_blocks)
+            return all_responses[len(captured_extra) - 1]
+
+        file_result: dict[str, object] = {
+            "ok": True,
+            "content": "",
+            "truncated": False,
+        }
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
+            patch(
+                "agentception.services.agent_loop.get_run_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic",
+                new_callable=AsyncMock,
+                return_value='{"files": ["agentception/models.py"], "searches": [], "plan": "no-op"}',
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic_with_tools",
+                side_effect=fake_llm,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+            mock_settings.ac_min_turn_delay_secs = 0.0
+
+            from agentception.services import agent_loop as al
+
+            with patch.object(al, "read_file", return_value=file_result):
+                await run_agent_loop("test-run-ctx-pressure-above", max_iterations=10)
+
+        assert len(captured_extra) == 2, (
+            f"Expected 2 LLM calls, got {len(captured_extra)}"
+        )
+
+        # Iteration 2 (index 1) must contain the context-pressure warning.
+        blocks_iter2 = captured_extra[1]
+        assert blocks_iter2 is not None, "extra_system_blocks must not be None on iteration 2"
+        warning_texts = [
+            str(b.get("text", ""))
+            for b in blocks_iter2
+            if isinstance(b, dict)
+        ]
+        assert any("⚠️ CONTEXT PRESSURE" in t for t in warning_texts), (
+            f"Expected '⚠️ CONTEXT PRESSURE' in iteration-2 extra_blocks, got: {warning_texts}"
+        )
+        assert any("110K input tokens" in t for t in warning_texts), (
+            f"Expected '110K input tokens' in iteration-2 extra_blocks, got: {warning_texts}"
+        )
+
+    @pytest.mark.anyio
+    async def test_context_pressure_warning_absent_below_threshold(
+        self, tmp_path: Path
+    ) -> None:
+        """Warning is absent on iteration 2 when iteration 1 returned only 50K tokens."""
+        from agentception.services.agent_loop import (
+            _CONTEXT_PRESSURE_THRESHOLD,
+            run_agent_loop,
+        )
+
+        worktree = tmp_path / "test-run-ctx-pressure-below"
+        worktree.mkdir()
+        task_spec = _make_task_spec(worktree)
+
+        # Iteration 1: read_file tool call with input_tokens=50_000 (below threshold).
+        # Iteration 2: stop.
+        first_response: ToolResponse = {
+            **_tool_response("read_file", {"path": "agentception/models.py"}),
+            "input_tokens": 50_000,
+        }
+        all_responses: list[ToolResponse] = [
+            first_response,
+            _stop_response("Done."),
+        ]
+
+        captured_extra: list[list[dict[str, object]] | None] = []
+
+        async def fake_llm(
+            *args: object,
+            extra_system_blocks: list[dict[str, object]] | None = None,
+            **kwargs: object,
+        ) -> ToolResponse:
+            captured_extra.append(extra_system_blocks)
+            return all_responses[len(captured_extra) - 1]
+
+        file_result: dict[str, object] = {
+            "ok": True,
+            "content": "",
+            "truncated": False,
+        }
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
+            patch(
+                "agentception.services.agent_loop.get_run_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic",
+                new_callable=AsyncMock,
+                return_value='{"files": ["agentception/models.py"], "searches": [], "plan": "no-op"}',
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic_with_tools",
+                side_effect=fake_llm,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+            mock_settings.ac_min_turn_delay_secs = 0.0
+
+            from agentception.services import agent_loop as al
+
+            with patch.object(al, "read_file", return_value=file_result):
+                await run_agent_loop("test-run-ctx-pressure-below", max_iterations=10)
+
+        assert len(captured_extra) == 2, (
+            f"Expected 2 LLM calls, got {len(captured_extra)}"
+        )
+
+        # Iteration 2 (index 1) must NOT contain the context-pressure warning.
+        blocks_iter2 = captured_extra[1]
+        if blocks_iter2 is not None:
+            warning_texts = [
+                str(b.get("text", ""))
+                for b in blocks_iter2
+                if isinstance(b, dict)
+            ]
+            assert not any("CONTEXT PRESSURE" in t for t in warning_texts), (
+                f"Context-pressure warning must NOT appear when tokens={50_000} "
+                f"<= threshold={_CONTEXT_PRESSURE_THRESHOLD}. Got: {warning_texts}"
+            )


### PR DESCRIPTION
Closes #886

## What

- Defines `_CONTEXT_PRESSURE_WARNING` module-level constant in `agentception/services/agent_loop.py` immediately after `_FINAL_STRETCH_WARNING`.
- Appends the warning block to `extra_blocks` each turn where `last_input_tokens > _CONTEXT_PRESSURE_THRESHOLD` (100 000), formatting in `tokens_k` and `remaining_k` (clamped to zero via `max(0, ...)`).
- Emits `logger.warning(...)` whenever the block is appended.
- Warning is naturally absent on the first iteration since `last_input_tokens` is initialised to `0` before the loop.

## Tests

Added `TestContextPressureWarning` class to `agentception/tests/test_agent_loop.py`:
- `test_context_pressure_warning_injected_above_threshold` — verifies warning appears in `extra_system_blocks` when `input_tokens=110_000`.
- `test_context_pressure_warning_absent_below_threshold` — verifies warning is absent when `input_tokens=50_000`.