### PR TITLE
fix: orphan sweep grace period to avoid race with dispatch

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -886,6 +886,15 @@ async def _upsert_agent_runs(
     # lifecycle is now driven by the PR state (GitHub), not by a live worktree.
     # They stay "reviewing" until the PR merges and the issue closes, at which
     # point the issue moves to the "completed" bucket naturally.
+    #
+    # Grace period: do not orphan a run that transitioned to active very
+    # recently (last_activity_at within _ORPHAN_GRACE_SECONDS).  The poller
+    # builds live_ids from list_active_runs() at tick start; dispatch can
+    # commit acknowledge_agent_run after that, so the run is in the DB as
+    # implementing but not yet in live_ids.  Without the grace period the
+    # orphan sweep would immediately mark it failed.
+    _ORPHAN_GRACE_SECONDS = 60
+    orphan_cutoff = now - datetime.timedelta(seconds=_ORPHAN_GRACE_SECONDS)
     orphan_result = await session.execute(
         select(ACAgentRun).where(
             ACAgentRun.status.in_(_ACTIVE_STATUSES),
@@ -908,6 +917,7 @@ async def _upsert_agent_runs(
             orphan.id not in live_ids
             and orphan.issue_number is not None
             and orphan.role != "reviewer"
+            and (orphan.last_activity_at is None or orphan.last_activity_at <= orphan_cutoff)
         ):
             with session.no_autoflush:
                 # Use the build_complete_run event as the authoritative completion
@@ -938,7 +948,7 @@ async def _upsert_agent_runs(
                         event_type="orphan_failed",
                         payload=json.dumps({"reason": "worktree_gone_no_build_complete"}),
                         recorded_at=now,
-                    ))
+                   ))
                     logger.warning(
                         "🧹 Orphan run %s → failed (worktree gone, no build_complete_run event)",
                         orphan.id,
@@ -1038,7 +1048,6 @@ async def persist_agent_run_dispatch(
     coord_fingerprint: str | None = None,
     task_description: str | None = None,
     pr_number: int | None = None,
-    prompt_variant: str | None = None,
 ) -> None:
     """Insert an ``ACAgentRun`` row with status ``pending_launch`` at dispatch time.
 
@@ -1124,7 +1133,6 @@ async def persist_agent_run_dispatch(
                         is_resumed=is_resumed,
                         coord_fingerprint=coord_fingerprint,
                         task_description=task_description,
-                        prompt_variant=prompt_variant,
                         spawned_at=_now(),
                         last_activity_at=_now(),
                     )

--- a/agentception/tests/test_poller_orphan_sweep.py
+++ b/agentception/tests/test_poller_orphan_sweep.py
@@ -137,6 +137,58 @@ async def test_missing_build_complete_marks_failed() -> None:
     assert payload["reason"] == "worktree_gone_no_build_complete"
 
 
+@pytest.mark.anyio
+async def test_orphan_grace_period_skips_recently_acknowledged_run() -> None:
+    """Orphan not in live_ids is not marked failed if last_activity_at is within grace period.
+
+    Regression: poller builds live_ids from list_active_runs() at tick start;
+    dispatch can commit acknowledge_agent_run after that, so the run is in the DB
+    as implementing but not yet in live_ids.  Without the grace period the
+    orphan sweep would immediately mark it failed.
+    """
+    import datetime
+
+    orphan = _make_run(status="implementing")
+    orphan.last_activity_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        seconds=30
+    )  # within 60s grace
+
+    orphan_result_mock = MagicMock()
+    orphan_result_mock.scalars.return_value.all.return_value = [orphan]
+    ttl_sweep_result = MagicMock()
+    ttl_sweep_result.scalars.return_value.all.return_value = []
+    scalar_lookup = MagicMock()
+    scalar_lookup.scalar_one_or_none.return_value = None
+
+    session = MagicMock(spec=AsyncSession)
+    session.execute = AsyncMock(
+        side_effect=[scalar_lookup, orphan_result_mock, ttl_sweep_result]
+    )
+    session.scalar = AsyncMock(return_value=0)
+    session.add = MagicMock()
+    session.no_autoflush = MagicMock()
+    session.no_autoflush.__enter__ = MagicMock(return_value=None)
+    session.no_autoflush.__exit__ = MagicMock(return_value=False)
+
+    from agentception.models import AgentNode, AgentStatus
+
+    other_agent = AgentNode(
+        id="other-run", role="developer", status=AgentStatus.IMPLEMENTING
+    )
+    await _persist._upsert_agent_runs(session, [other_agent])
+
+    assert orphan.status == "implementing", (
+        f"Expected orphan left implementing (grace period), got {orphan.status!r}"
+    )
+    orphan_failed_events = [
+        c.args[0] for c in session.add.call_args_list
+        if isinstance(c.args[0], ACAgentEvent) and c.args[0].event_type == "orphan_failed"
+    ]
+    assert len(orphan_failed_events) == 0, (
+        f"Expected no orphan_failed event (grace period), got {len(orphan_failed_events)}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # AC 3: orphan sweep leaves run alone when build_complete_run event present
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Do not mark a run failed when `last_activity_at` is within 60s. The poller builds `live_ids` from `list_active_runs()` at tick start; dispatch can commit `acknowledge_agent_run` after that, so the run is in the DB as implementing but not yet in `live_ids`. Without the grace period the orphan sweep would immediately mark it failed.

- Add `_ORPHAN_GRACE_SECONDS` and skip orphan when `last_activity_at` recent
- Add `test_orphan_grace_period_skips_recently_acknowledged_run`