### PR TITLE
fix(build_complete_run): release derived worktree path when DB has none

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -386,16 +386,24 @@ async def build_complete_run(
         # fail with "already used by worktree at …".  We only remove the
         # worktree directory and prune refs — branches are left intact because
         # the open PR still references the remote branch.
+        #
+        # When the DB has no worktree_path (e.g. null or run not found), derive
+        # the conventional path worktrees_dir/run_id so we still attempt release —
+        # otherwise the reviewer dispatch fails with "branch already used by worktree".
         worktree_released = True
         if agent_run_id:
             teardown_info = await get_agent_run_teardown(agent_run_id)
-            wt_path = teardown_info.get("worktree_path") if teardown_info else None
-            if wt_path is not None:
+            wt_path = (
+                (teardown_info.get("worktree_path") if teardown_info else None)
+                or str(Path(settings.worktrees_dir) / agent_run_id)
+            )
+            if wt_path and Path(wt_path).exists():
                 # Rebase onto dev and force-push before dispatching reviewer.
                 rebase_error = await _rebase_and_push_worktree(wt_path, agent_run_id)
                 if rebase_error is not None:
                     return rebase_error
 
+            if wt_path:
                 worktree_released = await release_worktree(
                     worktree_path=wt_path,
                     repo_dir=str(settings.repo_dir),

--- a/agentception/tests/test_build_commands_rebase.py
+++ b/agentception/tests/test_build_commands_rebase.py
@@ -26,6 +26,7 @@ Run targeted:
 """
 
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -281,11 +282,16 @@ async def test_no_worktree_path_skips_rebase_and_dispatches_reviewer() -> None:
 
     assert result == {"ok": True, "event": "done", "status": "completed"}
 
-    # No subprocess calls should have been made (rebase skipped).
+    # No subprocess calls should have been made (rebase skipped; derived path does not exist).
     mock_subprocess.assert_not_called()
 
-    # release_worktree must NOT have been called (nothing to release).
-    mock_release.assert_not_awaited()
+    # release_worktree is called with the derived path so the reviewer dispatch can succeed
+    # (branch not still held by a worktree). Idempotent when path is already gone.
+    mock_release.assert_awaited_once()
+    from agentception.config import settings
+    expected_wt = str(Path(settings.worktrees_dir) / agent_run_id)
+    call_kw = mock_release.await_args[1]
+    assert call_kw["worktree_path"] == expected_wt
 
     # auto-reviewer task must still be scheduled.
     task_names = [c.kwargs.get("name", "") for c in mock_create_task.call_args_list]
@@ -349,9 +355,14 @@ async def test_rebase_succeeds_with_empty_worktree_path_dict() -> None:
 
     assert result == {"ok": True, "event": "done", "status": "completed"}
 
-    # No subprocess calls — rebase was skipped.
+    # No subprocess calls — rebase was skipped (derived path does not exist).
     mock_subprocess.assert_not_called()
-    mock_release.assert_not_awaited()
+    # release_worktree called with derived path so reviewer dispatch can succeed.
+    mock_release.assert_awaited_once()
+    from agentception.config import settings
+    expected_wt = str(Path(settings.worktrees_dir) / agent_run_id)
+    call_kw = mock_release.await_args[1]
+    assert call_kw["worktree_path"] == expected_wt
 
     # Reviewer still dispatched.
     task_names = [c.kwargs.get("name", "") for c in mock_create_task.call_args_list]


### PR DESCRIPTION
When `get_agent_run_teardown` returns None or `worktree_path` is null we skipped `release_worktree` but still dispatched the reviewer, causing "branch already used by worktree" on reviewer dispatch. Now we derive the path as `worktrees_dir/run_id` and attempt release before dispatching; rebase only runs when the path exists. Prevents reviewer dispatch 500 after implementer completion.