### PR TITLE
feat(944): consume SSE activity messages and append live DOM rows to inspector feed

### DIFF
--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  formatActivitySummary,
+  appendActivityRow,
+  attachActivityFeedHandler,
+  type ActivityMessage,
+} from '../activity_feed';
+
+function makeSource(): EventSource {
+  return new EventTarget() as unknown as EventSource;
+}
+
+function dispatch(src: EventTarget, data: object): void {
+  src.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(data) }));
+}
+
+describe('formatActivitySummary', () => {
+  it('formats tool_invoked', () => {
+    expect(
+      formatActivitySummary('tool_invoked', { tool_name: 'run_command', arg_preview: 'echo ok' })
+    ).toBe('→ run_command echo ok');
+  });
+
+  it('formats shell_start', () => {
+    expect(formatActivitySummary('shell_start', { cmd_preview: 'echo hi', cwd: '/app' })).toBe(
+      '$ echo hi'
+    );
+  });
+
+  it('formats shell_done', () => {
+    expect(
+      formatActivitySummary('shell_done', { exit_code: 0, stdout_bytes: 10, stderr_bytes: 0 })
+    ).toBe('exit=0 stdout:10B');
+  });
+
+  it('formats file_read', () => {
+    expect(
+      formatActivitySummary('file_read', {
+        path: 'src/foo.py',
+        start_line: 1,
+        end_line: 10,
+        total_lines: 50,
+      })
+    ).toBe('read src/foo.py lines 1–10/50');
+  });
+
+  it('formats git_push', () => {
+    expect(formatActivitySummary('git_push', { branch: 'feat/944' })).toBe('git push → feat/944');
+  });
+
+  it('formats error with message', () => {
+    expect(formatActivitySummary('error', { message: 'connection refused' })).toBe(
+      '❌ connection refused'
+    );
+  });
+
+  it('returns subtype for unknown subtype', () => {
+    expect(formatActivitySummary('unknown_subtype', {})).toBe('unknown_subtype');
+  });
+});
+
+describe('appendActivityRow', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="activity-feed"></div>';
+  });
+
+  it('appends a row with data-subtype, summary, and time', () => {
+    const msg: ActivityMessage = {
+      t: 'activity',
+      subtype: 'shell_done',
+      payload: { exit_code: 0, stdout_bytes: 5, stderr_bytes: 0 },
+      recorded_at: '2026-03-13T14:30:00Z',
+    };
+    appendActivityRow(msg);
+    const row = document.querySelector('.activity-feed__row');
+    expect(row).not.toBeNull();
+    expect(row?.getAttribute('data-subtype')).toBe('shell_done');
+    expect(row?.querySelector('.activity-feed__summary')?.textContent).toBe('exit=0 stdout:5B');
+    expect(row?.querySelector('.activity-feed__ts')?.getAttribute('datetime')).toBe(
+      '2026-03-13T14:30:00Z'
+    );
+  });
+
+  it('does nothing when #activity-feed is missing', () => {
+    document.body.innerHTML = '';
+    appendActivityRow({
+      t: 'activity',
+      subtype: 'tool_invoked',
+      payload: { tool_name: 'x', arg_preview: 'y' },
+      recorded_at: '',
+    });
+    expect(document.querySelector('.activity-feed__row')).toBeNull();
+  });
+});
+
+describe('attachActivityFeedHandler', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="activity-feed"></div>';
+  });
+
+  it('appends a row when msg.t === "activity"', () => {
+    const src = makeSource();
+    attachActivityFeedHandler(src);
+    dispatch(src, {
+      t: 'activity',
+      subtype: 'github_tool',
+      payload: { tool_name: 'create_pull_request', arg_preview: '{}' },
+      recorded_at: '2026-03-13T12:00:00Z',
+    });
+    const row = document.querySelector('.activity-feed__row');
+    expect(row).not.toBeNull();
+    expect(row?.getAttribute('data-subtype')).toBe('github_tool');
+    expect(row?.querySelector('.activity-feed__summary')?.textContent).toContain('create_pull_request');
+  });
+
+  it('ignores non-activity messages', () => {
+    const src = makeSource();
+    attachActivityFeedHandler(src);
+    dispatch(src, { t: 'event', event_type: 'step_start', payload: {}, recorded_at: '' });
+    expect(document.querySelector('.activity-feed__row')).toBeNull();
+  });
+});

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -1,0 +1,144 @@
+/**
+ * activity_feed.ts — append live DOM rows for SSE activity messages.
+ *
+ * Consumes {"t": "activity", "subtype", "payload", "recorded_at", "id"} from
+ * the inspector stream and appends one row per message to #activity-feed.
+ * All text is set via textContent/setAttribute; no innerHTML with payload data.
+ */
+
+/** SSE activity message shape from the inspector stream. */
+export interface ActivityMessage {
+  t: 'activity';
+  subtype: string;
+  payload: Record<string, unknown>;
+  recorded_at: string;
+  id?: number;
+}
+
+function str(p: Record<string, unknown>, key: string): string {
+  const v = p[key];
+  if (v === undefined || v === null) return '';
+  return String(v);
+}
+
+function num(p: Record<string, unknown>, key: string): number {
+  const v = p[key];
+  if (typeof v === 'number' && !Number.isNaN(v)) return v;
+  if (typeof v === 'string') {
+    const n = parseInt(v, 10);
+    return Number.isNaN(n) ? 0 : n;
+  }
+  return 0;
+}
+
+/**
+ * Human-readable one-line summary from subtype and payload.
+ * Uses textContent-safe strings only (no innerHTML with payload).
+ */
+export function formatActivitySummary(subtype: string, payload: Record<string, unknown>): string {
+  const p = payload ?? {};
+  switch (subtype) {
+    case 'tool_invoked':
+      return `→ ${str(p, 'tool_name')} ${str(p, 'arg_preview')}`.trim();
+    case 'shell_start':
+      return `$ ${str(p, 'cmd_preview')}`.trim();
+    case 'shell_done':
+      return `exit=${num(p, 'exit_code')} stdout:${num(p, 'stdout_bytes')}B`;
+    case 'file_read':
+      return `read ${str(p, 'path')} lines ${num(p, 'start_line')}–${num(p, 'end_line')}/${num(p, 'total_lines')}`.trim();
+    case 'file_replaced':
+      return `replaced ${str(p, 'path')} (${num(p, 'replacement_count')}×)`.trim();
+    case 'file_inserted':
+      return `inserted ${str(p, 'path')}`.trim();
+    case 'file_written':
+      return `wrote ${str(p, 'path')} ${num(p, 'byte_count')}B`.trim();
+    case 'git_push':
+      return `git push → ${str(p, 'branch')}`.trim();
+    case 'github_tool':
+      return `🐙 ${str(p, 'tool_name')} ${str(p, 'arg_preview')}`.trim();
+    case 'llm_iter':
+      return `ITER ${num(p, 'iteration')} model=${str(p, 'model')} turns=${num(p, 'turns')}`.trim();
+    case 'llm_usage':
+      return `in=${num(p, 'input_tokens')} cw=${num(p, 'cache_write')} cr=${num(p, 'cache_read')}`;
+    case 'llm_reply':
+      return `(${num(p, 'chars')}ch) ${str(p, 'text_preview')}`.trim();
+    case 'llm_done':
+      return `${str(p, 'stop_reason')} → ${num(p, 'tool_call_count')} tool calls`.trim();
+    case 'delay':
+      return `⏳ ${num(p, 'secs')}s`;
+    case 'error':
+      return `❌ ${str(p, 'message')}`.trim();
+    default:
+      return subtype || 'activity';
+  }
+}
+
+/** Format recorded_at (ISO8601) to HH:MM:SS. */
+function formatTime(recordedAt: string): string {
+  try {
+    const d = new Date(recordedAt);
+    const h = d.getHours();
+    const m = d.getMinutes();
+    const s = d.getSeconds();
+    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Create a single activity row and append it to #activity-feed.
+ * One SSE message → one DOM append. No innerHTML with payload data.
+ */
+export function appendActivityRow(msg: ActivityMessage): void {
+  const feed = document.getElementById('activity-feed');
+  if (!feed) return;
+
+  const row = document.createElement('div');
+  row.className = 'activity-feed__row';
+  row.setAttribute('data-subtype', msg.subtype);
+
+  const icon = document.createElement('span');
+  icon.className = 'activity-feed__icon';
+  icon.setAttribute('aria-hidden', 'true');
+  icon.textContent = '•';
+
+  const summary = document.createElement('span');
+  summary.className = 'activity-feed__summary';
+  summary.textContent = formatActivitySummary(msg.subtype, msg.payload);
+
+  const ts = document.createElement('time');
+  ts.className = 'activity-feed__ts';
+  ts.textContent = formatTime(msg.recorded_at);
+  ts.setAttribute('datetime', msg.recorded_at);
+
+  row.appendChild(icon);
+  row.appendChild(summary);
+  row.appendChild(ts);
+  feed.appendChild(row);
+  row.scrollIntoView?.({ block: 'end', behavior: 'smooth' });
+}
+
+/**
+ * Register a handler on source that appends an activity row for each
+ * msg.t === "activity" SSE message. Does not alter other message handling.
+ */
+export function attachActivityFeedHandler(source: EventSource): void {
+  source.addEventListener('message', (evt: MessageEvent<string>) => {
+    let msg: { t: string; subtype?: string; payload?: Record<string, unknown>; recorded_at?: string; id?: number };
+    try {
+      msg = JSON.parse(evt.data) as typeof msg;
+    } catch {
+      return;
+    }
+    if (msg.t !== 'activity') return;
+    if (typeof msg.subtype !== 'string' || msg.payload === undefined) return;
+    appendActivityRow({
+      t: 'activity',
+      subtype: msg.subtype,
+      payload: typeof msg.payload === 'object' && msg.payload !== null ? msg.payload : {},
+      recorded_at: typeof msg.recorded_at === 'string' ? msg.recorded_at : '',
+      id: msg.id,
+    });
+  });
+}

--- a/agentception/static/js/build.ts
+++ b/agentception/static/js/build.ts
@@ -12,10 +12,11 @@
  */
 
 import { marked } from 'marked';
+import { attachActivityFeedHandler } from './activity_feed';
+import { attachEventCardHandler } from './event_card';
 import { attachFileEditHandler } from './file_edit_card';
 import { attachThoughtHandler } from './thought_block';
 import { attachToolCallHandler } from './tool_call_card';
-import { attachEventCardHandler } from './event_card';
 
 // ── Domain types ─────────────────────────────────────────────────────────────
 
@@ -246,6 +247,7 @@ export function buildPage() {
       attachThoughtHandler(src);
       attachToolCallHandler(src);
       attachEventCardHandler(src);
+      attachActivityFeedHandler(src);
       this.streamOpen = true;
 
       src.onerror = () => {

--- a/agentception/static/scss/pages/_activity-feed.scss
+++ b/agentception/static/scss/pages/_activity-feed.scss
@@ -1,0 +1,34 @@
+// ── Activity feed row (SSE activity messages) ─────────────────────────────────
+
+.activity-feed__row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary, #888);
+  max-width: 100%;
+  overflow-x: hidden;
+  word-break: break-word;
+
+  .activity-feed__icon {
+    flex-shrink: 0;
+    &[aria-hidden='true'] {
+      opacity: 0.7;
+    }
+  }
+
+  .activity-feed__summary {
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .activity-feed__ts {
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
+    opacity: 0.8;
+  }
+}

--- a/agentception/static/scss/pages/_build.scss
+++ b/agentception/static/scss/pages/_build.scss
@@ -2,6 +2,7 @@
 // Barrel: each partial owns its rule block. Edit the partial, not this file.
 // Cascade order must match the original monolithic _build.scss.
 
+@use 'activity-feed';
 @use 'inspector-layout';
 @use 'thought-block';
 @use 'file-edit-card';


### PR DESCRIPTION
Closes #944.

- **activity_feed.ts:** `ActivityMessage` interface; `formatActivitySummary(subtype, payload)` for all subtypes (tool_invoked, shell_start/done, file_*, git_push, github_tool, llm_*, delay, error); `appendActivityRow(msg)` builds `div.activity-feed__row` with `data-subtype`, `span.activity-feed__icon` (placeholder), `span.activity-feed__summary`, `time.activity-feed__ts` (HH:MM:SS from recorded_at) and appends to `#activity-feed`; `attachActivityFeedHandler(source)` listens for `msg.t === "activity"` and appends one row per message.
- **build.ts:** Call `attachActivityFeedHandler(src)` in `_openStream` alongside existing handlers.
- **_activity-feed.scss:** Styles for `.activity-feed__row`, `__icon`, `__summary`, `__ts`.
- **Tests:** `__tests__/activity_feed.test.ts` — formatActivitySummary (several subtypes), appendActivityRow (data-subtype/summary/time, no-op when feed missing), attachActivityFeedHandler (appends on activity, ignores non-activity).
- All payload text via `textContent`/`setAttribute` only; no `innerHTML` with payload data.