### PR TITLE
feat: add prompt_variant to ACAgentRun, AgentTaskSpec, and Alembic migration 0011

### DIFF
--- a/agentception/alembic/versions/0011_add_prompt_variant.py
+++ b/agentception/alembic/versions/0011_add_prompt_variant.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Add prompt_variant column to agent_runs for A/B prompt testing."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_runs",
+        sa.Column("prompt_variant", sa.String(64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_runs", "prompt_variant")

--- a/agentception/db/models.py
+++ b/agentception/db/models.py
@@ -177,6 +177,9 @@ class ACAgentRun(Base):
     total_cache_read_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
     """Cumulative tokens read from Anthropic's prompt cache (Turns 2-N)."""
 
+    prompt_variant: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    """Prompt variant tag for A/B testing (e.g. ``streamlined``). NULL = control."""
+
     spawned_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )

--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -1038,6 +1038,7 @@ async def persist_agent_run_dispatch(
     coord_fingerprint: str | None = None,
     task_description: str | None = None,
     pr_number: int | None = None,
+    prompt_variant: str | None = None,
 ) -> None:
     """Insert an ``ACAgentRun`` row with status ``pending_launch`` at dispatch time.
 
@@ -1123,6 +1124,7 @@ async def persist_agent_run_dispatch(
                         is_resumed=is_resumed,
                         coord_fingerprint=coord_fingerprint,
                         task_description=task_description,
+                        prompt_variant=prompt_variant,
                         spawned_at=_now(),
                         last_activity_at=_now(),
                     )

--- a/agentception/models/__init__.py
+++ b/agentception/models/__init__.py
@@ -328,6 +328,8 @@ class AgentTaskSpec(BaseModel):
     # Ad-hoc runs
     task_description: str | None = None
     """Inline task description for ad-hoc runs (POST /api/runs/adhoc)."""
+    prompt_variant: str | None = None
+    """Prompt variant tag for A/B testing. None = control/default."""
     # Planning pipeline — coordinator/conductor extended fields
     draft_id: str | None = None
     output_path: str | None = None

--- a/agentception/tests/test_prompt_variant_model.py
+++ b/agentception/tests/test_prompt_variant_model.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Tests for prompt_variant field on AgentTaskSpec and ACAgentRun."""
+
+import pytest
+
+from agentception.models import AgentTaskSpec
+from agentception.db.models import ACAgentRun
+
+
+@pytest.mark.anyio
+async def test_prompt_variant_defaults_none() -> None:
+    task = AgentTaskSpec()
+    assert task.prompt_variant is None
+
+
+@pytest.mark.anyio
+async def test_prompt_variant_stored_on_model() -> None:
+    """ACAgentRun accepts prompt_variant and stores it without error."""
+    run = ACAgentRun()
+    run.prompt_variant = "streamlined"
+    assert run.prompt_variant == "streamlined"
+
+
+@pytest.mark.anyio
+async def test_prompt_variant_none_when_not_set() -> None:
+    """ACAgentRun prompt_variant is None when not assigned."""
+    run = ACAgentRun()
+    assert run.prompt_variant is None


### PR DESCRIPTION
Closes #889

## What

- Adds `prompt_variant: Mapped[str | None]` column (`VARCHAR(64) NULL`) to `ACAgentRun` ORM model
- Adds `prompt_variant: str | None = None` field to `AgentTaskSpec` Pydantic model
- Creates Alembic migration `0011_add_prompt_variant.py` (reversible `add_column` / `drop_column`)
- Threads `prompt_variant` kwarg through `persist_agent_run_dispatch` — existing call sites in `dispatch.py` are untouched (default `None`)
- Adds `agentception/tests/test_prompt_variant_model.py` with 3 tests covering the new field

## Why

All developer runs share a single prompt template. Without a variant tag on the run row, cross-variant A/B comparisons are impossible. This change adds the storage layer; variant-aware file loading and metrics queries are out of scope.

## Verification

- mypy: 0 errors on all 3 modified source files
- pytest: 9/9 pass (`test_prompt_variant_model.py` + `test_persist.py`)