### PR TITLE
fix: navigate to /ship after project switch instead of reloading in place

### DIFF
--- a/agentception/static/js/nav.ts
+++ b/agentception/static/js/nav.ts
@@ -44,7 +44,10 @@ export function projectSwitcher(): ProjectSwitcherComponent {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ project_name: name }),
         });
-        if (res.ok) window.location.reload();
+        // Navigate to /ship so the redirect endpoint picks up the newly
+        // active project's gh_repo and lands on the correct board URL.
+        // A bare reload() would keep the old repo name in the path.
+        if (res.ok) window.location.href = '/ship';
       } catch {
         // Silently suppress.
       }


### PR DESCRIPTION
## Bug
`switchProject()` called `window.location.reload()` after a successful project switch. This reloaded the current URL (e.g. `/ship/agentception/some-initiative`) with the old repo name still in the path. The board route reads the repo from the URL, so it kept serving the previous project's data regardless of the updated `settings.gh_repo`.

## Fix
Replace `window.location.reload()` with `window.location.href = '/ship'`. The `/ship` redirect endpoint reads the newly updated `settings.gh_repo` and redirects to `/ship/{new-repo}/{first-initiative}` — the correct board URL for the active project.

## Change
- `agentception/static/js/nav.ts` — one line