### PR TITLE
fix: Kanban card bounce — stale status stays active, stall guard in upsert, cross-repo scope

### DIFF
--- a/agentception/db/persist.py
+++ b/agentception/db/persist.py
@@ -563,6 +563,10 @@ async def _recompute_workflow_state(session: object, repo: str) -> list[str]:
 
     # --- Build lookup structures ---
     runs_by_pr: dict[int, list[RunRow]] = {}
+    # Keyed by issue_number scoped to the current repo to avoid cross-repo
+    # collisions when two repos share the same issue number (e.g. both repos
+    # have an issue #42).  A run is considered "for this repo" when its
+    # gh_repo field matches OR when gh_repo is NULL (legacy rows pre-migration).
     latest_run_by_issue: dict[int, ACAgentRun] = {}
     run_pr_numbers: dict[str, int | None] = {}
 
@@ -575,7 +579,13 @@ async def _recompute_workflow_state(session: object, repo: str) -> list[str]:
                 pr_number=run.pr_number,
             )
             runs_by_pr.setdefault(run.pr_number, []).append(run_row)
-        if run.issue_number is not None and run.issue_number not in latest_run_by_issue:
+        # Only assign to latest_run_by_issue when the run belongs to this repo.
+        # gh_repo is NULL for runs created before migration 0012; those rows
+        # have no repo context and are treated as matching any repo (legacy
+        # fallback — will be resolved when the run next heartbeats and writes
+        # gh_repo).
+        run_repo_matches = run.gh_repo is None or run.gh_repo == repo
+        if run.issue_number is not None and run_repo_matches and run.issue_number not in latest_run_by_issue:
             latest_run_by_issue[run.issue_number] = run
 
     pr_info_map: dict[int, PRInfo] = {}
@@ -811,6 +821,7 @@ async def _recompute_workflow_state(session: object, repo: str) -> list[str]:
 
 
 from agentception.workflow.status import ACTIVE_STATUSES as _ACTIVE_STATUSES  # noqa: E402
+from agentception.workflow.status import TERMINAL_STATUSES  # noqa: E402
 
 
 async def _upsert_agent_runs(
@@ -852,17 +863,44 @@ async def _upsert_agent_runs(
                 )
             )
         else:
-            # Never overwrite pending_launch — only the Dispatcher's acknowledge
-            # endpoint may transition out of that state.  The poller can see the
-            # worktree on disk and would clobber it with "stale" otherwise, which
-            # would drain the queue before the Dispatcher ever reads it.
+            # Status write rules — order matters; first match wins:
             #
-            # Never overwrite adhoc runs (issue_number is None) — they are
-            # managed entirely by their asyncio task lifecycle.  The poller
-            # derives a synthetic display status for them that is not an accurate
-            # reflection of real run state, so writing it back would corrupt the
-            # DB row and cause the agent loop's terminal-state guard to fire.
-            if existing.status != "pending_launch" and existing.issue_number is not None:
+            # 1. Never overwrite ``pending_launch``.  Only the Dispatcher's
+            #    acknowledge endpoint may transition out of that state.  The
+            #    poller can see the worktree on disk and would clobber it with a
+            #    stale-derived status otherwise, which would drain the queue
+            #    before the Dispatcher ever reads it.
+            #
+            # 2. Never overwrite adhoc runs (issue_number is None).  They are
+            #    managed entirely by their asyncio task lifecycle.
+            #
+            # 3. Never overwrite a terminal state (completed, cancelled, stopped,
+            #    failed).  A mid-tick completion or cancellation must not be
+            #    reversed by a snapshot taken at tick start.
+            #
+            # 4. Never overwrite ``stalled`` with a live status.  The poller
+            #    watchdog writes ``stalled`` in a separate DB session
+            #    (detect_alerts → update_agent_status) that commits before
+            #    _upsert_agent_runs runs.  The snapshot used to build ``agents``
+            #    was taken before that commit and still shows ``implementing``; if
+            #    we allow the overwrite here the stall detection flip-flops every
+            #    tick and the card oscillates between ``active`` and ``todo``.
+            # Guard 4: don't overwrite "stalled" with a live snapshot status.
+            # agent.status.value comes from the tick-start snapshot and will be
+            # "implementing" (or similar); existing.status was written mid-tick
+            # by the watchdog.  "stalled" is not a terminal state so TERMINAL_STATUSES
+            # doesn't catch it — the explicit guard is required.
+            _stall_guard = (
+                existing.status == "stalled"
+                and agent.status.value != "stalled"
+            )
+            _may_write_status = (
+                existing.status != "pending_launch"
+                and existing.issue_number is not None
+                and existing.status not in TERMINAL_STATUSES
+                and not _stall_guard
+            )
+            if _may_write_status:
                 existing.status = agent.status.value
             # Only advance pr_number — never regress it to None.
             # persist_agent_event(done) writes pr_number from the agent's

--- a/agentception/tests/test_workflow_state_machine.py
+++ b/agentception/tests/test_workflow_state_machine.py
@@ -436,6 +436,11 @@ class TestAgentStatusEnum:
         assert "pending_launch" in LANE_ACTIVE_STATUSES
         assert "blocked" in LANE_ACTIVE_STATUSES
         assert "reviewing" in LANE_ACTIVE_STATUSES
