### PR TITLE
fix: fetch origin/dev before creating developer worktree

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -751,6 +751,17 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
             "reviewer" if is_reviewer else "continuation-developer",
         )
     else:
+        # Fetch dev so origin/dev reflects the latest merged PRs before we branch.
+        # Without this the container's ref tracker may lag behind GitHub by one or
+        # more commits, causing the worktree to start from a stale tip and the
+        # agent's push to diverge from origin/dev immediately.
+        _dev_fetch = await asyncio.create_subprocess_exec(
+            "git", "fetch", "origin", "dev",
+            cwd=str(settings.repo_dir),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await _dev_fetch.communicate()
         worktree_base = "origin/dev"
 
     try:


### PR DESCRIPTION
## Summary

- Developer dispatches were creating worktrees from a potentially stale `origin/dev` ref — no `git fetch` was happening before `git worktree add -b feat/issue-N /worktrees/issue-N origin/dev`
- If a PR merged to `dev` between the container's last fetch and the next dispatch, the worktree started one (or more) commits behind the real tip
- The agent's first push then diverged from `origin/dev`, triggering a rebase that was unnecessary and could produce conflicts
- Reviewers and continuation dispatches already fetched before creating their worktrees (lines 718–724); this PR mirrors that pattern for developers

## Fix

In the `else` branch at line 753, run `git fetch origin dev` before setting `worktree_base = "origin/dev"`. No logic change — same one-liner the reviewer path already uses, just for the developer path.

## Test plan
- [x] `mypy agentception/routes/api/dispatch.py` — clean
- [x] `pytest agentception/tests/test_dispatch.py` — 3/3 passed