### PR TITLE
fix: update stale patch paths, add _is_pr_merged mock, document context window management

### DIFF
--- a/agentception/tests/test_get_initiatives.py
+++ b/agentception/tests/test_get_initiatives.py
@@ -84,7 +84,7 @@ async def test_get_initiatives_returns_filed_with_open_issues() -> None:
     phases = _phase_rows([("auth-rewrite", _utc(100))])
     issues = _issue_rows([["auth-rewrite", "auth-rewrite/0-foundation"]])
 
-    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+    with patch("agentception.db.queries.board.get_session", _mock_two_query_session(phases, issues)):
         result = await get_initiatives("owner/repo")
 
     assert result == ["auth-rewrite"]
@@ -97,7 +97,7 @@ async def test_get_initiatives_excludes_when_all_issues_closed() -> None:
     # No open issues with an auth-rewrite/ prefix.
     issues = _issue_rows([])
 
-    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+    with patch("agentception.db.queries.board.get_session", _mock_two_query_session(phases, issues)):
         result = await get_initiatives("owner/repo")
 
     assert result == []
@@ -110,7 +110,7 @@ async def test_get_initiatives_excludes_when_no_scoped_phase_label() -> None:
     # Issue carries the initiative label but no scoped phase label — won't show on board.
     issues = _issue_rows([["auth-rewrite"]])
 
-    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+    with patch("agentception.db.queries.board.get_session", _mock_two_query_session(phases, issues)):
         result = await get_initiatives("owner/repo")
 
     assert result == []
@@ -122,7 +122,7 @@ async def test_get_initiatives_not_in_phases_never_appears() -> None:
     phases = _phase_rows([])  # nothing filed
     issues = _issue_rows([["mystery-initiative", "mystery-initiative/0-first"]])
 
-    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+    with patch("agentception.db.queries.board.get_session", _mock_two_query_session(phases, issues)):
         result = await get_initiatives("owner/repo")
 
     assert result == []
@@ -142,7 +142,7 @@ async def test_get_initiatives_ordered_most_recently_filed_first() -> None:
         ["ac-workflow", "ac-workflow/0-scaffold"],
     ])
 
-    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+    with patch("agentception.db.queries.board.get_session", _mock_two_query_session(phases, issues)):
         result = await get_initiatives("owner/repo")
 
     assert result == ["ac-plan", "ac-build", "ac-workflow"]
@@ -161,7 +161,7 @@ async def test_get_initiatives_mixed_open_and_closed() -> None:
         # ac-done has no open issues (all closed, not in this list).
     ])
 
-    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+    with patch("agentception.db.queries.board.get_session", _mock_two_query_session(phases, issues)):
         result = await get_initiatives("owner/repo")
 
     assert result == ["ac-plan"]
@@ -174,7 +174,7 @@ async def test_get_initiatives_empty_phases_returns_empty() -> None:
     phases = _phase_rows([])
     issues = _issue_rows([["any-label", "any-label/0-phase"]])
 
-    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+    with patch("agentception.db.queries.board.get_session", _mock_two_query_session(phases, issues)):
         result = await get_initiatives("owner/repo")
 
     assert result == []
@@ -187,7 +187,7 @@ async def test_get_initiatives_db_error_returns_empty() -> None:
     ctx_mock.__aenter__ = AsyncMock(side_effect=RuntimeError("DB unavailable"))
     ctx_mock.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("agentception.db.queries.get_session", return_value=ctx_mock):
+    with patch("agentception.db.queries.board.get_session", return_value=ctx_mock):
         result = await get_initiatives("owner/repo")
 
     assert result == []

--- a/agentception/tests/test_mcp_build_commands_pr3.py
+++ b/agentception/tests/test_mcp_build_commands_pr3.py
@@ -361,6 +361,11 @@ async def test_build_complete_run_reviewer_does_not_redispatch_reviewer() -> Non
             "agentception.mcp.build_commands.auto_dispatch_reviewer",
             new_callable=AsyncMock,
         ) as mock_dispatch,
