### PR TITLE
feat(943): extend inspector SSE to stream all activity events in chronological order

### DIFF
--- a/agentception/db/queries/__init__.py
+++ b/agentception/db/queries/__init__.py
@@ -115,6 +115,7 @@ from agentception.db.queries.messages import (
 
 from agentception.db.queries.events import (
     get_agent_events_tail as get_agent_events_tail,
+    get_all_events_tail as get_all_events_tail,
     get_file_edit_events as get_file_edit_events,
 )
 

--- a/agentception/db/queries/events.py
+++ b/agentception/db/queries/events.py
@@ -17,13 +17,14 @@ from agentception.db.queries.types import (
 
 logger = logging.getLogger(__name__)
 
-async def get_agent_events_tail(
+async def get_all_events_tail(
     run_id: str,
     after_id: int = 0,
 ) -> list[AgentEventRow]:
-    """Return MCP-reported events for *run_id* with ``id > after_id``.
+    """Return all agent events for *run_id* with ``id > after_id``, ordered by id ASC.
 
-    Used by the inspector SSE stream to incrementally push new events.
+    Includes every event_type (step_start, done, file_edit, activity, etc.).
+    Used by the inspector SSE stream to push events in chronological order.
     Falls back to ``[]`` on DB error.
     """
     try:
@@ -48,8 +49,20 @@ async def get_agent_events_tail(
             for row in rows
         ]
     except Exception as exc:
-        logger.warning("⚠️  get_agent_events_tail DB query failed (non-fatal): %s", exc)
+        logger.warning("⚠️  get_all_events_tail DB query failed (non-fatal): %s", exc)
         return []
+
+
+async def get_agent_events_tail(
+    run_id: str,
+    after_id: int = 0,
+) -> list[AgentEventRow]:
+    """Return MCP-reported events for *run_id* with ``id > after_id``.
+
+    Alias for get_all_events_tail. Used by the inspector SSE stream.
+    Falls back to ``[]`` on DB error.
+    """
+    return await get_all_events_tail(run_id, after_id)
 
 
 async def get_file_edit_events(run_id: str) -> list[FileEditEvent]:

--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -40,7 +40,7 @@ from agentception.db.queries import (
     PhaseGroupRow,
     RunForIssueRow,
     RunTreeNodeRow,
-    get_agent_events_tail,
+    get_all_events_tail,
     get_agent_thoughts_tail,
     get_file_edit_events,
     get_initiatives,
@@ -359,13 +359,15 @@ def _preview(text: str) -> str:
 async def _inspector_sse(run_id: str) -> AsyncGenerator[str, None]:
     """Yield SSE events for the inspector panel.
 
-    Interleaves structured MCP events (``ac_agent_events``) and raw thinking
-    messages (``ac_agent_messages``) in near-real-time.  Polls DB every 0.5 s
-    for near-real-time thought delivery.
+    Fetches all event types from ``ac_agent_events`` (via get_all_events_tail)
+    and thoughts from ``ac_agent_messages``, merges them by ``recorded_at``,
+    and emits in chronological order so the client sees the same sequence as
+    watch_run.py.  Polls DB every 0.5 s.
 
     Event shapes::
 
-        data: {"t": "event", "event_type": "step_start", "payload": {...}, "recorded_at": "..."}
+        data: {"t": "event", "event_type": "step_start", "payload": {...}, "recorded_at": "...", "id": N}
+        data: {"t": "activity", "subtype": "shell_done", "payload": {...}, "recorded_at": "...", "id": N}
         data: {"t": "thought", "role": "thinking", "content": "...", "recorded_at": "..."}
         data: {"t": "ping"}   -- keepalive every ~20 s
     """
@@ -374,57 +376,82 @@ async def _inspector_sse(run_id: str) -> AsyncGenerator[str, None]:
     ping_counter = 0
 
     while True:
-        events = await get_agent_events_tail(run_id, after_id=last_event_id)
-        for ev in events:
-            last_event_id = max(last_event_id, int(ev["id"]))
-            payload = json.dumps(
-                {
-                    "t": "event",
-                    "event_type": ev["event_type"],
-                    "payload": json.loads(ev["payload"]),
-                    "recorded_at": ev["recorded_at"],
-                }
-            )
-            # Supported event_types: step_start, done, file_edit, build_complete_run, orphan_failed
-            yield f"data: {payload}\n\n"
-
+        events = await get_all_events_tail(run_id, after_id=last_event_id)
         thoughts = await get_agent_thoughts_tail(
             run_id, after_seq=last_thought_seq
         )
-        for thought in thoughts:
-            last_thought_seq = max(last_thought_seq, int(thought["seq"]))
-            role = thought["role"]
-            if role == "tool_call":
-                payload = json.dumps(
-                    {
-                        "t": "tool_call",
-                        "tool_name": thought["tool_name"],
-                        "args_preview": _preview(thought["content"]),
-                        "recorded_at": thought["recorded_at"],
-                    }
-                )
-            elif role == "tool_result":
-                tool_name = thought["tool_name"]
-                if tool_name in _FILE_EDIT_TOOL_NAMES:
-                    continue  # file-edit results already have their own rendering path
-                payload = json.dumps(
-                    {
-                        "t": "tool_result",
-                        "tool_name": tool_name,
-                        "result_preview": _preview(thought["content"]),
-                        "recorded_at": thought["recorded_at"],
-                    }
-                )
+
+        # Merge by recorded_at so events and thoughts are emitted in chronological order.
+        merged: list[tuple[str, str, object]] = []
+        for ev in events:
+            merged.append((ev["recorded_at"], "event", ev))
+        for th in thoughts:
+            merged.append((th["recorded_at"], "thought", th))
+        merged.sort(key=lambda x: x[0])
+
+        for _recorded_at, kind, item in merged:
+            if kind == "event":
+                ev_item = item
+                assert isinstance(ev_item, dict)
+                last_event_id = max(last_event_id, int(ev_item["id"]))
+                payload_obj = json.loads(ev_item["payload"])
+                if ev_item["event_type"] == "activity":
+                    payload = json.dumps(
+                        {
+                            "t": "activity",
+                            "subtype": payload_obj.get("subtype", ""),
+                            "payload": payload_obj,
+                            "recorded_at": ev_item["recorded_at"],
+                            "id": ev_item["id"],
+                        }
+                    )
+                else:
+                    payload = json.dumps(
+                        {
+                            "t": "event",
+                            "event_type": ev_item["event_type"],
+                            "payload": payload_obj,
+                            "recorded_at": ev_item["recorded_at"],
+                            "id": ev_item["id"],
+                        }
+                    )
+                yield f"data: {payload}\n\n"
             else:
-                payload = json.dumps(
-                    {
-                        "t": "thought",
-                        "role": role,
-                        "content": thought["content"],
-                        "recorded_at": thought["recorded_at"],
-                    }
-                )
-            yield f"data: {payload}\n\n"
+                thought = item
+                assert isinstance(thought, dict)
+                last_thought_seq = max(last_thought_seq, int(thought["seq"]))
+                role = thought["role"]
+                if role == "tool_call":
+                    payload = json.dumps(
+                        {
+                            "t": "tool_call",
+                            "tool_name": thought["tool_name"],
+                            "args_preview": _preview(thought["content"]),
+                            "recorded_at": thought["recorded_at"],
+                        }
+                    )
+                elif role == "tool_result":
+                    tool_name = thought["tool_name"]
+                    if tool_name in _FILE_EDIT_TOOL_NAMES:
+                        continue
+                    payload = json.dumps(
+                        {
+                            "t": "tool_result",
+                            "tool_name": tool_name,
+                            "result_preview": _preview(thought["content"]),
+                            "recorded_at": thought["recorded_at"],
+                        }
+                    )
+                else:
+                    payload = json.dumps(
+                        {
+                            "t": "thought",
+                            "role": role,
+                            "content": thought["content"],
+                            "recorded_at": thought["recorded_at"],
+                        }
+                    )
+                yield f"data: {payload}\n\n"
 
         ping_counter += 1
         if ping_counter % 10 == 0:

--- a/agentception/tests/test_build_ui.py
+++ b/agentception/tests/test_build_ui.py
@@ -104,7 +104,7 @@ async def test_inspector_sse_poll_interval() -> None:
 
     with (
         patch(
-            "agentception.routes.ui.build_ui.get_agent_events_tail",
+            "agentception.routes.ui.build_ui.get_all_events_tail",
             new_callable=AsyncMock,
             return_value=[],
         ),
@@ -203,7 +203,7 @@ async def test_sse_stream_emits_file_edit_event_after_str_replace() -> None:
 
     with (
         patch(
-            "agentception.routes.ui.build_ui.get_agent_events_tail",
+            "agentception.routes.ui.build_ui.get_all_events_tail",
             side_effect=fake_events_tail,
         ),
         patch(

--- a/agentception/tests/test_build_ui_sse.py
+++ b/agentception/tests/test_build_ui_sse.py
@@ -37,7 +37,7 @@ def _make_thought(
 async def test_tool_call_emitted() -> None:
     with (
         patch(
-            "agentception.routes.ui.build_ui.get_agent_events_tail",
+            "agentception.routes.ui.build_ui.get_all_events_tail",
             new_callable=AsyncMock,
             return_value=[],
         ),
@@ -68,7 +68,7 @@ async def test_tool_call_emitted() -> None:
 async def test_tool_result_emitted() -> None:
     with (
         patch(
-            "agentception.routes.ui.build_ui.get_agent_events_tail",
+            "agentception.routes.ui.build_ui.get_all_events_tail",
             new_callable=AsyncMock,
             return_value=[],
         ),
@@ -98,7 +98,7 @@ async def test_tool_result_emitted() -> None:
 async def test_file_edit_tool_result_suppressed() -> None:
     with (
         patch(
-            "agentception.routes.ui.build_ui.get_agent_events_tail",
+            "agentception.routes.ui.build_ui.get_all_events_tail",
             new_callable=AsyncMock,
             return_value=[],
         ),

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -53,6 +53,18 @@ URLs are semantic: each path segment narrows the resource.
 | `GET` | `/ship/{initiative}/board` | HTMX board partial (polled every 5 s) |
 | `GET` | `/ship/runs/{run_id}/stream` | SSE stream for an agent run's events |
 
+#### `GET /ship/runs/{run_id}/stream` (SSE — inspector)
+
+Streams all agent events and thoughts for the given run in chronological order. Each `data:` line is a JSON object. The `t` field discriminates the message type:
+
+- **`t: "event"`** — Structured run events (step_start, done, file_edit, build_complete_run, orphan_failed). Shape: `{"t": "event", "event_type": "<type>", "payload": {...}, "recorded_at": "<ISO8601>", "id": <int>}`.
+- **`t: "activity"`** — Activity feed events (shell commands, file reads/writes, LLM usage, GitHub tool calls, etc.). Shape: `{"t": "activity", "subtype": "<subtype>", "payload": {...}, "recorded_at": "<ISO8601>", "id": <int>}`. Activity subtypes: `tool_invoked`, `llm_iter`, `llm_usage`, `llm_reply`, `llm_done`, `shell_start`, `shell_done`, `file_read`, `file_replaced`, `file_inserted`, `file_written`, `git_push`, `github_tool`, `delay`, `error`.
+- **`t: "thought"`** — Thinking/assistant message. Shape: `{"t": "thought", "role": "...", "content": "...", "recorded_at": "..."}`.
+- **`t: "tool_call"`** / **`t: "tool_result"`** — Tool invocation and result previews (same shape as before, with `recorded_at`).
+- **`t: "ping"`** — Keepalive (no payload).
+
+Events and thoughts are merged by `recorded_at` so the client sees the same order as `watch_run.py`. The cursor advances by `id` (events) and `seq` (thoughts); no event is delivered twice.
+
 ### Agents
 
 | Method | Path | Description |

--- a/tests/routes/test_inspector_sse.py
+++ b/tests/routes/test_inspector_sse.py
@@ -1,0 +1,146 @@
+"""Tests for inspector SSE: get_all_events_tail and activity events in stream (issue #943).
+
+Verifies that get_all_events_tail returns all event types ordered by id, that
+the cursor advances correctly, and that activity events are emitted as t=activity.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agentception.db.queries import AgentEventRow
+from agentception.db.queries.events import get_all_events_tail
+from agentception.routes.ui.build_ui import _inspector_sse
+
+_RUN_ID = "run-943"
+
+
+def _event_row(
+    id: int,
+    event_type: str,
+    payload: dict[str, object] | str,
+    recorded_at: str = "2026-03-13T12:00:00Z",
+) -> AgentEventRow:
+    return AgentEventRow(
+        id=id,
+        event_type=event_type,
+        payload=json.dumps(payload) if isinstance(payload, dict) else payload,
+        recorded_at=recorded_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_all_events_tail — returns all event types ordered by id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_activity_events_in_sse_stream() -> None:
+    """get_all_events_tail returns both step_start and activity (shell_done) rows ordered by id."""
+    step_row = _event_row(1, "step_start", {"step_name": "reading"}, "2026-03-13T12:00:00Z")
+    activity_row = _event_row(
+        2,
+        "activity",
+        {"subtype": "shell_done", "exit_code": 0, "stdout_bytes": 10, "stderr_bytes": 0},
+        "2026-03-13T12:00:01Z",
+    )
+
+    with patch(
+        "agentception.routes.ui.build_ui.get_all_events_tail",
+        new_callable=AsyncMock,
+        side_effect=[[step_row, activity_row], []],
+    ), patch(
+        "agentception.routes.ui.build_ui.get_agent_thoughts_tail",
+        new_callable=AsyncMock,
+        return_value=[],
+    ), patch(
+        "agentception.routes.ui.build_ui.asyncio.sleep",
+        side_effect=Exception("stop"),
+    ):
+        gen = _inspector_sse(_RUN_ID)
+        events: list[dict[str, object]] = []
+        try:
+            async for chunk in gen:
+                if chunk.startswith("data:"):
+                    events.append(json.loads(chunk.removeprefix("data: ").strip()))
+        except Exception:
+            pass
+
+    event_frames = [e for e in events if e.get("t") == "event"]
+    activity_frames = [e for e in events if e.get("t") == "activity"]
+    assert len(event_frames) == 1, f"Expected one t=event, got {events}"
+    assert event_frames[0]["event_type"] == "step_start"
+    assert event_frames[0]["id"] == 1
+    assert len(activity_frames) == 1, f"Expected one t=activity, got {events}"
+    assert activity_frames[0]["subtype"] == "shell_done"
+    assert activity_frames[0]["id"] == 2
+    payload = activity_frames[0]["payload"]
+    assert isinstance(payload, dict)
+    assert payload.get("exit_code") == 0
+    # Order: step (id=1) then activity (id=2)
+    assert events.index(activity_frames[0]) > events.index(event_frames[0])
+
+
+def _mock_db_row(id: int, event_type: str, payload: str, recorded_at: str) -> MagicMock:
+    row = MagicMock()
+    row.id = id
+    row.event_type = event_type
+    row.payload = payload
+    row.recorded_at = MagicMock(isoformat=lambda: recorded_at)
+    return row
+
+
+@pytest.mark.anyio
+async def test_sse_cursor_advances() -> None:
+    """get_all_events_tail(run_id, after_id=N) returns only rows with id > N."""
+    mock_rows = [
+        _mock_db_row(6, "activity", '{"subtype":"shell_done"}', "2026-03-13T12:00:00Z"),
+        _mock_db_row(7, "step_start", "{}", "2026-03-13T12:00:01Z"),
+    ]
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = mock_rows
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "agentception.db.queries.events.get_session",
+        return_value=mock_cm,
+    ):
+        result = await get_all_events_tail(_RUN_ID, after_id=5)
+
+    assert len(result) == 2
+    assert result[0]["id"] == 6
+    assert result[1]["id"] == 7
+
+
+@pytest.mark.anyio
+async def test_get_all_events_tail_returns_ordered_by_id() -> None:
+    """get_all_events_tail returns rows in id ascending order."""
+    mock_rows = [
+        _mock_db_row(10, "activity", '{"subtype":"shell_start"}', "2026-03-13T12:00:00Z"),
+        _mock_db_row(11, "step_start", "{}", "2026-03-13T12:00:01Z"),
+        _mock_db_row(12, "activity", '{"subtype":"shell_done"}', "2026-03-13T12:00:02Z"),
+    ]
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = mock_rows
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "agentception.db.queries.events.get_session",
+        return_value=mock_cm,
+    ):
+        result = await get_all_events_tail(_RUN_ID, after_id=0)
+
+    assert len(result) == 3
+    assert [r["id"] for r in result] == [10, 11, 12]
+    assert [r["event_type"] for r in result] == ["activity", "step_start", "activity"]


### PR DESCRIPTION
Closes #943.

- **Query:** `get_all_events_tail(run_id, after_id)` in `agentception/db/queries/events.py` returns all `ac_agent_events` rows with `id > after_id` ordered by id ASC. `get_agent_events_tail` delegates to it.
- **Inspector SSE:** `_inspector_sse` fetches events via `get_all_events_tail` and thoughts via `get_agent_thoughts_tail`, merges by `recorded_at`, and emits in chronological order. Activity events are emitted as `{"t": "activity", "subtype", "payload", "recorded_at", "id"}`; other events as `{"t": "event", "event_type", "payload", "recorded_at", "id"}`.
- **Tests:** `tests/routes/test_inspector_sse.py` — activity events in stream, cursor advances, ordered by id. Updated existing build_ui tests to patch `get_all_events_tail`.
- **Docs:** `docs/reference/api.md` — documented GET /ship/runs/{run_id}/stream and activity subtypes.