### PR TITLE
fix(security): path traversal in kill endpoint, shell injection in reviewer warmup, AC_API_KEY docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,15 @@ HOST_WORKTREES_DIR=~/.agentception/worktrees
 # Add a corresponding volume entry in docker-compose.override.yml if you change this.
 WORKTREES_DIR=/worktrees
 
+# ── Security ────────────────────────────────────────────────────────────────
+# ⚠️  IMPORTANT: Set this if the service is reachable from any network other
+# than localhost.  Without it, ALL /api/* endpoints — including dispatch,
+# reset-build, and sweep — are completely unauthenticated.
+# An attacker on the same LAN could drain your Anthropic credits or delete
+# your worktrees.  Generate a strong key with: openssl rand -hex 32
+# When set, every /api/* request must include:  Authorization: Bearer <key>
+AC_API_KEY=
+
 # ── Service ─────────────────────────────────────────────────────────────────
 # Port the AgentCeption FastAPI app listens on (inside the container).
 PORT=10003

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ See [docs/guides/local-llm-mlx.md](docs/guides/local-llm-mlx.md) for the full Ol
 
 See [docs/guides/setup.md](docs/guides/setup.md) for the full first-run walkthrough.
 
+> **Security note:** By default all `/api/*` endpoints are unauthenticated. If your machine is on a shared network (office LAN, cloud VM, dev box), set `AC_API_KEY` in `.env` before starting. Without it, anyone who can reach port 10003 can dispatch agents and burn your Anthropic credits. Generate a key with `openssl rand -hex 32`.
+
 ---
 
 ## MCP Integration (Cursor / Claude)

--- a/agentception/routes/control.py
+++ b/agentception/routes/control.py
@@ -77,7 +77,12 @@ async def kill_agent(slug: str) -> JSONResponse:
     logged as a warning but does not abort the overall operation — the goal is
     best-effort cleanup rather than strict atomicity.
     """
-    worktree = settings.worktrees_dir / slug
+    worktree = (settings.worktrees_dir / slug).resolve()
+    # Guard against path traversal: a slug like "../../etc" must not escape
+    # the worktrees directory, which would allow rmtree to delete arbitrary
+    # host paths.
+    if not worktree.is_relative_to(settings.worktrees_dir.resolve()):
+        raise HTTPException(status_code=400, detail="Invalid worktree slug")
     if not worktree.exists():
         raise HTTPException(status_code=404, detail=f"Worktree '{slug}' not found")
 

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -1649,10 +1649,22 @@ async def _run_reviewer_warmup(
     sections: list[str] = []
 
     # ── 1. Setup: fetch + checkout ──────────────────────────────────────────
-    await _shell_capture(
-        f"git fetch origin --quiet && git checkout {pr_branch} --quiet 2>&1 || true",
-        cwd=worktree_path,
-    )
+    # Use create_subprocess_exec (not shell=True) so pr_branch cannot inject
+    # shell metacharacters.  Two separate calls: fetch first, then checkout.
+    for _git_argv in (
+        ["git", "fetch", "origin", "--quiet"],
+        ["git", "checkout", pr_branch, "--quiet"],
+    ):
+        try:
+            _proc = await asyncio.create_subprocess_exec(
+                *_git_argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                cwd=worktree_path,
+            )
+            await asyncio.wait_for(_proc.communicate(), timeout=60.0)
+        except Exception:  # noqa: BLE001
+            pass  # non-fatal — reviewer degrades gracefully
 
     # ── 2. Changed file list ─────────────────────────────────────────────────
     changed_files_raw = await _shell_capture(


### PR DESCRIPTION
## Summary

Three real security fixes found during an open-source readiness sweep.

### 1. Path traversal → `shutil.rmtree` in `POST /api/control/kill/{slug}`

`slug` was appended directly to `worktrees_dir` with no containment check. A slug like `../../etc` would resolve outside the worktrees directory. If that path existed, `git worktree remove` would fail (not a real worktree), then the `shutil.rmtree` fallback would **delete the escaped directory**.

**Fix:** `resolve()` the path and assert `is_relative_to(worktrees_dir.resolve())` before any filesystem operation. Returns 400 on traversal attempt.

### 2. Shell injection via `pr_branch` in reviewer warmup

```python
# Before — shell=True with user-controlled branch name
f"git fetch origin --quiet && git checkout {pr_branch} --quiet 2>&1 || true"
```

A branch name containing `;`, `&&`, `$(...)` would execute arbitrary commands inside the container. Fixed by replacing with two sequential `asyncio.create_subprocess_exec` calls (no shell, branch name passed as a literal argument).

### 3. `AC_API_KEY` undocumented — all `/api/*` endpoints unauthenticated by default

Added a prominent warning block to `.env.example` explaining the risk (dispatch burns Anthropic credits, reset-build and sweep are destructive) and how to generate a key. Added a callout in `README.md` Quick Start.

## What was clean
- No hard-coded secrets anywhere
- SQL injection: clean (SQLAlchemy ORM throughout)
- No eval/exec of user input
- Swagger/ReDoc disabled in production
- No debug/admin routes

## Test plan
- [x] `mypy` clean on both changed Python files
- [x] 26 dispatch/label tests pass