### PR TITLE
feat(893): add HTMX A/B metrics panel to build page

### DIFF
--- a/agentception/routes/api/ab_metrics.py
+++ b/agentception/routes/api/ab_metrics.py
@@ -2,6 +2,9 @@
 
 Read-only endpoint for comparing control vs treatment (e.g. prompt_variant)
 without changing dispatch or prompts. Used when ready to analyse A/B experiments.
+
+When the request includes the HTMX header ``HX-Request: true``, returns an HTML
+partial (table) for in-place swap; otherwise returns JSON.
 """
 
 from __future__ import annotations
@@ -11,8 +14,11 @@ import logging
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import text
+from starlette.requests import Request
+from starlette.responses import Response
 
 from agentception.db.engine import get_session
+from agentception.routes.ui._shared import _TEMPLATES
 
 logger = logging.getLogger(__name__)
 
@@ -75,15 +81,19 @@ ORDER BY 1, 2
 """)
 
 
-@router.get("/metrics/ab", response_model=ABMetricsResponse)
+@router.get("/metrics/ab", response_model=None)
 async def get_metrics_ab(
+    request: Request,
     days: int = Query(default=7, ge=1, le=90, description="Lookback window in days (1–90)."),
-) -> ABMetricsResponse:
+) -> ABMetricsResponse | Response:
     """Return per-prompt-variant aggregates for completed developer runs.
 
     Runs with ``prompt_variant IS NULL`` are grouped as the ``control`` bucket.
     Pass rate is derived from reviewer grade (A/B = pass, C/D/F = fail) when
     available from the run's done event payload.
+
+    When the request includes the ``HX-Request: true`` header (HTMX), returns
+    HTML (partials/_ab_metrics.html) for in-place swap; otherwise returns JSON.
     """
     try:
         async with get_session() as session:
