### PR TITLE
docs: refresh README for LLM-agnostic backend and local model onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ One input. Zero boilerplate. The work happens.
 
 ## How It Works
 
-1. **Plan** — Paste anything. Claude converts it into a `PlanSpec`: phases, issues, dependencies, acceptance criteria.
+1. **Plan** — Paste anything. The LLM converts it into a `PlanSpec`: phases, issues, dependencies, acceptance criteria.
 2. **Review** — The YAML opens in an editor. Adjust anything. Click **Create Issues** to file everything on GitHub.
 3. **Ship** — The board shows your phases. Click **Launch** on an unlocked phase. A CTO agent surveys the board and cascades work down to coordinators and engineers, each working in an isolated git worktree. PRs appear. Phases unlock. You watch.
 
@@ -35,24 +35,72 @@ Most AI coding tools are power tools. They make individual developers faster. Ag
 
 ## Quick Start
 
+### Option A — Cloud (Anthropic)
+
 ```bash
 git clone https://github.com/cgcardona/agentception
 cd agentception
-cp .env.example .env        # fill in the required values below
+cp .env.example .env
+# Set ANTHROPIC_API_KEY, GITHUB_TOKEN, GH_REPO, HOST_WORKTREES_DIR
 docker compose up -d
 docker compose exec agentception alembic upgrade head
 open http://localhost:10003
 ```
 
-### Required environment variables
+### Option B — Local models on macOS (free, private)
 