+        patch(
+            "agentception.mcp.build_commands._is_pr_merged",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
         patch("asyncio.create_task"),
     ):
         result = await call_tool_async(

--- a/agentception/tests/test_persist_regression.py
+++ b/agentception/tests/test_persist_regression.py
@@ -194,7 +194,7 @@ async def test_get_initiatives_excludes_closed() -> None:
     # "mcp-audit-remediation/0-foundation" — all issues are closed.
     issues = _issue_rows([])
 
-    with patch("agentception.db.queries.get_session", _mock_two_query_session(phases, issues)):
+    with patch("agentception.db.queries.board.get_session", _mock_two_query_session(phases, issues)):
         result = await get_initiatives("owner/repo")
 
     assert result == [], (

--- a/agentception/tests/test_phase_grouping.py
+++ b/agentception/tests/test_phase_grouping.py
@@ -69,8 +69,8 @@ async def test_db_canonical_order_respected() -> None:
     ]
 
     with (
-        patch("agentception.db.queries.get_session") as mock_get_session,
-        patch("agentception.db.queries.get_initiative_phase_meta", new_callable=AsyncMock, return_value=meta),
+        patch("agentception.db.queries.board.get_session") as mock_get_session,
+        patch("agentception.db.queries.board.get_initiative_phase_meta", new_callable=AsyncMock, return_value=meta),
     ):
         mock_get_session.return_value = _mock_session(rows)
         groups = await get_issues_grouped_by_phase("owner/repo", initiative=initiative)
@@ -100,8 +100,8 @@ async def test_db_canonical_order_dep_graph_used_for_locking() -> None:
     ]
 
     with (
-        patch("agentception.db.queries.get_session") as mock_get_session,
-        patch("agentception.db.queries.get_initiative_phase_meta", new_callable=AsyncMock, return_value=meta),
+        patch("agentception.db.queries.board.get_session") as mock_get_session,
+        patch("agentception.db.queries.board.get_initiative_phase_meta", new_callable=AsyncMock, return_value=meta),
     ):
         mock_get_session.return_value = _mock_session(rows)
         groups = await get_issues_grouped_by_phase("owner/repo", initiative=initiative)
@@ -131,8 +131,8 @@ async def test_db_canonical_order_unlocks_when_dep_complete() -> None:
     ]
 
     with (
-        patch("agentception.db.queries.get_session") as mock_get_session,
-        patch("agentception.db.queries.get_initiative_phase_meta", new_callable=AsyncMock, return_value=meta),
+        patch("agentception.db.queries.board.get_session") as mock_get_session,
+        patch("agentception.db.queries.board.get_initiative_phase_meta", new_callable=AsyncMock, return_value=meta),
     ):
         mock_get_session.return_value = _mock_session(rows)
         groups = await get_issues_grouped_by_phase("owner/repo", initiative=initiative)
@@ -163,8 +163,8 @@ async def test_legacy_sort_used_when_no_db_rows() -> None:
     ]
 
     with (
-        patch("agentception.db.queries.get_session") as mock_get_session,
-        patch("agentception.db.queries.get_initiative_phase_meta", new_callable=AsyncMock, return_value=[]),
+        patch("agentception.db.queries.board.get_session") as mock_get_session,
+        patch("agentception.db.queries.board.get_initiative_phase_meta", new_callable=AsyncMock, return_value=[]),
     ):
         mock_get_session.return_value = _mock_session(rows)
         groups = await get_issues_grouped_by_phase("owner/repo", initiative=initiative)
@@ -188,8 +188,8 @@ async def test_legacy_sort_all_phases_unlocked_when_no_db_deps() -> None:
     ]
 
     with (
-        patch("agentception.db.queries.get_session") as mock_get_session,
-        patch("agentception.db.queries.get_initiative_phase_meta", new_callable=AsyncMock, return_value=[]),
+        patch("agentception.db.queries.board.get_session") as mock_get_session,
+        patch("agentception.db.queries.board.get_initiative_phase_meta", new_callable=AsyncMock, return_value=[]),
     ):
         mock_get_session.return_value = _mock_session(rows)
         groups = await get_issues_grouped_by_phase("owner/repo", initiative=initiative)
@@ -206,8 +206,8 @@ async def test_legacy_sort_all_phases_unlocked_when_no_db_deps() -> None:
 async def test_empty_state_returns_empty_list() -> None:
     """No issues and no DB rows → empty list, no phantom phase rows."""
     with (
-        patch("agentception.db.queries.get_session") as mock_get_session,
-        patch("agentception.db.queries.get_initiative_phase_meta", new_callable=AsyncMock, return_value=[]),
+        patch("agentception.db.queries.board.get_session") as mock_get_session,
+        patch("agentception.db.queries.board.get_initiative_phase_meta", new_callable=AsyncMock, return_value=[]),
     ):
         mock_get_session.return_value = _mock_session([])
         groups = await get_issues_grouped_by_phase("owner/repo", initiative="ac-new")
