### PR TITLE
fix: clear run events/messages on dispatch; dedupe read_file_lines in watch_run

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -22,7 +22,7 @@ import re
 import uuid
 from typing import TYPE_CHECKING, TypedDict
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 
 # Label namespace prefixes that are part of the taxonomy and must never be
 # interpreted as initiative slugs.  Any label whose prefix-before-"/" matches
@@ -1074,6 +1074,10 @@ async def persist_agent_run_dispatch(
     )
     try:
         async with get_session() as session:
+            # Clear previous run's events and messages so re-dispatches show a clean timeline.
+            await session.execute(delete(ACAgentEvent).where(ACAgentEvent.agent_run_id == run_id))
+            await session.execute(delete(ACAgentMessage).where(ACAgentMessage.agent_run_id == run_id))
+
             result = await session.execute(
                 select(ACAgentRun).where(ACAgentRun.id == run_id)
             )

--- a/scripts/watch_run.py
+++ b/scripts/watch_run.py
@@ -287,16 +287,10 @@ def process_line(raw: str, run_id_filter: str | None) -> str | None:
 
         if tool_name in _RESULT_LINE_TOOLS:
             st.pending_arg = parsed.get("path", "")
+            # read_file_lines: skip here — file_tools logs a result line with path+lines+total;
+            # we render that one only to avoid showing the same read twice.
             if tool_name == "read_file_lines":
-                path = parsed.get("path", "")
-                lines = parsed.get("lines", "")
-                if path or lines:
-                    path_short = _shorten_path(path) if path else "?"
-                    line_info = f"  {GREY}lines {lines}{RESET}" if lines else ""
-                    return (
-                        f"{ts}  {tag}{BLUE}{_tool_icon('read_file_lines')} read{RESET}  "
-                        f"{WHITE}{path_short}{RESET}{line_info}"
-                    )
+                return None
             return None
         if tool_name in _DISPATCH_ONLY_TOOLS:
             path = parsed.get("path", "")


### PR DESCRIPTION
- **persist:** Delete ACAgentEvent and ACAgentMessage for run_id at start of persist_agent_run_dispatch so re-dispatches show a clean timeline in the inspector.
- **watch_run:** Do not render the dispatch_tool line for read_file_lines; show only the file_tools result line (path + lines + total) to avoid duplicate lines per read.