### PR TITLE
feat(942): emit activity events from shell_tools, git helper, and GitHub MCP

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -2269,11 +2269,25 @@ async def _dispatch_single_tool(
         await session.flush()
 
     if name in _LOCAL_TOOL_NAMES:
-        return await _dispatch_local_tool(name, args, worktree_path)
+        return await _dispatch_local_tool(
+            name, args, worktree_path, run_id=run_id, session=session
+        )
 
     if name in github_tool_names and github_client is not None:
         try:
             text = await github_client.call_tool(name, args)
+            # activity event — see docs/reference/activity-events.md
+            if session is not None:
+                try:
+                    persist_activity_event(
+                        session,
+                        run_id,
+                        "github_tool",
+                        {"tool_name": name, "arg_preview": str(args)[:120]},
+                    )
+                    await session.flush()
+                except Exception as exc:
+                    logger.warning("⚠️ persist github_tool failed: %s", exc)
             return {"ok": True, "result": text}
         except RuntimeError as exc:
             logger.error("❌ github_mcp tool %s failed: %s", name, exc)
@@ -2286,6 +2300,9 @@ async def _dispatch_local_tool(
     name: str,
     args: dict[str, object],
     worktree_path: Path,
+    *,
+    run_id: str | None = None,
+    session: AsyncSession | None = None,
 ) -> dict[str, object]:
     """Route a local tool call to the appropriate file or shell function."""
 
@@ -2394,7 +2411,9 @@ async def _dispatch_local_tool(
             return {"ok": False, "error": "run_command: 'command' must be a string"}
         cwd_raw = args.get("cwd")
         cwd = _resolve(cwd_raw, worktree_path) if cwd_raw is not None else worktree_path
-        return await run_command(command_raw, cwd)
+        return await run_command(
+            command_raw, cwd, run_id=run_id, session=session
+        )
 
     if name == "git_commit_and_push":
         branch_raw = args.get("branch")
@@ -2421,6 +2440,8 @@ async def _dispatch_local_tool(
             str_paths,
             worktree_path,
             base=base,
+            run_id=run_id,
+            session=session,
         )
 
     if name == "search_codebase":

--- a/agentception/tests/test_build_commands_rebase.py
+++ b/agentception/tests/test_build_commands_rebase.py
@@ -290,7 +290,9 @@ async def test_no_worktree_path_skips_rebase_and_dispatches_reviewer() -> None:
     mock_release.assert_awaited_once()
     from agentception.config import settings
     expected_wt = str(Path(settings.worktrees_dir) / agent_run_id)
-    call_kw = mock_release.await_args[1]
+    await_args = mock_release.await_args
+    assert await_args is not None
+    call_kw = await_args[1]
     assert call_kw["worktree_path"] == expected_wt
 
     # auto-reviewer task must still be scheduled.
@@ -361,7 +363,9 @@ async def test_rebase_succeeds_with_empty_worktree_path_dict() -> None:
     mock_release.assert_awaited_once()
     from agentception.config import settings
     expected_wt = str(Path(settings.worktrees_dir) / agent_run_id)
-    call_kw = mock_release.await_args[1]
+    await_args = mock_release.await_args
+    assert await_args is not None
+    call_kw = await_args[1]
     assert call_kw["worktree_path"] == expected_wt
 
     # Reviewer still dispatched.

--- a/agentception/tools/shell_tools.py
+++ b/agentception/tools/shell_tools.py
@@ -26,6 +26,10 @@ import re
 import shlex
 from pathlib import Path
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agentception.db import activity_events
+
 logger = logging.getLogger(__name__)
 
 # Maximum captured output per stream to prevent memory exhaustion.
@@ -138,6 +142,8 @@ async def run_command(
     cwd: str | Path | None = None,
     *,
     timeout: int = _DEFAULT_TIMEOUT,
+    run_id: str | None = None,
+    session: AsyncSession | None = None,
 ) -> dict[str, object]:
     """Execute *command* in a subprocess and return structured output.
 
@@ -168,6 +174,21 @@ async def run_command(
 
     cwd_path = Path(cwd) if cwd else None
     logger.info("✅ run_command — %s (cwd=%s)", shlex.quote(command), cwd_path)
+    # activity event — see docs/reference/activity-events.md
+    if run_id and session is not None:
+        try:
+            activity_events.persist_activity_event(
+                session,
+                run_id,
+                "shell_start",
+                {
+                    "cmd_preview": command[:200],
+                    "cwd": str(cwd_path) if cwd_path else "",
+                },
+            )
+            await session.flush()
+        except Exception as exc:
+            logger.warning("⚠️ persist shell_start failed: %s", exc)
 
     try:
         proc = await asyncio.create_subprocess_shell(
@@ -209,6 +230,23 @@ async def run_command(
         len(stdout),
         len(stderr),
     )
+    # activity event — see docs/reference/activity-events.md
+    if run_id and session is not None:
+        try:
+            activity_events.persist_activity_event(
+                session,
+                run_id,
+                "shell_done",
+                {
+                    "exit_code": exit_code,
+                    "stdout_bytes": len(raw_out),
+                    "stderr_bytes": len(raw_err),
+                },
+            )
+            await session.flush()
+        except Exception as exc:
+            logger.warning("⚠️ persist shell_done failed: %s", exc)
+
     return {
         "ok": True,
         "stdout": stdout,
@@ -240,6 +278,8 @@ async def git_commit_and_push(
     worktree_path: Path,
     *,
     base: str = "origin/dev",
+    run_id: str | None = None,
+    session: AsyncSession | None = None,
 ) -> dict[str, object]:
     """Create a branch, stage files, commit, and push in one atomic call.
 
@@ -314,4 +354,17 @@ async def git_commit_and_push(
     sha = sha.strip() if code == 0 else "(unknown)"
 
     logger.info("✅ git_commit_and_push — pushed %s → origin/%s", sha[:12], branch)
+    # activity event — see docs/reference/activity-events.md
+    if run_id and session is not None:
+        try:
+            activity_events.persist_activity_event(
+                session,
+                run_id,
+                "git_push",
+                {"branch": branch},
+            )
+            await session.flush()
+        except Exception as exc:
+            logger.warning("⚠️ persist git_push failed: %s", exc)
+
     return {"ok": True, "branch": branch, "sha": sha, "stdout": push_out}

--- a/tests/tools/test_shell_github_activity_events.py
+++ b/tests/tools/test_shell_github_activity_events.py
@@ -1,0 +1,203 @@
+"""Tests for activity event emission from shell_tools and GitHub MCP (issue #942).
+
+Verifies that run_command emits shell_start and shell_done, git_commit_and_push
+emits git_push, the GitHub MCP dispatch path emits github_tool, and that a
+persist failure never propagates to the caller.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agentception.tools.shell_tools import git_commit_and_push, run_command
+
+
+_RUN_ID = "issue-942"
+
+
+# ---------------------------------------------------------------------------
+# shell_start + shell_done
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_shell_start_and_done_emitted() -> None:
+    """run_command with run_id and session emits shell_start then shell_done."""
+    mock_session = AsyncMock()
+    mock_session.flush = AsyncMock()
+
+    with patch(
+        "agentception.tools.shell_tools.activity_events.persist_activity_event"
+    ) as mock_persist:
+        result = await run_command(
+            "echo ok",
+            run_id=_RUN_ID,
+            session=mock_session,
+        )
+
+    assert result.get("ok") is True
+    assert result.get("exit_code") == 0
+    assert mock_persist.call_count == 2
+
+    first_call = mock_persist.call_args_list[0]
+    assert first_call[0][2] == "shell_start"
+    payload_start = first_call[0][3]
+    assert "cmd_preview" in payload_start
+    assert "ok" in payload_start["cmd_preview"]
+    assert payload_start["cwd"] == ""
+
+    second_call = mock_persist.call_args_list[1]
+    assert second_call[0][2] == "shell_done"
+    payload_done = second_call[0][3]
+    assert payload_done["exit_code"] == 0
+    assert "stdout_bytes" in payload_done
+    assert "stderr_bytes" in payload_done
+    mock_session.flush.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# github_tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_github_tool_event_emitted(tmp_path: Path) -> None:
+    """Dispatch path for a GitHub MCP tool calls persist with subtype github_tool."""
+    import json
+
+    from agentception.services.agent_loop import _dispatch_single_tool
+    from agentception.services.llm import ToolCall, ToolCallFunction
+
+    tc = ToolCall(
+        id="call_gh",
+        type="function",
+        function=ToolCallFunction(
+            name="create_pull_request",
+            arguments=json.dumps({"title": "Test", "body": "Body", "head": "feat/x"}),
+        ),
+    )
+    mock_session = AsyncMock()
+    mock_session.flush = AsyncMock()
+    mock_github = AsyncMock()
+    mock_github.call_tool = AsyncMock(return_value="PR #1 created")
+
+    with patch(
+        "agentception.services.agent_loop.persist_activity_event"
+    ) as mock_persist:
+        result = await _dispatch_single_tool(
+            tc,
+            tmp_path,
+            _RUN_ID,
+            session=mock_session,
+            github_client=mock_github,
+            github_tool_names=frozenset({"create_pull_request"}),
+        )
+
+    assert result.get("ok") is True
+    # tool_invoked first, then github_tool
+    assert mock_persist.call_count >= 2
+    github_calls = [c for c in mock_persist.call_args_list if c[0][2] == "github_tool"]
+    assert len(github_calls) == 1
+    payload = github_calls[0][0][3]
+    assert payload["tool_name"] == "create_pull_request"
+    assert "arg_preview" in payload
+
+
+# ---------------------------------------------------------------------------
+# persist failure must not break shell
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_persist_failure_does_not_break_shell() -> None:
+    """When persist_activity_event raises, run_command still succeeds."""
+    mock_session = AsyncMock()
+    mock_session.flush = AsyncMock()
+
+    with patch(
+        "agentception.tools.shell_tools.activity_events.persist_activity_event",
+        side_effect=Exception("db down"),
+    ):
+        result = await run_command(
+            "echo ok",
+            run_id=_RUN_ID,
+            session=mock_session,
+        )
+
+    assert result.get("ok") is True
+    assert result.get("exit_code") == 0
+    assert "stdout" in result
+
+
+# ---------------------------------------------------------------------------
+# no event when run_id or session missing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_no_shell_events_when_run_id_none() -> None:
+    """When run_id is None, no shell_start/shell_done persist calls."""
+    mock_session = AsyncMock()
+
+    with patch(
+        "agentception.tools.shell_tools.activity_events.persist_activity_event"
+    ) as mock_persist:
+        result = await run_command("echo ok", session=mock_session)
+
+    assert result.get("ok") is True
+    mock_persist.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_no_shell_events_when_session_none() -> None:
+    """When session is None, no shell_start/shell_done persist calls."""
+    with patch(
+        "agentception.tools.shell_tools.activity_events.persist_activity_event"
+    ) as mock_persist:
+        result = await run_command("echo ok", run_id=_RUN_ID)
+
+    assert result.get("ok") is True
+    mock_persist.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# git_push
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_git_push_event_emitted(tmp_path: Path) -> None:
+    """git_commit_and_push with run_id and session emits git_push after success."""
+    mock_session = AsyncMock()
+    mock_session.flush = AsyncMock()
+    # _git is called: rev-parse HEAD (branch), add, commit, push, rev-parse HEAD (sha).
+    # Return current branch "feat/942" so checkout is skipped, then success for rest.
+    async def fake_git(args: list[str], cwd: Path) -> tuple[int, str, str]:
+        if args[:2] == ["rev-parse", "--abbrev-ref"]:
+            return (0, "feat/942", "")
+        if args == ["rev-parse", "HEAD"]:
+            return (0, "abc123", "")
+        return (0, "", "")
+
+    with (
+        patch(
+            "agentception.tools.shell_tools.activity_events.persist_activity_event"
+        ) as mock_persist,
+        patch("agentception.tools.shell_tools._git", side_effect=fake_git),
+    ):
+        result = await git_commit_and_push(
+            "feat/942",
+            "msg",
+            ["any-path"],
+            tmp_path,
+            run_id=_RUN_ID,
+            session=mock_session,
+        )
+
+    assert result.get("ok") is True
+    git_push_calls = [c for c in mock_persist.call_args_list if c[0][2] == "git_push"]
+    assert len(git_push_calls) == 1
+    assert git_push_calls[0][0][3]["branch"] == "feat/942"


### PR DESCRIPTION
Closes #942.

- **shell_start** / **shell_done**: in `run_command`, after existing log lines; payloads `cmd_preview`/`cwd` and `exit_code`/`stdout_bytes`/`stderr_bytes`.
- **git_push**: in `git_commit_and_push`, after successful push; payload `branch`.
- **github_tool**: in agent_loop when dispatching a GitHub MCP tool; payload `tool_name`, `arg_preview`.
- Optional `run_id` and `session` on `run_command` and `git_commit_and_push`; persist only when both set; call sites in `_dispatch_local_tool` pass them through.
- All persist calls wrapped in try/except; DB failures never propagate.
- New tests: `tests/tools/test_shell_github_activity_events.py` (shell_start/done, github_tool, persist failure, no-event when run_id/session missing, git_push).
- Mypy fix: `test_build_commands_rebase.py` — `await_args` can be `None`.