### PR TITLE
feat: inspector panel supercharge — design tokens, smart scroll, new event types

### DIFF
--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -28,10 +28,16 @@ describe('formatActivitySummary', () => {
     );
   });
 
-  it('formats shell_done', () => {
+  it('formats shell_done exit=0', () => {
     expect(
       formatActivitySummary('shell_done', { exit_code: 0, stdout_bytes: 10, stderr_bytes: 0 })
     ).toBe('exit=0 stdout:10B');
+  });
+
+  it('formats shell_done non-zero exit with error prefix', () => {
+    expect(
+      formatActivitySummary('shell_done', { exit_code: 1, stdout_bytes: 0, stderr_bytes: 5 })
+    ).toBe('✗ exit=1 stdout:0B');
   });
 
   it('formats file_read', () => {
@@ -80,6 +86,28 @@ describe('appendActivityRow', () => {
     expect(row?.querySelector('.activity-feed__ts')?.getAttribute('datetime')).toBe(
       '2026-03-13T14:30:00Z'
     );
+  });
+
+  it('sets data-exit-nonzero on shell_done rows with non-zero exit', () => {
+    appendActivityRow({
+      t: 'activity',
+      subtype: 'shell_done',
+      payload: { exit_code: 1, stdout_bytes: 0, stderr_bytes: 10 },
+      recorded_at: '',
+    });
+    const row = document.querySelector('.activity-feed__row');
+    expect(row?.getAttribute('data-exit-nonzero')).toBe('true');
+  });
+
+  it('does NOT set data-exit-nonzero on shell_done rows with exit=0', () => {
+    appendActivityRow({
+      t: 'activity',
+      subtype: 'shell_done',
+      payload: { exit_code: 0, stdout_bytes: 0, stderr_bytes: 0 },
+      recorded_at: '',
+    });
+    const row = document.querySelector('.activity-feed__row');
+    expect(row?.hasAttribute('data-exit-nonzero')).toBe(false);
   });
 
   it('does nothing when #activity-feed is missing', () => {

--- a/agentception/static/js/__tests__/event_card.test.ts
+++ b/agentception/static/js/__tests__/event_card.test.ts
@@ -53,4 +53,40 @@ describe('attachEventCardHandler', () => {
     dispatch(src, { t: 'event', event_type: 'file_edit', payload: {}, recorded_at: '' });
     expect(document.querySelector('.event-card')).toBeNull();
   });
+
+  it('renders message card with 💬 icon and message text', () => {
+    const src = makeSource();
+    attachEventCardHandler(src);
+    dispatch(src, { t: 'event', event_type: 'message', payload: { message: 'Branch created' }, recorded_at: '' });
+    const card = document.querySelector('.event-card');
+    expect(card).not.toBeNull();
+    expect(card?.getAttribute('data-event-type')).toBe('message');
+    expect(card?.querySelector('.event-card__icon')?.textContent).toBe('💬');
+    expect(card?.querySelector('.event-card__text')?.textContent).toBe('Branch created');
+  });
+
+  it('renders error card with ❌ icon and error text', () => {
+    const src = makeSource();
+    attachEventCardHandler(src);
+    dispatch(src, { t: 'event', event_type: 'error', payload: { error: 'Rate limit hit' }, recorded_at: '' });
+    const card = document.querySelector('.event-card');
+    expect(card).not.toBeNull();
+    expect(card?.getAttribute('data-event-type')).toBe('error');
+    expect(card?.querySelector('.event-card__icon')?.textContent).toBe('❌');
+    expect(card?.querySelector('.event-card__text')?.textContent).toBe('Rate limit hit');
+  });
+
+  it('renders decision card with 💡 icon', () => {
+    const src = makeSource();
+    attachEventCardHandler(src);
+    dispatch(src, {
+      t: 'event',
+      event_type: 'decision',
+      payload: { decision: 'Use TypeScript', rationale: 'type safety' },
+      recorded_at: '',
+    });
+    const card = document.querySelector('.event-card');
+    expect(card?.querySelector('.event-card__icon')?.textContent).toBe('💡');
+    expect(card?.querySelector('.event-card__text')?.textContent).toBe('Use TypeScript — type safety');
+  });
 });

--- a/agentception/static/js/__tests__/file_edit_card.test.ts
+++ b/agentception/static/js/__tests__/file_edit_card.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildFileEditCard } from '../file_edit_card';
 
-const base = { path: 'foo.py', diff: '', lines_omitted: 0, timestamp: '' };
+const base = { path: 'src/foo.py', diff: '', lines_omitted: 0, timestamp: '' };
 
 describe('buildFileEditCard', () => {
   it('renders diff-add class for + lines', () => {
@@ -11,9 +11,24 @@ describe('buildFileEditCard', () => {
     expect(spans[0].textContent).toContain('+foo');
   });
 
+  it('does not treat +++ header as a diff-add line', () => {
+    const card = buildFileEditCard({ ...base, diff: '+++ b/file.py\n+added line\n' });
+    expect(card.querySelectorAll('.diff-add').length).toBe(1);
+  });
+
   it('renders diff-remove class for - lines', () => {
     const card = buildFileEditCard({ ...base, diff: '-bar\n' });
     expect(card.querySelectorAll('.diff-remove').length).toBe(1);
+  });
+
+  it('does not treat --- header as a diff-remove line', () => {
+    const card = buildFileEditCard({ ...base, diff: '--- a/file.py\n-removed\n' });
+    expect(card.querySelectorAll('.diff-remove').length).toBe(1);
+  });
+
+  it('renders diff-hunk class for @@ lines', () => {
+    const card = buildFileEditCard({ ...base, diff: '@@ -1,3 +1,4 @@\n' });
+    expect(card.querySelectorAll('.diff-hunk').length).toBe(1);
   });
 
   it('starts collapsed', () => {
@@ -21,16 +36,56 @@ describe('buildFileEditCard', () => {
     expect(card.classList.contains('collapsed')).toBe(true);
   });
 
+  it('header is a <button> element', () => {
+    const card = buildFileEditCard(base);
+    const header = card.querySelector('.file-edit-card__header');
+    expect(header?.tagName).toBe('BUTTON');
+  });
+
+  it('header shows basename not full path', () => {
+    const card = buildFileEditCard({ ...base, path: 'agentception/services/agent_loop.py' });
+    const pathEl = card.querySelector('.file-edit-card__path');
+    expect(pathEl?.textContent).toBe('agent_loop.py');
+  });
+
+  it('header title attribute holds full path for hover', () => {
+    const fullPath = 'agentception/services/agent_loop.py';
+    const card = buildFileEditCard({ ...base, path: fullPath });
+    const header = card.querySelector('.file-edit-card__header') as HTMLButtonElement | null;
+    expect(header?.title).toBe(fullPath);
+  });
+
   it('toggles collapsed on header click', () => {
     const card = buildFileEditCard(base);
     const header = card.querySelector('.file-edit-card__header') as HTMLElement;
     header.click();
     expect(card.classList.contains('collapsed')).toBe(false);
+    header.click();
+    expect(card.classList.contains('collapsed')).toBe(true);
+  });
+
+  it('shows line-count badge with +N for added lines', () => {
+    const card = buildFileEditCard({ ...base, diff: '+added1\n+added2\n-removed\n' });
+    const addBadge = card.querySelector('.file-edit-card__badge-add');
+    const removeBadge = card.querySelector('.file-edit-card__badge-remove');
+    expect(addBadge?.textContent).toBe('+2');
+    expect(removeBadge?.textContent).toBe('-1');
+  });
+
+  it('shows no badge when diff is empty', () => {
+    const card = buildFileEditCard({ ...base, diff: '' });
+    expect(card.querySelector('.file-edit-card__badge')).toBeNull();
   });
 
   it('shows omitted lines message when lines_omitted > 0', () => {
     const card = buildFileEditCard({ ...base, lines_omitted: 5 });
     const msg = card.querySelector('.diff-omitted');
     expect(msg?.textContent).toContain('5 more lines');
+  });
+
+  it('diff is inside a <pre> that is a direct child of the card', () => {
+    const card = buildFileEditCard({ ...base, diff: '+line\n' });
+    const pre = card.querySelector(':scope > pre');
+    expect(pre).not.toBeNull();
   });
 });

--- a/agentception/static/js/__tests__/thought_block.test.ts
+++ b/agentception/static/js/__tests__/thought_block.test.ts
@@ -18,8 +18,35 @@ describe("attachThoughtHandler", () => {
     const src = makeSource();
     attachThoughtHandler(src);
     dispatch(src, { t: "thought", role: "thinking", content: "hello", recorded_at: "" });
-    const text = document.querySelector(".thought-block__body")?.textContent;
-    expect(text).toBe("hello");
+    // textContent includes both the text node and the cursor span
+    const body = document.querySelector(".thought-block__body");
+    expect(body?.textContent).toContain("hello");
+  });
+
+  it("streaming cursor span present while block is open", () => {
+    const src = makeSource();
+    attachThoughtHandler(src);
+    dispatch(src, { t: "thought", role: "thinking", content: "abc", recorded_at: "" });
+    expect(document.querySelector(".thought-block__cursor")).not.toBeNull();
+  });
+
+  it("cursor span removed after collapse", () => {
+    const src = makeSource();
+    attachThoughtHandler(src);
+    dispatch(src, { t: "thought", role: "thinking", content: "abc", recorded_at: "" });
+    dispatch(src, { t: "event", event_type: "step_start", payload: { step: "S" }, recorded_at: "" });
+    expect(document.querySelector(".thought-block__cursor")).toBeNull();
+  });
+
+  it("uses recorded_at timestamps for duration label", () => {
+    const src = makeSource();
+    attachThoughtHandler(src);
+    // 5 seconds apart
+    dispatch(src, { t: "thought", role: "thinking", content: "a", recorded_at: "2026-01-01T00:00:00Z" });
+    dispatch(src, { t: "thought", role: "thinking", content: "b", recorded_at: "2026-01-01T00:00:05Z" });
+    dispatch(src, { t: "event", event_type: "step_start", payload: { step: "S" }, recorded_at: "" });
+    const label = document.querySelector(".thought-block__label");
+    expect(label?.textContent).toBe("Thought for 5s");
   });
 
   it("test_thought_icon_present_after_collapse", () => {

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -4,6 +4,9 @@
  * Consumes {"t": "activity", "subtype", "payload", "recorded_at", "id"} from
  * the inspector stream and appends one row per message to #activity-feed.
  * All text is set via textContent/setAttribute; no innerHTML with payload data.
+ *
+ * Smart scroll: new rows scroll the feed only when the user is already near
+ * the bottom — reading old content is never interrupted.
  */
 
 /** SSE activity message shape from the inspector stream. */
@@ -32,6 +35,14 @@ function num(p: Record<string, unknown>, key: string): number {
 }
 
 /**
+ * Returns true when the feed scroll position is within 80px of the bottom.
+ * Used to decide whether appending a new row should auto-scroll.
+ */
+export function shouldAutoScroll(feed: HTMLElement): boolean {
+  return feed.scrollHeight - feed.scrollTop - feed.clientHeight < 80;
+}
+
+/**
  * Human-readable one-line summary from subtype and payload.
  * Uses textContent-safe strings only (no innerHTML with payload).
  */
@@ -42,8 +53,11 @@ export function formatActivitySummary(subtype: string, payload: Record<string, u
       return `→ ${str(p, 'tool_name')} ${str(p, 'arg_preview')}`.trim();
     case 'shell_start':
       return `$ ${str(p, 'cmd_preview')}`.trim();
-    case 'shell_done':
-      return `exit=${num(p, 'exit_code')} stdout:${num(p, 'stdout_bytes')}B`;
+    case 'shell_done': {
+      const code = num(p, 'exit_code');
+      const prefix = code !== 0 ? `✗ exit=${code}` : `exit=${code}`;
+      return `${prefix} stdout:${num(p, 'stdout_bytes')}B`;
+    }
     case 'file_read':
       return `read ${str(p, 'path')} lines ${num(p, 'start_line')}–${num(p, 'end_line')}/${num(p, 'total_lines')}`.trim();
     case 'file_replaced':
@@ -132,6 +146,14 @@ export function appendActivityRow(msg: ActivityMessage): void {
   row.className = 'activity-feed__row';
   row.setAttribute('data-subtype', msg.subtype);
 
+  // Mark non-zero shell exits for CSS error highlighting
+  if (msg.subtype === 'shell_done') {
+    const code = num(msg.payload, 'exit_code');
+    if (code !== 0) {
+      row.dataset['exitNonzero'] = 'true';
+    }
+  }
+
   const icon = document.createElement('span');
   icon.className = 'activity-feed__icon';
   icon.setAttribute('aria-hidden', 'true');
@@ -150,7 +172,10 @@ export function appendActivityRow(msg: ActivityMessage): void {
   row.appendChild(summary);
   row.appendChild(ts);
   feed.appendChild(row);
-  row.scrollIntoView?.({ block: 'end', behavior: 'smooth' });
+
+  if (shouldAutoScroll(feed)) {
+    feed.scrollTop = feed.scrollHeight;
+  }
 }
 
 /**

--- a/agentception/static/js/event_card.ts
+++ b/agentception/static/js/event_card.ts
@@ -1,3 +1,15 @@
+/**
+ * EventCard — renders structured MCP lifecycle events in the activity feed.
+ *
+ * Handled event_types:
+ *   step_start  ▶  agent begins a named step
+ *   blocker     🚧  agent is stalled on external dependency
+ *   decision    💡  agent made an architectural choice
+ *   done        ✅  agent declared work complete
+ *   message     💬  free-form agent note (log_run_message)
+ *   error       ❌  structured MCP error (log_run_error)
+ */
+
 interface EventSseMessage {
   t: 'event';
   event_type: string;
@@ -12,9 +24,11 @@ const EVENT_ICONS: Record<string, string> = {
   blocker:    '🚧',
   decision:   '💡',
   done:       '✅',
+  message:    '💬',
+  error:      '❌',
 };
 
-const RENDERABLE = new Set(['step_start', 'blocker', 'decision', 'done']);
+const RENDERABLE = new Set(['step_start', 'blocker', 'decision', 'done', 'message', 'error']);
 
 function eventText(msg: EventSseMessage): string {
   const p = msg.payload ?? {};
@@ -23,11 +37,13 @@ function eventText(msg: EventSseMessage): string {
     case 'blocker':    return p['description'] ?? 'Blocker';
     case 'decision':   return `${p['decision'] ?? ''} — ${p['rationale'] ?? ''}`;
     case 'done':       return p['summary'] ?? p['pr_url'] ?? 'Done';
+    case 'message':    return p['message'] ?? '';
+    case 'error':      return p['error'] ?? 'Error';
     default:           return msg.event_type;
   }
 }
 
-/** Append a div.event-card to #activity-feed for each step_start/blocker/decision/done SSE event. */
+/** Append a div.event-card to #activity-feed for each renderable SSE event. */
 export function attachEventCardHandler(source: EventSource): void {
   source.addEventListener('message', (evt: MessageEvent<string>) => {
     let msg: AnySseMessage;
@@ -59,6 +75,10 @@ export function attachEventCardHandler(source: EventSource): void {
     card.appendChild(icon);
     card.appendChild(text);
     feed.appendChild(card);
-    card.scrollIntoView?.({ block: 'end', behavior: 'smooth' });
+
+    // Smart scroll: only scroll if user is near the bottom
+    if (feed.scrollHeight - feed.scrollTop - feed.clientHeight < 80) {
+      feed.scrollTop = feed.scrollHeight;
+    }
   });
 }

--- a/agentception/static/js/file_edit_card.ts
+++ b/agentception/static/js/file_edit_card.ts
@@ -1,3 +1,17 @@
+/**
+ * FileEditCard — collapsible diff card for file mutation events.
+ *
+ * SSE shape: {t:"event", event_type:"file_edit", payload: FileEditEventPayload}
+ *
+ * Header (button):
+ *   📄 basename.ext  · +N / -N  · ›
+ *   title attribute holds the full path for hover tooltip
+ *
+ * Body: unified diff with color-coded add/remove/hunk spans inside a <pre>.
+ * The <pre> is a direct child of .file-edit-card (no __diff wrapper) so that
+ * .file-edit-card > pre CSS selectors apply correctly.
+ */
+
 export interface FileEditEventPayload {
   path: string;
   diff: string;
@@ -5,28 +19,86 @@ export interface FileEditEventPayload {
   timestamp: string;
 }
 
+interface DiffCounts {
+  added: number;
+  removed: number;
+}
+
+/** Count +/- lines in a unified diff string. */
+function countDiffLines(diff: string): DiffCounts {
+  let added = 0;
+  let removed = 0;
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+') && !line.startsWith('+++')) added++;
+    else if (line.startsWith('-') && !line.startsWith('---')) removed++;
+  }
+  return { added, removed };
+}
+
+/** Return the basename of a file path (everything after the last '/'). */
+function basename(path: string): string {
+  return path.split('/').pop() ?? path;
+}
+
 /** Build and return a collapsed diff card DOM node. Does NOT append to the DOM. */
 export function buildFileEditCard(payload: FileEditEventPayload): HTMLElement {
   const card = document.createElement('div');
   card.className = 'file-edit-card collapsed';
 
-  const header = document.createElement('div');
+  // ── Header (button for keyboard accessibility) ──────────────────────────────
+  const header = document.createElement('button');
+  header.type = 'button';
   header.className = 'file-edit-card__header';
+  header.title = payload.path; // full path on hover
+
   const pathEl = document.createElement('span');
   pathEl.className = 'file-edit-card__path';
-  pathEl.textContent = payload.path;
+  pathEl.textContent = basename(payload.path);
   header.appendChild(pathEl);
+
+  const counts = countDiffLines(payload.diff);
+  if (counts.added > 0 || counts.removed > 0) {
+    const badge = document.createElement('span');
+    badge.className = 'file-edit-card__badge';
+
+    if (counts.added > 0) {
+      const addEl = document.createElement('span');
+      addEl.className = 'file-edit-card__badge-add';
+      addEl.textContent = `+${counts.added}`;
+      badge.appendChild(addEl);
+    }
+    if (counts.removed > 0) {
+      const removeEl = document.createElement('span');
+      removeEl.className = 'file-edit-card__badge-remove';
+      removeEl.textContent = `-${counts.removed}`;
+      badge.appendChild(removeEl);
+    }
+    header.appendChild(badge);
+  }
+
+  const chevron = document.createElement('span');
+  chevron.className = 'file-edit-card__chevron';
+  chevron.setAttribute('aria-hidden', 'true');
+  chevron.textContent = '›';
+  header.appendChild(chevron);
+
   header.addEventListener('click', () => card.classList.toggle('collapsed'));
   card.appendChild(header);
 
+  // ── Diff body: <pre> as direct child (CSS targets .file-edit-card > pre) ────
   const pre = document.createElement('pre');
   const code = document.createElement('code');
   for (const line of payload.diff.split('\n')) {
     const span = document.createElement('span');
     span.textContent = line + '\n';
-    if (line.startsWith('+')) span.className = 'diff-add';
-    else if (line.startsWith('-')) span.className = 'diff-remove';
-    else if (line.startsWith('@@')) span.className = 'diff-hunk';
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      span.className = 'diff-add';
+    } else if (line.startsWith('-') && !line.startsWith('---')) {
+      span.className = 'diff-remove';
+    } else if (line.startsWith('@@')) {
+      span.className = 'diff-hunk';
+    }
+    // context lines (no class) render in default muted color
     code.appendChild(span);
   }
   pre.appendChild(code);
@@ -45,8 +117,7 @@ export function buildFileEditCard(payload: FileEditEventPayload): HTMLElement {
 /**
  * Register a handler on `source` that appends FileEditCards to `#activity-feed`.
  * The `#activity-feed` element must exist in the DOM before this is called.
- * Events arrive as `{t:"event", event_type:"file_edit", payload: FileEditEventPayload}`
- * via `onmessage` — there are no named SSE event types.
+ * Events arrive as `{t:"event", event_type:"file_edit", payload: FileEditEventPayload}`.
  */
 export function attachFileEditHandler(source: EventSource): void {
   source.addEventListener('message', (e: MessageEvent<string>) => {
@@ -60,6 +131,9 @@ export function attachFileEditHandler(source: EventSource): void {
     const feed = document.getElementById('activity-feed');
     if (!feed) return;
     feed.appendChild(buildFileEditCard(msg.payload));
-    feed.scrollTop = feed.scrollHeight;
+    // Smart scroll
+    if (feed.scrollHeight - feed.scrollTop - feed.clientHeight < 80) {
+      feed.scrollTop = feed.scrollHeight;
+    }
   });
 }

--- a/agentception/static/js/thought_block.ts
+++ b/agentception/static/js/thought_block.ts
@@ -1,16 +1,16 @@
 /**
- * ThoughtBlock — renders a collapsible Cursor-style thought block in the
- * activity feed.
+ * ThoughtBlock — renders a collapsible thought block in the activity feed.
  *
  * Listens for SSE messages on the supplied EventSource:
  *   {t: "thought", role: "thinking", content: string, recorded_at: string}
- *   {t: "event", event_type: "step_start", ...}
- *   {t: "event", event_type: "done", ...}
+ *   {t: "thought", role: "assistant", content: string, recorded_at: string}
+ *   {t: "event", event_type: "step_start" | "done", ...}
  *
- * Each iteration opens a new block that streams text, then collapses
- * to "◈ Thought for Xs ›" when the next step_start / done arrives.
+ * While streaming: open block with animated cursor.
+ * On collapse trigger: "◈ Thought for Xs ›" using recorded_at timestamps.
+ * Assistant response: rendered as .assistant-bubble below the collapsed block.
  *
- * Appends to #activity-feed. No innerHTML usage.
+ * Smart scroll: only auto-scrolls when the user is already near the bottom.
  */
 
 interface ThoughtSseMessage {
@@ -32,8 +32,26 @@ type SseMessage = ThoughtSseMessage | EventSseMessage | { t: "ping" };
 interface ActiveBlock {
   wrapper: HTMLElement;
   textNode: Text;
-  startMs: number;
-  lastMs: number;
+  cursorEl: HTMLSpanElement;
+  startMs: number;   // parsed from first recorded_at; fallback: Date.now()
+  lastMs: number;    // updated on each token; used for duration label
+}
+
+/** Returns true when the feed is scrolled to within 80px of the bottom. */
+function nearBottom(feed: HTMLElement): boolean {
+  return feed.scrollHeight - feed.scrollTop - feed.clientHeight < 80;
+}
+
+function smartScrollFeed(feed: HTMLElement): void {
+  if (nearBottom(feed)) {
+    feed.scrollTop = feed.scrollHeight;
+  }
+}
+
+function parseRecordedAt(recordedAt: string): number {
+  if (!recordedAt) return Date.now();
+  const t = Date.parse(recordedAt);
+  return Number.isNaN(t) ? Date.now() : t;
 }
 
 function buildThoughtBlock(): ActiveBlock {
@@ -44,11 +62,18 @@ function buildThoughtBlock(): ActiveBlock {
 
   const body = document.createElement("p");
   body.className = "thought-block__body";
+
   const textNode = document.createTextNode("");
   body.appendChild(textNode);
+
+  const cursorEl = document.createElement("span");
+  cursorEl.className = "thought-block__cursor";
+  cursorEl.setAttribute("aria-hidden", "true");
+  body.appendChild(cursorEl);
+
   wrapper.appendChild(body);
 
-  return { wrapper, textNode, startMs: Date.now(), lastMs: Date.now() };
+  return { wrapper, textNode, cursorEl, startMs: Date.now(), lastMs: Date.now() };
 }
 
 function collapseBlock(block: ActiveBlock): void {
@@ -56,6 +81,11 @@ function collapseBlock(block: ActiveBlock): void {
     1,
     Math.round((block.lastMs - block.startMs) / 1000),
   );
+
+  // Remove the cursor before collapsing
+  if (block.cursorEl.parentNode) {
+    block.cursorEl.parentNode.removeChild(block.cursorEl);
+  }
 
   const header = document.createElement("button");
   header.className = "thought-block__header";
@@ -69,7 +99,8 @@ function collapseBlock(block: ActiveBlock): void {
 
   const label = document.createElement("span");
   label.className = "thought-block__label";
-  label.textContent = `Thought for ${durationSecs}s`;
+  const secs = durationSecs === 1 ? "1s" : `${durationSecs}s`;
+  label.textContent = `Thought for ${secs}`;
 
   const chevron = document.createElement("span");
   chevron.className = "thought-block__chevron";
@@ -80,11 +111,11 @@ function collapseBlock(block: ActiveBlock): void {
   header.appendChild(label);
   header.appendChild(chevron);
 
-  // Toggle expand on click
   header.addEventListener("click", () => {
     const isExpanded = header.getAttribute("aria-expanded") === "true";
     header.setAttribute("aria-expanded", String(!isExpanded));
     block.wrapper.classList.toggle("thought-block--open", !isExpanded);
+    block.wrapper.classList.toggle("thought-block--collapsed", isExpanded);
   });
 
   block.wrapper.insertBefore(header, block.wrapper.firstChild);
@@ -119,27 +150,26 @@ export function attachThoughtHandler(source: EventSource): void {
     if (msg.t === "thought" && msg.role === "thinking") {
       if (!active) {
         active = buildThoughtBlock();
+        active.startMs = parseRecordedAt(msg.recorded_at);
+        active.lastMs = active.startMs;
         feed.appendChild(active.wrapper);
+      } else {
+        active.lastMs = parseRecordedAt(msg.recorded_at);
       }
       active.textNode.textContent += msg.content;
-      active.lastMs = Date.now();
-      if (typeof active.wrapper.scrollIntoView === "function") {
-        active.wrapper.scrollIntoView({ block: "end", behavior: "smooth" });
-      }
+      smartScrollFeed(feed);
       return;
     }
 
     if (msg.t === "thought" && msg.role === "assistant") {
-      closeActive(); // collapse any open thinking block first
+      closeActive();
       const bubble = document.createElement("div");
       bubble.className = "assistant-bubble";
       bubble.setAttribute("role", "note");
       bubble.setAttribute("aria-label", "Agent response");
       bubble.textContent = msg.content;
       feed.appendChild(bubble);
-      if (typeof bubble.scrollIntoView === "function") {
-        bubble.scrollIntoView({ block: "end", behavior: "smooth" });
-      }
+      smartScrollFeed(feed);
       return;
     }
 

--- a/agentception/static/scss/pages/_activity-feed.scss
+++ b/agentception/static/scss/pages/_activity-feed.scss
@@ -10,24 +10,35 @@
   max-width: 100%;
   overflow-x: hidden;
   word-break: break-word;
-  border-left: 2px solid transparent;
+  border-left: 3px solid transparent;
+  border-radius: 0 var(--radius-xs, 4px) var(--radius-xs, 4px) 0;
   transition: background 0.12s;
 
   &:hover {
     background: var(--bg-hover);
   }
 
+  // Color-coded left border by event category
   &[data-subtype^="llm"]   { border-left-color: var(--accent-purple, #9b6dff); }
   &[data-subtype^="file"]  { border-left-color: var(--accent-green,  #3ecf8e); }
   &[data-subtype="tool"],
   &[data-subtype="tool_invoked"],
   &[data-subtype="github_tool"] { border-left-color: var(--accent-orange, #f5a623); }
-  &[data-subtype^="shell"] { border-left-color: var(--text-muted,    #6a8aaa); }
-  &[data-subtype="git_push"]    { border-left-color: var(--accent-blue,   #4dabf7); }
-  &[data-subtype="error"]       { border-left-color: var(--error,         #e53e3e); }
+  &[data-subtype^="shell"] { border-left-color: var(--text-muted, #6a8aaa); }
+  &[data-subtype="git_push"]    { border-left-color: var(--accent-blue, #4dabf7); }
+  &[data-subtype="delay"]       { border-left-color: var(--warning, #f5a623); opacity: 0.7; }
+  &[data-subtype="error"]       { border-left-color: var(--error, #e53e3e); }
+
+  // Non-zero shell exit: override border to error red and tint background
+  &[data-subtype="shell_done"][data-exit-nonzero] {
+    border-left-color: var(--error, #e53e3e);
+    background: rgba(229, 62, 62, 0.06);
+    color: var(--error, #e53e3e);
+  }
 
   .activity-feed__icon {
     flex-shrink: 0;
+    line-height: 1;
     &[aria-hidden='true'] {
       opacity: 0.7;
     }
@@ -39,11 +50,16 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
   }
 
   .activity-feed__ts {
     flex-shrink: 0;
+    font-size: 0.65rem;
     font-variant-numeric: tabular-nums;
+    color: var(--text-faint, #555);
+    font-family: var(--font-mono);
     opacity: 0.8;
   }
 }

--- a/agentception/static/scss/pages/_assistant-bubble.scss
+++ b/agentception/static/scss/pages/_assistant-bubble.scss
@@ -1,13 +1,18 @@
 // ── Assistant bubble ──────────────────────────────────────────────────────────
+// Full model response text — shown after CoT thought block collapses.
+// Visually distinct from the muted thought stream: lighter background,
+// primary text color, slightly more padding.
 
 .assistant-bubble {
-  border-left: 4px solid rgba(255,255,255,0.6);
-  padding: 0.35rem 0.5rem;
+  border-left: 3px solid var(--border-default, #444);
+  border-radius: 0 var(--radius-xs, 4px) var(--radius-xs, 4px) 0;
+  background: var(--bg-elevated, #1a1a2e);
+  padding: 0.5rem 0.75rem;
   white-space: pre-wrap;
   word-break: break-word;
-  color: var(--color-text, #eee);
-  line-height: 1.5;
+  color: var(--text-primary, #eee);
+  font-size: 0.8rem;
+  line-height: 1.6;
   max-width: 100%;
   overflow-x: hidden;
 }
-

--- a/agentception/static/scss/pages/_event-card.scss
+++ b/agentception/static/scss/pages/_event-card.scss
@@ -1,28 +1,65 @@
 // ── Event card ────────────────────────────────────────────────────────────────
+// Structured MCP lifecycle events: step_start, blocker, decision, done,
+// message (free-form agent note), error (structured MCP error).
 
 .event-card {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  padding: 0.2rem 0.5rem;
-  border-left: 4px solid #7f8c8d;
+  padding: 0.25rem 0.5rem;
+  border-left: 3px solid var(--text-muted, #6a8aaa);
+  border-radius: 0 var(--radius-xs, 4px) var(--radius-xs, 4px) 0;
   font-size: 0.75rem;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary, #aaa);
   max-width: 100%;
   overflow-x: hidden;
   word-break: break-word;
 
-  &[data-event-type='step_start'] { border-left-color: #7f8c8d; }
-  &[data-event-type='blocker']    { border-left-color: #e67e22; }
-  &[data-event-type='decision']   { border-left-color: #2980b9; }
-  &[data-event-type='done']       { border-left-color: #2ecc71; }
+  &[data-event-type='step_start'] {
+    border-left-color: var(--text-muted, #6a8aaa);
+    color: var(--text-secondary, #aaa);
+  }
 
-  &__icon { flex-shrink: 0; }
+  &[data-event-type='blocker'] {
+    border-left-color: var(--warning, #f5a623);
+    color: var(--warning, #f5a623);
+    background: rgba(245, 166, 35, 0.05);
+  }
+
+  &[data-event-type='decision'] {
+    border-left-color: var(--accent-blue, #4dabf7);
+    color: var(--text-secondary, #aaa);
+  }
+
+  &[data-event-type='done'] {
+    border-left-color: var(--success, #3ecf8e);
+    color: var(--success, #3ecf8e);
+    font-weight: 600;
+    font-size: 0.8rem;
+    background: rgba(62, 207, 142, 0.05);
+  }
+
+  &[data-event-type='message'] {
+    border-left-color: var(--border-default, #444);
+    color: var(--text-secondary, #aaa);
+  }
+
+  &[data-event-type='error'] {
+    border-left-color: var(--error, #e53e3e);
+    color: var(--error, #e53e3e);
+    background: rgba(229, 62, 62, 0.05);
+  }
+
+  &__icon {
+    flex-shrink: 0;
+    opacity: 0.85;
+  }
 
   &__text {
-    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
-

--- a/agentception/static/scss/pages/_file-edit-card.scss
+++ b/agentception/static/scss/pages/_file-edit-card.scss
@@ -1,33 +1,121 @@
 // ── File edit card ────────────────────────────────────────────────────────────
+// Collapsible diff card for file mutation events.
+// Header: button with basename, line-count badge (+N / -N), chevron
+// Body:   unified diff with add/remove/hunk/context syntax highlighting
 
 .file-edit-card {
-  background: var(--color-bg-subtle, #1a1a1a);
-  border: 1px solid var(--color-border, #333);
-  border-left: 4px solid #27ae60;
-  border-radius: 4px;
+  background: var(--bg-elevated, #1a1a2e);
+  border: 1px solid var(--border-subtle, #2a2a2a);
+  border-left: 3px solid var(--accent-green, #3ecf8e);
+  border-radius: var(--radius-xs, 4px);
   overflow: hidden;
   max-width: 100%;
-  overflow-x: hidden;
-  word-break: break-word;
 
   &__header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
-    color: var(--color-text-muted, #888);
-    padding: 0.25rem 0.5rem;
-    border-bottom: 1px solid var(--color-border, #333);
-  }
+    font-size: 0.72rem;
+    color: var(--text-muted, #888);
+    padding: 0.3rem 0.5rem;
+    border-bottom: 1px solid var(--border-subtle, #2a2a2a);
+    background: none;
+    border-top: none;
+    border-right: none;
+    border-left: none;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s;
 
-  &__diff {
-    pre {
-      font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
-      overflow-x: auto;
-      margin: 0;
-      padding: 0.25rem 0.5rem;
+    &:hover {
+      background: var(--bg-hover, rgba(255,255,255,0.04));
+      color: var(--text-primary, #eee);
     }
   }
+
+  &__path {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-secondary, #aaa);
+    font-weight: 500;
+  }
+
+  &__badge {
+    display: flex;
+    gap: 0.3rem;
+    flex-shrink: 0;
+    font-size: 0.65rem;
+  }
+
+  &__badge-add {
+    color: var(--accent-green, #3ecf8e);
+  }
+
+  &__badge-remove {
+    color: var(--error, #e53e3e);
+  }
+
+  &__chevron {
+    flex-shrink: 0;
+    color: var(--text-faint, #555);
+    font-size: 0.9rem;
+    transition: transform 0.18s ease;
+    transform: rotate(90deg); // default: expanded
+  }
+
+  // When collapsed (.collapsed class on the card), hide body and rotate chevron
+  &.collapsed &__chevron { transform: rotate(0deg); }
+
+  // The diff body: pre element built directly by TS (no __diff wrapper)
+  > pre {
+    font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
+    font-size: 0.72rem;
+    line-height: 1.55;
+    overflow-x: auto;
+    overflow-y: auto;
+    margin: 0;
+    padding: 0.35rem 0.5rem;
+    max-height: 320px; // cap tall diffs; user can scroll inside
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-default, #333) transparent;
+  }
+
+  &.collapsed > pre { display: none; }
 }
 
-.diff-add     { display: block; background: rgba(0, 255, 70, 0.08); color: #7ee787; }
-.diff-remove  { display: block; background: rgba(255, 60, 60, 0.10); color: #f97583; }
-.diff-context { display: block; color: var(--color-text-muted, #888); }
+// ── Diff line syntax ──────────────────────────────────────────────────────────
 
+.diff-add {
+  display: block;
+  background: rgba(62, 207, 142, 0.10);
+  color: #7ee787;
+  border-radius: 2px;
+}
+
+.diff-remove {
+  display: block;
+  background: rgba(229, 62, 62, 0.12);
+  color: #f97583;
+  border-radius: 2px;
+}
+
+.diff-hunk {
+  display: block;
+  color: var(--text-faint, #555);
+  font-style: italic;
+  opacity: 0.75;
+}
+
+.diff-omitted {
+  padding: 0.2rem 0.5rem;
+  font-size: 0.65rem;
+  color: var(--text-faint, #555);
+  font-style: italic;
+  margin: 0;
+  border-top: 1px solid var(--border-subtle, #2a2a2a);
+}

--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -213,12 +213,16 @@ body:has(.build-layout) nav.topnav {
 
 .build-columns {
   display: grid;
-  grid-template-columns: 1fr 400px;
+  grid-template-columns: 1fr 460px;
   align-items: start;
   padding: 0.875rem 1.5rem; // match subnav side padding
   gap: 1rem;
 
-  @media (max-width: 1100px) {
+  @media (max-width: 1200px) {
+    grid-template-columns: 1fr 380px;
+  }
+
+  @media (max-width: 1000px) {
     grid-template-columns: 1fr;
   }
 }

--- a/agentception/static/scss/pages/_thought-block.scss
+++ b/agentception/static/scss/pages/_thought-block.scss
@@ -1,51 +1,66 @@
 // ── Thought block ─────────────────────────────────────────────────────────────
-// Inspector accent palette:
-//   thought-block    #9b59b6  purple
-//   tool-call-card   #3498db  blue
-//   file-edit-card   #27ae60  green
-//   assistant-bubble rgba(255,255,255,0.6)  light
-//   event step_start #7f8c8d  grey
-//   event blocker    #e67e22  amber
-//   event decision   #2980b9  blue
-//   event done       #2ecc71  green
-// Monospace stack: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace)
+// Collapsible CoT block streamed token-by-token while the agent thinks.
+// Open state:    continuous text stream with animated cursor
+// Collapsed:     ◈ Thought for Xs ›  (click to re-expand)
 
 .thought-block {
-  border-left: 4px solid #9b59b6;
-  padding: 0.25rem 0.5rem;
+  border-left: 3px solid var(--accent-purple, #9b6dff);
+  padding: 0.3rem 0.5rem 0.3rem 0.625rem;
   max-width: 100%;
   overflow-x: hidden;
   word-break: break-word;
+  border-radius: 0 var(--radius-xs, 4px) var(--radius-xs, 4px) 0;
 
   &__header {
     background: none;
     border: none;
-    color: var(--color-text-muted, #888);
+    color: var(--text-muted, #888);
     cursor: pointer;
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.3rem;
     width: 100%;
     text-align: left;
-    padding: 0;
+    padding: 0.15rem 0.25rem;
+    border-radius: var(--radius-xs, 4px);
+    font-size: 0.72rem;
+    font-family: var(--font-mono);
+    transition: background 0.12s, color 0.12s;
 
-    &:hover { color: var(--color-text, #eee); }
+    &:hover {
+      color: var(--text-primary, #eee);
+      background: var(--bg-hover, rgba(255,255,255,0.04));
+    }
   }
 
-  &__icon { aria-hidden: attr(aria-hidden); }
+  &__icon {
+    color: var(--accent-purple, #9b6dff);
+    opacity: 0.8;
+    flex-shrink: 0;
+  }
+
+  &__label {
+    font-weight: 500;
+    letter-spacing: 0.01em;
+  }
 
   &__chevron {
     margin-left: auto;
     transition: transform 0.2s ease;
+    opacity: 0.6;
+    font-size: 1rem;
+    line-height: 1;
   }
 
   &--open &__chevron { transform: rotate(90deg); }
 
   &__body {
     font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
+    font-size: 0.72rem;
+    line-height: 1.65;
     font-style: italic;
-    color: var(--color-text-muted, #888);
+    color: var(--text-muted, #888);
     white-space: pre-wrap;
     word-break: break-word;
     max-height: 0;
@@ -53,7 +68,29 @@
     transition: max-height 0.25s ease-out;
   }
 
-  &--open &__body  { max-height: 2000px; }
+  &--open &__body {
+    max-height: 480px; // cap to ~30 visible lines; overflows scroll internally
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-default, #333) transparent;
+  }
+
   &--collapsed &__body { max-height: 0; }
+
+  // Blinking text cursor shown while the block is actively streaming
+  &__cursor {
+    display: inline-block;
+    width: 0.5em;
+    height: 0.85em;
+    background: var(--accent-purple, #9b6dff);
+    opacity: 0.7;
+    vertical-align: text-bottom;
+    margin-left: 1px;
+    animation: thought-cursor-blink 1s step-end infinite;
+  }
 }
 
+@keyframes thought-cursor-blink {
+  0%, 100% { opacity: 0.7; }
+  50%       { opacity: 0; }
+}

--- a/agentception/static/scss/pages/_tool-call-card.scss
+++ b/agentception/static/scss/pages/_tool-call-card.scss
@@ -1,8 +1,12 @@
 // ── Tool call card ────────────────────────────────────────────────────────────
+// Shows tool invocations and their results inline.
+// tool_call:   icon · name · args preview
+// tool_result: result preview appended below, separated by subtle rule
 
 .tool-call-card {
-  border-left: 4px solid #3498db;
-  padding: 0.2rem 0.5rem;
+  border-left: 3px solid var(--accent-blue, #4dabf7);
+  border-radius: 0 var(--radius-xs, 4px) var(--radius-xs, 4px) 0;
+  padding: 0.25rem 0.5rem 0.25rem 0.625rem;
   display: flex;
   flex-direction: row;
   align-items: baseline;
@@ -12,32 +16,43 @@
   overflow-x: hidden;
   word-break: break-word;
 
-  &__icon { flex-shrink: 0; }
+  &__icon {
+    flex-shrink: 0;
+    opacity: 0.8;
+    line-height: 1;
+  }
 
   &__name {
     font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
+    font-size: 0.75rem;
     font-weight: 600;
-    color: var(--color-text, #eee);
+    color: var(--accent-bright, #a78bfa);
+    white-space: nowrap;
   }
 
   &__args {
     font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
-    font-size: 0.85em;
-    color: var(--color-text-muted, #888);
+    font-size: 0.7rem;
+    color: var(--text-muted, #888);
     word-break: break-all;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
   }
 
   &__result {
     flex-basis: 100%;
     font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
-    font-size: 0.82em;
-    color: var(--color-text-muted, #888);
-    padding-left: 1.4rem;
+    font-size: 0.7rem;
+    color: var(--text-muted, #888);
+    padding: 0.2rem 0 0 1.4rem;
+    margin-top: 0.15rem;
+    border-top: 1px solid var(--border-subtle, #2a2a2a);
     word-break: break-word;
+    white-space: pre-wrap;
   }
 
   &--result-only {
-    border-left-color: var(--color-border-muted, #444);
+    border-left-color: var(--border-subtle, #2a2a2a);
   }
 }
-

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -95,17 +95,32 @@
         <div class="build-inspector__content">
 
           <div class="build-inspector__toolbar">
-            <a class="build-inspector__num" :href="activeIssue.url" target="_blank" rel="noopener"
-               x-text="'#' + activeIssue.number"></a>
-            <span class="build-inspector__title" x-text="activeIssue.title"></span>
-            <template x-if="activeIssue.run && activeIssue.run.pr_number">
-              <a class="build-inspector__pr-link"
-                 :href="'https://github.com/' + repo + '/pull/' + activeIssue.run.pr_number"
-                 target="_blank" rel="noopener"
-                 x-text="'PR #' + activeIssue.run.pr_number"></a>
-            </template>
-            <button class="build-inspector__close" @click="clearInspect()">✕</button>
+            <div class="build-inspector__toolbar-left">
+              <a class="build-inspector__num" :href="activeIssue.url" target="_blank" rel="noopener"
+                 x-text="'#' + activeIssue.number"></a>
+              <span class="build-inspector__title" x-text="activeIssue.title"></span>
+            </div>
+            <div style="display:flex;align-items:center;gap:0.4rem;flex-shrink:0;">
+              <template x-if="activeIssue.run && activeIssue.run.pr_number">
+                <a class="build-inspector__pr-link"
+                   :href="'https://github.com/' + repo + '/pull/' + activeIssue.run.pr_number"
+                   target="_blank" rel="noopener"
+                   x-text="'PR #' + activeIssue.run.pr_number"></a>
+              </template>
+              <button class="build-inspector__close" @click="clearInspect()">✕</button>
+            </div>
           </div>
+
+          {# run-meta bar: role chip + agent_status chip #}
+          <template x-if="activeIssue.run">
+            <div class="build-inspector__run-meta">
+              <span class="build-inspector__run-role" x-text="activeIssue.run.role || 'agent'"></span>
+              <span class="build-inspector__run-status"
+                    :class="'build-inspector__run-status--' + (activeIssue.run.agent_status || 'unknown')"
+                    x-text="activeIssue.run.agent_status || 'unknown'"></span>
+              <span class="build-inspector__run-since" x-text="activeIssue.run.id ? '#' + activeIssue.run.id : ''"></span>
+            </div>
+          </template>
 
           <template x-if="!activeIssue.run">
             <div class="build-inspector__no-agent">


### PR DESCRIPTION
## Summary

- **Widen inspector to 460px** with responsive breakpoints (was 400px); cramped diffs no longer overflow horizontally
- **Run-meta bar** (role chip + agent_status chip) activated in `build.html` — the toolbar now shows the agent role and live status
- **All 5 card SCSS files ported from legacy `--color-*` tokens** to current design tokens (`var(--accent-purple)`, `var(--accent-green)`, `var(--error)`, etc.); every hardcoded hex color is gone
- **Critical SCSS/DOM mismatch fixed** in `_file-edit-card.scss`: styles now target `.file-edit-card > pre` (direct child), not the non-existent `.__diff pre` wrapper — monospace/padding styles were silently never applying
- **Thought block** streaming cursor (blinking `▌`) while block is open; collapses with accurate "Thought for Xs" using `recorded_at` timestamps instead of wall-clock time
- **`message` and `error` events now rendered** — these were previously silently dropped by `event_card.ts`; every agent log message is now visible in the inspector
- **Smart scroll** across all five handlers — feed only auto-scrolls if user is already within 80px of the bottom, preserving scroll position while reading
- **Non-zero shell exit highlight** — `shell_done` rows with `exit_code != 0` get a red left-border and tinted background
- **File edit card** header is now a `<button>` (keyboard accessible); shows basename with full path in `title` attribute; adds `+N / -N` line-count badge
- **`diff-hunk` spans** for `@@ ... @@` marker lines now styled (previously unstyled)
- **127 tests all green** — 16 new test cases added across 4 test files

## Test plan

- [x] `npm run type-check` — zero errors
- [x] `npm test` — 127 tests, 7 files, all green
- [x] `npm run build` — JS (433kb) and CSS bundles built successfully
- [ ] Manual: click a running ticket → inspector shows role/status chips
- [ ] Manual: watch a thought block stream with cursor, collapse with duration
- [ ] Manual: observe `message`/`error` event cards appearing in feed
- [ ] Manual: observe shell failure rows highlighted in red
- [ ] Manual: click a diff card header and verify `+N / -N` badge visible