### PR TITLE
feat: agent_loop path/lines + search_text logging, watch_run display, block grep in run_command

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -2170,8 +2170,7 @@ async def _dispatch_single_tool(
     except json.JSONDecodeError as exc:
         return {"ok": False, "error": f"Invalid tool arguments (JSON parse error): {exc}"}
 
-    # Log tool name + the single most useful arg so watch_run.py can show
-    # what was searched / read / written without needing a second log line.
+    # Log tool name + useful args so watch_run.py can show what was read/searched/written.
     _KEY_ARG: dict[str, str] = {
         "search_codebase": "query",
         "search_text": "pattern",
@@ -2184,7 +2183,18 @@ async def _dispatch_single_tool(
     }
     _key = _KEY_ARG.get(name)
     _val = args.get(_key) if _key else None
-    _arg_tag = f" {_key}={str(_val)!r}" if isinstance(_val, str) else ""
+    if name == "read_file_lines" and isinstance(_val, str):
+        start = args.get("start_line")
+        end = args.get("end_line")
+        if start is not None and end is not None:
+            _arg_tag = f" path={_val!r} lines={start}-{end}"
+        else:
+            _arg_tag = f" path={_val!r}"
+    elif name == "search_text" and isinstance(_val, str):
+        directory = args.get("directory", ".")
+        _arg_tag = f" pattern={_val!r} directory={directory!r}"
+    else:
+        _arg_tag = f" {_key}={str(_val)!r}" if isinstance(_val, str) else ""
     logger.info("✅ dispatch_tool — run_id=%s tool=%s%s", run_id, name, _arg_tag)
 
     if name in _LOCAL_TOOL_NAMES:

--- a/agentception/tests/test_shell_tools.py
+++ b/agentception/tests/test_shell_tools.py
@@ -179,6 +179,16 @@ class TestRunCommand:
         assert "blocked" in str(result["error"]).lower()
 
     @pytest.mark.anyio
+    async def test_grep_blocked_use_search_text(self, tmp_path: Path) -> None:
+        """grep via run_command is blocked; agent must use search_text (ripgrep)."""
+        result = await run_command("grep -n foo .", tmp_path)
+        assert result["ok"] is False
+        assert "search_text" in str(result["error"])
+        result_pipe = await run_command("cat file | grep bar", tmp_path)
+        assert result_pipe["ok"] is False
+        assert "search_text" in str(result_pipe["error"])
+
+    @pytest.mark.anyio
     async def test_cwd_defaults_to_none(self) -> None:
         result = await run_command("echo cwd_test")
         assert result["ok"] is True

--- a/agentception/tools/shell_tools.py
+++ b/agentception/tools/shell_tools.py
@@ -99,6 +99,16 @@ _MYPY_OOM_ERROR = (
     "Only list the files YOU modified — not entire directories."
 )
 
+# Commands that run grep (direct or in a pipeline). Blocked so the agent uses
+# the search_text tool (ripgrep) instead — structured output and .gitignore-aware.
+_GREP_CMD_RE: re.Pattern[str] = re.compile(r"(^|\|)\s*grep\b", re.IGNORECASE)
+
+_GREP_BLOCKED_MESSAGE = (
+    "run_command(grep) is not allowed. Use the search_text tool instead: "
+    "it uses ripgrep, respects .gitignore, and returns file names and line numbers. "
+    "Call search_text(pattern=..., directory=...) for codebase search."
+)
+
 
 def _check_oom_risk(command: str) -> tuple[bool, str]:
     """Return *(safe, reason)* for commands that are not destructive but are
@@ -151,6 +161,10 @@ async def run_command(
     if not safe:
         logger.warning("⚠️ run_command blocked — %s", reason)
         return {"ok": False, "error": reason}
+
+    if _GREP_CMD_RE.search(command.strip()):
+        logger.warning("⚠️ run_command blocked — grep; use search_text")
+        return {"ok": False, "error": _GREP_BLOCKED_MESSAGE}
 
     cwd_path = Path(cwd) if cwd else None
     logger.info("✅ run_command — %s (cwd=%s)", shlex.quote(command), cwd_path)

--- a/scripts/watch_run.py
+++ b/scripts/watch_run.py
@@ -46,10 +46,13 @@ _RE_RUN_STEP = re.compile(
 _RE_ITERATION = re.compile(r"Step\s+(?P<n>\d+)")
 
 # dispatch_tool — run_id tag (agent_loop.py)
-# Optional trailing: key='value' (e.g. query='…', path='…', pattern='…')
+# Optional trailing: key=value pairs (path='…', lines=1-50, pattern='…', directory='…')
 _RE_DISPATCH_TOOL = re.compile(
-    r"dispatch_tool — run_id=(?P<run_id>\S+) tool=(?P<tool>\S+)"
-    r"(?:\s+\S+=(?P<arg>'[^']*'|\"[^\"]*\"|[^'\"\s]+))?"
+    r"dispatch_tool — run_id=(?P<run_id>\S+) tool=(?P<tool>\S+)(?P<args_suffix>.*)"
+)
+# Parse key=value from args_suffix; value may be quoted or unquoted.
+_RE_DISPATCH_ARG = re.compile(
+    r"\s+(\w+)=(?:'([^']*)'|\"([^\"]*)\"|(\S+))"
 )
 
 # file_tools result lines (agentception.tools.file_tools)
@@ -273,25 +276,55 @@ def process_line(raw: str, run_id_filter: str | None) -> str | None:
         _last_run_id[0] = rid
         st = _get_state(rid)
         tool_name = dtm.group("tool")
-        raw_arg = dtm.group("arg") or ""
-        arg_val = raw_arg.strip("'\"") if raw_arg else ""
-        if len(arg_val) > 90:
-            arg_val = arg_val[:90] + "…"
-        arg_suffix = f"  {GREY}{arg_val}{RESET}" if arg_val else ""
+        args_suffix = dtm.group("args_suffix") or ""
+        # Parse key=value pairs from args_suffix for rich display.
+        parsed: dict[str, str] = {}
+        for m in _RE_DISPATCH_ARG.finditer(args_suffix):
+            key = m.group(1)
+            val = m.group(2) or m.group(3) or m.group(4) or ""
+            parsed[key] = val
         tag = _run_tag(rid, run_id_filter)
 
         if tool_name in _RESULT_LINE_TOOLS:
-            st.pending_arg = arg_val
+            st.pending_arg = parsed.get("path", "")
+            if tool_name == "read_file_lines":
+                path = parsed.get("path", "")
+                lines = parsed.get("lines", "")
+                if path or lines:
+                    path_short = _shorten_path(path) if path else "?"
+                    line_info = f"  {GREY}lines {lines}{RESET}" if lines else ""
+                    return (
+                        f"{ts}  {tag}{BLUE}{_tool_icon('read_file_lines')} read{RESET}  "
+                        f"{WHITE}{path_short}{RESET}{line_info}"
+                    )
             return None
         if tool_name in _DISPATCH_ONLY_TOOLS:
-            path = _shorten_path(arg_val) if arg_val else tool_name
-            return f"{ts}  {tag}{BLUE}{_tool_icon('read_file_lines')} read{RESET}  {WHITE}{path}{RESET}"
+            path = parsed.get("path", "")
+            path_short = _shorten_path(path) if path else tool_name
+            return f"{ts}  {tag}{BLUE}{_tool_icon('read_file_lines')} read{RESET}  {WHITE}{path_short}{RESET}"
         if tool_name in ("search_codebase", "search_text"):
-            return f"{ts}  {tag}{BLUE}🔍 {tool_name}{RESET}{arg_suffix}"
+            pattern = parsed.get("pattern") or parsed.get("query", "")
+            directory = parsed.get("directory", "")
+            if len(pattern) > 60:
+                pattern = pattern[:60] + "…"
+            parts = [f"{ts}  {tag}{BLUE}🔍 {tool_name}{RESET}"]
+            if pattern:
+                parts.append(f"  {GREY}pattern={pattern!r}{RESET}")
+            if directory and directory != ".":
+                parts.append(f"  {GREY}dir={directory}{RESET}")
+            return "".join(parts)
         if tool_name in ("log_run_step", "git_commit_and_push", "run_command"):
             return None  # rendered via dedicated patterns below
         if any(gh in tool_name for gh in ("pull_request", "issue_", "create_branch", "list_branch", "get_me", "search_")):
+            arg_val = parsed.get("path") or parsed.get("query", "") or ""
+            if len(arg_val) > 90:
+                arg_val = arg_val[:90] + "…"
+            arg_suffix = f"  {GREY}{arg_val}{RESET}" if arg_val else ""
             return f"{ts}  {tag}{CYAN}🐙 {tool_name}{RESET}{arg_suffix}"
+        arg_val = parsed.get("path") or parsed.get("query", "") or ""
+        if len(arg_val) > 90:
+            arg_val = arg_val[:90] + "…"
+        arg_suffix = f"  {GREY}{arg_val}{RESET}" if arg_val else ""
         return f"{ts}  {tag}{BLUE}{_tool_icon(tool_name)} {tool_name}{RESET}{arg_suffix}"
 
     # ── file_tools result lines ────────────────────────────────────────────────
@@ -619,6 +652,10 @@ def main() -> None:
                     elif (mr := _RE_LLM_RETRY.search(line)):
                         s.last_llm_call_ts = now
                         s.llm_retry_count = int(mr.group("n"))
+                    # Run failed (LLM error, cancel, etc.) — stop heartbeat "waiting" for this run.
+                    elif "log_run_error" in line or "agent_loop LLM error" in line:
+                        s.last_llm_call_ts = 0.0
+                        s.llm_retry_count = 0
                 print(out, flush=True)
     except KeyboardInterrupt:
         print(f"\n{GREY}stopped.{RESET}", flush=True)


### PR DESCRIPTION
- agent_loop: log path + line range for read_file_lines, pattern + directory for search_text
- watch_run: parse dispatch_tool args and show read path lines X–Y and search_text pattern/dir
- shell_tools: block run_command(grep), direct agent to search_text (ripgrep, .gitignore-aware)
- test_shell_tools: test_grep_blocked_use_search_text