### PR TITLE
feat(activity-feed): left-border color coding by event subtype

### DIFF
--- a/agentception/static/scss/pages/_activity-feed.scss
+++ b/agentception/static/scss/pages/_activity-feed.scss
@@ -10,6 +10,21 @@
   max-width: 100%;
   overflow-x: hidden;
   word-break: break-word;
+  border-left: 2px solid transparent;
+  transition: background 0.12s;
+
+  &:hover {
+    background: var(--bg-hover);
+  }
+
+  &[data-subtype^="llm"]   { border-left-color: var(--accent-purple, #9b6dff); }
+  &[data-subtype^="file"]  { border-left-color: var(--accent-green,  #3ecf8e); }
+  &[data-subtype="tool"],
+  &[data-subtype="tool_invoked"],
+  &[data-subtype="github_tool"] { border-left-color: var(--accent-orange, #f5a623); }
+  &[data-subtype^="shell"] { border-left-color: var(--text-muted,    #6a8aaa); }
+  &[data-subtype="git_push"]    { border-left-color: var(--accent-blue,   #4dabf7); }
+  &[data-subtype="error"]       { border-left-color: var(--error,         #e53e3e); }
 
   .activity-feed__icon {
     flex-shrink: 0;


### PR DESCRIPTION
## Summary

Adds left-border color coding to `.activity-feed__row` in the inspector panel.

Supersedes #1002 (closes #999). The previous PR used `#555` for shell events — nearly invisible on the dark theme because `--text-tertiary` doesn't exist in this design system. This PR uses the correct token (`var(--text-muted, #6a8aaa)`) and applies CSS variables with hex fallbacks for all six event types.

| `data-subtype` | CSS variable | Fallback |
|---|---|---|
| `llm*` | `--accent-purple` | `#9b6dff` |
| `file*` | `--accent-green` | `#3ecf8e` |
| `tool*`, `tool_invoked`, `github_tool` | `--accent-orange` | `#f5a623` |
| `shell*` | `--text-muted` | `#6a8aaa` |
| `git_push` | `--accent-blue` | `#4dabf7` |
| `error` | `--error` | `#e53e3e` |

## Test plan
- [x] `npm run build:css` passes
- [x] Only `_activity-feed.scss` modified
- [x] All colors use CSS variables with fallbacks