### PR TITLE
chore: ship resync UX, poll docs, and dispatch script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,14 +48,13 @@ PORT=10003
 
 # ── Polling / Cache ──────────────────────────────────────────────────────────
 # How often (seconds) the background poller fetches GitHub data.
-# Default: 30
-# POLL_INTERVAL_SECONDS=30
+# Default: 5  (safe for GitHub rate limits; uncomment to override)
+# POLL_INTERVAL_SECONDS=5
 
 # GitHub API response cache TTL in seconds.
 # MUST be strictly less than POLL_INTERVAL_SECONDS so every poller tick sees
-# live GitHub data.  Recommended: min(POLL_INTERVAL_SECONDS / 2, 30).
-# Default: 15  (half of the default 30 s poll interval)
-# GITHUB_CACHE_SECONDS=15
+# live GitHub data.  Default: 4  (just under the 5 s poll interval)
+# GITHUB_CACHE_SECONDS=4
 
 # Log level: DEBUG, INFO, WARNING, ERROR
 LOG_LEVEL=INFO

--- a/agentception/routes/api/resync.py
+++ b/agentception/routes/api/resync.py
@@ -89,7 +89,12 @@ async def post_resync_issues(request: Request) -> HTMLResponse | JSONResponse:
         return JSONResponse(status_code=503, content=body_err.model_dump())
 
     if htmx:
-        return HTMLResponse(content="", status_code=200)
+        # Trigger immediate board refresh so the UI shows fresh data from GitHub.
+        return HTMLResponse(
+            content="",
+            status_code=200,
+            headers={"HX-Trigger": "refreshBoard"},
+        )
 
     body_ok = ResyncOkResponse(ok=True, **counts)
     return JSONResponse(status_code=200, content=body_ok.model_dump())

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -31,15 +31,16 @@
         </button>
         <span class="build-header__live" title="Board refreshes every 5 s">● LIVE</span>
 
-        {# ── Force resync ─────────────────────────────────────────────── #}
+        {# ── Force resync: button spins while fetching, then board refreshes ─ #}
         <button
+          id="resync-btn"
           class="build-header__resync-btn"
           hx-post="/api/control/resync-issues"
           hx-target="#resync-result"
           hx-swap="innerHTML"
-          hx-indicator="#resync-indicator"
-          title="Force resync"
-          aria-label="Force resync"
+          hx-indicator="#resync-btn"
+          title="Refresh from GitHub"
+          aria-label="Refresh from GitHub"
         ><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"
              width="16" height="16" fill="none"
              stroke="currentColor" stroke-width="1.75" stroke-linecap="round"
@@ -47,15 +48,6 @@
           <path d="M13.5 8A5.5 5.5 0 1 1 10 3.07"/>
           <polyline points="10 1 10 4 13 4"/>
         </svg></button>
-        <span id="resync-indicator" class="htmx-indicator" aria-live="polite">
-          <svg aria-hidden="true"
-               width="18" height="18" viewBox="0 0 24 24"
-               fill="none" stroke="currentColor"
-               stroke-width="2.5" stroke-linecap="round">
-            <path d="M12 2a10 10 0 1 1-10 10" />
-          </svg>
-          <span class="sr-only">Loading…</span>
-        </span>
       </div>
     </header>
     {# resync-result sits outside <header> so injected content appears below the header row #}

--- a/agentception/tests/test_build_page_structure.py
+++ b/agentception/tests/test_build_page_structure.py
@@ -138,12 +138,11 @@ def test_build_board_partial_has_no_load_trigger() -> None:
     )
 
 
-def test_build_page_has_htmx_indicator() -> None:
-    """build.html must contain an element with class 'htmx-indicator' for the resync spinner."""
+def test_build_page_resync_button_is_own_indicator() -> None:
+    """Resync button is its own HTMX indicator so it spins in place (no separate spinner)."""
     html = _render("build.html", _BUILD_CTX)
-    assert "htmx-indicator" in html, (
-        "build.html does not contain 'htmx-indicator'. "
-        "The resync spinner must use the .htmx-indicator class so HTMX toggles it automatically."
+    assert 'id="resync-btn"' in html and 'hx-indicator="#resync-btn"' in html, (
+        "Resync button must have id=resync-btn and hx-indicator=#resync-btn so it spins when clicked."
     )
 
 

--- a/agentception/tests/test_build_ui.py
+++ b/agentception/tests/test_build_ui.py
@@ -73,8 +73,8 @@ def test_force_resync_button_present(client: TestClient) -> None:
     assert 'id="resync-result"' in html, (
         "A div with id='resync-result' must exist to receive the HTMX swap"
     )
-    assert 'aria-label="Force resync"' in html, (
-        "Force resync button must have aria-label='Force resync' for accessibility"
+    assert 'aria-label="Refresh from GitHub"' in html, (
+        "Resync button must have aria-label='Refresh from GitHub' for accessibility"
     )
     assert 'class="build-header__resync-btn"' in html, (
         "Force resync button must carry the build-header__resync-btn CSS class"

--- a/docs/reference/poller.md
+++ b/docs/reference/poller.md
@@ -26,7 +26,7 @@ Each **tick** performs the following steps in order:
 6. **Phase advance** — optionally advance the active phase label when all issues
    in the current phase are resolved.
 
-Default tick cadence: **30 seconds** (configurable via `settings.poll_interval`).
+Default tick cadence: **5 seconds** (configurable via `POLL_INTERVAL_SECONDS` / `settings.poll_interval_seconds`). 5s is safe for GitHub API rate limits.
 
 ---
 

--- a/scripts/dispatch_issue_941.py
+++ b/scripts/dispatch_issue_941.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""One-off: dispatch a developer for GitHub issue #941 via POST /api/dispatch/issue.
+
+Run from repo root. Requires AgentCeption running (e.g. docker compose up -d).
+Fetches issue title/body from GitHub API, then POSTs to localhost:10003.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+GITHUB_ISSUE_URL = "https://api.github.com/repos/cgcardona/agentception/issues/941"
+DISPATCH_URL = os.environ.get("AC_DISPATCH_URL", "http://localhost:10003/api/dispatch/issue")
+
+
+def main() -> None:
+    # Fetch issue from GitHub (no auth for public repo)
+    req = urllib.request.Request(
+        GITHUB_ISSUE_URL,
+        headers={"Accept": "application/vnd.github+json"},
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        data = json.loads(resp.read().decode())
+    title = data["title"]
+    body = data["body"] or ""
+
+    payload = {
+        "issue_number": 941,
+        "issue_title": title,
+        "issue_body": body,
+        "role": "developer",
+        "repo": "cgcardona/agentception",
+    }
+    body_bytes = json.dumps(payload).encode("utf-8")
+    dispatch_req = urllib.request.Request(
+        DISPATCH_URL,
+        data=body_bytes,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(dispatch_req, timeout=60) as resp:
+        out = json.loads(resp.read().decode())
+    print(json.dumps(out, indent=2))
+    print("run_id:", out.get("run_id"), "— agent loop fired.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Commits all previously uncommitted changes on dev so dispatched agents run with the latest code.

- **Mission Control:** Reload button spins in place (no separate loading spinner), triggers immediate board refresh via HX-Trigger after resync; button is its own HTMX indicator.
- **resync.py:** Return `HX-Trigger: refreshBoard` on HTMX success.
- **.env.example + poller.md:** Document 5s poll default; align with config.
- **Tests:** resync button indicator assertion; aria-label update.
- **scripts/dispatch_issue_941.py:** One-off script to dispatch an issue via the API.