### PR TITLE
fix: worktree reaper no longer loops on absent or unregistered directories

### DIFF
--- a/agentception/services/teardown.py
+++ b/agentception/services/teardown.py
@@ -12,6 +12,7 @@ Keeping teardown here prevents the MCP layer from importing the routes layer
 
 import asyncio
 import logging
+import shutil
 from pathlib import Path
 
 from agentception.config import settings
@@ -46,17 +47,32 @@ async def release_worktree(worktree_path: str, repo_dir: str) -> bool:
         if rm_proc.returncode == 0:
             logger.info("✅ release_worktree: removed %s", worktree_path)
         else:
+            # git rejects directories that are no longer registered in its
+            # worktree list (e.g. after a container restart that reset the git
+            # process state).  Fall back to shutil.rmtree — the directory is
+            # orphaned and safe to force-remove.
             logger.warning(
-                "⚠️  release_worktree: worktree remove failed: %s",
+                "⚠️  release_worktree: git worktree remove failed (%s) — "
+                "falling back to shutil.rmtree for %s",
                 stderr.decode().strip(),
+                worktree_path,
             )
-            prune_proc = await asyncio.create_subprocess_exec(
-                "git", "-C", repo, "worktree", "prune",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            await prune_proc.communicate()
-            return False
+            try:
+                shutil.rmtree(worktree_path)
+                logger.info("✅ release_worktree: force-removed %s via shutil.rmtree", worktree_path)
+            except Exception as rm_exc:
+                logger.warning(
+                    "⚠️  release_worktree: shutil.rmtree also failed for %s: %s",
+                    worktree_path,
+                    rm_exc,
+                )
+                prune_proc = await asyncio.create_subprocess_exec(
+                    "git", "-C", repo, "worktree", "prune",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                await prune_proc.communicate()
+                return False
     else:
         logger.info("ℹ️  release_worktree: %s already gone — skipping", worktree_path)
 

--- a/agentception/services/worktree_reaper.py
+++ b/agentception/services/worktree_reaper.py
@@ -53,6 +53,16 @@ async def reap_stale_worktrees() -> int:
     for run in runs:
         worktree_path = run["worktree_path"]
         if not Path(worktree_path).exists():
+            # Directory is already gone — clear the stale DB reference so this
+            # run is never returned by get_terminal_runs_with_worktrees again.
+            # Without this, the reaper logs a "stale" entry on every pass for
+            # runs whose directories were cleaned up outside of release_worktree
+            # (e.g. container restart, manual deletion).
+            logger.info(
+                "ℹ️  worktree reaper: dir absent, clearing stale DB ref for run %r",
+                run["id"],
+            )
+            await clear_run_worktree_path(run["id"])
             continue
         logger.info(
             "⚠️  worktree reaper: releasing stale worktree dir for run %r at %s",

--- a/agentception/tests/test_worktree_reaper.py
+++ b/agentception/tests/test_worktree_reaper.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 """Tests for the worktree reaper.
 
-Critical invariant: the reaper must call release_worktree (dir removal only),
-never teardown_agent_worktree (which deletes remote branches and closes open PRs).
+Critical invariants:
+- The reaper must call release_worktree (dir removal only), never
+  teardown_agent_worktree (which deletes remote branches and closes open PRs).
+- When a worktree directory is already gone, the reaper must clear the DB ref
+  so the run never appears in future reaper passes (the stale-loop bug).
 """
 
 from pathlib import Path
@@ -50,8 +53,14 @@ async def test_reaper_calls_release_not_teardown(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
-async def test_reaper_skips_missing_dirs(tmp_path: Path) -> None:
-    """Reaper skips runs whose worktree directory no longer exists on disk."""
+async def test_reaper_clears_db_ref_for_missing_dirs(tmp_path: Path) -> None:
+    """Reaper clears the DB ref when the directory is already gone.
+
+    Regression for the stale-loop bug: when a worktree directory no longer
+    exists on disk, the old code did `continue` without clearing the DB.
+    get_terminal_runs_with_worktrees() would then return the same run on every
+    subsequent pass, spamming the log indefinitely.
+    """
     absent = str(tmp_path / "issue-100")  # directory not created
 
     with (
@@ -65,6 +74,10 @@ async def test_reaper_skips_missing_dirs(tmp_path: Path) -> None:
             new_callable=AsyncMock,
         ) as mock_release,
         patch(
+            "agentception.services.worktree_reaper.clear_run_worktree_path",
+            new_callable=AsyncMock,
+        ) as mock_clear,
+        patch(
             "agentception.services.worktree_reaper.settings",
             new_callable=MagicMock,
             repo_dir="/app",
@@ -74,8 +87,11 @@ async def test_reaper_skips_missing_dirs(tmp_path: Path) -> None:
 
         count = await reap_stale_worktrees()
 
+    # Directory already gone — release_worktree is never called, but the DB
+    # reference IS cleared so the run never reappears in future passes.
     assert count == 0
     mock_release.assert_not_called()
+    mock_clear.assert_awaited_once_with("issue-100")
 
 
 @pytest.mark.anyio
@@ -212,3 +228,70 @@ async def test_reaper_does_not_clear_db_when_release_fails(tmp_path: Path) -> No
 
     assert count == 0
     mock_clear.assert_not_called()
+
+
+# ── release_worktree fallback tests ───────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_release_worktree_falls_back_to_rmtree_when_git_rejects(tmp_path: Path) -> None:
+    """release_worktree uses shutil.rmtree when git worktree remove fails.
+
+    Regression for the 'is not a working tree' loop: after a container restart
+    git's worktree registry is reset, so git worktree remove --force fails even
+    though the directory exists.  The old code returned False, the reaper never
+    cleared the DB, and the same run appeared in every subsequent pass.
+    """
+    stale_dir = tmp_path / "issue-824"
+    stale_dir.mkdir()
+
+    import asyncio
+
+    async def fake_run(*args: object, **kwargs: object) -> object:  # noqa: ARG001
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.communicate = AsyncMock(return_value=(b"", b"fatal: not a working tree"))
+        return proc
+
+    with (
+        patch("agentception.services.teardown.asyncio.create_subprocess_exec", side_effect=fake_run),
+        patch("agentception.services.teardown.shutil.rmtree") as mock_rmtree,
+    ):
+        from agentception.services.teardown import release_worktree
+
+        result = await release_worktree(
+            worktree_path=str(stale_dir),
+            repo_dir=str(tmp_path),
+        )
+
+    assert result is True
+    mock_rmtree.assert_called_once_with(str(stale_dir))
+
+
+@pytest.mark.anyio
+async def test_release_worktree_returns_false_when_both_git_and_rmtree_fail(tmp_path: Path) -> None:
+    """release_worktree returns False only when both git and shutil.rmtree fail."""
+    stale_dir = tmp_path / "issue-825"
+    stale_dir.mkdir()
+
+    async def fake_run(*args: object, **kwargs: object) -> object:  # noqa: ARG001
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.communicate = AsyncMock(return_value=(b"", b"fatal: not a working tree"))
+        return proc
+
+    with (
+        patch("agentception.services.teardown.asyncio.create_subprocess_exec", side_effect=fake_run),
+        patch(
+            "agentception.services.teardown.shutil.rmtree",
+            side_effect=OSError("permission denied"),
+        ),
+    ):
+        from agentception.services.teardown import release_worktree
+
+        result = await release_worktree(
+            worktree_path=str(stale_dir),
+            repo_dir=str(tmp_path),
+        )
+
+    assert result is False


### PR DESCRIPTION
## Summary

Two bugs caused the same old terminal runs to appear in every reaper pass, growing the log indefinitely:

**Bug 1 — missing-dir `continue` without DB cleanup (`worktree_reaper.py`)**
When `Path(worktree_path).exists()` was `False`, `reap_stale_worktrees()` did `continue` without calling `clear_run_worktree_path()`. The DB record stayed set, so `get_terminal_runs_with_worktrees()` returned the same run on every 15-minute tick forever.

**Bug 2 — `git worktree remove` fails with "is not a working tree" (`teardown.py`)**
After a container restart, git's worktree registry is reset but the directory survives on disk. `git worktree remove --force` then fails. `release_worktree()` returned `False`, the reaper skipped `clear_run_worktree_path()`, and the loop repeated every pass.

**Fixes:**
- `reap_stale_worktrees()`: call `clear_run_worktree_path()` for absent directories before `continue`.
- `release_worktree()`: fall back to `shutil.rmtree()` when git rejects the directory; only return `False` if even the force-delete fails.

## Test plan

- [x] `mypy` — zero errors
- [x] `pytest agentception/tests/test_worktree_reaper.py` — 8/8 pass
- [x] Regression test added for absent-dir DB-clear path
- [x] Regression test added for git-rejected / rmtree-fallback path