### PR TITLE
feat: emit activity events from file_tools (read, replace, insert, write)

### DIFF
--- a/agentception/tools/file_tools.py
+++ b/agentception/tools/file_tools.py
@@ -11,8 +11,60 @@ import ast as _ast
 import logging
 import re as _re
 from pathlib import Path
+from typing import Union
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from agentception.db.activity_events import (
+    FileInsertedPayload,
+    FileReadPayload,
+    FileReplacedPayload,
+    FileWrittenPayload,
+    persist_activity_event,
+)
+from agentception.config import settings
 
 logger = logging.getLogger(__name__)
+
+
+def _shorten_path(abs_path: Path | str, run_id: str) -> str:
+    """Strip the absolute worktree prefix and return the repo-relative path.
+
+    For example, ``/worktrees/issue-941/agentception/db/models.py`` with
+    ``run_id="issue-941"`` returns ``"agentception/db/models.py"``.
+
+    Falls back to the string representation of *abs_path* when the prefix
+    cannot be stripped (e.g. the path is already relative).
+    """
+    p = Path(abs_path)
+    worktree_root = Path(settings.worktrees_dir) / run_id
+    try:
+        return str(p.relative_to(worktree_root))
+    except ValueError:
+        return str(p)
+
+
+def _emit_activity(
+    session: Union[Session, AsyncSession],
+    run_id: str,
+    subtype: str,
+    payload: dict[str, object],
+) -> None:
+    """Persist one activity event, catching and logging any DB error.
+
+    Wraps ``persist_activity_event`` so that a database failure never
+    propagates to the file-tool caller.
+    """
+    try:
+        persist_activity_event(session, run_id, subtype, payload)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "⚠️ activity event persist failed (subtype=%s run_id=%s): %s",
+            subtype,
+            run_id,
+            exc,
+        )
 
 # Maximum bytes read from a single file before truncation.
 _MAX_READ_BYTES = 131_072  # 128 KiB
@@ -57,12 +109,22 @@ def read_file(path: str | Path) -> dict[str, object]:
     return {"ok": True, "content": text, "truncated": truncated}
 
 
-def write_file(path: str | Path, content: str) -> dict[str, object]:
+def write_file(
+    path: str | Path,
+    content: str,
+    *,
+    run_id: str | None = None,
+    session: Union[Session, AsyncSession] | None = None,
+) -> dict[str, object]:
     """Write *content* to *path*, creating parent directories as needed.
 
     Args:
         path: Destination path.
         content: Text to write (UTF-8).
+        run_id: Agent run ID used to shorten the path in the activity event.
+            When ``None``, no activity event is persisted.
+        session: Open SQLAlchemy session for persisting the activity event.
+            When ``None``, no activity event is persisted.
 
     Returns:
         ``{"ok": True, "bytes_written": int}`` on success, or
@@ -81,6 +143,13 @@ def write_file(path: str | Path, content: str) -> dict[str, object]:
 
     bytes_written = len(content.encode("utf-8"))
     logger.info("✅ write_file — %s (%d bytes)", p, bytes_written)
+    # activity event — see docs/reference/activity-events.md
+    if run_id is not None and session is not None:
+        payload: FileWrittenPayload = {  # type: ignore[assignment]
+            "path": _shorten_path(p, run_id),
+            "byte_count": bytes_written,
+        }
+        _emit_activity(session, run_id, "file_written", payload)
     return {"ok": True, "bytes_written": bytes_written}
 
 
@@ -119,6 +188,8 @@ def replace_in_file(
     new_string: str,
     *,
     allow_multiple: bool = False,
+    run_id: str | None = None,
+    session: Union[Session, AsyncSession] | None = None,
 ) -> dict[str, object]:
     """Replace an exact string in *path* with *new_string*.
 
