### PR TITLE
fix: project switcher guard fires against server-confirmed state

### DIFF
--- a/.agentception/pipeline-config.json
+++ b/.agentception/pipeline-config.json
@@ -20,7 +20,7 @@
       "gh_repo": "aaronrene/GeodesicDomeDesigner"
     }
   ],
-  "active_project": "GeodesicDomeDesigner",
+  "active_project": "agentception",
   "approval_required_labels": [
     "db-schema",
     "security",

--- a/agentception/static/js/__tests__/nav.test.ts
+++ b/agentception/static/js/__tests__/nav.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { projectSwitcher } from '../nav';
+
+// Minimal Alpine.js-like `this` context: methods are bound to the same object.
+function makeComponent(): ReturnType<typeof projectSwitcher> {
+  const obj = projectSwitcher();
+  // Bind every method to the component itself (Alpine does this at runtime).
+  const bound = Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => [k, typeof v === 'function' ? (v as (...a: unknown[]) => unknown).bind(obj) : v]),
+  ) as ReturnType<typeof projectSwitcher>;
+  // Keep the original object in sync so method calls mutate the right scope.
+  return obj;
+}
+
+describe('projectSwitcher()', () => {
+  let comp: ReturnType<typeof projectSwitcher>;
+
+  beforeEach(() => {
+    comp = projectSwitcher();
+    // Bind methods to the component (replicating Alpine's behaviour).
+    comp.load = comp.load.bind(comp);
+    comp.switchProject = comp.switchProject.bind(comp);
+    vi.restoreAllMocks();
+    // Reset window.location mock.
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { href: '/' },
+    });
+  });
+
+  // ── initial state ──────────────────────────────────────────────────────────
+
+  it('initialises with empty projects and null active/confirmed', () => {
+    expect(comp.projects).toEqual([]);
+    expect(comp.activeProject).toBeNull();
+    expect(comp.confirmedProject).toBeNull();
+  });
+
+  // ── load() ─────────────────────────────────────────────────────────────────
+
+  it('load sets projects, activeProject, and confirmedProject from API', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ projects: ['agentception', 'GeodesicDomeDesigner'], active_project: 'agentception' }),
+    }));
+
+    await comp.load();
+
+    expect(comp.projects).toEqual(['agentception', 'GeodesicDomeDesigner']);
+    expect(comp.activeProject).toBe('agentception');
+    expect(comp.confirmedProject).toBe('agentception');
+  });
+
+  it('load is silent on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('offline')));
+    await expect(comp.load()).resolves.toBeUndefined();
+    expect(comp.projects).toEqual([]);
+  });
+
+  it('load is silent when response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({ ok: false }));
+    await comp.load();
+    expect(comp.projects).toEqual([]);
+  });
+
+  // ── switchProject() ────────────────────────────────────────────────────────
+
+  it('switchProject calls API and navigates to /ship on success', async () => {
+    comp.confirmedProject = 'agentception';
+    comp.activeProject = 'GeodesicDomeDesigner'; // x-model already mutated this
+
+    const mockFetch = vi.fn().mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await comp.switchProject('GeodesicDomeDesigner');
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/config/switch-project', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ project_name: 'GeodesicDomeDesigner' }),
+    });
+    expect(window.location.href).toBe('/ship');
+    expect(comp.confirmedProject).toBe('GeodesicDomeDesigner');
+  });
+
+  it('switchProject is a no-op when name equals confirmedProject (not activeProject)', async () => {
+    // This is the key regression test: x-model updates activeProject before
+    // @change fires, so activeProject === name.  We must guard against
+    // confirmedProject, not activeProject.
+    comp.confirmedProject = 'agentception';
+    comp.activeProject = 'agentception'; // x-model already set this to same value
+
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    await comp.switchProject('agentception');
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('switchProject proceeds even though activeProject already equals name', async () => {
+    // Simulates the exact Alpine.js timing issue: x-model set activeProject
+    // to 'GeodesicDomeDesigner' before the @change handler fires, but
+    // confirmedProject is still 'agentception'.
+    comp.confirmedProject = 'agentception';
+    comp.activeProject = 'GeodesicDomeDesigner'; // x-model already mutated
+
+    const mockFetch = vi.fn().mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await comp.switchProject('GeodesicDomeDesigner');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(window.location.href).toBe('/ship');
+  });
+
+  it('switchProject reverts activeProject on failed response', async () => {
+    comp.confirmedProject = 'agentception';
+    comp.activeProject = 'GeodesicDomeDesigner';
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({ ok: false }));
+
+    await comp.switchProject('GeodesicDomeDesigner');
+
+    expect(comp.activeProject).toBe('agentception');
+    expect(comp.confirmedProject).toBe('agentception');
+    expect(window.location.href).toBe('/');
+  });
+
+  it('switchProject reverts activeProject on network error', async () => {
+    comp.confirmedProject = 'agentception';
+    comp.activeProject = 'GeodesicDomeDesigner';
+
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('offline')));
+
+    await comp.switchProject('GeodesicDomeDesigner');
+
+    expect(comp.activeProject).toBe('agentception');
+    expect(comp.confirmedProject).toBe('agentception');
+  });
+
+  it('switchProject is a no-op for empty string', async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+    await comp.switchProject('');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/agentception/static/js/nav.ts
+++ b/agentception/static/js/nav.ts
@@ -3,6 +3,12 @@
  *
  * Fetches the pipeline-config and renders a project <select> in the nav bar.
  * Hidden via x-show when no projects are configured.
+ *
+ * Design note: Alpine's x-model updates `activeProject` synchronously before
+ * the @change handler fires, so comparing `name === this.activeProject` inside
+ * switchProject would always be true and short-circuit every switch.  We track
+ * `confirmedProject` (the last server-acknowledged value) separately and guard
+ * against that instead.
  */
 
 'use strict';
@@ -15,6 +21,7 @@ interface ConfigResponse {
 interface ProjectSwitcherComponent {
   projects: string[];
   activeProject: string | null;
+  confirmedProject: string | null;
   load(): Promise<void>;
   switchProject(name: string): Promise<void>;
 }
@@ -23,6 +30,7 @@ export function projectSwitcher(): ProjectSwitcherComponent {
   return {
     projects: [],
     activeProject: null,
+    confirmedProject: null,
 
     async load(): Promise<void> {
       try {
@@ -31,25 +39,35 @@ export function projectSwitcher(): ProjectSwitcherComponent {
         const cfg = (await res.json()) as ConfigResponse;
         this.projects = cfg.projects ?? [];
         this.activeProject = cfg.active_project ?? null;
+        this.confirmedProject = cfg.active_project ?? null;
       } catch {
         // Network error — silently suppress.
       }
     },
 
     async switchProject(name: string): Promise<void> {
-      if (!name || name === this.activeProject) return;
+      // Guard against the confirmed server state, not `activeProject`, because
+      // x-model already mutated `activeProject` before this handler fires.
+      if (!name || name === this.confirmedProject) return;
       try {
         const res = await fetch('/api/config/switch-project', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ project_name: name }),
         });
-        // Navigate to /ship so the redirect endpoint picks up the newly
-        // active project's gh_repo and lands on the correct board URL.
-        // A bare reload() would keep the old repo name in the path.
-        if (res.ok) window.location.href = '/ship';
+        if (res.ok) {
+          this.confirmedProject = name;
+          // Navigate to /ship so the redirect endpoint picks up the newly
+          // active project's gh_repo and lands on the correct board URL.
+          // A bare reload() would keep the old repo name in the path.
+          window.location.href = '/ship';
+        } else {
+          // Revert the dropdown to the last confirmed state on failure.
+          this.activeProject = this.confirmedProject;
+        }
       } catch {
-        // Silently suppress.
+        // Revert the dropdown to the last confirmed state on network error.
+        this.activeProject = this.confirmedProject;
       }
     },
   };


### PR DESCRIPTION
## Summary

- **Root cause**: Alpine.js `x-model` mutates `activeProject` synchronously _before_ the `@change` handler fires. The guard `name === this.activeProject` was therefore always `true` — the `fetch` call to `/api/config/switch-project` was never made, so no project ever actually switched.
- **Fix**: Added a `confirmedProject` field that tracks the last server-acknowledged active project. The guard now compares against `confirmedProject` (server state) instead of `activeProject` (UI binding state).
- **Failure UX**: On API error or network failure the dropdown reverts to `confirmedProject` so the UI stays consistent with the backend.
- **Default project**: Reset `active_project` in `pipeline-config.json` from `"GeodesicDomeDesigner"` to `"agentception"`.

## Test plan

- [x] `npm run type-check` — zero errors
- [x] `npm test` — 109/109 pass (includes new `nav.test.ts` with 10 cases covering the Alpine timing regression)
- [x] `npm run build:js` — bundle rebuilt
- [x] Container restarted