### PR TITLE
feat(local-llm): Ollama as primary backend, per-usecase model routing, LiteLLM proxy guide

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -217,16 +217,67 @@ class AgentCeptionSettings(BaseSettings):
     ``local_llm_completion_token_ceiling`` when sending requests. Set via
     ``LOCAL_LLM_MAX_TOKENS``."""
 
-    local_llm_completion_token_ceiling: int = 4096
+    local_llm_completion_token_ceiling: int = 8192
     """Hard cap on ``max_tokens`` sent to the local OpenAI-compatible server.
-    mlx-openai-server rejects values above 4096 with HTTP 422. Other servers
-    can raise this if they allow larger generation budgets. Set via
+    Ollama (the recommended backend) supports full context lengths; 8192 is a
+    safe default for a 35B 4-bit model. If you still use mlx-openai-server,
+    lower this to 4096 to avoid HTTP 422 errors. Set via
     ``LOCAL_LLM_COMPLETION_TOKEN_CEILING``."""
 
     local_llm_max_system_chars: int = 6000
     """Max characters for the system prompt when using the local LLM. Truncates
     role + cognitive arch so small models get a digest. Set via
     ``LOCAL_LLM_MAX_SYSTEM_CHARS``."""
+
+    # ── Per-usecase overrides (Phase 3: two models, purpose-matched) ─────────
+    # When LiteLLM Proxy is in use, set these to different model names so the
+    # proxy routes planning calls to the large model and agent tool calls to the
+    # fast model.  When unset, fall back to LOCAL_LLM_BASE_URL / LOCAL_LLM_MODEL.
+
+    local_llm_base_url_plan: str = ""
+    """Base URL override for planning/streaming calls (Phase 1A YAML generation).
+    When set, overrides ``local_llm_base_url`` for ``completion_stream`` calls.
+    Useful when the 35B planning model is on a different port than the agent
+    tool-call model.  Leave empty to share one endpoint.  Set via
+    ``LOCAL_LLM_BASE_URL_PLAN``."""
+
+    local_llm_model_plan: str = ""
+    """Model name override for planning/streaming calls (Phase 1A).
+    When set, overrides ``local_llm_model`` so LiteLLM Proxy can route to the
+    large (35B) model instance.  Leave empty to use ``LOCAL_LLM_MODEL``.
+    Set via ``LOCAL_LLM_MODEL_PLAN``."""
+
+    local_llm_base_url_agent: str = ""
+    """Base URL override for agent tool-call turns.
+    When set, overrides ``local_llm_base_url`` for ``completion_with_tools``
+    calls.  Useful when the 8B agent model is on a different port.  Leave
+    empty to share one endpoint.  Set via ``LOCAL_LLM_BASE_URL_AGENT``."""
+
+    local_llm_model_agent: str = ""
+    """Model name override for agent tool-call turns.
+    When set, overrides ``local_llm_model`` so LiteLLM Proxy can route to the
+    fast (8B) model instance.  Leave empty to use ``LOCAL_LLM_MODEL``.
+    Set via ``LOCAL_LLM_MODEL_AGENT``."""
+
+    @property
+    def effective_local_base_url_plan(self) -> str:
+        """Base URL for planning/streaming calls (falls back to local_llm_base_url)."""
+        return (self.local_llm_base_url_plan or self.local_llm_base_url).rstrip("/")
+
+    @property
+    def effective_local_model_plan(self) -> str:
+        """Model name for planning/streaming calls (falls back to local_llm_model)."""
+        return self.local_llm_model_plan or self.local_llm_model
+
+    @property
+    def effective_local_base_url_agent(self) -> str:
+        """Base URL for agent tool-call turns (falls back to local_llm_base_url)."""
+        return (self.local_llm_base_url_agent or self.local_llm_base_url).rstrip("/")
+
+    @property
+    def effective_local_model_agent(self) -> str:
+        """Model name for agent tool-call turns (falls back to local_llm_model)."""
+        return self.local_llm_model_agent or self.local_llm_model
 
     github_token: str = ""
     """GitHub Personal Access Token for GitHub API calls and the GitHub MCP server.