@@ -231,9 +231,9 @@ async def test_explicit_phase_order_arg_overrides_db() -> None:
     ]
 
     with (
-        patch("agentception.db.queries.get_session") as mock_get_session,
+        patch("agentception.db.queries.board.get_session") as mock_get_session,
         # get_initiative_phase_meta should NOT be called when phase_order is given
-        patch("agentception.db.queries.get_initiative_phase_meta", new_callable=AsyncMock, return_value=[]) as mock_meta,
+        patch("agentception.db.queries.board.get_initiative_phase_meta", new_callable=AsyncMock, return_value=[]) as mock_meta,
     ):
         mock_get_session.return_value = _mock_session(rows)
         groups = await get_issues_grouped_by_phase(
@@ -261,8 +261,8 @@ async def test_no_initiative_does_not_call_meta_and_needs_explicit_order() -> No
     rows = [_make_issue(1, "ac-x", "ac-x/0-base")]
 
     with (
-        patch("agentception.db.queries.get_session") as mock_get_session,
-        patch("agentception.db.queries.get_initiative_phase_meta", new_callable=AsyncMock) as mock_meta,
+        patch("agentception.db.queries.board.get_session") as mock_get_session,
+        patch("agentception.db.queries.board.get_initiative_phase_meta", new_callable=AsyncMock) as mock_meta,
     ):
         mock_get_session.return_value = _mock_session(rows)
         groups = await get_issues_grouped_by_phase("owner/repo", initiative=None)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -308,6 +308,18 @@ parallel-agent conflict-reduction reason as the query submodules.
 
 ---
 
+## Context window management
+
+Five mechanisms in `agentception/services/agent_loop.py` keep the context window from overflowing:
+
+1. **Per-turn token logging** — `last_input_tokens` is captured from each `call_anthropic_with_tools` response and logged at INFO level with iteration number, input tokens, output tokens, and cache hit count (line ∼705).
+2. **Token-aware history pruning** — `_prune_history()` applies a message-count guard (`_MAX_HISTORY_MESSAGES = 20`), then when `last_input_tokens > _MAX_INPUT_TOKEN_ESTIMATE` (140 000), runs a character-heuristic loop that drops messages from index 1 until the estimate falls below the threshold, always keeping `messages[0]` (task briefing) and the last `_HISTORY_TAIL = 14` messages.
+3. **Context pressure warning** — when `last_input_tokens > _CONTEXT_PRESSURE_THRESHOLD` (100 000), `_CONTEXT_PRESSURE_WARNING` is injected into `extra_blocks` each turn, advising targeted reads and `replace_in_file` and reporting the remaining context budget.
+4. **Context checkpoint summarisation** — when the token-budget loop drops more than 4 messages, `_summarise_history()` (async, max 1 000 tokens) compresses the dropped messages into a `[Context checkpoint]` user message inserted at index 1, preserving a compressed record of prior work.
+5. **Stop-reason=length recovery** — when the API returns `stop_reason="length"`, a one-sentence continuation hint is injected so the agent can resume without losing the current task context.
+
+---
+
 ## Further Reading
 
 - [Plan Spec format](plan-spec.md)


### PR DESCRIPTION
Closes #888

## What changed

### Test fixes
- **`test_phase_grouping.py`** — all 8 `get_session` / `get_initiative_phase_meta` patches updated from `agentception.db.queries.*` to `agentception.db.queries.board.*` (post-#876 module split)
- **`test_get_initiatives.py`** — same patch path fix for all 8 `get_session` patches
- **`test_persist_regression.py`** — same patch path fix for `get_session`
- **`test_mcp_build_commands_pr3.py`** — added `_is_pr_merged` mock (returning `True`) to `test_build_complete_run_reviewer_does_not_redispatch_reviewer` so it no longer makes a live GitHub API call

### Docs
- Added `## Context window management` section to `docs/architecture.md` documenting the five mechanisms in `agent_loop.py`: per-turn token logging, token-aware history pruning, context pressure warning, context checkpoint summarisation, and stop-reason=length recovery

## Verification
- `mypy --follow-imports=silent` on all 4 modified test files: ✅ zero errors
- `pytest` on all 4 test files: ✅ 42/42 passed