@@ -91,20 +101,28 @@ async def get_metrics_ab(
             rows = result.mappings().all()
     except Exception as exc:
         logger.warning("⚠️ get_metrics_ab DB query failed (non-fatal): %s", exc)
-        return ABMetricsResponse(variants=[])
+        response = ABMetricsResponse(variants=[])
+    else:
+        variants = [
+            ABVariantMetrics(
+                variant=str(row["variant"]),
+                role=str(row["role"]),
+                runs=int(row["runs"]),
+                avg_iterations=float(row["avg_iterations"]),
+                avg_input_tokens=float(row["avg_input_tokens"]),
+                total_tokens=int(row["total_tokens"]),
+                pass_rate=float(row["pass_rate"]),
+                passed=int(row["passed"]),
+                failed=int(row["failed"]),
+            )
+            for row in rows
+        ]
+        response = ABMetricsResponse(variants=variants)
 
-    variants = [
-        ABVariantMetrics(
-            variant=str(row["variant"]),
-            role=str(row["role"]),
-            runs=int(row["runs"]),
-            avg_iterations=float(row["avg_iterations"]),
-            avg_input_tokens=float(row["avg_input_tokens"]),
-            total_tokens=int(row["total_tokens"]),
-            pass_rate=float(row["pass_rate"]),
-            passed=int(row["passed"]),
-            failed=int(row["failed"]),
+    if request.headers.get("HX-Request") == "true":
+        return _TEMPLATES.TemplateResponse(
+            request,
+            "partials/_ab_metrics.html",
+            {"variants": [v.model_dump() for v in response.variants]},
         )
-        for row in rows
-    ]
-    return ABMetricsResponse(variants=variants)
+    return response

--- a/agentception/static/scss/pages/_ab_metrics.scss
+++ b/agentception/static/scss/pages/_ab_metrics.scss
@@ -1,0 +1,38 @@
+// ── A/B metrics panel (Mission Control build page) ─────────────────────────────
+
+.ab-metrics {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+
+  th,
+  td {
+    padding: 4px 8px;
+    text-align: right;
+  }
+
+  th:first-child,
+  td:first-child {
+    text-align: left;
+  }
+
+  thead th {
+    border-bottom: 1px solid var(--border);
+    font-weight: 600;
+  }
+
+  tr:nth-child(even) {
+    background: var(--surface-2);
+  }
+
+  .no-data {
+    text-align: center;
+    color: var(--muted);
+  }
+}
+
+.loading-placeholder {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin: 0.5rem 0;
+}

--- a/agentception/static/scss/pages/_build.scss
+++ b/agentception/static/scss/pages/_build.scss
@@ -3,6 +3,7 @@
 // Cascade order must match the original monolithic _build.scss.
 
 @use 'activity-feed';
+@use 'ab_metrics';
 @use 'inspector-layout';
 @use 'thought-block';
 @use 'file-edit-card';

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -146,6 +146,16 @@
     </aside>
   </div>{# /.build-columns #}
 
+  {# ── A/B metrics panel (HTMX polled every 30s) ───────────────────────────── #}
+  <div id="ab-metrics-panel"
+       class="build-ab-metrics"
+       hx-get="/api/metrics/ab"
+       hx-trigger="load, every 30s"
+       hx-target="#ab-metrics-panel"
+       hx-swap="innerHTML">
+    <p class="loading-placeholder">Loading A/B metrics…</p>
+  </div>
+
 </div>{# /.build-layout #}
 
 {# ── Org Designer overlay ─────────────────────────────────────────────────── #}

--- a/agentception/templates/partials/_ab_metrics.html
+++ b/agentception/templates/partials/_ab_metrics.html
@@ -1,0 +1,26 @@
+<table class="ab-metrics">
+  <thead>
+    <tr>
+      <th>Variant</th>
+      <th>Runs</th>
+      <th>Avg Iters</th>
+      <th>Pass Rate</th>
+      <th>Avg Tokens</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for v in variants %}
+  <tr>
+    <td>{{ v.variant }}</td>
+    <td>{{ v.runs }}</td>
+    <td>{{ "%.1f"|format(v.avg_iterations) }}</td>
+    <td>{{ "%.0f%%"|format(v.pass_rate * 100) }}</td>
+    <td>{{ v.avg_input_tokens | int }}</td>
+  </tr>
+  {% else %}
+  <tr>
+    <td colspan="5" class="no-data">No completed runs in the last 7 days.</td>
+  </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -700,6 +700,8 @@ Returns per-variant aggregates for completed developer runs over a lookback wind
 | `passed` | `integer` | Count of runs with grade A or B |
 | `failed` | `integer` | Count of runs with grade C, D, or F |
 
+**A/B Metrics Panel (HTMX):** When the request includes the header `HX-Request: true`, the endpoint returns HTML (`Content-Type: text/html`) — a table partial for in-place swap on the Mission Control build page. When the header is absent, the response is JSON as above.
+
 #### `GET /api/metrics/daily`
 
 

--- a/tests/test_ab_metrics_panel.py
+++ b/tests/test_ab_metrics_panel.py
@@ -1,0 +1,122 @@
+"""Tests for the A/B metrics HTMX panel on the build page (issue #893)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from html.parser import HTMLParser
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture()
+async def client() -> AsyncGenerator[AsyncClient, None]:
+    """ASGI test client for the metrics/ab route only."""
+    from fastapi import FastAPI
+
+    from agentception.routes.api.ab_metrics import router as ab_router
+
+    app = FastAPI()
+    app.include_router(ab_router)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+def test_ab_panel_polling_div_in_build_html() -> None:
+    """build.html contains the A/B metrics panel div with HTMX polling attributes."""
+    root = Path(__file__).resolve().parent.parent
+    build_html = root / "agentception" / "templates" / "build.html"
+    content = build_html.read_text()
+
+    class FindAbPanel(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__()
+            self.found: dict[str, str] = {}
+
+        def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+            if tag != "div":
+                return
+            attrs_d = dict((k, v or "") for k, v in attrs)
+            if attrs_d.get("id") == "ab-metrics-panel":
+                self.found = attrs_d
+
+    parser = FindAbPanel()
+    parser.feed(content)
+    assert parser.found.get("id") == "ab-metrics-panel"
+    assert parser.found.get("hx-get") == "/api/metrics/ab"
+    hx_trigger = parser.found.get("hx-trigger", "")
+    assert "every 30s" in hx_trigger
+
+
+@pytest.mark.anyio
+async def test_ab_metrics_htmx_returns_html(client: AsyncClient) -> None:
+    """GET /api/metrics/ab with HX-Request: true returns HTML with table.ab-metrics."""
+    mock_result = MagicMock()
+    mock_result.mappings.return_value.all.return_value = [
+        {
+            "variant": "control",
+            "role": "developer",
+            "runs": 5,
+            "avg_iterations": 4.0,
+            "avg_input_tokens": 1000.0,
+            "total_tokens": 5000,
+            "pass_rate": 0.8,
+            "passed": 4,
+            "failed": 1,
+        },
+    ]
+
+    async def fake_execute(*args: object, **kwargs: object) -> MagicMock:
+        return mock_result
+
+    mock_session = AsyncMock()
+    mock_session.execute = fake_execute
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "agentception.routes.api.ab_metrics.get_session",
+        return_value=mock_cm,
+    ):
+        response = await client.get(
+            "/metrics/ab",
+            headers={"HX-Request": "true"},
+        )
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    assert '<table class="ab-metrics">' in response.text
+
+
+@pytest.mark.anyio
+async def test_ab_metrics_json_unaffected(client: AsyncClient) -> None:
+    """GET /api/metrics/ab without HX-Request returns JSON ABMetricsResponse."""
+    mock_result = MagicMock()
+    mock_result.mappings.return_value.all.return_value = []
+
+    async def fake_execute(*args: object, **kwargs: object) -> MagicMock:
+        return mock_result
+
+    mock_session = AsyncMock()
+    mock_session.execute = fake_execute
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "agentception.routes.api.ab_metrics.get_session",
+        return_value=mock_cm,
+    ):
+        response = await client.get("/metrics/ab")
+
+    assert response.status_code == 200
+    assert "application/json" in response.headers.get("content-type", "")
+    data = response.json()
+    assert "variants" in data
+    assert isinstance(data["variants"], list)


### PR DESCRIPTION
## Summary
Implements **#893**: HTMX A/B metrics panel on Mission Control build page.

## What changed
- **build.html:** Polling div `#ab-metrics-panel` with `hx-get="/api/metrics/ab"`, `hx-trigger="load, every 30s"`, placeholder "Loading A/B metrics…"
- **partials/_ab_metrics.html:** Table (Variant, Runs, Avg Iters, Pass Rate, Avg Tokens); empty state "No completed runs in the last 7 days."
- **ab_metrics.py:** When `HX-Request: true` return `TemplateResponse` (HTML partial); otherwise JSON unchanged. `response_model=None` so FastAPI allows both return types.
- **_ab_metrics.scss:** Table styles + `.loading-placeholder`; imported in `pages/_build.scss`
- **test_ab_metrics_panel.py:** Polling div present in build.html; HTMX returns HTML with `<table class="ab-metrics">`; JSON path unchanged
- **api.md:** A/B Metrics Panel subsection (HX-Request → HTML)

## Acceptance
- [x] build.html has div with id, hx-get, hx-trigger containing `every 30s`
- [x] partials/_ab_metrics.html exists with table.ab-metrics
- [x] GET with HX-Request: true → text/html
- [x] GET without header → application/json
- [x] _ab_metrics.scss imported in barrel
- [x] mypy clean on ab_metrics.py