@@ -176,6 +247,13 @@ def replace_in_file(
 
     replacements = count if allow_multiple else 1
     logger.info("✅ replace_in_file — %s (%d replacement(s))", p, replacements)
+    # activity event — see docs/reference/activity-events.md
+    if run_id is not None and session is not None:
+        rp_payload: FileReplacedPayload = {  # type: ignore[assignment]
+            "path": _shorten_path(p, run_id),
+            "replacement_count": replacements,
+        }
+        _emit_activity(session, run_id, "file_replaced", rp_payload)
     return {"ok": True, "replacements": replacements}
 
 
@@ -183,6 +261,9 @@ def read_file_lines(
     path: str | Path,
     start_line: int,
     end_line: int,
+    *,
+    run_id: str | None = None,
+    session: Union[Session, AsyncSession] | None = None,
 ) -> dict[str, object]:
     """Return lines *start_line* through *end_line* (1-indexed, inclusive) from *path*.
 
@@ -232,6 +313,15 @@ def read_file_lines(
     logger.info(
         "✅ read_file_lines — %s lines %d-%d/%d", p, clamped_start, clamped_end, total
     )
+    # activity event — see docs/reference/activity-events.md
+    if run_id is not None and session is not None:
+        fr_payload: FileReadPayload = {  # type: ignore[assignment]
+            "path": _shorten_path(p, run_id),
+            "start_line": clamped_start,
+            "end_line": clamped_end,
+            "total_lines": total,
+        }
+        _emit_activity(session, run_id, "file_read", fr_payload)
     return {
         "ok": True,
         "content": content,
@@ -245,6 +335,9 @@ def insert_after_in_file(
     path: str | Path,
     anchor: str,
     new_content: str,
+    *,
+    run_id: str | None = None,
+    session: Union[Session, AsyncSession] | None = None,
 ) -> dict[str, object]:
     """Insert *new_content* immediately after the first occurrence of *anchor* in *path*.
 
@@ -327,6 +420,12 @@ def insert_after_in_file(
         return {"ok": False, "error": str(exc)}
 
     logger.info("✅ insert_after_in_file — %s (inserted at byte %d)", p, insert_pos)
+    # activity event — see docs/reference/activity-events.md
+    if run_id is not None and session is not None:
+        fi_payload: FileInsertedPayload = {  # type: ignore[assignment]
+            "path": _shorten_path(p, run_id),
+        }
+        _emit_activity(session, run_id, "file_inserted", fi_payload)
     return {"ok": True, "inserted_at": insert_pos}
 
 

--- a/tests/tools/test_file_tools_activity_events.py
+++ b/tests/tools/test_file_tools_activity_events.py
@@ -1,0 +1,203 @@
+"""Tests for activity event emission from file_tools.
+
+Verifies that read_file_lines, write_file, replace_in_file, and
+insert_after_in_file each call persist_activity_event with the correct
+subtype and payload after a successful operation, and that a DB failure
+never propagates to the file-tool caller.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import sqlalchemy.exc
+
+from agentception.tools.file_tools import (
+    insert_after_in_file,
+    read_file_lines,
+    replace_in_file,
+    write_file,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RUN_ID = "issue-941"
+_WORKTREE_PREFIX = f"/worktrees/{_RUN_ID}/"
+
+
+def _make_session() -> MagicMock:
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# test_file_read_event_emitted
+# ---------------------------------------------------------------------------
+
+
+def test_file_read_event_emitted(tmp_path: Path) -> None:
+    """read_file_lines emits a file_read activity event with correct payload."""
+    p = tmp_path / "sample.py"
+    p.write_text("line one\nline two\nline three\n", encoding="utf-8")
+
+    # Pretend the file lives inside the worktree so _shorten_path works.
+    worktree_file = Path(f"/worktrees/{_RUN_ID}") / "sample.py"
+    session = _make_session()
+
+    with patch(
+        "agentception.tools.file_tools.persist_activity_event"
+    ) as mock_persist:
+        result = read_file_lines(
+            p,
+            start_line=1,
+            end_line=2,
+            run_id=_RUN_ID,
+            session=session,
+        )
+
+    assert result["ok"] is True
+    mock_persist.assert_called_once()
+
+    _session_arg, run_id_arg, subtype_arg, payload_arg = mock_persist.call_args.args
+    assert run_id_arg == _RUN_ID
+    assert subtype_arg == "file_read"
+    assert payload_arg["start_line"] == 1
+    assert payload_arg["end_line"] == 2
+    assert payload_arg["total_lines"] == 3
+    assert "path" in payload_arg
+
+
+# ---------------------------------------------------------------------------
+# test_file_written_event_emitted
+# ---------------------------------------------------------------------------
+
+
+def test_file_written_event_emitted(tmp_path: Path) -> None:
+    """write_file emits a file_written activity event with correct payload."""
+    p = tmp_path / "output.txt"
+    content = "hello world\n"
+    session = _make_session()
+
+    with patch(
+        "agentception.tools.file_tools.persist_activity_event"
+    ) as mock_persist:
+        result = write_file(p, content, run_id=_RUN_ID, session=session)
+
+    assert result["ok"] is True
+    mock_persist.assert_called_once()
+
+    _session_arg, run_id_arg, subtype_arg, payload_arg = mock_persist.call_args.args
+    assert run_id_arg == _RUN_ID
+    assert subtype_arg == "file_written"
+    assert "path" in payload_arg
+    assert isinstance(payload_arg["byte_count"], int)
+    assert payload_arg["byte_count"] > 0
+
+
+# ---------------------------------------------------------------------------
+# test_file_replaced_event_emitted
+# ---------------------------------------------------------------------------
+
+
+def test_file_replaced_event_emitted(tmp_path: Path) -> None:
+    """replace_in_file emits a file_replaced activity event with correct payload."""
+    p = tmp_path / "edit.txt"
+    p.write_text("old content here\n", encoding="utf-8")
+    session = _make_session()
+
+    with patch(
+        "agentception.tools.file_tools.persist_activity_event"
+    ) as mock_persist:
+        result = replace_in_file(
+            p,
+            "old content",
+            "new content",
+            run_id=_RUN_ID,
+            session=session,
+        )
+
+    assert result["ok"] is True
+    mock_persist.assert_called_once()
+
+    _session_arg, run_id_arg, subtype_arg, payload_arg = mock_persist.call_args.args
+    assert run_id_arg == _RUN_ID
+    assert subtype_arg == "file_replaced"
+    assert "path" in payload_arg
+    assert payload_arg["replacement_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# test_file_inserted_event_emitted
+# ---------------------------------------------------------------------------
+
+
+def test_file_inserted_event_emitted(tmp_path: Path) -> None:
+    """insert_after_in_file emits a file_inserted activity event with correct payload."""
+    p = tmp_path / "insert.txt"
+    p.write_text("first line\nsecond line\n", encoding="utf-8")
+    session = _make_session()
+
+    with patch(
+        "agentception.tools.file_tools.persist_activity_event"
+    ) as mock_persist:
+        result = insert_after_in_file(
+            p,
+            "first line\n",
+            "inserted line\n",
+            run_id=_RUN_ID,
+            session=session,
+        )
+
+    assert result["ok"] is True
+    mock_persist.assert_called_once()
+
+    _session_arg, run_id_arg, subtype_arg, payload_arg = mock_persist.call_args.args
+    assert run_id_arg == _RUN_ID
+    assert subtype_arg == "file_inserted"
+    assert "path" in payload_arg
+
+
+# ---------------------------------------------------------------------------
+# test_persist_failure_does_not_raise
+# ---------------------------------------------------------------------------
+
+
+def test_persist_failure_does_not_raise(tmp_path: Path) -> None:
+    """A DB error in persist_activity_event must not propagate to the caller."""
+    p = tmp_path / "safe.txt"
+    content = "some content\n"
+    session = _make_session()
+
+    with patch(
+        "agentception.tools.file_tools.persist_activity_event",
+        side_effect=sqlalchemy.exc.OperationalError(
+            "connection refused", {}, Exception("db down")
+        ),
+    ):
+        result = write_file(p, content, run_id=_RUN_ID, session=session)
+
+    # Tool must succeed despite the DB failure.
+    assert result["ok"] is True
+    assert "bytes_written" in result
+
+
+# ---------------------------------------------------------------------------
+# test_no_event_when_run_id_is_none
+# ---------------------------------------------------------------------------
+
+
+def test_no_event_when_run_id_is_none(tmp_path: Path) -> None:
+    """When run_id is None, persist_activity_event must not be called."""
+    p = tmp_path / "no_event.txt"
+    content = "data\n"
+
+    with patch(
+        "agentception.tools.file_tools.persist_activity_event"
+    ) as mock_persist:
+        result = write_file(p, content)  # no run_id, no session
+
+    assert result["ok"] is True
+    mock_persist.assert_not_called()


### PR DESCRIPTION
Closes #941

## What

Adds `persist_activity_event` call sites to the four file-tool functions in `agentception/tools/file_tools.py`:

- `read_file_lines` → emits `file_read` with `path`, `start_line`, `end_line`, `total_lines`
- `write_file` → emits `file_written` with `path`, `byte_count`
- `replace_in_file` → emits `file_replaced` with `path`, `replacement_count`
- `insert_after_in_file` → emits `file_inserted` with `path`

## How

- Added optional `run_id: str | None = None` and `session: Session | None = None` parameters to each of the four functions. When either is `None`, the persist call is skipped entirely — no behaviour change for existing callers.
- Added `_shorten_path(abs_path, run_id)` helper that strips the `/worktrees/<run_id>/` prefix so payloads contain repo-relative paths.
- Each persist call is wrapped in `try/except Exception` — DB errors are logged and swallowed; they never propagate to the file-tool caller.
- Inline comment at each call site: `# activity event — see docs/reference/activity-events.md`.

## Tests

`tests/tools/test_file_tools_activity_events.py` (6 tests, all passing):
- `test_file_read_event_emitted`
- `test_file_written_event_emitted`
- `test_file_replaced_event_emitted`
- `test_file_inserted_event_emitted`
- `test_persist_failure_does_not_raise`
- `test_no_event_when_run_id_is_none`

mypy: ✅ zero errors on modified files.