+        # "stale" is a computed display value (not a DB-stored AgentStatus).
+        # It must be in LANE_ACTIVE_STATUSES so that cards for runs that have
+        # not heartbeated for >30 min stay in the "active" lane rather than
+        # bouncing back to "todo".  Regression for the card-bounce bug.
+        assert "stale" in LANE_ACTIVE_STATUSES
 
     def test_reset_statuses(self) -> None:
         assert RESET_STATUSES == {
@@ -472,6 +477,26 @@ class TestComputeAgentStatus:
 
     def test_unknown_status_normalised(self) -> None:
         assert compute_agent_status("garbage_status", None) == "failed"
+
+    def test_stale_agent_stays_in_active_lane(self) -> None:
+        """Regression: a run whose compute_agent_status returns 'stale' must
+        keep its card in the 'active' swim lane, not bounce it to 'todo'."""
+        import datetime
+        from agentception.workflow.state_machine import _compute_lane
+        now = datetime.datetime.now(datetime.timezone.utc)
+        old = now - datetime.timedelta(hours=2)
+        stale_status = compute_agent_status("implementing", old, now=now)
+        assert stale_status == "stale"
+        lane = _compute_lane(
+            issue_state="open",
+            agent_status=stale_status,
+            pr_state=None,
+            pr_merged_recently=False,
+        )
+        assert lane == "active", (
+            f"Stale agent returned lane={lane!r}; expected 'active'. "
+            "Card-bounce regression: 'stale' must be in LANE_ACTIVE_STATUSES."
+        )
 
 
 # ===========================================================================

--- a/agentception/workflow/status.py
+++ b/agentception/workflow/status.py
@@ -88,6 +88,10 @@ RESET_STATUSES: frozenset[str] = frozenset({
 })
 
 #: States that place an issue card in the ``active`` swim lane (when no PR exists).
+#: ``"stale"`` is a computed display value (not stored in the DB) returned by
+#: :func:`compute_agent_status` when a live run has not heartbeated for
+#: :data:`STALE_THRESHOLD`.  It must appear here so that ``_compute_lane``
+#: keeps the card in ``active`` rather than falling through to ``todo``.
 LANE_ACTIVE_STATUSES: frozenset[str] = frozenset({
     AgentStatus.IMPLEMENTING.value,
     AgentStatus.PENDING_LAUNCH.value,
@@ -95,6 +99,7 @@ LANE_ACTIVE_STATUSES: frozenset[str] = frozenset({
     AgentStatus.REVIEWING.value,
     AgentStatus.STALLED.value,
     AgentStatus.RECOVERING.value,
+    "stale",  # computed — see compute_agent_status(); never stored in the DB
 })
 
 #: Terminal states — no further transitions are possible.


### PR DESCRIPTION
## Summary

Three interlocking bugs caused Kanban cards to bounce backward to previous lanes.

### Bug 1 (Critical): `'stale'` missing from `LANE_ACTIVE_STATUSES`

`compute_agent_status()` returns the string `'stale'` (never stored in the DB) when a live run has not heartbeated for >30 minutes. `_compute_lane` checked `agent_status in LANE_ACTIVE_STATUSES` to decide the swim lane, but `'stale'` was absent from that set. Every issue whose agent had been quiet for 30+ minutes fell through to `LANE_TODO` on every poller tick — card bounced from `active` back to `todo`.

**Fix:** Added `'stale'` to `LANE_ACTIVE_STATUSES` with a comment explaining it is a computed display value, never a DB-stored status.

### Bug 2 (Critical): `_upsert_agent_runs` overwrote `'stalled'` back to `'implementing'`

The poller's `detect_alerts` watchdog writes `'stalled'` mid-tick via a separate DB session. `_upsert_agent_runs` then ran with the tick-start snapshot (which still showed `'implementing'`) and overwrote the stalled status, causing stall detection to flip-flop every tick and Bug 1 to trigger permanently.

**Fix:** Added explicit guards to the status-overwrite path:
- Never overwrite `'stalled'` with a live snapshot status
- Never overwrite any terminal state (`completed`, `cancelled`, `stopped`, `failed`) — prevents mid-tick transitions from being reversed

### Bug 3 (Medium): `latest_run_by_issue` cross-repo collision

`_recompute_workflow_state` built `latest_run_by_issue` keyed by `issue_number` alone (no repo filter). Two repos sharing the same issue number (e.g. both have `#42`) would use the wrong run for lane computation in one of them.

**Fix:** Scoped the lookup to `run.gh_repo == repo`, with a null fallback for legacy rows that predate the `gh_repo` column.

## Test plan

- [x] `mypy agentception/ tests/` — zero errors (300 files)
- [x] `pytest test_workflow_state_machine.py test_persist.py test_poller_orphan_sweep.py` — 65 passed
- [x] Regression test `test_stale_agent_stays_in_active_lane` added — verifies `compute_agent_status('implementing', 2h_ago)` returns `'stale'` and `_compute_lane` maps it to `'active'`
- [x] `'stale' in LANE_ACTIVE_STATUSES` assertion added to `test_lane_active_includes_all_relevant`