### PR TITLE
fix: preemptive nudge before loop guard; only dispatch reviewer after worktree release

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -386,6 +386,7 @@ async def build_complete_run(
         # fail with "already used by worktree at …".  We only remove the
         # worktree directory and prune refs — branches are left intact because
         # the open PR still references the remote branch.
+        worktree_released = True
         if agent_run_id:
             teardown_info = await get_agent_run_teardown(agent_run_id)
             wt_path = teardown_info.get("worktree_path") if teardown_info else None
@@ -395,16 +396,30 @@ async def build_complete_run(
                 if rebase_error is not None:
                     return rebase_error
 
-                await release_worktree(
+                worktree_released = await release_worktree(
                     worktree_path=wt_path,
                     repo_dir=str(settings.repo_dir),
                 )
+                if not worktree_released:
+                    logger.warning(
+                        "⚠️ build_complete_run: worktree release failed for run_id=%r — "
+                        "reviewer not dispatched (would fail with branch already in use)",
+                        agent_run_id,
+                    )
+                    return {
+                        "ok": False,
+                        "error": (
+                            "Worktree release failed; reviewer was not dispatched. "
+                            "The PR is open. Retry build_complete_run after the worktree is released, "
+                            "or an operator can run release_worktree and dispatch the reviewer manually."
+                        ),
+                    }
 
-        # Fire-and-forget: reviewer failure never affects the implementer's result.
-        asyncio.create_task(
-            auto_dispatch_reviewer(issue_number=issue_number, pr_url=pr_url),
-            name=f"auto-reviewer-{issue_number}",
-        )
+        if worktree_released:
+            asyncio.create_task(
+                auto_dispatch_reviewer(issue_number=issue_number, pr_url=pr_url),
+                name=f"auto-reviewer-{issue_number}",
+            )
 
     return {"ok": True, "event": "done", "status": "completed"}
 

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -289,6 +289,19 @@ using write_file or replace_in_file. If the symbol does not exist, create it —
 absence is the task, not a blocker. Writing resets this guard.
 """
 
+# Injected one turn before the loop guard fires. Tells the model to call a write
+# tool in this response instead of saying "I will write" and calling read again.
+# Do not include "LOOP GUARD" here so tests that assert "LOOP GUARD" not in
+# extra_blocks (when a write resets the counter) still pass.
+_LOOP_GUARD_PREEMPTIVE_NUDGE = """\
+⚠️  ONE TURN BEFORE READ-ONLY LOCK — read/search tools lock after this response
+
+You have not written code for several turns. If you have enough context to implement,
+call write_file, replace_in_file, or insert_after_in_file in this response.
+Do not output that you will write and then call read_file or search again — that
+will be rejected on the next turn. Issue a write tool call now.
+"""
+
 # Injected every turn (via extra_blocks) once any file has been written.
 # Lives outside the prunable history window so the agent always knows which
 # files it has already modified, even after the middle of history is dropped.
@@ -642,6 +655,18 @@ async def run_agent_loop(
         )
         # Always pass the full (constant) tool list so the cache key is stable.
         active_tool_defs: list[ToolDefinition] = tool_defs
+        # One turn before guard fires: nudge the model to call a write tool in this response.
+        if (
+            loop_guard_enabled
+            and not guard_active
+            and iteration > 0
+            and iterations_since_write == loop_guard_threshold - 1
+        ):
+            extra_blocks.append({"type": "text", "text": _LOOP_GUARD_PREEMPTIVE_NUDGE})
+            logger.info(
+                "ℹ️ loop_guard preemptive nudge — run_id=%s iteration=%d iterations_since_write=%d",
+                run_id, iteration, iterations_since_write,
+            )
         if guard_active:
             override_text = _LOOP_GUARD_OVERRIDE.format(n=iterations_since_write)
             extra_blocks.append({"type": "text", "text": override_text})

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -1098,6 +1098,111 @@ class TestLoopGuard:
             )
 
     @pytest.mark.anyio
+    async def test_preemptive_nudge_injected_one_turn_before_loop_guard(
+        self, tmp_path: Path
+    ) -> None:
+        """Preemptive nudge appears when iterations_since_write == threshold - 1.
+
+        One turn before the loop guard fires we inject a nudge telling the model
+        to call a write tool in this response. The nudge must not contain
+        'LOOP GUARD' (that string is reserved for the full guard override).
+        """
+        from agentception.services.agent_loop import (
+            _LOOP_GUARD_THRESHOLD,
+            run_agent_loop,
+        )
+
+        worktree = tmp_path / "test-run-preemptive"
+        worktree.mkdir()
+        task_spec = _make_task_spec(worktree)
+
+        # With threshold=2: after 1 read we have iterations_since_write=1.
+        # The next request (index 1) gets the preemptive nudge. Then we return
+        # another read so the run continues; then write + stop.
+        nudge_turn_index = 1
+        all_responses = (
+            [_tool_response("read_file", {"path": "agentception/models.py"})]
+            + [_tool_response("read_file", {"path": "agentception/other.py"})]
+            + [_tool_response("write_file", {"path": "agentception/new.py", "content": "# x"})]
+            + [_stop_response("Done.")]
+        )
+
+        captured_extra: list[list[dict[str, object]] | None] = []
+
+        async def fake_llm(
+            *args: object,
+            extra_system_blocks: list[dict[str, object]] | None = None,
+            **kwargs: object,
+        ) -> ToolResponse:
+            captured_extra.append(extra_system_blocks)
+            return all_responses[len(captured_extra) - 1]
+
+        file_result: dict[str, object] = {"ok": True, "content": "# stub", "truncated": False}
+        write_result: dict[str, object] = {"ok": True}
+
+        with (
+            patch("agentception.services.agent_loop.settings") as mock_settings,
+            patch(
+                "agentception.services.agent_loop._load_task",
+                new_callable=AsyncMock,
+                return_value=task_spec,
+            ),
+            patch(
+                "agentception.services.agent_loop.get_run_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic",
+                new_callable=AsyncMock,
+                return_value='{"files": ["agentception/models.py"], "searches": [], "plan": "no-op"}',
+            ),
+            patch(
+                "agentception.services.agent_loop.call_anthropic_with_tools",
+                side_effect=fake_llm,
+            ),
+            patch(
+                "agentception.services.agent_loop.build_complete_run",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.log_run_step",
+                new_callable=AsyncMock,
+                return_value={"ok": True},
+            ),
+            patch(
+                "agentception.services.agent_loop.GitHubMCPClient",
+                return_value=_mock_github_client(),
+            ),
+        ):
+            mock_settings.worktrees_dir = tmp_path
+            mock_settings.repo_dir = tmp_path
+            mock_settings.ac_min_turn_delay_secs = 0.0
+
+            from agentception.services import agent_loop as al
+
+            with (
+                patch.object(al, "read_file", return_value=file_result),
+                patch.object(al, "write_file", return_value=write_result),
+            ):
+                await run_agent_loop("test-run-preemptive", max_iterations=20)
+
+        assert len(captured_extra) > nudge_turn_index, "Expected at least 2 LLM requests"
+        blocks = captured_extra[nudge_turn_index]
+        assert blocks is not None
+        all_text = " ".join(
+            str(b["text"]) for b in blocks if isinstance(b.get("text"), str)
+        )
+        assert "ONE TURN BEFORE READ-ONLY LOCK" in all_text, (
+            "Preemptive nudge must be injected one turn before guard fires"
+        )
+        assert "Issue a write tool call now" in all_text
+        assert "LOOP GUARD" not in all_text, (
+            "Preemptive nudge must not contain LOOP GUARD (reserved for full override)"
+        )
+
+    @pytest.mark.anyio
     async def test_symbol_absence_injects_override_on_repeated_search(
         self, tmp_path: Path
     ) -> None:

--- a/agentception/tests/test_build_commands.py
+++ b/agentception/tests/test_build_commands.py
@@ -443,6 +443,74 @@ async def test_build_complete_run_accepted_with_valid_pr_url() -> None:
 
 
 @pytest.mark.anyio
+async def test_implementer_completion_fails_when_release_worktree_returns_false() -> None:
+    """build_complete_run returns error and does not dispatch reviewer when release_worktree fails.
+
+    Regression: if git worktree remove fails, dispatching the reviewer would fail with
+    'feat/issue-N is already used by worktree at /worktrees/issue-N'. We must not
+    dispatch until the worktree is actually released.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    agent_run_id = "issue-939"
+    wt_path = "/worktrees/issue-939"
+
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="developer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_teardown",
+            new_callable=AsyncMock,
+            return_value={"worktree_path": wt_path, "branch": "feat/issue-939"},
+        ),
+        patch(
+            "agentception.mcp.build_commands.release_worktree",
+            new_callable=AsyncMock,
+            return_value=False,
+        ) as mock_release,
+        patch(
+            "agentception.mcp.build_commands.auto_dispatch_reviewer",
+            new_callable=AsyncMock,
+        ) as mock_reviewer,
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+        ) as mock_create_task,
+        patch(
+            "agentception.mcp.build_commands._rebase_and_push_worktree",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        result = await build_complete_run(
+            issue_number=939,
+            pr_url="https://github.com/cgcardona/agentception/pull/950",
+            agent_run_id=agent_run_id,
+        )
+
+    assert result["ok"] is False
+    assert "error" in result
+    assert "worktree" in str(result["error"]).lower() or "release" in str(result["error"]).lower()
+    mock_release.assert_awaited_once()
+    mock_reviewer.assert_not_called()
+    # Reviewer must not be dispatched (create_task with auto_dispatch_reviewer).
+    task_calls = mock_create_task.call_args_list
+    reviewer_calls = [c for c in task_calls if "reviewer" in str(c)]
+    assert not reviewer_calls, "reviewer must not be dispatched when release_worktree fails"
+
+
+@pytest.mark.anyio
 async def test_build_complete_run_rejects_whitespace_grade_from_reviewer() -> None:
     """build_complete_run returns an error dict when reviewer passes grade='   '.
 


### PR DESCRIPTION
- **agent_loop:** Inject "ONE TURN BEFORE READ-ONLY LOCK" nudge when `iterations_since_write == threshold - 1` so the model is told to call a write tool in that response instead of saying "I will write" and calling read again.
- **build_commands:** Only call `auto_dispatch_reviewer` when `release_worktree` returns True; return an error to the agent when release fails so we never dispatch reviewer while the branch is still in use.
- **Tests:** `test_preemptive_nudge_injected_one_turn_before_loop_guard`, `test_implementer_completion_fails_when_release_worktree_returns_false`.