### PR TITLE
feat(local-llm): full pipeline for local Qwen 3.5 35B, doc and flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ GH_REPO=cgcardona/your-repo
 # API key from https://console.anthropic.com → API Keys
 # Required for Phase 1A planning (brain dump → PlanSpec YAML) and all agent runs.
 ANTHROPIC_API_KEY=
+# Optional: use local OpenAI-compatible LLM (e.g. mlx_lm.server) for developer agent only.
+# USE_LOCAL_LLM=true
+# LOCAL_LLM_BASE_URL=http://host.docker.internal:8080
 
 # ── Task Runner ─────────────────────────────────────────────────────────────
 # Task runner backend for agent execution.

--- a/agentception/config.py
+++ b/agentception/config.py
@@ -24,7 +24,7 @@ import json
 import logging
 from pathlib import Path
 
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -145,6 +145,49 @@ class AgentCeptionSettings(BaseSettings):
     falls back to the keyword-based heuristic classifier — no LLM is required
     for the service to start.
     """
+    use_local_llm: bool = False
+    """When True, the developer agent uses the local LLM at ``local_llm_base_url``
+    instead of Anthropic. Set via ``USE_LOCAL_LLM`` env var (e.g. ``true``).
+    Planner and reviewer still use Anthropic."""
+
+    @field_validator("use_local_llm", mode="before")
+    @classmethod
+    def _parse_use_local_llm(cls, v: object) -> bool:
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, str):
+            return v.strip().lower() in ("true", "1", "yes")
+        return False
+
+    local_llm_base_url: str = "http://host.docker.internal:8080"
+    """Base URL of the local OpenAI-compatible server (e.g. mlx_lm.server).
+    Used when ``use_local_llm`` is True. From Docker, use host.docker.internal
+    to reach a server running on the host. Set via ``LOCAL_LLM_BASE_URL``."""
+
+    local_llm_chat_path: str = "/v1/chat/completions"
+    """Path appended to ``local_llm_base_url`` for chat requests. Some servers
+    use ``/chat/completions`` without the ``/v1`` prefix. Set via
+    ``LOCAL_LLM_CHAT_PATH``."""
+
+    local_llm_model: str = ""
+    """Model name sent in the request. If empty, omit so the server uses its
+    loaded model (avoids 404 from mlx_lm.server when it doesn't know \"local\").
+    Set via ``LOCAL_LLM_MODEL``."""
+
+    local_llm_max_context_chars: int = 12_000
+    """Max characters for the first user message when using the local LLM.
+    Small models (e.g. Qwen 4B) are easily overloaded; truncating the task
+    briefing keeps context manageable. Set via ``LOCAL_LLM_MAX_CONTEXT_CHARS``."""
+
+    local_llm_max_tokens: int = 4096
+    """Max tokens for local LLM completion. Small models struggle with 32k;
+    use 4096 or 8192. Set via ``LOCAL_LLM_MAX_TOKENS``."""
+
+    local_llm_max_system_chars: int = 6000
+    """Max characters for the system prompt when using the local LLM. Truncates
+    role + cognitive arch so small models get a digest. Set via
+    ``LOCAL_LLM_MAX_SYSTEM_CHARS``."""
+
     github_token: str = ""
     """GitHub Personal Access Token for GitHub API calls and the GitHub MCP server.
 

--- a/agentception/routes/api/__init__.py
+++ b/agentception/routes/api/__init__.py
@@ -31,6 +31,7 @@ from .resync import router as _resync
 from .telemetry import router as _telemetry
 from .wizard import router as _wizard
 from .ab_metrics import router as _ab_metrics
+from .local_llm import router as _local_llm
 from .metrics import router as _metrics
 from .worktrees import router as _worktrees
 
@@ -56,3 +57,4 @@ router.include_router(_plan)
 router.include_router(_presets)
 router.include_router(_metrics)
 router.include_router(_ab_metrics)
+router.include_router(_local_llm)

--- a/agentception/routes/api/local_llm.py
+++ b/agentception/routes/api/local_llm.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Minimal local-LLM probe and hello-agent endpoints.
+
+- GET /hello — one-shot completion (no agent loop).
+- POST /hello-agent — dispatch a minimal agent run that says "hello world" via the local LLM.
+"""
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from agentception.config import settings
+from agentception.db.persist import acknowledge_agent_run, persist_agent_run_dispatch
+from agentception.services.agent_loop import run_agent_loop
+from agentception.services.llm import call_local_completion
+
+router = APIRouter(prefix="/local-llm", tags=["local-llm"])
+
+
+@router.get("/hello")
+async def local_llm_hello() -> dict[str, str | bool]:
+    """One-shot completion: ask the local LLM to reply 'hello world'.
+
+    Requires ``USE_LOCAL_LLM=true``. Returns the model's reply so you can
+    confirm the pipeline works without running a full developer agent.
+    """
+    if not settings.use_local_llm:
+        raise HTTPException(
+            503,
+            detail="Local LLM is disabled. Set USE_LOCAL_LLM=true and restart.",
+        )
+    try:
+        reply = await call_local_completion(
+            system="You are a helpful assistant. Reply briefly.",
+            user_message="Reply with exactly: hello world",
+            max_tokens=128,
+        )
+    except Exception as exc:
+        raise HTTPException(502, detail=f"Local LLM request failed: {exc!s}") from exc
+    return {"ok": True, "reply": reply}
+
+
+class HelloAgentResponse(BaseModel):
+    run_id: str
+    status: str = "implementing"
+
+
+@router.post("/hello-agent", response_model=HelloAgentResponse)
+async def local_llm_hello_agent() -> HelloAgentResponse:
+    """Dispatch a minimal agent run that uses the local LLM to reply "hello world".
+
+    Creates a run with run_id ``local-hello-<uuid>``, a minimal task (no tools,
+    one user message), and fires the agent loop. The agent responds with text
+    only and the run completes. Requires ``USE_LOCAL_LLM=true``.
+    """
+    if not settings.use_local_llm:
+        raise HTTPException(
+            503,
+            detail="Local LLM is disabled. Set USE_LOCAL_LLM=true and restart.",
+        )
+    run_id = f"local-hello-{uuid.uuid4().hex[:8]}"
+    worktree_path = str(Path(settings.worktrees_dir) / run_id)
+    host_worktree_path = str(Path(settings.host_worktrees_dir) / run_id)
+    Path(worktree_path).mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    batch_id = f"local-hello-{stamp}-{uuid.uuid4().hex[:4]}"
+    await persist_agent_run_dispatch(
+        run_id=run_id,
+        issue_number=0,
+        role="developer",
+        branch="local-hello",
+        worktree_path=worktree_path,
+        batch_id=batch_id,
+        host_worktree_path=host_worktree_path,
+        cognitive_arch=None,
+        gh_repo=settings.gh_repo,
+    )
+    await acknowledge_agent_run(run_id)
+    asyncio.create_task(run_agent_loop(run_id), name=f"agent-loop-{run_id}")
+    return HelloAgentResponse(run_id=run_id, status="implementing")

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -60,6 +60,7 @@ from agentception.services.llm import (
     _MODEL,
     call_anthropic,
     call_anthropic_with_tools,
+    call_local_with_tools,
 )
 from agentception.services.code_indexer import search_codebase
 from agentception.services.github_mcp_client import GitHubMCPClient
@@ -525,7 +526,11 @@ async def run_agent_loop(
     else:
         tool_defs = all_tool_defs
 
-    initial_message = await _fetch_task_briefing(run_id, task, worktree_path)
+    if run_id.startswith("local-hello") and settings.use_local_llm:
+        initial_message = "Reply with exactly: hello world."
+        tool_defs = []
+    else:
+        initial_message = await _fetch_task_briefing(run_id, task, worktree_path)
 
     messages: list[dict[str, object]] = [{"role": "user", "content": initial_message}]
 
@@ -755,16 +760,48 @@ async def run_agent_loop(
             try:
                 bounded = await _prune_history(_truncate_tool_results(messages), last_input_tokens=last_input_tokens)
                 _active_model = _HAIKU_MODEL if task.role == "reviewer" else _MODEL
-                response: ToolResponse = await call_anthropic_with_tools(
-                    bounded,
-                    system=system_prompt,
-                    tools=active_tool_defs,
-                    model=_active_model,
-                    extra_system_blocks=extra_blocks or None,
-                    session=session,
-                    run_id=run_id,
-                    iteration=iteration,
-                )
+                if settings.use_local_llm and task.role == "developer":
+                    # Same pipeline as Anthropic: full system prompt (role + cognitive arch + runtime
+                    # note), same tools, same extra_system_blocks. Only the LLM endpoint and context
+                    # caps differ. Cap context so small local models (e.g. Qwen 4B) aren't overloaded.
+                    local_messages = _truncate_first_user_message_for_local_llm(
+                        bounded,
+                        max_chars=settings.local_llm_max_context_chars,
+                    )
+                    system_for_local = system_prompt
+                    if len(system_prompt) > settings.local_llm_max_system_chars:
+                        system_for_local = (
+                            system_prompt[: settings.local_llm_max_system_chars]
+                            + "\n\n[System prompt truncated for local model.]"
+                        )
+                        logger.warning(
+                            "⚠️ local LLM: truncated system prompt from %d to %d chars",
+                            len(system_prompt),
+                            settings.local_llm_max_system_chars,
+                        )
+                    response = await call_local_with_tools(
+                        local_messages,
+                        system=system_for_local,
+                        tools=active_tool_defs,
+                        model="local",
+                        temperature=0.0,
+                        max_tokens=settings.local_llm_max_tokens,
+                        extra_system_blocks=extra_blocks or None,
+                        session=session,
+                        run_id=run_id,
+                        iteration=iteration,
+                    )
+                else:
+                    response = await call_anthropic_with_tools(
+                        bounded,
+                        system=system_prompt,
+                        tools=active_tool_defs,
+                        model=_active_model,
+                        extra_system_blocks=extra_blocks or None,
+                        session=session,
+                        run_id=run_id,
+                        iteration=iteration,
+                    )
             except Exception as exc:
                 _record_llm_call()  # stamp even on error so next delay is measured correctly
                 logger.exception("❌ agent_loop LLM error on iteration %d", iteration)
@@ -1908,6 +1945,38 @@ async def _run_recon_phase(
 # ---------------------------------------------------------------------------
 # Context management — keep token count bounded across iterations
 # ---------------------------------------------------------------------------
+
+
+def _truncate_first_user_message_for_local_llm(
+    messages: list[dict[str, object]],
+    max_chars: int,
+) -> list[dict[str, object]]:
+    """Truncate the first user message to max_chars when using a small local LLM.
+
+    Avoids overloading models like Qwen 4B with a 50k+ character task briefing.
+    Only the first message is considered; its content must be a string.  Returns
+    a copy so the original list is unchanged.
+    """
+    if not messages or max_chars <= 0:
+        return list(messages)
+    first = messages[0]
+    if first.get("role") != "user":
+        return list(messages)
+    content = first.get("content", "")
+    if not isinstance(content, str) or len(content) <= max_chars:
+        return list(messages)
+    truncated = content[:max_chars] + (
+        "\n\n[Context truncated for local model. Use the objective and AC above.]"
+    )
+    out = [dict(first)]
+    out[0]["content"] = truncated
+    out.extend(messages[1:])
+    logger.warning(
+        "⚠️ local LLM: truncated first user message from %d to %d chars",
+        len(content),
+        max_chars,
+    )
+    return out
 
 
 def _build_tool_id_map(messages: list[dict[str, object]]) -> dict[str, str]:

--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -863,3 +863,225 @@ async def call_anthropic_with_tools(
         cache_creation_input_tokens=cache_creation_tokens,
         cache_read_input_tokens=cache_read_tokens,
     )
+
+
+# ---------------------------------------------------------------------------
+# Local OpenAI-compatible server (e.g. mlx_lm.server) — used when use_local_llm
+# ---------------------------------------------------------------------------
+
+
+def _tools_to_openai(tools: list[ToolDefinition]) -> list[dict[str, object]]:
+    """Convert internal tool definitions to OpenAI /v1/chat/completions format."""
+    out: list[dict[str, object]] = []
+    for t in tools:
+        fn = t["function"]
+        out.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": fn["name"],
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                },
+            }
+        )
+    return out
+
+
+async def call_local_with_tools(
+    messages: list[dict[str, object]],
+    *,
+    system: str,
+    tools: list[ToolDefinition],
+    model: str = "local",
+    temperature: float = 0.0,
+    max_tokens: int = 32000,
+    extra_system_blocks: list[dict[str, object]] | None = None,
+    session: AsyncSession | None = None,
+    run_id: str | None = None,
+    iteration: int = 0,
+) -> ToolResponse:
+    """Call a local OpenAI-compatible server (e.g. mlx_lm.server) with tool use.
+
+    Same contract as :func:`call_anthropic_with_tools`: accepts OpenAI-format
+    messages and tools, returns :class:`ToolResponse`. Use when
+    ``settings.use_local_llm`` is True.
+    """
+    base = settings.local_llm_base_url.rstrip("/")
+    url = f"{base}{settings.local_llm_chat_path}"
+    system_content = system
+    if extra_system_blocks:
+        for blk in extra_system_blocks:
+            if isinstance(blk, dict) and blk.get("type") == "text":
+                text = blk.get("text", "")
+                if isinstance(text, str) and text:
+                    system_content = f"{system_content}\n\n{text}"
+    request_messages: list[dict[str, object]] = [
+        {"role": "system", "content": system_content},
+        *messages,
+    ]
+    payload: dict[str, object] = {
+        "messages": request_messages,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+    }
+    if tools:
+        payload["tools"] = _tools_to_openai(tools)
+        payload["tool_choice"] = "auto"
+    if settings.local_llm_model:
+        payload["model"] = settings.local_llm_model
+    # Else omit model so servers like mlx_lm.server use their loaded model (avoids 404).
+    if session is not None and run_id is not None:
+        persist_activity_event(
+            session,
+            run_id,
+            "llm_iter",
+            {"iteration": iteration, "model": model, "turns": len(messages)},
+        )
+        await session.flush()
+
+    logger.info(
+        "✅ Local LLM tool-use call — url=%s turns=%d tools=%d",
+        url,
+        len(messages),
+        len(tools),
+    )
+    timeout = httpx.Timeout(connect=10.0, read=300.0, write=60.0, pool=10.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(url, json=payload)
+        resp.raise_for_status()
+
+    data: object = resp.json()
+    if not isinstance(data, dict):
+        raise ValueError(f"Local LLM response not a dict: {type(data)}")
+
+    choices: object = data.get("choices", [])
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("Local LLM response has no choices")
+    first: object = choices[0]
+    if not isinstance(first, dict):
+        raise ValueError("Local LLM first choice not a dict")
+    msg: object = first.get("message", {})
+    if not isinstance(msg, dict):
+        raise ValueError("Local LLM message not a dict")
+
+    finish: object = first.get("finish_reason", "stop")
+    if finish == "tool_calls":
+        stop_reason = "tool_calls"
+    elif finish == "length":
+        stop_reason = "length"
+    else:
+        stop_reason = "stop"
+
+    content = str(msg.get("content") or "").strip()
+    raw_calls: object = msg.get("tool_calls") or []
+    tool_calls: list[ToolCall] = []
+    if isinstance(raw_calls, list):
+        for tc in raw_calls:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function")
+            if not isinstance(fn, dict):
+                continue
+            args = fn.get("arguments", "{}")
+            tool_calls.append(
+                ToolCall(
+                    id=str(tc.get("id", "")),
+                    type="function",
+                    function=ToolCallFunction(
+                        name=str(fn.get("name", "")),
+                        arguments=args if isinstance(args, str) else json.dumps(args),
+                    ),
+                )
+            )
+
+    usage: object = data.get("usage", {})
+    input_tokens = 0
+    output_tokens = 0
+    if isinstance(usage, dict):
+        input_tokens = int(usage.get("prompt_tokens", 0) or 0)
+        output_tokens = int(usage.get("completion_tokens", 0) or 0)
+    # Same log shape as Anthropic path so watch_run.py shows reply and done.
+    if content.strip():
+        snippet = content.replace("\n", " ").strip()
+        logger.info("✅ LLM reply — chars=%d text=%s", len(content), snippet)
+    logger.info(
+        "✅ LLM tool-use done — stop_reason=%s content_chars=%d tool_calls=%d",
+        stop_reason,
+        len(content),
+        len(tool_calls),
+    )
+    if session is not None and run_id is not None:
+        persist_activity_event(
+            session,
+            run_id,
+            "llm_usage",
+            {"input_tokens": input_tokens, "cache_write": 0, "cache_read": 0},
+        )
+        await session.flush()
+        if content:
+            persist_activity_event(
+                session,
+                run_id,
+                "llm_reply",
+                {"chars": len(content), "text_preview": content[:200]},
+            )
+            await session.flush()
+        persist_activity_event(
+            session,
+            run_id,
+            "llm_done",
+            {"stop_reason": stop_reason, "tool_call_count": len(tool_calls)},
+        )
+        await session.flush()
+
+    return ToolResponse(
+        stop_reason=stop_reason,
+        content=content,
+        tool_calls=tool_calls,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+
+async def call_local_completion(
+    system: str,
+    user_message: str,
+    *,
+    max_tokens: int = 128,
+) -> str:
+    """Single-turn completion against the local OpenAI-compatible server (no tools).
+
+    Used by the ``GET /api/local-llm/hello`` endpoint to verify the local model
+    responds. Returns the assistant's text content.
+    """
+    base = settings.local_llm_base_url.rstrip("/")
+    url = f"{base}{settings.local_llm_chat_path}"
+    payload: dict[str, object] = {
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user_message},
+        ],
+        "temperature": 0.0,
+        "max_tokens": max_tokens,
+    }
+    if settings.local_llm_model:
+        payload["model"] = settings.local_llm_model
+    timeout = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(url, json=payload)
+        resp.raise_for_status()
+    data: object = resp.json()
+    if not isinstance(data, dict):
+        raise ValueError(f"Local LLM response not a dict: {type(data)}")
+    choices: object = data.get("choices", [])
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("Local LLM response has no choices")
+    first: object = choices[0]
+    if not isinstance(first, dict):
+        raise ValueError("Local LLM first choice not a dict")
+    msg: object = first.get("message", {})
+    if not isinstance(msg, dict):
+        raise ValueError("Local LLM message not a dict")
+    content: object = msg.get("content")
+    return str(content).strip() if content else ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
       # Override via HOST_REPO_DIR in .env when the repo is not at the default.
       HOST_REPO_DIR: ${HOST_REPO_DIR:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # Optional: developer agent uses local OpenAI-compatible server (e.g. mlx_lm.server on host).
+      USE_LOCAL_LLM: ${USE_LOCAL_LLM:-false}
+      LOCAL_LLM_BASE_URL: ${LOCAL_LLM_BASE_URL:-http://host.docker.internal:8080}
       # gh CLI reads GITHUB_TOKEN when the keychain (macOS) is unavailable inside Docker.
       # Set GITHUB_TOKEN in .env to a PAT with repo+issues scope.
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
@@ -83,6 +86,11 @@ services:
     dns:
       - "1.1.1.1"
       - "8.8.8.8"
+    # Let the container reach a server on the host (e.g. MLX server on port 8080).
+    # Docker Desktop on Mac/Windows provides host.docker.internal by default;
+    # Linux and some other runtimes do not, so we set it explicitly.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - agentception-net
     command: >

--- a/docs/guides/local-llm-mlx.md
+++ b/docs/guides/local-llm-mlx.md
@@ -23,11 +23,7 @@ Two common options:
 - **Text-only (mlx-lm):** for chat/completion and the built-in OpenAI-compatible server.
 - **Vision/multimodal (mlx-vlm):** required for the 4-bit 35B model from mlx-community (`Qwen3.5-35B-A3B-4bit`).
 
-For the **35B 4-bit** model (fits ~48 GB):
-
-```bash
-pip install -U mlx-vlm
-```
+For the **35B 4-bit** model (fits ~48 GB) you need **mlx-vlm ≥ 0.3.12** (for `qwen3_5_moe` support). If you use mlx-openai-server, install it first then run `pip install -U "mlx-vlm>=0.3.12"` in a second step to avoid pip `ResolutionImpossible`. If you see "Model type qwen3_5_moe not supported", upgrade mlx-vlm (see "48 GB Mac" runbook below).
 
 For **text-only** models and the standard server (e.g. smaller Qwen or other MLX checkpoints):
 
@@ -45,7 +41,7 @@ A practical option for 35B on 48 GB is the **4-bit quantized** MLX conversion fr
 |-------|------------------|---------|--------|
 | Qwen 3.5 35B (4-bit) | `mlx-community/Qwen3.5-35B-A3B-4bit` | `mlx-vlm` | Fits 48 GB; supports text and vision. |
 
-Smaller models (e.g. 7B, 14B) can use `mlx-lm` and `Qwen/Qwen2.5-7B-Instruct-MLX` or community conversions; adjust the commands below accordingly.
+Smaller **Qwen 3.5** models (4B, 9B) use `mlx-lm` and are listed in the "Larger Qwen for real coding" section below; Qwen 2.5 (7B, 14B) is also available from mlx-community if you prefer that line.
 
 ---
 
@@ -94,13 +90,25 @@ Type prompts at the prompt; exit with your shell’s EOF (e.g. Ctrl+D).
 
 Start a local HTTP server that exposes `/v1/chat/completions`:
 
-**mlx-lm** (text models):
+**mlx-lm** (text models, e.g. 4B/9B):
 
 ```bash
 mlx_lm.server --model Qwen/Qwen2.5-7B-Instruct-MLX --host 0.0.0.0 --port 8080
 ```
 
-**mlx-vlm** (if the package provides a server command for the 35B model, use the same pattern with the model ID above). Default is often `localhost:8080`.
+**Qwen 3.5 35B (48 GB Mac)** — use **mlx-openai-server** (multimodal). Command below works on all versions (e.g. 1.1.x and 1.4+). If you see “No such option: --reasoning-parser”.
+
+```bash
+pip install -U mlx-openai-server
+mlx-openai-server launch \
+  --model-path mlx-community/Qwen3.5-35B-A3B-4bit \
+  --model-type multimodal \
+  --port 8080
+```
+
+Optional (v1.4.1+ only): add `--reasoning-parser qwen3_5` and `--tool-call-parser qwen3_coder`. If you see "No such option: --reasoning-parser", omit them (e.g. you have 1.1.x or Python 3.13 with no newer wheel).
+
+Bind to all interfaces so Docker can reach it: add `--host 0.0.0.0` if the server supports it (see mlx-openai-server docs). AgentCeption uses `host.docker.internal:8080` by default.
 
 Then test with:
 
@@ -152,6 +160,229 @@ Open `~/mlx_resource_run.txt` after the run to inspect CPU/GPU/ANE utilization d
 - **Latency:** Wall-clock time from prompt submit to last token (or to EOS).
 - **Throughput:** (Generated tokens) / (wall-clock seconds) → tokens per second.
 - **Resource usage:** Use the powermetrics output or Activity Monitor to see whether CPU, GPU, or ANE is dominant and whether the machine is thermally or memory-bound.
+
+---
+
+## AgentCeption integration (developer agent with local model)
+
+When the local server is running, you can point the **developer** agent at it so it uses the local model instead of Anthropic for tool-use turns.
+
+1. **Start the MLX server on the host** (in a separate terminal, so Metal/GPU is available):
+
+   ```bash
+   cd /path/to/agentception
+   .venv-mlx/bin/mlx_lm.server --model mlx-community/Qwen3-4B-Instruct-2507-4bit --host 0.0.0.0 --port 8080
+   ```
+
+   Leave this running. From inside Docker, the agent reaches it at `host.docker.internal:8080`.
+
+2. **Enable the local LLM** in AgentCeption:
+
+   - Set `USE_LOCAL_LLM=true` in `.env` (or in `docker-compose.override.yml` under `agentception.environment`).
+   - Optionally set `LOCAL_LLM_BASE_URL=http://host.docker.internal:8080` (this is the default).
+   - Restart the stack: `docker compose restart agentception`.
+
+3. **Probe the local model (no agent)** — confirm the server responds:
+
+   ```bash
+   curl -s http://localhost:10003/api/local-llm/hello
+   ```
+
+   You should get `{"ok": true, "reply": "hello world"}` (or similar). If you get 502, the container cannot reach the MLX server; check `host.docker.internal` and that the server is running on the host.
+
+4. **Optional: run an agent that says "hello world"** — same model, but through the full agent loop (one turn, no tools):
+
+   ```bash
+   curl -s -X POST http://localhost:10003/api/local-llm/hello-agent
+   ```
+
+   Returns `{"run_id": "local-hello-<uuid>", "status": "implementing"}`. Watch with `python scripts/watch_run.py local-hello-<uuid>` or check the Build dashboard; the run completes after one LLM reply.
+
+5. **Dispatch a developer agent** as usual (e.g. from the Build dashboard or `POST /api/dispatch/issue`). Only the **developer** role uses the local model; the planner and reviewer still use Anthropic. The local path uses the **same pipeline** as Anthropic: full system prompt (role file + cognitive architecture + runtime note), same task briefing, same tools, and same extra blocks (context pressure, pytest stop, etc.). Only the LLM endpoint and context caps differ, so real tickets run identically—just against your local Qwen instead of Claude.
+
+6. **Scale up: basic coding** — Use the same local model for a small coding task. Keep `USE_LOCAL_LLM=true`. Dispatch a developer for a minimal issue (e.g. "In `docs/guides/dispatch.md` add one sentence in the Request shape section: 'Always pass issue_body.'"). Example:
+
+   ```bash
+   # From repo root; replace 969 with your small issue number
+   BODY=$(curl -s -H "Accept: application/vnd.github+json" \
+     "https://api.github.com/repos/cgcardona/agentception/issues/969" | \
+     python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps({
+       'issue_number': 969, 'issue_title': d['title'], 'issue_body': d['body'] or '',
+       'role': 'developer', 'repo': 'cgcardona/agentception'
+     }))")
+   curl -s -X POST http://localhost:10003/api/dispatch/issue \
+     -H "Content-Type: application/json" -d "$BODY"
+   python3 scripts/watch_run.py issue-969
+   ```
+
+   The agent gets the full tool set (read_file, search_codebase, replace_in_file, etc.) with context truncated to `LOCAL_LLM_MAX_CONTEXT_CHARS` / `LOCAL_LLM_MAX_SYSTEM_CHARS`. If the model stalls or loops, lower those caps or try an even smaller task.
+
+7. **Turn off** when done: set `USE_LOCAL_LLM=false` (or remove it) and restart so the next run uses Anthropic again.
+
+### Small models (e.g. Qwen 4B) — context caps
+
+Small local models are easily overloaded by the full task briefing and system prompt. AgentCeption truncates context when using the local LLM so a "hello world" run can complete. You can tune these in `.env`:
+
+| Env var | Default | Purpose |
+|--------|---------|--------|
+| `LOCAL_LLM_MAX_CONTEXT_CHARS` | 12000 | Max characters for the first user message (task briefing). |
+| `LOCAL_LLM_MAX_SYSTEM_CHARS` | 6000 | Max characters for the system prompt (role + cognitive arch). |
+| `LOCAL_LLM_MAX_TOKENS` | 4096 | Max completion tokens per turn (avoid 32k for small models). |
+
+If the agent stalls or produces no tool calls, ensure the MLX server is reachable from the container (`host.docker.internal`; on Linux add `extra_hosts: ["host.docker.internal:host-gateway"]` in docker-compose) and consider lowering the caps further.
+
+### Pushing further (Qwen 4B and up)
+
+With the defaults above, the following have been verified with Qwen 4B (e.g. `mlx-community/Qwen3-4B-Instruct-2507-4bit`):
+
+- **Hello world** — one turn, no tools (`POST /api/local-llm/hello-agent`).
+- **Single-file doc edit** — search → read → replace → done (e.g. add one sentence to a guide). Full developer tool set (12 tools), truncated context.
+
+To push further:
+
+- **Multi-file or add-a-test** — Try an issue that touches 2–3 files or adds a test. If the model stalls or loops, lower `LOCAL_LLM_MAX_CONTEXT_CHARS` / `LOCAL_LLM_MAX_SYSTEM_CHARS` a bit.
+- **Larger Qwen 3.5** — See the "Larger Qwen for real coding" section below for 9B and 35B Qwen 3.5 models and recommended env caps.
+- **Watch script** — Use `python3 scripts/watch_run.py <run_id>`; the ITER line shows `local` (green) when the run is using the local LLM so you can confirm the provider.
+
+### Larger Qwen 3.5 for real coding
+
+Use a **Qwen 3.5** model that fits your Mac’s unified memory. Same AgentCeption setup (`USE_LOCAL_LLM=true`); only the model and (optionally) context caps change.
+
+| Mac RAM (unified) | Model | Hugging Face ID | Notes |
+|-------------------|--------|------------------|--------|
+| 8–16 GB | Qwen 3.5 4B | `mlx-community/Qwen3.5-4B-OptiQ-4bit` | Same family as the 4B you used; optional upgrade from Qwen3-4B. |
+| 16–24 GB | Qwen 3.5 9B | `mlx-community/Qwen3.5-9B-4bit` | Good step up for real coding; more context and better tool use. |
+| 48 GB | Qwen 3.5 35B (MoE) | `mlx-community/Qwen3.5-35B-A3B-4bit` | Use **mlx-openai-server** (multimodal). Best quality; avoid on 24 GB or less. |
+
+**1. Install and start the server** (one of the following; adjust port if needed):
+
+```bash
+# Qwen 3.5 9B (recommended for 16–24 GB; real coding)
+.venv-mlx/bin/mlx_lm.server --model mlx-community/Qwen3.5-9B-4bit --host 0.0.0.0 --port 8080
+
+# Qwen 3.5 35B (48 GB Mac) — use mlx-openai-server (see "48 GB Mac: Qwen 3.5 35B" below)
+mlx-openai-server launch \
+  --model-path mlx-community/Qwen3.5-35B-A3B-4bit \
+  --model-type multimodal \
+  --port 8080
+```
+
+For 35B we recommend [mlx-openai-server](https://github.com/cubist38/mlx-openai-server) (multimodal + tool-call parsing). A dedicated runbook for 48 GB Macs is in the next subsection.
+
+**2. Raise context caps** in `.env` so the larger model gets more of the briefing and system prompt (optional but recommended for 9B/35B):
+
+```bash
+LOCAL_LLM_MAX_CONTEXT_CHARS=24000
+LOCAL_LLM_MAX_SYSTEM_CHARS=12000
+LOCAL_LLM_MAX_TOKENS=8192
+```
+
+Restart AgentCeption, then dispatch developer agents as usual. They will use the new model at `host.docker.internal:8080` with no code changes.
+
+### 48 GB Mac: Qwen 3.5 35B with AgentCeption
+
+Step-by-step to run the 35B 4-bit model with AgentCeption on a 48 GB Apple Silicon Mac.
+
+**1. Create a venv and install mlx-openai-server, then mlx-vlm ≥ 0.3.12** (35B MoE needs recent mlx-vlm)
+
+Install in **two steps** so pip does not hit `ResolutionImpossible` (mlx-openai-server pins mlx-vlm==0.3.0):
+
+```bash
+python3 -m venv .venv-mlx
+source .venv-mlx/bin/activate
+pip install -U mlx-openai-server
+pip install -U "mlx-vlm>=0.3.12"
+```
+
+You may see dependency conflict warnings after the second command; **try running the server anyway**—newer mlx-vlm usually works. If the 35B server fails with "Model type qwen3_5_moe not supported", the mlx-vlm upgrade did not take effect; retry the second step or use `pip install -U --force-reinstall "mlx-vlm>=0.3.12"`.
+
+If the server fails with **"Qwen3VLVideoProcessor requires the Torchvision library"** (or PyTorch), the model's processor config pulls in a video component that needs torch/torchvision at load time. Install them (inference still uses MLX):
+
+```bash
+pip install torch torchvision
+```
+
+**2. Start the 35B server on port 8080** (so AgentCeption’s default `host.docker.internal:8080` works)
+
+```bash
+mlx-openai-server launch \
+  --model-path mlx-community/Qwen3.5-35B-A3B-4bit \
+  --model-type multimodal \
+  --port 8080
+```
+
+If your version is v1.4.1+ you can add `--reasoning-parser qwen3_5` and `--tool-call-parser qwen3_coder`. If you get "No such option", use the command above as-is (common with 1.1.x or Python 3.13).
+
+First run downloads the model from Hugging Face. If the server only binds to localhost, check the project’s docs for `--host 0.0.0.0` so Docker can reach it from the container.
+
+**3. Configure AgentCeption**
+
+In `.env`:
+
+```bash
+USE_LOCAL_LLM=true
+LOCAL_LLM_BASE_URL=http://host.docker.internal:8080
+LOCAL_LLM_MAX_CONTEXT_CHARS=24000
+LOCAL_LLM_MAX_SYSTEM_CHARS=12000
+LOCAL_LLM_MAX_TOKENS=8192
+```
+
+Leave `LOCAL_LLM_MODEL` unset (or empty) so the server uses its loaded model.
+
+**4. Ensure Docker can reach the host**
+
+`docker-compose.yml` should have:
+
+```yaml
+extra_hosts: ["host.docker.internal:host-gateway"]
+```
+
+**5. Restart AgentCeption and verify**
+
+```bash
+docker compose restart agentception
+curl -s http://localhost:10003/api/local-llm/hello
+```
+
+Expect `{"ok": true, "reply": "..."}`. Then dispatch a developer agent (e.g. from the Build UI or MCP) with an issue and watch with `python3 scripts/watch_run.py issue-<N>`. The ITER line should show `local` (green) when the run uses the 35B model.
+
+### Sample coding task (test code generation)
+
+Use the following as a GitHub issue to see what code the local model can produce. Create the issue, then dispatch a developer with `USE_LOCAL_LLM=true` and watch with `python3 scripts/watch_run.py issue-<N>`.
+
+**Title:** `Add clamp() helper and test (local LLM code gen)`
+
+**Body:**
+
+```markdown
+## Context
+Small code-generation test for the local LLM (Qwen 4B) pipeline.
+
+## Objective
+1. Create `agentception/utils.py` with a single function:
+   - `def clamp(value: float, low: float, high: float) -> float`
+   - Return `value` clamped to the range `[low, high]` (if value < low return low; if value > high return high; else return value).
+   - Add `from __future__ import annotations` at the top and a one-line module docstring.
+2. Create `agentception/tests/test_utils.py` with one test:
+   - `def test_clamp_returns_value_within_bounds()`
+   - Assert `clamp(5.0, 0.0, 10.0) == 5.0`, `clamp(-1.0, 0.0, 10.0) == 0.0`, `clamp(11.0, 0.0, 10.0) == 10.0`.
+   - Use the same `from __future__ import annotations` and a test module docstring if you like.
+
+## Acceptance criteria
+- [ ] `agentception/utils.py` exists with `clamp()` and type hints.
+- [ ] `agentception/tests/test_utils.py` exists and `pytest agentception/tests/test_utils.py -v` passes.
+```
+
+After the run, run `docker compose exec agentception pytest agentception/tests/test_utils.py -v` and `mypy agentception/utils.py` to confirm the code is valid.
+
+**If no PR appeared:** The agent must push the branch (`git_commit_and_push`) before calling `create_pull_request`; GitHub only creates a PR when the head branch exists on the remote. If the model called `create_pull_request` first (or the push failed), you'll see "couldn't find remote ref feat/issue-N" and no PR. To recover: from the host, push the worktree branch and open the PR manually:
+
+```bash
+cd ~/.agentception/worktrees/agentception/issue-970   # or your run's worktree
+git status                                            # see if there are commits
+git push -u origin feat/issue-970                    # push the branch
+gh pr create --base dev --fill                        # create PR from the branch
+```
 
 ---
 

--- a/scripts/watch_run.py
+++ b/scripts/watch_run.py
@@ -90,6 +90,9 @@ _RE_GITHUB_TOOL = re.compile(
 _RE_LLM_CALL = re.compile(
     r"LLM tool-use call — model=(?P<model>\S+) turns=(?P<turns>\d+) tools=(?P<tools>\d+)"
 )
+_RE_LOCAL_LLM_CALL = re.compile(
+    r"Local LLM tool-use call — url=\S+ turns=(?P<turns>\d+) tools=(?P<tools>\d+)"
+)
 _RE_LLM_RETRY = re.compile(r"LLM retry (?P<n>\d+)/(?P<max>\d+) after (?P<secs>[\d.]+)s")
 _RE_LLM_USAGE = re.compile(
     r"LLM usage — input=(?P<input>\d+) cache_written=(?P<cw>\d+) cache_read=(?P<cr>\d+)"
@@ -123,11 +126,17 @@ class _RunState:
     history_len: int = 0
     pending_arg: str = ""      # key arg from last dispatch_tool
     colour_idx: int = 0        # index into _RUN_COLOURS for this run's prefix
+    last_llm_was_local: bool = False  # so heartbeat can say "local" vs "LLM"
 
 
 # Assign colours round-robin as new run_ids are seen.
 _run_states: dict[str, _RunState] = {}
 _next_colour_idx: list[int] = [0]   # list so inner func can mutate it
+
+# Dedupe "loop ready" per run_id: docker compose logs --follow replays buffered
+# lines, so we see one "agent_loop start" per past dispatch. Show only the first
+# per run_id per session; clear on teardown so a re-dispatch shows again.
+_seen_loop_ready: set[str] = set()
 
 
 def _get_state(run_id: str) -> _RunState:
@@ -226,8 +235,13 @@ def process_line(raw: str, run_id_filter: str | None) -> str | None:
     rsm = _RE_RUN_START.search(msg)
     if rsm:
         rid = rsm.group("run_id")
+        if not run_id_filter or rid == run_id_filter:
+            _last_run_id[0] = rid  # so LLM reply/done (no run_id in log) match this run
         if run_id_filter and rid != run_id_filter:
             return None
+        if rid in _seen_loop_ready:
+            return None  # dedupe: buffer may replay multiple starts from past dispatches
+        _seen_loop_ready.add(rid)
         tools = rsm.group("tools")
         tag = _run_tag(rid, run_id_filter)
         return f"{ts}  {tag}{GREY}    loop ready — {tools} tools available{RESET}"
@@ -432,13 +446,30 @@ def process_line(raw: str, run_id_filter: str | None) -> str | None:
         if run_id_filter and rid != run_id_filter:
             return None
         st = _get_state(rid)
+        st.last_llm_was_local = False
         st.history_len = int(lm.group("turns"))
         iteration = st.iteration
         iter_tag = str(iteration) if iteration else "?"
         short_id = rid.replace("issue-", "#").replace("review-", "rv-")
         tag = _run_tag(rid, run_id_filter)
         return (
-            f"\n{ts}  {tag}{MAGENTA}{BOLD}╔══ ITER {iter_tag}  [{short_id}]{RESET}"
+            f"\n{ts}  {tag}{MAGENTA}{BOLD}╔══ ITER {iter_tag}  [{short_id}]  model={lm.group('model')}{RESET}"
+        )
+    # Local LLM (e.g. Qwen via MLX) — same header but show "local" so you can confirm provider
+    llm = _RE_LOCAL_LLM_CALL.search(msg)
+    if llm:
+        rid = _last_run_id[0]
+        if run_id_filter and rid != run_id_filter:
+            return None
+        st = _get_state(rid)
+        st.last_llm_was_local = True
+        st.history_len = int(llm.group("turns"))
+        iteration = st.iteration
+        iter_tag = str(iteration) if iteration else "?"
+        short_id = rid.replace("issue-", "#").replace("review-", "rv-")
+        tag = _run_tag(rid, run_id_filter)
+        return (
+            f"\n{ts}  {tag}{MAGENTA}{BOLD}╔══ ITER {iter_tag}  [{short_id}]  {GREEN}local{RESET}{RESET}"
         )
 
     # ── LLM token usage ───────────────────────────────────────────────────────
@@ -526,6 +557,7 @@ def process_line(raw: str, run_id_filter: str | None) -> str | None:
     tdm = _RE_TEARDOWN.search(msg)
     if tdm:
         teardown_rid = tdm.group("run_id")
+        _seen_loop_ready.discard(teardown_rid)  # next dispatch of same run_id shows "loop ready" again
         if run_id_filter and teardown_rid != run_id_filter:
             return None
         tag = _run_tag(teardown_rid, run_id_filter)
@@ -546,6 +578,7 @@ class _SilenceState:
     last_output_ts: float = 0.0
     last_llm_call_ts: float = 0.0
     llm_retry_count: int = 0
+    last_llm_was_local: bool = False
 
 
 _silence_lock = threading.Lock()
@@ -561,10 +594,12 @@ def _heartbeat(run_id_filter: str | None) -> None:
     while not _stop_heartbeat.wait(timeout=5):
         now = _time_mod.time()
         with _silence_lock:
-            snapshot = {rid: (s.last_output_ts, s.last_llm_call_ts, s.llm_retry_count)
-                        for rid, s in _silence.items()}
+            snapshot = {
+                rid: (s.last_output_ts, s.last_llm_call_ts, s.llm_retry_count, s.last_llm_was_local)
+                for rid, s in _silence.items()
+            }
 
-        for rid, (last_out, last_llm, retry_count) in snapshot.items():
+        for rid, (last_out, last_llm, retry_count, last_llm_was_local) in snapshot.items():
             if run_id_filter and rid != run_id_filter:
                 continue
             silent_for = now - last_out if last_out else 0.0
@@ -583,7 +618,8 @@ def _heartbeat(run_id_filter: str | None) -> None:
                         f" — LIKELY STUCK (container crash?){RESET}"
                     )
                 else:
-                    label = f"{YELLOW}⏳ waiting for Anthropic response{retry_tag} — {llm_wait}s elapsed{RESET}"
+                    provider = "local" if last_llm_was_local else "LLM"
+                    label = f"{YELLOW}⏳ waiting for {provider} response{retry_tag} — {llm_wait}s elapsed{RESET}"
             else:
                 if silent_for >= STUCK_AFTER_S:
                     label = f"{RED}{BOLD}⚠️  no agent activity for {int(silent_for)}s — run may be dead{RESET}"
@@ -640,6 +676,11 @@ def main() -> None:
                     if _RE_LLM_CALL.search(line):
                         s.last_llm_call_ts = now
                         s.llm_retry_count = 0
+                        s.last_llm_was_local = False
+                    elif _RE_LOCAL_LLM_CALL.search(line):
+                        s.last_llm_call_ts = now
+                        s.llm_retry_count = 0
+                        s.last_llm_was_local = True
                     elif _RE_LLM_DONE.search(line):
                         s.last_llm_call_ts = 0.0
                         s.llm_retry_count = 0


### PR DESCRIPTION
Full pipeline for local LLM (Qwen 3.5 35B) with same system prompt, cognitive arch, and tools as Anthropic.

- Config, LLM service, agent loop local path, /api/local-llm/hello and hello-agent
- Docker extra_hosts, watch script local indicator
- Docs: 48 GB runbook, mlx-openai-server, mlx-vlm >= 0.3.12, two-step install, torch/torchvision for processor