### PR TITLE
Remove dead engineer role; gate ONNX pre-injection on worktree_index_enabled

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -854,9 +854,14 @@ async def dispatch_agent(req: DispatchRequest) -> DispatchResponse:
     #
     # Query: prefer the symbol-rich issue title + backtick-wrapped code refs
     # over a raw body slice, which for most issues is background prose.
+    #
+    # Gated on worktree_index_enabled: the ONNX embedding + reranking models
+    # are only loaded when code-search is active.  WORKTREE_INDEX_ENABLED=false
+    # (performance / local-LLM mode) skips this entire block to avoid loading
+    # ~2 GB of ONNX models before the agent even starts.
     from agentception.services.context_assembler import _extract_code_queries  # noqa: PLC0415
     code_matches: list[SearchMatch] = []
-    if task_description:
+    if task_description and settings.worktree_index_enabled:
         dispatch_queries = _extract_code_queries(req.issue_title or "", effective_issue_body)
         # Use the first (most signal-dense) query for the dispatch-time snippet.
         search_query = dispatch_queries[0] if dispatch_queries else (

--- a/agentception/services/cognitive_arch.py
+++ b/agentception/services/cognitive_arch.py
@@ -109,8 +109,6 @@ ROLE_DEFAULT_FIGURE: dict[str, str] = {
     "mobile-coordinator":        "wozniak",
     "security-coordinator":      "bruce_schneier",
     "product-coordinator":       "steve_jobs",
-    # Fallback
-    "engineer":                  "hopper",
 }
 
 


### PR DESCRIPTION
## Summary

- **Delete dead `engineer` role entry** from `cognitive_arch.py`. No `.agentception/roles/engineer.md` file exists, and the dict's own `.get(role, "hopper")` default already handles any unknown role — making the explicit entry redundant dead code.
- **Gate dispatch-time `search_codebase()` on `settings.worktree_index_enabled`**. Previously, the ONNX embedding + reranking models (~2 GB RSS: jina-v2, BM25, bge-reranker) were loaded on every agent dispatch even when `WORKTREE_INDEX_ENABLED=false`. With this fix, local-LLM / performance mode fully skips the pre-injection block, keeping agent startup lean.

## Test plan
- [x] `mypy` clean on both changed files
- [x] 50 tests pass (`test_agentception_roles.py`, `test_label_context_and_dispatch.py`)
- [x] No references to `"engineer"` role remain outside `.agentception/roles/` file listing