-| Variable | Description |
-|----------|-------------|
-| `DATABASE_URL` | PostgreSQL connection string (see `docker-compose.yml` for defaults) |
-| `GITHUB_TOKEN` | GitHub PAT with `repo` + `issues` scope |
-| `GH_REPO` | Repo this instance manages — `owner/repo` |
-| `ANTHROPIC_API_KEY` | Anthropic API key for Phase 1A planning and agent execution |
-| `HOST_WORKTREES_DIR` | Host path where agent worktrees are created |
+Run agents entirely on your own hardware with [Ollama](https://ollama.com). No API key, no cloud, no usage bill. Runs on Apple Silicon via Metal — GPU-accelerated.
+
+```bash
+# 1. Install Ollama and pull a model
+brew install ollama
+brew services start ollama
+ollama pull qwen2.5-coder:7b      # fast, good quality (~4 GB)
+# ollama pull qwen2.5-coder:32b   # better quality, needs 16 GB+ RAM
+
+# 2. Clone and configure
+git clone https://github.com/cgcardona/agentception
+cd agentception
+cp .env.example .env
+```
+
+Then set in `.env`:
+
+```bash
+LLM_PROVIDER=local
+LOCAL_LLM_BASE_URL=http://host.docker.internal:11434
+LOCAL_LLM_MODEL=qwen2.5-coder:7b
+GITHUB_TOKEN=ghp_...
+GH_REPO=owner/repo
+HOST_WORKTREES_DIR=/path/to/worktrees
+```
+
+```bash
+# 3. Start
+docker compose up -d
+docker compose exec agentception alembic upgrade head
+open http://localhost:10003
+```
+
+> **Performance tip:** Set `WORKTREE_INDEX_ENABLED=false` in `.env` to skip per-agent code indexing (saves ~2 GB RSS and significant CPU) when running on constrained hardware.
+
+See [docs/guides/local-llm-mlx.md](docs/guides/local-llm-mlx.md) for the full Ollama setup guide and model recommendations.
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GITHUB_TOKEN` | ✅ | GitHub PAT with `repo` + `issues` scope |
+| `GH_REPO` | ✅ | Repo this instance manages — `owner/repo` |
+| `HOST_WORKTREES_DIR` | ✅ | Host path where agent worktrees are created |
+| `DATABASE_URL` | ✅ | PostgreSQL connection string (default in `docker-compose.yml`) |
+| `LLM_PROVIDER` | — | `anthropic` (default) or `local` |
+| `ANTHROPIC_API_KEY` | Cloud only | Required when `LLM_PROVIDER=anthropic` |
+| `LOCAL_LLM_BASE_URL` | Local only | Ollama base URL, e.g. `http://host.docker.internal:11434` |
+| `LOCAL_LLM_MODEL` | Local only | Model tag, e.g. `qwen2.5-coder:7b` |
+| `WORKTREE_INDEX_ENABLED` | — | `true`/`false` — enable per-agent code search (default `false`) |
 
 See [docs/guides/setup.md](docs/guides/setup.md) for the full first-run walkthrough.
 
@@ -74,7 +122,7 @@ AgentCeption exposes an MCP server so Cursor and Claude can invoke tools directl
 }
 ```
 
-See [docs/guides/mcp.md](docs/guides/mcp.md) for the full tool reference.
+See [docs/guides/integrate.md](docs/guides/integrate.md) for the full tool reference.
 
 ---
 
@@ -83,25 +131,26 @@ See [docs/guides/mcp.md](docs/guides/mcp.md) for the full tool reference.
 | Guide | What it covers |
 |-------|----------------|
 | [Setup](docs/guides/setup.md) | First-run, Docker, environment variables |
-| [MCP Integration](docs/guides/mcp.md) | Cursor / Claude tool integration |
+| [Local LLM / Ollama](docs/guides/local-llm-mlx.md) | Running agents on local hardware with Ollama |
+| [Local LLM Scaling](docs/guides/local-llm-scaling.md) | Multi-agent concurrency and LiteLLM proxy |
+| [MCP Integration](docs/guides/integrate.md) | Cursor / Claude tool integration |
+| [Dispatching Agents](docs/guides/dispatch.md) | How to launch, monitor, and cancel agent runs |
 | [Developer Workflow](docs/guides/developer-workflow.md) | Bind mounts, mypy, tests, build pipeline |
 | [Contributing](docs/guides/contributing.md) | Branch conventions, PR process, commit style |
 
 | Reference | What it covers |
 |-----------|----------------|
 | [API Routes](docs/reference/api.md) | Every HTTP endpoint — semantic URL taxonomy |
-| [Task Context Spec](.agentception/agent-task-spec.md) | DB-backed RunContextRow — all fields and access patterns |
-| [Type Contracts](docs/reference/type-contracts.md) | Pydantic models, TypedDicts, layer contracts |
 | [Cognitive Architecture](docs/reference/cognitive-arch.md) | Figures, archetypes, skill domains, atoms |
-| [YAML Configuration](docs/reference/yaml-config.md) | `config.yaml`, `team.yaml`, `role-taxonomy.yaml` |
+| [Type Contracts](docs/reference/type-contracts.md) | Pydantic models, TypedDicts, layer contracts |
 
 ---
 
 ## Stack
 
-Python 3.11 · FastAPI · Jinja2 · HTMX · Alpine.js · SCSS · Pydantic v2 · SQLAlchemy (async) · Alembic · PostgreSQL · Qdrant
+Python 3.12 · FastAPI · Jinja2 · HTMX · Alpine.js · SCSS · Pydantic v2 · SQLAlchemy (async) · Alembic · PostgreSQL · Qdrant
 
-Models: `claude-sonnet-4-6` and `claude-opus-4-6` via the Anthropic API directly.
+**LLM backends:** Anthropic (`claude-sonnet-4-6`, `claude-opus-4-6`) or any [Ollama](https://ollama.com)-compatible local model. Switch with a single env var — no code changes required.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Two clear quick-start paths**: Option A (Anthropic/cloud) and Option B (Ollama/local, free, private) — with copy-pasteable commands for each
- **`ANTHROPIC_API_KEY` is no longer listed as required** — it's cloud-only; local users don't need it
- **Full local onboarding**: `brew install ollama`, model pull, `.env` snippet, performance tip for `WORKTREE_INDEX_ENABLED=false`
- **Python version fix**: 3.11 → 3.12
- **MCP doc link fix**: `mcp.md` → `integrate.md`
- **Updated docs table**: adds Local LLM, Local LLM Scaling, and Dispatch guides
- **Stack section rewritten**: removes Anthropic hardcoding, describes the LLM-agnostic backend
- **"How It Works" step 1**: "Claude converts it" → "The LLM converts it"