### PR TITLE
feat(892): add GET /api/metrics/ab for per-variant A/B metrics

### DIFF
--- a/agentception/routes/api/__init__.py
+++ b/agentception/routes/api/__init__.py
@@ -30,6 +30,7 @@ from .presets import router as _presets
 from .resync import router as _resync
 from .telemetry import router as _telemetry
 from .wizard import router as _wizard
+from .ab_metrics import router as _ab_metrics
 from .metrics import router as _metrics
 from .worktrees import router as _worktrees
 
@@ -54,3 +55,4 @@ router.include_router(_wizard)
 router.include_router(_plan)
 router.include_router(_presets)
 router.include_router(_metrics)
+router.include_router(_ab_metrics)

--- a/agentception/routes/api/ab_metrics.py
+++ b/agentception/routes/api/ab_metrics.py
@@ -1,0 +1,110 @@
+"""A/B metrics API — per-prompt-variant aggregates for developer runs.
+
+Read-only endpoint for comparing control vs treatment (e.g. prompt_variant)
+without changing dispatch or prompts. Used when ready to analyse A/B experiments.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import text
+
+from agentception.db.engine import get_session
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class ABVariantMetrics(BaseModel):
+    """Per-variant aggregate KPIs for completed developer runs."""
+
+    model_config = ConfigDict(frozen=True)
+
+    variant: str
+    role: str
+    runs: int
+    avg_iterations: float
+    avg_input_tokens: float
+    total_tokens: int
+    pass_rate: float
+    passed: int
+    failed: int
+
+
+class ABMetricsResponse(BaseModel):
+    """Response shape for GET /api/metrics/ab."""
+
+    model_config = ConfigDict(frozen=True)
+
+    variants: list[ABVariantMetrics]
+
+
+_AB_QUERY = text("""
+SELECT
+  COALESCE(r.prompt_variant, 'control') AS variant,
+  r.role,
+  COUNT(DISTINCT r.id)::int AS runs,
+  COALESCE(AVG(iter.cnt), 0)::float AS avg_iterations,
+  COALESCE(AVG(r.total_input_tokens), 0)::float AS avg_input_tokens,
+  COALESCE(SUM(r.total_input_tokens + r.total_output_tokens), 0)::int AS total_tokens,
+  COALESCE(AVG(CASE WHEN e.grade IN ('A','B') THEN 1.0 ELSE 0.0 END), 0)::float AS pass_rate,
+  COUNT(CASE WHEN e.grade IN ('A','B') THEN 1 END)::int AS passed,
+  COUNT(CASE WHEN e.grade IN ('C','D','F') THEN 1 END)::int AS failed
+FROM agent_runs r
+LEFT JOIN (
+  SELECT agent_run_id, COUNT(*) AS cnt
+  FROM agent_events
+  WHERE event_type = 'step_start'
+  GROUP BY agent_run_id
+) iter ON iter.agent_run_id = r.id
+LEFT JOIN (
+  SELECT agent_run_id,
+         payload::json->>'grade' AS grade
+  FROM agent_events
+  WHERE event_type = 'done'
+) e ON e.agent_run_id = r.id
+WHERE r.role = 'developer'
+  AND r.status = 'completed'
+  AND r.spawned_at > NOW() - (:days::integer * INTERVAL '1 day')
+GROUP BY COALESCE(r.prompt_variant, 'control'), r.role
+ORDER BY 1, 2
+""")
+
+
+@router.get("/metrics/ab", response_model=ABMetricsResponse)
+async def get_metrics_ab(
+    days: int = Query(default=7, ge=1, le=90, description="Lookback window in days (1–90)."),
+) -> ABMetricsResponse:
+    """Return per-prompt-variant aggregates for completed developer runs.
+
+    Runs with ``prompt_variant IS NULL`` are grouped as the ``control`` bucket.
+    Pass rate is derived from reviewer grade (A/B = pass, C/D/F = fail) when
+    available from the run's done event payload.
+    """
+    try:
+        async with get_session() as session:
+            result = await session.execute(_AB_QUERY, {"days": days})
+            rows = result.mappings().all()
+    except Exception as exc:
+        logger.warning("⚠️ get_metrics_ab DB query failed (non-fatal): %s", exc)
+        return ABMetricsResponse(variants=[])
+
+    variants = [
+        ABVariantMetrics(
+            variant=str(row["variant"]),
+            role=str(row["role"]),
+            runs=int(row["runs"]),
+            avg_iterations=float(row["avg_iterations"]),
+            avg_input_tokens=float(row["avg_input_tokens"]),
+            total_tokens=int(row["total_tokens"]),
+            pass_rate=float(row["pass_rate"]),
+            passed=int(row["passed"]),
+            failed=int(row["failed"]),
+        )
+        for row in rows
+    ]
+    return ABMetricsResponse(variants=variants)

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -663,8 +663,45 @@ Read-only endpoints that expose daily KPI snapshots from the database.
 |--------|------|-------------|
 | `GET` | `/api/metrics/daily` | KPI snapshot for a single calendar day |
 | `GET` | `/api/metrics/daily/range` | KPI snapshots for a date range (max 30 days) |
+| `GET` | `/api/metrics/ab` | Per-prompt-variant A/B metrics for developer runs |
+
+#### `GET /api/metrics/ab`
+
+Returns per-variant aggregates for completed developer runs over a lookback window. Used to compare control vs treatment when running prompt A/B experiments. Runs with `prompt_variant IS NULL` are grouped as the **control** bucket.
+
+| Query param | Type | Required | Description |
+|-------------|------|----------|-------------|
+| `days` | `integer` | no | Lookback window in days (1–90). Default: 7. |
+
+**Status codes:**
+
+| Code | Meaning |
+|------|---------|
+| `200` | Success — `ABMetricsResponse` (always; empty `variants` when no data) |
+| `422` | `days` outside 1–90 |
+
+**Response schema — `ABMetricsResponse`:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `variants` | `list[ABVariantMetrics]` | One entry per distinct `(variant, role)` |
+
+**`ABVariantMetrics`:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `variant` | `string` | `"control"` or the value of `prompt_variant` (e.g. `"streamlined"`) |
+| `role` | `string` | Agent role (e.g. `"developer"`) |
+| `runs` | `integer` | Number of completed runs in the window |
+| `avg_iterations` | `float` | Mean step_start count per run |
+| `avg_input_tokens` | `float` | Mean input tokens per run |
+| `total_tokens` | `integer` | Sum of input + output tokens across runs |
+| `pass_rate` | `float` | Fraction of runs with reviewer grade A or B (from done event payload) |
+| `passed` | `integer` | Count of runs with grade A or B |
+| `failed` | `integer` | Count of runs with grade C, D, or F |
 
 #### `GET /api/metrics/daily`
+
 
 Returns a `DailyMetricsResponse` for the requested date.
 

--- a/tests/test_ab_metrics.py
+++ b/tests/test_ab_metrics.py
@@ -1,0 +1,148 @@
+"""Tests for GET /api/metrics/ab — per-variant A/B metrics."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture()
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    """ASGI test client for the metrics/ab route only."""
+    from fastapi import FastAPI
+
+    from agentception.routes.api.ab_metrics import router as ab_router
+
+    app = FastAPI()
+    app.include_router(ab_router)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+def _mock_result_two_rows() -> list[dict[str, object]]:
+    """Two rows: control and streamlined."""
+    return [
+        {
+            "variant": "control",
+            "role": "developer",
+            "runs": 10,
+            "avg_iterations": 5.2,
+            "avg_input_tokens": 50000.0,
+            "total_tokens": 520000,
+            "pass_rate": 0.8,
+            "passed": 8,
+            "failed": 2,
+        },
+        {
+            "variant": "streamlined",
+            "role": "developer",
+            "runs": 10,
+            "avg_iterations": 4.1,
+            "avg_input_tokens": 42000.0,
+            "total_tokens": 410000,
+            "pass_rate": 0.9,
+            "passed": 9,
+            "failed": 1,
+        },
+    ]
+
+
+@pytest.mark.anyio
+async def test_ab_metrics_response_shape(client: AsyncClient) -> None:
+    """GET /api/metrics/ab returns 200 with ABMetricsResponse and both variants."""
+    mock_rows = _mock_result_two_rows()
+    mock_result = MagicMock()
+    mock_result.mappings.return_value.all.return_value = mock_rows
+
+    async def fake_execute(*args: object, **kwargs: object) -> MagicMock:
+        return mock_result
+
+    mock_session = AsyncMock()
+    mock_session.execute = fake_execute
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "agentception.routes.api.ab_metrics.get_session",
+        return_value=mock_cm,
+    ):
+        response = await client.get("/metrics/ab")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "variants" in data
+    assert len(data["variants"]) == 2
+    variants = {v["variant"]: v for v in data["variants"]}
+    assert "control" in variants
+    assert "streamlined" in variants
+    assert variants["control"]["runs"] == 10
+    assert variants["control"]["pass_rate"] == 0.8
+    assert variants["streamlined"]["avg_iterations"] == 4.1
+
+
+@pytest.mark.anyio
+async def test_ab_metrics_empty_db(client: AsyncClient) -> None:
+    """GET /api/metrics/ab with no data returns 200 and empty variants list."""
+    mock_result = MagicMock()
+    mock_result.mappings.return_value.all.return_value = []
+
+    async def fake_execute(*args: object, **kwargs: object) -> MagicMock:
+        return mock_result
+
+    mock_session = AsyncMock()
+    mock_session.execute = fake_execute
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "agentception.routes.api.ab_metrics.get_session",
+        return_value=mock_cm,
+    ):
+        response = await client.get("/metrics/ab")
+
+    assert response.status_code == 200
+    assert response.json() == {"variants": []}
+
+
+@pytest.mark.anyio
+async def test_ab_metrics_days_param(client: AsyncClient) -> None:
+    """GET /api/metrics/ab?days=30 passes days to the query."""
+    mock_result = MagicMock()
+    mock_result.mappings.return_value.all.return_value = []
+
+    async def fake_execute(statement: object, params: object) -> MagicMock:
+        # Ensure days param is passed (params may be dict or tuple)
+        if isinstance(params, dict):
+            assert params.get("days") == 30
+        return mock_result
+
+    mock_session = AsyncMock()
+    mock_session.execute = fake_execute
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "agentception.routes.api.ab_metrics.get_session",
+        return_value=mock_cm,
+    ):
+        response = await client.get("/metrics/ab", params={"days": 30})
+
+    assert response.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_ab_metrics_days_clamped(client: AsyncClient) -> None:
+    """days=0 is clamped to 1 (Query(ge=1)); invalid values return 422."""
+    response = await client.get("/metrics/ab", params={"days": 0})
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
Implements **#892**: read-only endpoint for per-variant A/B metrics to support prompt A/B testing.

## What changed
- **New route:** `GET /api/metrics/ab?days=N` (default 7, clamp 1–90)
- **Models:** `ABVariantMetrics`, `ABMetricsResponse` (variants list)
- **Query:** Joins `agent_runs` to `agent_events` for iteration count (step_start) and grade (done payload); `COALESCE(prompt_variant, 'control')` for variant
- **Behavior:** 200 with `variants: []` when no data or on DB error (no 404/500)
- **Router:** Registered in `agentception/routes/api/__init__.py`
- **Tests:** `tests/test_ab_metrics.py` — shape, empty DB, days param, 422 for days=0
- **Docs:** `docs/reference/api.md` — GET /api/metrics/ab section

## Safety
- **Additive only.** No changes to dispatch, default prompts, or existing routes. Does not affect current setup.
- Read-only; no writes. Ready for Phase 2 (dashboard/HTMX) when you enable A/B testing.