--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -1056,8 +1056,7 @@ async def call_local_with_tools(
     messages and tools, returns :class:`ToolResponse`. Used when
     ``settings.effective_llm_provider`` is ``local``.
     """
-    base = settings.local_llm_base_url.rstrip("/")
-    url = f"{base}{settings.local_llm_chat_path}"
+    url = f"{settings.effective_local_base_url_agent}{settings.local_llm_chat_path}"
     system_content = system
     if extra_system_blocks:
         for blk in extra_system_blocks:
@@ -1077,8 +1076,9 @@ async def call_local_with_tools(
     if tools:
         payload["tools"] = _tools_to_openai(tools)
         payload["tool_choice"] = "auto"
-    if settings.local_llm_model:
-        payload["model"] = settings.local_llm_model
+    agent_model = settings.effective_local_model_agent
+    if agent_model:
+        payload["model"] = agent_model
     # Else omit model so servers like mlx_lm.server use their loaded model (avoids 404).
     if session is not None and run_id is not None:
         persist_activity_event(
@@ -1223,8 +1223,15 @@ def _local_completion_payload(
     temperature: float = 0.0,
     max_tokens: int = 128,
     stream: bool = False,
+    model_override: str = "",
 ) -> dict[str, object]:
-    """Build request body for local single-turn completion (no tools)."""
+    """Build request body for local single-turn completion (no tools).
+
+    ``model_override`` lets call sites specify a use-case-specific model name
+    (e.g. the large 35B planning model vs the fast 8B agent model) without
+    changing the global ``LOCAL_LLM_MODEL`` setting.  When empty, falls back
+    to ``settings.local_llm_model``.
+    """
     capped = _local_cap_max_tokens(max_tokens)
     payload: dict[str, object] = {
         "messages": [
@@ -1234,11 +1241,11 @@ def _local_completion_payload(
         "temperature": temperature,
         "max_tokens": capped,
         "stream": stream,
-        "repetition_penalty": 1.1,
         "frequency_penalty": 0.3,
     }
-    if settings.local_llm_model:
-        payload["model"] = settings.local_llm_model
+    model = model_override or settings.local_llm_model
+    if model:
+        payload["model"] = model
     return payload
 
 
@@ -1248,15 +1255,23 @@ async def call_local_completion(
     *,
     temperature: float = 0.0,
     max_tokens: int = 128,
+    base_url_override: str = "",
+    model_override: str = "",
 ) -> str:
     """Single-turn completion against the local OpenAI-compatible server (no tools).
 
     Returns the assistant's text content, normalized (thinking/reasoning stripped).
     Used by the public completion() and as fallback for completion_stream().
+
+    ``base_url_override`` / ``model_override`` let call sites target a different
+    Ollama instance or model (e.g. the large planning model) without touching the
+    global config.  When empty, the global config values are used.
     """
-    url = _local_chat_url()
+    base = (base_url_override or settings.local_llm_base_url).rstrip("/")
+    url = f"{base}{settings.local_llm_chat_path}"
     payload = _local_completion_payload(
-        system, user_message, temperature=temperature, max_tokens=max_tokens
+        system, user_message, temperature=temperature, max_tokens=max_tokens,
+        model_override=model_override,
     )
     timeout = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0)
     async with httpx.AsyncClient(timeout=timeout) as client:
@@ -1358,26 +1373,34 @@ async def _local_completion_stream(
 
     If the server does not support streaming (4xx, invalid SSE, etc.), falls back
     to a single completion and yields one content chunk so the contract is always satisfied.
+
+    Uses ``settings.effective_local_base_url_plan`` and
+    ``settings.effective_local_model_plan`` so planning calls can target a
+    different Ollama instance or model than agent tool-call turns.
     """
+    plan_base_url = settings.effective_local_base_url_plan
+    plan_model = settings.effective_local_model_plan
+    plan_url = f"{plan_base_url}{settings.local_llm_chat_path}"
+
     async def _raw_sse() -> AsyncGenerator[LLMChunk, None]:
         """Parse raw SSE deltas into LLMChunk without think-tag normalisation."""
-        url = _local_chat_url()
         payload = _local_completion_payload(
             system,
             user_message,
             temperature=temperature,
             max_tokens=max_tokens,
             stream=True,
+            model_override=plan_model,
         )
         # read=90s is the inter-chunk idle timeout: if the server stops sending any
-        # SSE data for 90 seconds we abort.  At 870 tok/s (typical for mlx) the
+        # SSE data for 90 seconds we abort.  At 870 tok/s (typical for Ollama) the
         # gap between tokens is milliseconds; 90 s is generous enough for a cold
         # prefill (4 s for a 4 k-token prompt) while still catching a hung server
-        # on the second request instead of waiting the original 300 s.
+        # on the second request instead of waiting indefinitely.
         timeout = httpx.Timeout(connect=10.0, read=90.0, write=30.0, pool=10.0)
         try:
             async with httpx.AsyncClient(timeout=timeout) as client:
-                async with client.stream("POST", url, json=payload) as resp:
+                async with client.stream("POST", plan_url, json=payload) as resp:
                     resp.raise_for_status()
                     yielded_any = False
                     async for line in resp.aiter_lines():
@@ -1427,6 +1450,8 @@ async def _local_completion_stream(
                 user_message,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                base_url_override=plan_base_url,
+                model_override=plan_model,
             )
         except httpx.ReadTimeout:
             raise RuntimeError(

--- a/agentception/tests/test_config.py
+++ b/agentception/tests/test_config.py
@@ -439,7 +439,31 @@ def test_llm_provider_env_anthropic(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
 
 def test_local_llm_completion_token_ceiling_default(tmp_path: Path) -> None:
-    """mlx-openai-server max_tokens ceiling default matches adapter clamp."""
+    """Ollama-compatible default ceiling; must be lowered to 4096 for mlx-openai-server."""
     s = AgentCeptionSettings(repo_dir=tmp_path)
-    assert s.local_llm_completion_token_ceiling == 4096
+    assert s.local_llm_completion_token_ceiling == 8192
+
+
+def test_per_usecase_overrides_fall_back_to_global(tmp_path: Path) -> None:
+    """When per-usecase overrides are unset, effective URLs/models equal global values."""
+    s = AgentCeptionSettings(repo_dir=tmp_path)
+    assert s.effective_local_base_url_plan == s.local_llm_base_url.rstrip("/")
+    assert s.effective_local_base_url_agent == s.local_llm_base_url.rstrip("/")
+    assert s.effective_local_model_plan == s.local_llm_model
+    assert s.effective_local_model_agent == s.local_llm_model
+
+
+def test_per_usecase_overrides_applied_when_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When per-usecase overrides are set they are used instead of global values."""
+    monkeypatch.setenv("LOCAL_LLM_BASE_URL_PLAN", "http://plan-host:11434")
+    monkeypatch.setenv("LOCAL_LLM_MODEL_PLAN", "qwen-plan")
+    monkeypatch.setenv("LOCAL_LLM_BASE_URL_AGENT", "http://agent-host:11435")
+    monkeypatch.setenv("LOCAL_LLM_MODEL_AGENT", "qwen-agent")
+    s = _make_settings(tmp_path)
+    assert s.effective_local_base_url_plan == "http://plan-host:11434"
+    assert s.effective_local_model_plan == "qwen-plan"
+    assert s.effective_local_base_url_agent == "http://agent-host:11435"
+    assert s.effective_local_model_agent == "qwen-agent"
 

--- a/docs/guides/local-llm-mlx.md
+++ b/docs/guides/local-llm-mlx.md
@@ -1,22 +1,22 @@
-# Local LLM with MLX (Qwen 3.5 on Apple Silicon)
+# Local LLM with Ollama (and MLX) on Apple Silicon
 
-This guide describes how to run **Qwen 3.5 35B** (or a quantized variant) locally on macOS using the MLX framework, and how to capture CPU, GPU, and Neural Engine usage during inference. It supports the prototype in [issue #964](https://github.com/cgcardona/agentception/issues/964) and the AgentCeption **local provider** integration.
+This guide explains how to run **Qwen 3.5 35B** (or a quantized variant) locally on macOS and connect it to AgentCeption's **local provider**. **Ollama is the recommended inference backend.** `mlx-openai-server` is documented as a developer-only footnote.
 
 **Target hardware:** Apple Silicon Mac (M1/M2/M3/M4) with at least 24 GB unified memory; 48 GB recommended for the 35B 4-bit model.
 
 AgentCeption uses a **provider-agnostic LLM contract**. When the effective provider is **local**, all LLM calls (planning, streaming preview, agent loop) go to your **Chat Completions–compatible** HTTP server on the host instead of Anthropic. Thinking vs content is **normalized by the adapter**: stream chunks always have `type: "thinking"` or `type: "content"`; completion returns only the final answer string. See [LLM contract and provider abstraction](../reference/llm-contract.md) for the full contract and config model.
 
-### Naming: “OpenAI” in tooling — not OpenAI’s cloud
+### Naming: "OpenAI" in tooling — not OpenAI's cloud
 
 You will see names like **OpenAI-compatible** and the package **`mlx-openai-server`**. Here is what that means:
 
 | Phrase / name | Meaning |
 |---------------|--------|
-| **OpenAI-compatible / Chat Completions API** | The HTTP shape many tools use: `POST /v1/chat/completions`, JSON body with `messages`, response with `choices[].message`. It is a **wire format**—not a claim that traffic goes to OpenAI Inc. AgentCeption’s local adapter speaks that format to **whatever server you run** (MLX on your Mac). |
-| **`mlx-openai-server`** | Upstream CLI and PyPI package name for a **local** MLX server that implements that API. Model weights and inference stay **on your machine**. The name reflects API compatibility, not vendor. |
-| **`mlx_lm.server`** | Another local server (text models) with the same style of API—also **not** OpenAI’s service. |
+| **OpenAI-compatible / Chat Completions API** | The HTTP shape many tools use: `POST /v1/chat/completions`, JSON body with `messages`, response with `choices[].message`. It is a **wire format** — not a claim that traffic goes to OpenAI Inc. |
+| **Ollama** | Production-grade local inference server. Implements the OpenAI-compatible API. **Recommended.** |
+| **`mlx-openai-server`** | Developer-preview local MLX server. Single-process, no request queue, KV cache saturates after large generations. **For development and one-off tests only.** |
 
-So: **no OpenAI account or cloud call is required** for the local provider. You are the datacenter; the “OpenAI” wording is only about **request/response shape**, so the same client code can talk to many backends.
+So: **no OpenAI account or cloud call is required** for the local provider. You are the datacenter; the "OpenAI" wording is only about **request/response shape**, so the same client code can talk to many backends.
 
 ---
 
@@ -33,13 +33,26 @@ When the effective provider is **local**, the following env vars apply. Set them
 
 | Env var | Default | Purpose |
 |---------|---------|--------|
-| `LOCAL_LLM_BASE_URL` | `http://host.docker.internal:8080` | Base URL of your **local** Chat Completions–compatible server (no trailing slash). From Docker, use `host.docker.internal` to reach a server on the host. |
-| `LOCAL_LLM_CHAT_PATH` | `/v1/chat/completions` | Path appended to the base URL for chat completions. Some servers use `/chat/completions` without `/v1`. |
-| `LOCAL_LLM_MODEL` | *(empty)* | Model name sent in requests. If empty, the field is omitted so servers like mlx_lm use their loaded model (avoids 404). |
+| `LOCAL_LLM_BASE_URL` | `http://host.docker.internal:11434` | Base URL of your local Chat Completions–compatible server (no trailing slash). From Docker, use `host.docker.internal` to reach a server on the host. Ollama default port is **11434**. |
+| `LOCAL_LLM_CHAT_PATH` | `/v1/chat/completions` | Path appended to the base URL for chat completions. Ollama exposes this path. |
+| `LOCAL_LLM_MODEL` | *(empty)* | Model name sent in requests. For Ollama, set this to the exact tag (e.g. `qwen3.5:35b-a3b-q4_K_M`). If empty, some servers use their loaded model; Ollama requires a model name. |
 | `LOCAL_LLM_MAX_CONTEXT_CHARS` | `12000` | Max characters for the first user message (task briefing) when using the local LLM. Reduces load on small models. |
 | `LOCAL_LLM_MAX_SYSTEM_CHARS` | `6000` | Max characters for the system prompt (role + cognitive arch). Truncation is applied when using the local provider. |
 | `LOCAL_LLM_MAX_TOKENS` | `4096` | Desired max completion tokens per turn (agent loop). Never sent above the ceiling below. |
-| `LOCAL_LLM_COMPLETION_TOKEN_CEILING` | `4096` | Hard cap on `max_tokens` in every local chat request. **mlx-openai-server** rejects larger values with **422** (`max_tokens too high`). Raise only if your server allows it. |
+| `LOCAL_LLM_COMPLETION_TOKEN_CEILING` | `8192` | Hard cap on `max_tokens` in every local chat request. Ollama supports 8192+; lower to 4096 only if you are using `mlx-openai-server` (which returns 422 above 4096). |
+
+### Per-usecase model overrides (Phase 3 — two models)
+
+When routing through LiteLLM Proxy with separate model instances for planning and agent tool calls:
+
+| Env var | Default | Purpose |
+|---------|---------|--------|
+| `LOCAL_LLM_BASE_URL_PLAN` | *(empty, falls back to `LOCAL_LLM_BASE_URL`)* | Base URL for Phase 1A planning/streaming calls only. |
+| `LOCAL_LLM_MODEL_PLAN` | *(empty, falls back to `LOCAL_LLM_MODEL`)* | Model name for planning calls. Route to the large 35B model. |
+| `LOCAL_LLM_BASE_URL_AGENT` | *(empty, falls back to `LOCAL_LLM_BASE_URL`)* | Base URL for agent tool-call turns only. |
+| `LOCAL_LLM_MODEL_AGENT` | *(empty, falls back to `LOCAL_LLM_MODEL`)* | Model name for agent calls. Route to the fast 8B model. |
+
+See [Local LLM Scaling](local-llm-scaling.md) for the full multi-agent scaling guide.
 
 **Effective provider:** If `USE_LOCAL_LLM=true`, the effective provider is **local** regardless of `LLM_PROVIDER`. Otherwise the effective provider is the value of `LLM_PROVIDER`. Only the effective provider is used when deciding which adapter to call.
 
@@ -50,204 +63,160 @@ When the effective provider is **local**, the following env vars apply. Set them
 The local adapter in `agentception/services/llm.py` implements the same **contract** as the Anthropic path:
 
 - **Completion:** Single request to your server; response `choices[0].message.content` is normalized (string or list of parts; reasoning parts stripped) and returned as a single final-answer string.
-- **Streaming:** If the server supports `stream: true`, the adapter parses SSE and maps `delta.content` / `delta.reasoning_content` to `LLMChunk(type="content", ...)` and `LLMChunk(type="thinking", ...)`. If streaming is not supported or fails, it falls back to one completion and yields one content chunk so the contract is always satisfied.
+- **Streaming:** If the server supports `stream: true`, the adapter parses SSE and maps `delta.content` / `delta.reasoning_content` to `LLMChunk(type="content", ...)` and `LLMChunk(type="thinking", ...)`. Models that embed `<think>...</think>` tags in `content` (Qwen3, DeepSeek) are handled by `_normalize_think_tags`, which reclassifies the enclosed text as `thinking` chunks transparently. If streaming is not supported or fails, it falls back to one completion and yields one content chunk so the contract is always satisfied.
 - **Tools:** Same request/response shape as completion but with `tools` and `tool_choice`; response content and `tool_calls` are normalized to the shared `ToolResponse` type.
 
 No caller code (plan UI, phase planner, agent loop) branches on provider; they all use `completion()`, `completion_stream()`, or `completion_with_tools()`. See [LLM contract](../reference/llm-contract.md) for details.
 
 ---
 
-## How Plan 1A uses the local provider
+## Recommended setup: Ollama
 
-When the **effective provider is local** (`LLM_PROVIDER=local` or `USE_LOCAL_LLM=true`), every LLM call goes to your server:
+Ollama is the recommended local inference backend. It is production-grade:
 
-| Use case | Entry point | Request to your server |
-|----------|-------------|-------------------------|
-| **Plan 1A (generate YAML)** | Phase planner → `completion()` | POST to `LOCAL_LLM_BASE_URL` + `LOCAL_LLM_CHAT_PATH` with a **non-streaming** body (see below). |
-| **Plan 1A preview (Build UI)** | Plan UI → `completion_stream()` | First tries POST with `"stream": true`; if the server errors (e.g. 422), falls back to the same non-streaming body and yields one chunk. |
-| **Agent loop (tools)** | Agent loop → `completion_with_tools()` | POST with `tools` and `tool_choice`; same URL. |
+- **Built-in request queue** — handles concurrent requests without crashing
+- **Model keep-alive** — model stays loaded between requests; no restart needed
+- **KV cache management** — proper context window enforcement; returns an error cleanly if context is exceeded, rather than hanging
+- **Prefix caching** — if multiple agents share the same system prompt prefix, the KV computation for that prefix is cached and reused
+- **OpenAI-compatible API** — AgentCeption's `agentception/services/llm.py` works unchanged; only config values change
 
-**Non-streaming body** (what Plan 1A and the stream fallback send):
-
-- `messages`: `[{"role": "system", "content": "<system prompt>"}, {"role": "user", "content": "<user text>"}]`
-- `temperature`: number (e.g. `0.2` for Plan 1A)
-- `max_tokens`: number — AgentCeption **clamps** to ``LOCAL_LLM_COMPLETION_TOKEN_CEILING`` (default 4096) before sending; Plan 1A asks for 8192 on Anthropic but local mlx would 422 above 4096 without this cap.
-- `stream`: `false`
-- `model`: **only present if `LOCAL_LLM_MODEL` is set**. When unset, we omit `model` so servers like mlx_lm use their loaded model.
-
-**422 from mlx-openai-server — common causes:** (1) **`max_tokens` above 4096** — the server responds with `max_tokens too high`; AgentCeption clamps to `LOCAL_LLM_COMPLETION_TOKEN_CEILING` (default 4096) so Phase 1A no longer triggers this. (2) Some servers **require** a `model` field — set `LOCAL_LLM_MODEL` to a value your server accepts and restart AgentCeption.
-
----
-
-## Verify with curl
-
-Use these from the **host** (same machine as the MLX server). Replace `http://localhost:8080` with your server URL if different.
-
-**1. Minimal request (no `model`)** — matches AgentCeption when `LOCAL_LLM_MODEL` is unset:
+### Install Ollama
 
 ```bash
-curl -s http://localhost:8080/v1/chat/completions \
+# macOS (via Homebrew)
+brew install ollama
+
+# Or download from https://ollama.com/download
+```
+
+### Pull a model
+
+```bash
+# Qwen 3.5 35B (MoE, 4-bit) — requires ~20 GB unified memory for weights
+ollama pull qwen3.5:35b-a3b-q4_K_M
+
+# Qwen 3.5 9B (4-bit) — for 16–24 GB Macs
+ollama pull qwen3.5:9b
+
+# Qwen 3.5 4B (4-bit) — for 8–16 GB Macs
+ollama pull qwen3.5:4b
+```
+
+### Start the Ollama server
+
+```bash
+# Start in the background (listens on 0.0.0.0:11434 by default)
+ollama serve
+```
+
+Ollama binds to `0.0.0.0:11434` by default, so Docker containers reach it at `host.docker.internal:11434`.
+
+### Configure AgentCeption
+
+In `.env`:
+
+```bash
+LLM_PROVIDER=local
+LOCAL_LLM_BASE_URL=http://host.docker.internal:11434
+LOCAL_LLM_CHAT_PATH=/v1/chat/completions
+LOCAL_LLM_MODEL=qwen3.5:35b-a3b-q4_K_M
+LOCAL_LLM_COMPLETION_TOKEN_CEILING=8192
+LOCAL_LLM_MAX_CONTEXT_CHARS=24000
+LOCAL_LLM_MAX_SYSTEM_CHARS=12000
+LOCAL_LLM_MAX_TOKENS=8192
+```
+
+Then restart AgentCeption:
+
+```bash
+docker compose restart agentception
+```
+
+### Verify
+
+```bash
+# From the host
+curl -s http://localhost:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "messages": [
-      {"role": "system", "content": "You are a helpful assistant."},
-      {"role": "user", "content": "Reply with exactly: hello world"}
-    ],
-    "temperature": 0.2,
-    "max_tokens": 128,
+    "model": "qwen3.5:35b-a3b-q4_K_M",
+    "messages": [{"role": "user", "content": "Reply with exactly: hello world"}],
+    "temperature": 0.0,
+    "max_tokens": 32,
     "stream": false
   }'
-```
 
-If you get **422**, your server likely requires `model`. Try **2** with a `model` field.
-
-**2. With `model`** — use this if your server requires a model name. Set `LOCAL_LLM_MODEL` to the same value in `.env`:
-
-```bash
-curl -s http://localhost:8080/v1/chat/completions \
+# From inside Docker
+docker compose exec agentception curl -s http://host.docker.internal:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{
-    "messages": [
-      {"role": "system", "content": "You are a helpful assistant."},
-      {"role": "user", "content": "Reply with exactly: hello world"}
-    ],
-    "temperature": 0.2,
-    "max_tokens": 128,
-    "stream": false,
-    "model": "default"
-  }'
-```
+  -d '{"model":"qwen3.5:35b-a3b-q4_K_M","messages":[{"role":"user","content":"Say hi"}],"temperature":0,"max_tokens":16,"stream":false}'
 
-Common values servers accept: `default`, `local`, or the exact model id (e.g. `Qwen/Qwen2.5-7B-Instruct-MLX`). If **2** returns 200 and a JSON body with `choices[0].message.content`, set in `.env`:
-
-```bash
-LOCAL_LLM_MODEL=default
-```
-
-(or the value that worked), then restart AgentCeption and retry Plan 1A.
-
-**3. From inside Docker** (to match AgentCeption’s network path), use the same URL the container uses:
-
-```bash
-docker compose exec agentception curl -s http://host.docker.internal:8080/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"messages":[{"role":"user","content":"Say hi"}],"temperature":0,"max_tokens":64,"stream":false}'
-```
-
-If **1** or **2** works on the host but **3** fails, the container cannot reach the server (e.g. `host.docker.internal` not resolving or server bound only to localhost). Ensure the server listens on `0.0.0.0` or that Docker has `extra_hosts: ["host.docker.internal:host-gateway"]`.
-
----
-
-## Prerequisites
-
-| Requirement | Notes |
-|-------------|--------|
-| macOS | Apple Silicon only (M-series). Intel Macs are not supported by MLX. |
-| Python | 3.11 or newer. Prefer a venv or conda environment. |
-| Memory | 48 GB unified memory recommended for Qwen 3.5 35B 4-bit to avoid swap. |
-
----
-
-## Install MLX and model runtime
-
-Two common options:
-
-- **Text-only (mlx-lm):** for chat/completion and the built-in OpenAI-compatible server.
-- **Vision/multimodal (mlx-vlm):** required for the 4-bit 35B model from mlx-community (`Qwen3.5-35B-A3B-4bit`).
-
-For the **35B 4-bit** model (fits ~48 GB) you need **mlx-vlm ≥ 0.3.12** (for `qwen3_5_moe` support). If you use mlx-openai-server, install it first then run `pip install -U "mlx-vlm>=0.3.12"` in a second step to avoid pip `ResolutionImpossible`. If you see "Model type qwen3_5_moe not supported", upgrade mlx-vlm (see "48 GB Mac" runbook below).
-
-For **text-only** models and the standard server (e.g. smaller Qwen or other MLX checkpoints):
-
-```bash
-pip install -U mlx-lm
+# Confirm AgentCeption reaches the local model
+curl -s http://localhost:10003/api/local-llm/hello
+# Expect: {"ok": true, "reply": "..."}
 ```
 
 ---
 
-## Model choice: Qwen 3.5 35B
+## AgentCeption integration
 
-A practical option for 35B on 48 GB is the **4-bit quantized** MLX conversion from the mlx-community:
+When Ollama is running, point the agent at it so it uses the local model instead of Anthropic.
 
-| Model | Hugging Face ID | Package | Notes |
-|-------|------------------|---------|--------|
-| Qwen 3.5 35B (4-bit) | `mlx-community/Qwen3.5-35B-A3B-4bit` | `mlx-vlm` | Fits 48 GB; supports text and vision. |
+1. **Start Ollama on the host:**
 
-Smaller **Qwen 3.5** models (4B, 9B) use `mlx-lm` and are listed in the "Larger Qwen for real coding" section below; Qwen 2.5 (7B, 14B) is also available from mlx-community if you prefer that line.
+   ```bash
+   ollama serve
+   ```
+
+2. **Enable the local provider** in AgentCeption:
+
+   - Set `LLM_PROVIDER=local` (or `USE_LOCAL_LLM=true`) in `.env`.
+   - Set `LOCAL_LLM_BASE_URL=http://host.docker.internal:11434`.
+   - Set `LOCAL_LLM_MODEL` to the pulled model tag.
+   - Restart: `docker compose restart agentception`.
+
+3. **Probe the local model (no agent):**
+
+   ```bash
+   curl -s http://localhost:10003/api/local-llm/hello
+   ```
+
+   You should get `{"ok": true, "reply": "..."}`. If you get 502, the container cannot reach Ollama; check `host.docker.internal` and that Ollama is running on the host.
+
+4. **Optional: run an agent that says "hello world":**
+
+   ```bash
+   curl -s -X POST http://localhost:10003/api/local-llm/hello-agent
+   ```
+
+   Returns `{"run_id": "local-hello-<uuid>", "status": "implementing"}`. Watch with `python3 scripts/watch_run.py local-hello-<uuid>`.
+
+5. **Dispatch a developer agent** as usual (Build dashboard or `POST /api/dispatch/issue`). The local path uses the same pipeline as Anthropic: full system prompt, same tools, same task briefing. Only the LLM endpoint and context caps differ.
+
+6. **Turn off** when done: set `LLM_PROVIDER=anthropic` (or remove `USE_LOCAL_LLM`) and restart.
 
 ---
 
-## Run inference (minimal test)
+## Model choice by Mac RAM
 
-### Option A: Generate (one-off prompt)
+| Mac RAM (unified) | Model | Ollama tag | Notes |
+|-------------------|-------|------------|-------|
+| 8–16 GB | Qwen 3.5 4B | `qwen3.5:4b` | Fast; limited context |
+| 16–24 GB | Qwen 3.5 9B | `qwen3.5:9b` | Good for real coding tasks |
+| 48 GB+ | Qwen 3.5 35B (MoE) | `qwen3.5:35b-a3b-q4_K_M` | Best quality; preferred for planning |
 
-**With mlx-vlm** (35B 4-bit):
-
-```bash
-python -m mlx_vlm.generate \
-  --model mlx-community/Qwen3.5-35B-A3B-4bit \
-  --max-tokens 100 \
-  --temperature 0.0 \
-  --prompt "Write a one-line Python function that returns the sum of two integers."
-```
-
-The first run downloads the model from Hugging Face; later runs use the cache.
-
-**With mlx-lm** (smaller text-only, e.g. 7B):
+**Recommended context caps by model:**
 
 ```bash
-mlx_lm.generate \
-  --model Qwen/Qwen2.5-7B-Instruct-MLX \
-  --max-tokens 100 \
-  --prompt "Write a one-line Python function that returns the sum of two integers."
-```
+# Qwen 3.5 9B (16–24 GB)
+LOCAL_LLM_MAX_CONTEXT_CHARS=24000
+LOCAL_LLM_MAX_SYSTEM_CHARS=12000
+LOCAL_LLM_MAX_TOKENS=8192
 
-### Option B: Interactive chat
-
-**mlx-vlm:**
-
-```bash
-python -m mlx_vlm.chat --model mlx-community/Qwen3.5-35B-A3B-4bit
-```
-
-**mlx-lm:**
-
-```bash
-mlx_lm.chat --model Qwen/Qwen2.5-7B-Instruct-MLX
-```
-
-Type prompts at the prompt; exit with your shell’s EOF (e.g. Ctrl+D).
-
-### Option C: Local Chat Completions server (for AgentCeption integration)
-
-Start a **local** HTTP server that exposes the same routes as OpenAI’s Chat Completions API (`/v1/chat/completions`). Inference runs on your Mac; nothing is sent to OpenAI’s cloud.
-
-**mlx-lm** (text models, e.g. 4B/9B) — `mlx_lm.server`:
-
-```bash
-mlx_lm.server --model Qwen/Qwen2.5-7B-Instruct-MLX --host 0.0.0.0 --port 8080
-```
-
-**Qwen 3.5 35B (48 GB Mac)** — use **`mlx-openai-server`** (multimodal). That is the **package name** for a local OpenAI Chat Completions–compatible server; it does not call OpenAI. Command below works on all versions (e.g. 1.1.x and 1.4+). If you see “No such option: --reasoning-parser”, omit those flags.
-
-```bash
-pip install -U mlx-openai-server
-mlx-openai-server launch \
-  --model-path mlx-community/Qwen3.5-35B-A3B-4bit \
-  --model-type multimodal \
-  --port 8080
-```
-
-Optional (v1.4.1+ only): add `--reasoning-parser qwen3_5` and `--tool-call-parser qwen3_coder`. If you see "No such option: --reasoning-parser", omit them (e.g. you have 1.1.x or Python 3.13 with no newer wheel).
-
-Bind to all interfaces so Docker can reach it: add `--host 0.0.0.0` if the server supports it (see mlx-openai-server docs). AgentCeption uses `host.docker.internal:8080` by default.
-
-Then test with:
-
-```bash
-curl -s http://localhost:8080/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model": "default", "messages": [{"role": "user", "content": "Say hello in one word."}], "max_tokens": 20}'
+# Qwen 3.5 4B (8–16 GB) — more conservative
+LOCAL_LLM_MAX_CONTEXT_CHARS=12000
+LOCAL_LLM_MAX_SYSTEM_CHARS=6000
+LOCAL_LLM_MAX_TOKENS=4096
 ```
 
 ---
@@ -287,200 +256,77 @@ sudo powermetrics -i 2000 -n 10 -o ~/mlx_resource_run.txt -s cpu_power,gpu_power
 
 Open `~/mlx_resource_run.txt` after the run to inspect CPU/GPU/ANE utilization during inference.
 
-### Interpreting results
+---
 
-- **Latency:** Wall-clock time from prompt submit to last token (or to EOS).
-- **Throughput:** (Generated tokens) / (wall-clock seconds) → tokens per second.
-- **Resource usage:** Use the powermetrics output or Activity Monitor to see whether CPU, GPU, or ANE is dominant and whether the machine is thermally or memory-bound.
+## Scaling beyond one agent
+
+For multi-agent workloads (10+ concurrent agents), add LiteLLM Proxy as a routing and load-balancing layer between AgentCeption and Ollama. See [Local LLM Scaling](local-llm-scaling.md).
 
 ---
 
-## AgentCeption integration (developer agent with local model)
+## Verify with curl (generic)
 
-When the local server is running, you can point the **developer** agent at it so it uses the local model instead of Anthropic for tool-use turns.
+These work for any OpenAI-compatible backend (Ollama or otherwise). Replace the URL and model name to match your setup.
 
-1. **Start the MLX server on the host** (in a separate terminal, so Metal/GPU is available):
-
-   ```bash
-   cd /path/to/agentception
-   .venv-mlx/bin/mlx_lm.server --model mlx-community/Qwen3-4B-Instruct-2507-4bit --host 0.0.0.0 --port 8080
-   ```
-
-   Leave this running. From inside Docker, the agent reaches it at `host.docker.internal:8080`.
-
-2. **Enable the local provider** in AgentCeption:
-
-   - Set **either** `LLM_PROVIDER=local` **or** `USE_LOCAL_LLM=true` in `.env` (or in `docker-compose.override.yml` under `agentception.environment`). See [Config and environment](#config-and-environment) for the full table.
-   - Optionally set `LOCAL_LLM_BASE_URL=http://host.docker.internal:8080` (this is the default).
-   - Restart the stack: `docker compose restart agentception`.
-
-3. **Probe the local model (no agent)** — confirm the server responds:
-
-   ```bash
-   curl -s http://localhost:10003/api/local-llm/hello
-   ```
-
-   You should get `{"ok": true, "reply": "hello world"}` (or similar). If you get 502, the container cannot reach the MLX server; check `host.docker.internal` and that the server is running on the host.
-
-4. **Optional: run an agent that says "hello world"** — same model, but through the full agent loop (one turn, no tools):
-
-   ```bash
-   curl -s -X POST http://localhost:10003/api/local-llm/hello-agent
-   ```
-
-   Returns `{"run_id": "local-hello-<uuid>", "status": "implementing"}`. Watch with `python scripts/watch_run.py local-hello-<uuid>` or check the Build dashboard; the run completes after one LLM reply.
-
-5. **Dispatch a developer agent** as usual (e.g. from the Build dashboard or `POST /api/dispatch/issue`). Only the **developer** role uses the local model; the planner and reviewer still use Anthropic. The local path uses the **same pipeline** as Anthropic: full system prompt (role file + cognitive architecture + runtime note), same task briefing, same tools, and same extra blocks (context pressure, pytest stop, etc.). Only the LLM endpoint and context caps differ, so real tickets run identically—just against your local Qwen instead of Claude.
-
-6. **Scale up: basic coding** — Use the same local model for a small coding task. Keep the effective provider as **local** (`LLM_PROVIDER=local` or `USE_LOCAL_LLM=true`). Dispatch a developer for a minimal issue (e.g. "In `docs/guides/dispatch.md` add one sentence in the Request shape section: 'Always pass issue_body.'"). Example:
-
-   ```bash
-   # From repo root; replace 969 with your small issue number
-   BODY=$(curl -s -H "Accept: application/vnd.github+json" \
-     "https://api.github.com/repos/cgcardona/agentception/issues/969" | \
-     python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps({
-       'issue_number': 969, 'issue_title': d['title'], 'issue_body': d['body'] or '',
-       'role': 'developer', 'repo': 'cgcardona/agentception'
-     }))")
-   curl -s -X POST http://localhost:10003/api/dispatch/issue \
-     -H "Content-Type: application/json" -d "$BODY"
-   python3 scripts/watch_run.py issue-969
-   ```
-
-   The agent gets the full tool set (read_file, search_codebase, replace_in_file, etc.) with context truncated to `LOCAL_LLM_MAX_CONTEXT_CHARS` / `LOCAL_LLM_MAX_SYSTEM_CHARS`. If the model stalls or loops, lower those caps or try an even smaller task.
-
-7. **Turn off** when done: set `LLM_PROVIDER=anthropic` (or `USE_LOCAL_LLM=false` / remove it) and restart so the next run uses Anthropic again.
-
-### Small models (e.g. Qwen 4B) — context caps
-
-Small local models are easily overloaded by the full task briefing and system prompt. AgentCeption truncates context when the **effective provider is local** so a "hello world" run can complete. Tune these in `.env`; see [Config and environment](#config-and-environment) for the full list:
-
-| Env var | Default | Purpose |
-|--------|---------|--------|
-| `LOCAL_LLM_MAX_CONTEXT_CHARS` | 12000 | Max characters for the first user message (task briefing). |
-| `LOCAL_LLM_MAX_SYSTEM_CHARS` | 6000 | Max characters for the system prompt (role + cognitive arch). |
-| `LOCAL_LLM_MAX_TOKENS` | 4096 | Desired max completion tokens (agent loop). |
-| `LOCAL_LLM_COMPLETION_TOKEN_CEILING` | 4096 | Max `max_tokens` sent to the server (mlx caps at 4096). |
-
-If the agent stalls or produces no tool calls, ensure the MLX server is reachable from the container (`host.docker.internal`; on Linux add `extra_hosts: ["host.docker.internal:host-gateway"]` in docker-compose) and consider lowering the caps further.
-
-### Pushing further (Qwen 4B and up)
-
-With the defaults above, the following have been verified with Qwen 4B (e.g. `mlx-community/Qwen3-4B-Instruct-2507-4bit`):
-
-- **Hello world** — one turn, no tools (`POST /api/local-llm/hello-agent`).
-- **Single-file doc edit** — search → read → replace → done (e.g. add one sentence to a guide). Full developer tool set (12 tools), truncated context.
-
-To push further:
-
-- **Multi-file or add-a-test** — Try an issue that touches 2–3 files or adds a test. If the model stalls or loops, lower `LOCAL_LLM_MAX_CONTEXT_CHARS` / `LOCAL_LLM_MAX_SYSTEM_CHARS` a bit.
-- **Larger Qwen 3.5** — See the "Larger Qwen for real coding" section below for 9B and 35B Qwen 3.5 models and recommended env caps.
-- **Watch script** — Use `python3 scripts/watch_run.py <run_id>`; the ITER line shows `local` (green) when the run is using the local LLM so you can confirm the provider.
-
-### Larger Qwen 3.5 for real coding
-
-Use a **Qwen 3.5** model that fits your Mac’s unified memory. Same AgentCeption setup (`USE_LOCAL_LLM=true`); only the model and (optionally) context caps change.
-
-| Mac RAM (unified) | Model | Hugging Face ID | Notes |
-|-------------------|--------|------------------|--------|
-| 8–16 GB | Qwen 3.5 4B | `mlx-community/Qwen3.5-4B-OptiQ-4bit` | Same family as the 4B you used; optional upgrade from Qwen3-4B. |
-| 16–24 GB | Qwen 3.5 9B | `mlx-community/Qwen3.5-9B-4bit` | Good step up for real coding; more context and better tool use. |
-| 48 GB | Qwen 3.5 35B (MoE) | `mlx-community/Qwen3.5-35B-A3B-4bit` | Use **mlx-openai-server** (multimodal). Best quality; avoid on 24 GB or less. |
-
-**1. Install and start the server** (one of the following; adjust port if needed):
+**1. Minimal request:**
 
 ```bash
-# Qwen 3.5 9B (recommended for 16–24 GB; real coding)
-.venv-mlx/bin/mlx_lm.server --model mlx-community/Qwen3.5-9B-4bit --host 0.0.0.0 --port 8080
-
-# Qwen 3.5 35B (48 GB Mac) — use mlx-openai-server (see "48 GB Mac: Qwen 3.5 35B" below)
-mlx-openai-server launch \
-  --model-path mlx-community/Qwen3.5-35B-A3B-4bit \
-  --model-type multimodal \
-  --port 8080
+curl -s http://localhost:11434/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3.5:35b-a3b-q4_K_M",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "Reply with exactly: hello world"}
+    ],
+    "temperature": 0.2,
+    "max_tokens": 128,
+    "stream": false
+  }'
 ```
 
-For 35B we recommend [mlx-openai-server](https://github.com/cubist38/mlx-openai-server) — **local** multimodal server with Chat Completions–compatible HTTP (name = API shape, not OpenAI Inc.). A dedicated runbook for 48 GB Macs is in the next subsection.
-
-**2. Raise context caps** in `.env` so the larger model gets more of the briefing and system prompt (optional but recommended for 9B/35B):
+**2. From inside Docker** (to match AgentCeption's network path):
 
 ```bash
-LOCAL_LLM_MAX_CONTEXT_CHARS=24000
-LOCAL_LLM_MAX_SYSTEM_CHARS=12000
-LOCAL_LLM_MAX_TOKENS=8192
+docker compose exec agentception curl -s http://host.docker.internal:11434/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"qwen3.5:35b-a3b-q4_K_M","messages":[{"role":"user","content":"Say hi"}],"temperature":0,"max_tokens":64,"stream":false}'
 ```
 
-Restart AgentCeption, then dispatch developer agents as usual. With the effective provider set to **local**, they will use the new model at `host.docker.internal:8080` with no code changes.
+If the host call works but the Docker call fails, check that Ollama is not bound only to `127.0.0.1`. Ollama binds to `0.0.0.0` by default, so this should work without extra config.
 
-### 48 GB Mac: Qwen 3.5 35B with AgentCeption
+---
 
-Step-by-step to run the 35B 4-bit model with AgentCeption on a 48 GB Apple Silicon Mac.
+## Developer footnote: mlx-openai-server
 
-**1. Create a venv and install mlx-openai-server, then mlx-vlm ≥ 0.3.12** (35B MoE needs recent mlx-vlm)
+`mlx-openai-server` is a developer preview tool. It is **not suitable for multi-agent workloads** because:
 
-Install in **two steps** so pip does not hit `ResolutionImpossible` (mlx-openai-server pins mlx-vlm==0.3.0):
+- Single-process, no request queue — one request at a time
+- No KV cache management — cache saturates after a large generation (~4000 tok); subsequent requests hang until server restart
+- Hard max-token cap of 4096 (returns HTTP 422 above this)
+- No model keep-alive between requests
+
+Use it only for one-off tests or model exploration on a Mac that does not have Ollama installed. If you must use it, set `LOCAL_LLM_COMPLETION_TOKEN_CEILING=4096` and expect to restart it between large generations.
+
+**Quick start (mlx-openai-server, developer use only):**
 
 ```bash
-python3 -m venv .venv-mlx
-source .venv-mlx/bin/activate
 pip install -U mlx-openai-server
+# For the 35B 4-bit model, also upgrade mlx-vlm:
 pip install -U "mlx-vlm>=0.3.12"
-```
 
-You may see dependency conflict warnings after the second command; **try running the server anyway**—newer mlx-vlm usually works. If the 35B server fails with "Model type qwen3_5_moe not supported", the mlx-vlm upgrade did not take effect; retry the second step or use `pip install -U --force-reinstall "mlx-vlm>=0.3.12"`.
-
-If the server fails with **"Qwen3VLVideoProcessor requires the Torchvision library"** (or PyTorch), the model's processor config pulls in a video component that needs torch/torchvision at load time. Install them (inference still uses MLX):
-
-```bash
-pip install torch torchvision
-```
-
-**2. Start the 35B server on port 8080** (so AgentCeption’s default `host.docker.internal:8080` works)
-
-```bash
 mlx-openai-server launch \
   --model-path mlx-community/Qwen3.5-35B-A3B-4bit \
   --model-type multimodal \
+  --host 0.0.0.0 \
   --port 8080
 ```
 
-If your version is v1.4.1+ you can add `--reasoning-parser qwen3_5` and `--tool-call-parser qwen3_coder`. If you get "No such option", use the command above as-is (common with 1.1.x or Python 3.13).
+Then set `LOCAL_LLM_BASE_URL=http://host.docker.internal:8080` and `LOCAL_LLM_COMPLETION_TOKEN_CEILING=4096` in `.env`.
 
-First run downloads the model from Hugging Face. If the server only binds to localhost, check the project’s docs for `--host 0.0.0.0` so Docker can reach it from the container.
+---
 
-**3. Configure AgentCeption**
-
-In `.env`:
-
-```bash
-LLM_PROVIDER=local
-# Or: USE_LOCAL_LLM=true
-LOCAL_LLM_BASE_URL=http://host.docker.internal:8080
-LOCAL_LLM_MAX_CONTEXT_CHARS=24000
-LOCAL_LLM_MAX_SYSTEM_CHARS=12000
-LOCAL_LLM_MAX_TOKENS=8192
-```
-
-Leave `LOCAL_LLM_MODEL` unset (or empty) so the server uses its loaded model. See [Config and environment](#config-and-environment) for all local-provider env vars.
-
-**4. Ensure Docker can reach the host**
-
-`docker-compose.yml` should have:
-
-```yaml
-extra_hosts: ["host.docker.internal:host-gateway"]
-```
-
-**5. Restart AgentCeption and verify**
-
-```bash
-docker compose restart agentception
-curl -s http://localhost:10003/api/local-llm/hello
-```
-
-Expect `{"ok": true, "reply": "..."}`. Then dispatch a developer agent (e.g. from the Build UI or MCP) with an issue and watch with `python3 scripts/watch_run.py issue-<N>`. The ITER line should show `local` (green) when the run uses the 35B model.
-
-### Sample coding task (test code generation)
+## Sample coding task (test code generation)
 
 Use the following as a GitHub issue to see what code the local model can produce. Create the issue, ensure the effective provider is **local** (`LLM_PROVIDER=local` or `USE_LOCAL_LLM=true`), then dispatch a developer and watch with `python3 scripts/watch_run.py issue-<N>`.
 
@@ -490,49 +336,30 @@ Use the following as a GitHub issue to see what code the local model can produce
 
 ```markdown
 ## Context
-Small code-generation test for the local LLM (Qwen 4B) pipeline.
+Small code-generation test for the local LLM (Qwen) pipeline.
 
 ## Objective
 1. Create `agentception/utils.py` with a single function:
    - `def clamp(value: float, low: float, high: float) -> float`
-   - Return `value` clamped to the range `[low, high]` (if value < low return low; if value > high return high; else return value).
+   - Return `value` clamped to the range `[low, high]`.
    - Add `from __future__ import annotations` at the top and a one-line module docstring.
 2. Create `agentception/tests/test_utils.py` with one test:
    - `def test_clamp_returns_value_within_bounds()`
    - Assert `clamp(5.0, 0.0, 10.0) == 5.0`, `clamp(-1.0, 0.0, 10.0) == 0.0`, `clamp(11.0, 0.0, 10.0) == 10.0`.
-   - Use the same `from __future__ import annotations` and a test module docstring if you like.
 
 ## Acceptance criteria
 - [ ] `agentception/utils.py` exists with `clamp()` and type hints.
 - [ ] `agentception/tests/test_utils.py` exists and `pytest agentception/tests/test_utils.py -v` passes.
 ```
 
-After the run, run `docker compose exec agentception pytest agentception/tests/test_utils.py -v` and `mypy agentception/utils.py` to confirm the code is valid.
-
-**If no PR appeared:** The agent must push the branch (`git_commit_and_push`) before calling `create_pull_request`; GitHub only creates a PR when the head branch exists on the remote. If the model called `create_pull_request` first (or the push failed), you'll see "couldn't find remote ref feat/issue-N" and no PR. To recover: from the host, push the worktree branch and open the PR manually:
-
-```bash
-cd ~/.agentception/worktrees/agentception/issue-970   # or your run's worktree
-git status                                            # see if there are commits
-git push -u origin feat/issue-970                    # push the branch
-gh pr create --base dev --fill                        # create PR from the branch
-```
-
----
-
-## Checklist for issue #964
-
-- [ ] One of the run options above (generate, chat, or server) completes successfully with Qwen 3.5 35B (or the 4-bit variant) on your Mac.
-- [ ] At least one run has been measured with powermetrics or Activity Monitor; note CPU, GPU, and ANE usage.
-- [ ] You have a repeatable command (or short script) and the model ID/path documented above for the next step (AgentCeption local provider).
+After the run, verify: `docker compose exec agentception pytest agentception/tests/test_utils.py -v` and `mypy agentception/utils.py`.
 
 ---
 
 ## References
 
-- [LLM contract and provider abstraction](../reference/llm-contract.md) — AgentCeption’s LLM contract, provider selection, and how to add a provider.
-- [MLX LM](https://github.com/ml-explore/mlx-lm) — run LLMs with MLX (text).
-- [MLX VLM](https://github.com/ml-explore/mlx-vlm) — vision/language models, used for Qwen 3.5 35B 4-bit.
+- [Local LLM Scaling](local-llm-scaling.md) — multi-agent scaling with LiteLLM Proxy and multiple Ollama instances.
+- [LLM contract and provider abstraction](../reference/llm-contract.md) — AgentCeption's LLM contract, provider selection, and how to add a provider.
+- [Ollama](https://ollama.com) — local inference server (recommended).
 - [mlx-community/Qwen3.5-35B-A3B-4bit](https://huggingface.co/mlx-community/Qwen3.5-35B-A3B-4bit) — 4-bit quantized Qwen 3.5 35B for MLX.
-- [Qwen docs: MLX LM](https://qwen.readthedocs.io/en/latest/run_locally/mlx-lm.html) — Qwen + mlx-lm.
 - [powermetrics(1)](https://keith.github.io/xcode-man-pages/powermetrics.1.html) — macOS power and usage sampling.

--- a/docs/guides/local-llm-scaling.md
+++ b/docs/guides/local-llm-scaling.md
@@ -1,0 +1,314 @@
+# Local LLM Scaling with LiteLLM Proxy
+
+This guide covers the multi-agent scaling architecture for running dozens to hundreds of AgentCeption agents against local models on Apple Silicon. It assumes you have completed the basic [Ollama setup](local-llm-mlx.md) (Phase 1) and now need to scale beyond a single Ollama instance.
+
+---
+
+## The fundamental constraint
+
+Apple Silicon is unified memory — one model at a time.
+
+| Hardware | Model fit | Realistic throughput (Qwen 3.5 35B 4-bit) |
+|----------|-----------|------------------------------------------|
+| M4 Max 128 GB | 1 instance (~18 GB for weights) | ~870 tok/s single-stream |
+| Mac Pro M4 Ultra 192 GB | 2 instances | ~1700 tok/s across 2 streams |
+| 4× Mac Studio M4 Max | 4 instances | ~3500 tok/s, true parallelism |
+
+For agent tool calls (200–500 tok/turn at 870 tok/s): **~100–200 tool calls/minute per machine**. With a queue, a single chip can support ~5–10 concurrent agents without degradation. Beyond that, you need more hardware — there is no software fix for physics.
+
+---
+
+## Architecture overview
+
+```
+Agent pool (1 → N agents)
+        │
+        ▼
+AgentCeption LLM layer  (agentception/services/llm.py)
+completion() / completion_stream() / completion_with_tools()
+        │
+        ▼
+LiteLLM Proxy  (localhost:4000)
+ ├── request queue
+ ├── load balancer
+ └── cloud fallback (Anthropic)
+        │
+        ├─── Ollama instance 1  (port 11434) — Qwen 3.5 35B, planning
+        ├─── Ollama instance 2  (port 11435) — Qwen 3.5 8B, agent tool calls
+        └─── Anthropic API      (cloud fallback when local is saturated)
+```
+
+Each phase below is independent — implement only as far as your agent count requires.
+
+---
+
+## Phase 1: Single Ollama instance (1–10 agents)
+
+**Already covered in [local-llm-mlx.md](local-llm-mlx.md).** Ollama handles a request queue natively; up to ~5–10 concurrent agents can share one Ollama instance without degradation.
+
+Configuration:
+
+```bash
+# .env
+LLM_PROVIDER=local
+LOCAL_LLM_BASE_URL=http://host.docker.internal:11434
+LOCAL_LLM_MODEL=qwen3.5:35b-a3b-q4_K_M
+LOCAL_LLM_COMPLETION_TOKEN_CEILING=8192
+```
+
+---
+
+## Phase 2: LiteLLM Proxy (10–100 agents)
+
+LiteLLM Proxy accepts the OpenAI API shape that AgentCeption already sends and adds:
+
+- **Request queuing** across multiple Ollama instances
+- **Load balancing** — round-robin or least-busy across backends
+- **Anthropic cloud fallback** when local capacity is saturated or a request fails
+- **Retries and rate limiting**
+- **Per-model spend and token tracking** across the fleet
+
+The only AgentCeption config change: point `LOCAL_LLM_BASE_URL` at the proxy.
+
+### Install LiteLLM Proxy
+
+```bash
+pip install 'litellm[proxy]'
+```
+
+Or run via Docker (see docker-compose snippet below).
+
+### Create `litellm-config.yaml`
+
+```yaml
+# litellm-config.yaml
+# Place alongside docker-compose.yml or pass via --config flag.
+
+model_list:
+  # Large model for Phase 1A planning (35B)
+  - model_name: qwen-plan
+    litellm_params:
+      model: ollama/qwen3.5:35b-a3b-q4_K_M
+      api_base: http://localhost:11434
+      stream_timeout: 120
+
+  # Fast model for agent tool calls (8B)
+  - model_name: qwen-agent
+    litellm_params:
+      model: ollama/qwen3.5:9b
+      api_base: http://localhost:11435
+      stream_timeout: 60
+
+  # Cloud fallback — used when local is saturated or fails
+  - model_name: claude-fallback
+    litellm_params:
+      model: anthropic/claude-sonnet-4-6
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+router_settings:
+  # Retry failed requests on the next available backend
+  num_retries: 2
+  # Queue requests when all backends are busy (instead of 429-ing immediately)
+  routing_strategy: least-busy
+
+general_settings:
+  # Expose Prometheus metrics at /metrics
+  enable_prometheus: true
+```
+
+### Run LiteLLM Proxy
+
+```bash
+# Start with config
+litellm --config litellm-config.yaml --port 4000
+```
+
+Or via Docker:
+
+```yaml
+# docker-compose.override.yml snippet — add to your existing file
+services:
+  litellm-proxy:
+    image: ghcr.io/berriai/litellm:main-latest
+    command: ["--config", "/config.yaml", "--port", "4000", "--num_workers", "4"]
+    volumes:
+      - ./litellm-config.yaml:/config.yaml:ro
+    ports:
+      - "4000:4000"
+    environment:
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+```
+
+### Configure AgentCeption to use the proxy
+
+```bash
+# .env — point at the proxy instead of Ollama directly
+LOCAL_LLM_BASE_URL=http://host.docker.internal:4000
+
+# Use generic model names — proxy routes to the right Ollama instance
+LOCAL_LLM_MODEL=qwen-plan          # default model (used for planning)
+
+# Per-usecase overrides (see Phase 3 below)
+LOCAL_LLM_MODEL_PLAN=qwen-plan
+LOCAL_LLM_MODEL_AGENT=qwen-agent
+```
+
+Restart AgentCeption:
+
+```bash
+docker compose restart agentception
+```
+
+### Verify
+
+```bash
+# Health check
+curl http://localhost:4000/health
+
+# Test a completion through the proxy
+curl -s http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen-plan",
+    "messages": [{"role": "user", "content": "Reply with: hello world"}],
+    "temperature": 0.0,
+    "max_tokens": 32,
+    "stream": false
+  }'
+
+# Confirm AgentCeption reaches local model through proxy
+curl -s http://localhost:10003/api/local-llm/hello
+```
+
+---
+
+## Phase 3: Two models, purpose-matched (100+ agents)
+
+The key insight: **not all LLM calls need a 35B model.**
+
+| Call type | Prompt size | Output size | Model needed |
+|-----------|-------------|-------------|--------------|
+| Plan 1A (YAML generation) | Large (~4k tok) | Large (~4k tok) | 35B — quality matters |
+| Agent tool calls | Medium (~2k tok) | Small (200–500 tok) | 8B — speed matters |
+| Recon / research | Medium | Medium | 8B or 35B |
+
+With two models on the same machine (e.g. M4 Max 128 GB: 35B takes ~18 GB, 8B takes ~5 GB, 23 GB total), you serve planning with the large model and agent loops with the small model. Throughput for agent tool calls roughly 4×.
+
+### Run two Ollama instances
+
+```bash
+# Instance 1 — port 11434 — large planning model
+OLLAMA_HOST=0.0.0.0:11434 ollama serve &
+
+# Instance 2 — port 11435 — fast agent model
+OLLAMA_HOST=0.0.0.0:11435 ollama serve &
+
+# Pull models on each instance
+OLLAMA_HOST=localhost:11434 ollama pull qwen3.5:35b-a3b-q4_K_M
+OLLAMA_HOST=localhost:11435 ollama pull qwen3.5:9b
+```
+
+> **Note:** Ollama uses a single binary; run two processes with different `OLLAMA_HOST` values to get two independent instances on different ports.
+
+### Update litellm-config.yaml
+
+The config already routes by model name (`qwen-plan` → instance 1, `qwen-agent` → instance 2). Verify `api_base` matches the ports you used:
+
+```yaml
+model_list:
+  - model_name: qwen-plan
+    litellm_params:
+      model: ollama/qwen3.5:35b-a3b-q4_K_M
+      api_base: http://localhost:11434   # large model
+
+  - model_name: qwen-agent
+    litellm_params:
+      model: ollama/qwen3.5:9b
+      api_base: http://localhost:11435   # fast model
+```
+
+### Configure AgentCeption per-usecase overrides
+
+```bash
+# .env
+LOCAL_LLM_BASE_URL=http://host.docker.internal:4000  # proxy
+LOCAL_LLM_MODEL_PLAN=qwen-plan    # Phase 1A → 35B
+LOCAL_LLM_MODEL_AGENT=qwen-agent  # agent tool calls → 8B
+```
+
+AgentCeption's `completion_stream()` uses `LOCAL_LLM_MODEL_PLAN`; `completion_with_tools()` uses `LOCAL_LLM_MODEL_AGENT`. Both resolve through the proxy to the correct Ollama instance.
+
+---
+
+## Phase 4: Multi-machine (1000+ agents)
+
+Beyond a single Apple Silicon chip, the options are:
+
+1. **Multiple Mac Studios/Mac Pros** — each runs its own Ollama instance. Add them to `litellm-config.yaml` as additional backends under the same model name; LiteLLM load-balances across all of them.
+
+   ```yaml
+   model_list:
+     - model_name: qwen-agent
+       litellm_params:
+         model: ollama/qwen3.5:9b
+         api_base: http://mac-studio-1.local:11434
+
+     - model_name: qwen-agent
+       litellm_params:
+         model: ollama/qwen3.5:9b
+         api_base: http://mac-studio-2.local:11434
+   ```
+
+2. **Cloud burst to Anthropic** — when local capacity is fully saturated (all queues at maximum), LiteLLM falls back to the `claude-fallback` model defined in the config. No code change required.
+
+3. **Anthropic primary for agents, local for planning** — set `LLM_PROVIDER=anthropic` and only override the planning path with `LOCAL_LLM_BASE_URL_PLAN` + `LOCAL_LLM_MODEL_PLAN` pointing at a local Ollama instance. Agent tool calls use Anthropic; planning uses local.
+
+---
+
+## Monitoring
+
+LiteLLM Proxy exposes Prometheus metrics at `http://localhost:4000/metrics` when `enable_prometheus: true` is set in the config. Key metrics:
+
+| Metric | What it shows |
+|--------|---------------|
+| `litellm_request_total` | Total requests per model and status |
+| `litellm_total_tokens_used` | Token consumption per model |
+| `litellm_latency_seconds` | Per-model latency histogram |
+| `litellm_queue_length` | Current queue depth |
+
+Connect to Grafana or any Prometheus-compatible dashboard for live monitoring.
+
+---
+
+## Troubleshooting
+
+**Ollama not reachable from Docker:**
+Ensure Ollama is listening on `0.0.0.0`, not `127.0.0.1`. Check with `curl http://localhost:11434/api/tags`. If bound to loopback only, set `OLLAMA_HOST=0.0.0.0:11434`.
+
+**LiteLLM proxy returns 429:**
+All backends are saturated. Add more Ollama instances or fall back to Anthropic by including a `claude-fallback` entry in the config.
+
+**Proxy routes to wrong model:**
+Check that `LOCAL_LLM_MODEL_PLAN` and `LOCAL_LLM_MODEL_AGENT` in `.env` exactly match the `model_name` strings in `litellm-config.yaml`.
+
+**High latency on first request:**
+Ollama loads the model on first request (cold start). Run a warm-up request after starting Ollama:
+
+```bash
+curl -s http://localhost:11434/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"qwen3.5:35b-a3b-q4_K_M","messages":[{"role":"user","content":"hi"}],"max_tokens":1}' \
+  > /dev/null
+```
+
+---
+
+## References
+
+- [Local LLM with Ollama setup](local-llm-mlx.md) — Phase 1 runbook.
+- [LLM contract and provider abstraction](../reference/llm-contract.md) — AgentCeption's LLM contract.
+- [Ollama](https://ollama.com) — local inference server.
+- [LiteLLM Proxy docs](https://docs.litellm.ai/docs/proxy/quick_start) — full proxy configuration reference.


### PR DESCRIPTION
## Summary

- **Ollama as primary backend**: Rewrites `docs/guides/local-llm-mlx.md` to feature Ollama as the recommended production-grade inference server; demotes `mlx-openai-server` to a developer footnote with a clear explanation of why it fails under load (no queue, KV cache saturation, 4096 token cap).
- **Remove `repetition_penalty`**: Drops the non-standard parameter from `_local_completion_payload` — it is not in the OpenAI spec and is silently rejected by Ollama's compat endpoint. `frequency_penalty` (standard) stays.
- **Raise token ceiling default 4096 → 8192**: The old cap was a `mlx-openai-server` workaround. Ollama supports full context lengths; 8192 is a safe default.
- **Per-usecase model/URL overrides**: Adds `LOCAL_LLM_BASE_URL_PLAN`, `LOCAL_LLM_MODEL_PLAN`, `LOCAL_LLM_BASE_URL_AGENT`, `LOCAL_LLM_MODEL_AGENT` env vars + config properties. `completion_stream()` uses the plan overrides; `completion_with_tools()` uses the agent overrides. Enables Phase 3 two-model routing through LiteLLM Proxy without touching caller code.
- **New `docs/guides/local-llm-scaling.md`**: Four-phase scaling architecture (single Ollama → LiteLLM Proxy → two models, purpose-matched → multi-machine), with `litellm-config.yaml`, docker-compose snippet, monitoring (Prometheus metrics), and troubleshooting.

## Test plan
- [x] `mypy agentception/ tests/` — zero errors
- [x] `typing_audit.py --max-any 0` — passes
- [x] `test_config.py` — updated ceiling assertion, two new per-usecase override tests — all pass
- [x] `test_llm.py` — all existing + think-tag tests pass
- [x] `generate.py --check` — no drift