### PR TITLE
fix: clear worktree_path in DB after reaper releases worktree

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -1370,6 +1370,24 @@ async def update_agent_status(run_id: str, status: str) -> bool:
         return False
 
 
+async def clear_run_worktree_path(run_id: str) -> bool:
+    """Set worktree_path to None for *run_id* so the reaper stops re-finding it.
+
+    Called by the worktree reaper after successfully releasing a worktree dir.
+    Returns True on success, False if run not found or DB error.
+    """
+    try:
+        async with get_session() as session:
+            await session.execute(
+                update(ACAgentRun).where(ACAgentRun.id == run_id).values(worktree_path=None)
+            )
+            await session.commit()
+        return True
+    except Exception as exc:
+        logger.warning("⚠️  clear_run_worktree_path failed for %s: %s", run_id, exc)
+        return False
+
+
 async def accumulate_token_usage(
     run_id: str,
     input_tokens: int,

--- a/agentception/services/teardown.py
+++ b/agentception/services/teardown.py
@@ -21,7 +21,7 @@ from agentception.services.run_factory import _WORKTREE_COLLECTION_PREFIX
 logger = logging.getLogger(__name__)
 
 
-async def release_worktree(worktree_path: str, repo_dir: str) -> None:
+async def release_worktree(worktree_path: str, repo_dir: str) -> bool:
     """Remove the worktree directory and prune stale refs — branches untouched.
 
     Used by :func:`build_complete_run` immediately before dispatching the PR
@@ -31,6 +31,9 @@ async def release_worktree(worktree_path: str, repo_dir: str) -> None:
     here because the open PR still references the remote branch.
 
     Safe to call even if the worktree dir no longer exists (idempotent).
+
+    Returns True if the worktree was removed or was already gone; False if
+    ``git worktree remove`` failed (caller may retry or clear DB anyway).
     """
     repo = repo_dir
     if Path(worktree_path).exists():
@@ -47,6 +50,13 @@ async def release_worktree(worktree_path: str, repo_dir: str) -> None:
                 "⚠️  release_worktree: worktree remove failed: %s",
                 stderr.decode().strip(),
             )
+            prune_proc = await asyncio.create_subprocess_exec(
+                "git", "-C", repo, "worktree", "prune",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await prune_proc.communicate()
+            return False
     else:
         logger.info("ℹ️  release_worktree: %s already gone — skipping", worktree_path)
 
@@ -56,6 +66,7 @@ async def release_worktree(worktree_path: str, repo_dir: str) -> None:
         stderr=asyncio.subprocess.PIPE,
     )
     await prune_proc.communicate()
+    return True  # removed or already gone
 
 
 async def teardown_agent_worktree(run_id: str) -> None:

--- a/agentception/services/worktree_reaper.py
+++ b/agentception/services/worktree_reaper.py
@@ -24,6 +24,7 @@ import logging
 from pathlib import Path
 
 from agentception.config import settings
+from agentception.db.persist import clear_run_worktree_path
 from agentception.db.queries import get_terminal_runs_with_worktrees
 from agentception.services.teardown import release_worktree
 
@@ -58,8 +59,9 @@ async def reap_stale_worktrees() -> int:
             run["id"],
             worktree_path,
         )
-        await release_worktree(worktree_path=worktree_path, repo_dir=repo_dir)
-        reaped += 1
+        if await release_worktree(worktree_path=worktree_path, repo_dir=repo_dir):
+            await clear_run_worktree_path(run["id"])
+            reaped += 1
 
     if reaped:
         logger.info("✅ worktree reaper: released %d stale worktree dir(s)", reaped)

--- a/agentception/tests/test_worktree_reaper.py
+++ b/agentception/tests/test_worktree_reaper.py
@@ -142,3 +142,73 @@ async def test_reaper_counts_multiple_released_dirs(tmp_path: Path) -> None:
 
     assert count == 2
     assert mock_release.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_reaper_clears_db_only_when_release_succeeds(tmp_path: Path) -> None:
+    """Reaper clears worktree_path in DB only after release_worktree returns True."""
+    fake_worktree = tmp_path / "issue-101"
+    fake_worktree.mkdir()
+
+    with (
+        patch(
+            "agentception.services.worktree_reaper.get_terminal_runs_with_worktrees",
+            new_callable=AsyncMock,
+            return_value=[{"id": "issue-101", "worktree_path": str(fake_worktree), "branch": "feat/issue-101"}],
+        ),
+        patch(
+            "agentception.services.worktree_reaper.release_worktree",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.services.worktree_reaper.clear_run_worktree_path",
+            new_callable=AsyncMock,
+        ) as mock_clear,
+        patch(
+            "agentception.services.worktree_reaper.settings",
+            new_callable=MagicMock,
+            repo_dir="/app",
+        ),
+    ):
+        from agentception.services.worktree_reaper import reap_stale_worktrees
+
+        count = await reap_stale_worktrees()
+
+    assert count == 1
+    mock_clear.assert_awaited_once_with("issue-101")
+
+
+@pytest.mark.anyio
+async def test_reaper_does_not_clear_db_when_release_fails(tmp_path: Path) -> None:
+    """Reaper does not clear worktree_path when release_worktree returns False."""
+    fake_worktree = tmp_path / "issue-102"
+    fake_worktree.mkdir()
+
+    with (
+        patch(
+            "agentception.services.worktree_reaper.get_terminal_runs_with_worktrees",
+            new_callable=AsyncMock,
+            return_value=[{"id": "issue-102", "worktree_path": str(fake_worktree), "branch": "feat/issue-102"}],
+        ),
+        patch(
+            "agentception.services.worktree_reaper.release_worktree",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "agentception.services.worktree_reaper.clear_run_worktree_path",
+            new_callable=AsyncMock,
+        ) as mock_clear,
+        patch(
+            "agentception.services.worktree_reaper.settings",
+            new_callable=MagicMock,
+            repo_dir="/app",
+        ),
+    ):
+        from agentception.services.worktree_reaper import reap_stale_worktrees
+
+        count = await reap_stale_worktrees()
+
+    assert count == 0
+    mock_clear.assert_not_called()


### PR DESCRIPTION
Reaper was re-finding the same terminal runs every pass because we never cleared worktree_path after release_worktree(). Now we call clear_run_worktree_path(run_id) only when release_worktree returns True. release_worktree now returns bool for success/failure.