### PR TITLE
fix: pre-seed ac_issues immediately after Phase 1B issue creation

### DIFF
--- a/agentception/readers/issue_creator.py
+++ b/agentception/readers/issue_creator.py
@@ -37,6 +37,7 @@ from agentception.db.persist import (
     persist_initiative_phases,
     persist_issue_depends_on,
     persist_plan_issues,
+    upsert_issues,
 )
 from agentception.models import PlanIssue, PlanSpec
 from agentception.readers.github import add_label_to_issue, ensure_label_exists
@@ -294,14 +295,14 @@ async def _create_one(
     issue: PlanIssue,
     labels: list[str],
     prev_phase_label: str | None = None,
-) -> tuple[str, int, str]:
-    """Create a single issue; return (issue.id, github_number, html_url)."""
+) -> tuple[str, int, str, str]:
+    """Create a single issue; return (issue.id, github_number, html_url, final_body)."""
     body = _embed_skills(issue.body, issue.skills)
     body = _embed_cognitive_arch(body, issue.cognitive_arch)
     if prev_phase_label is not None:
         body = _embed_phase_gate(body, prev_phase_label)
     number, url = await _gh_create_issue(repo, issue.title, body, labels)
-    return issue.id, number, url
+    return issue.id, number, url, body
 
 
 # ── Public async generator ────────────────────────────────────────────────
@@ -327,12 +328,12 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
     batch_id = f"batch-{uuid.uuid4().hex[:12]}"
     total_issues = sum(len(p.issues) for p in spec.phases)
     id_to_number: dict[str, int] = {}
-    id_to_body: dict[str, str] = {
-        issue.id: issue.body
-        for phase in spec.phases
-        for issue in phase.issues
-    }
     created: list[CreatedIssue] = []
+    # Track final (post-embedding) bodies and labels per GitHub issue number so we
+    # can immediately upsert the new rows into ac_issues after creation — without
+    # waiting for the next poller tick.
+    number_to_body: dict[int, str] = {}
+    number_to_labels: dict[int, list[str]] = {}
 
     yield StartEvent(t="start", total=total_issues, initiative=spec.initiative)
 
@@ -357,14 +358,14 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
             if phase_idx > 0
             else None
         )
-        phase_tasks: list[asyncio.Task[tuple[str, int, str]]] = [
+        phase_tasks: list[asyncio.Task[tuple[str, int, str, str]]] = [
             asyncio.create_task(_create_one(repo, issue, labels, prev_phase_label))
             for issue in phase.issues
         ]
 
         for task in asyncio.as_completed(phase_tasks):
             try:
-                issue_id, number, url = await task
+                issue_id, number, url, final_body = await task
             except Exception as exc:
                 yield FilingErrorEvent(t="error", detail=str(exc))
                 # Cancel remaining tasks in this phase before aborting.
@@ -374,6 +375,8 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
 
             index += 1
             id_to_number[issue_id] = number
+            number_to_body[number] = final_body
+            number_to_labels[number] = list(labels)
 
             # Find the title for this issue_id.
             title = next(
@@ -422,7 +425,7 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
 
             issue_deps[our_number] = blocker_numbers
 
-            original_body = id_to_body.get(issue.id, issue.body)
+            original_body = number_to_body.get(our_number, issue.body)
             blocked_line = (
                 "\n\n---\n**Blocked by:** "
                 + ", ".join(f"#{n}" for n in blocker_numbers)
@@ -451,12 +454,35 @@ async def file_issues(spec: PlanSpec) -> AsyncGenerator[IssueFileEvent, None]:
                     our_number,
                     [f"#{n}" for n in blocker_numbers],
                 )
+                # Reflect the blocked/deps label in our local tracking so the
+                # immediate upsert below records the correct label set.
+                if "blocked/deps" not in number_to_labels.get(our_number, []):
+                    number_to_labels.setdefault(our_number, []).append("blocked/deps")
 
             yield BlockedEvent(
                 t="blocked",
                 number=our_number,
                 blocked_by=blocker_numbers,
             )
+
+    # Immediately upsert newly created issues into ac_issues so the Ship board
+    # is populated the moment the user navigates there — without waiting for the
+    # next poller tick (which could take up to 5 seconds).
+    issue_gh_dicts: list[dict[str, object]] = [
+        {
+            "number": c["number"],
+            "title": c["title"],
+            "state": "open",
+            "labels": number_to_labels.get(c["number"], []),
+            "body": number_to_body.get(c["number"], ""),
+        }
+        for c in created
+    ]
+    try:
+        await upsert_issues(issues=issue_gh_dicts, active_label=None, repo=repo)
+        logger.info("✅ issue_creator: pre-seeded %d issues into ac_issues", len(issue_gh_dicts))
+    except Exception as exc:
+        logger.warning("⚠️ issue_creator: pre-seed upsert failed (poller will recover): %s", exc)
 
     # Persist dep relationships to DB so the Build board can display them.
     await persist_issue_depends_on(repo, issue_deps)

--- a/agentception/tests/test_issue_creator.py
+++ b/agentception/tests/test_issue_creator.py
@@ -131,10 +131,28 @@ async def test_file_issues_emits_start_event() -> None:
     spec = _make_spec()
 
     with (
+        patch(
+            "agentception.readers.issue_creator.enrich_plan_with_codebase_context",
+            new_callable=AsyncMock,
+            return_value=spec,
+        ),
         patch("agentception.readers.issue_creator.ensure_label_exists", new_callable=AsyncMock),
         patch(
             "asyncio.create_subprocess_exec",
             return_value=_mock_proc(stdout=_issue_url(42)),
+        ),
+        patch("agentception.readers.issue_creator.upsert_issues", new_callable=AsyncMock),
+        patch(
+            "agentception.readers.issue_creator.persist_initiative_phases",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.readers.issue_creator.persist_issue_depends_on",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.readers.issue_creator.persist_plan_issues",
+            new_callable=AsyncMock,
         ),
     ):
         events = await _collect(file_issues(spec))
@@ -742,6 +760,98 @@ async def test_file_issues_body_edit_failure_is_non_fatal() -> None:
     # Body edit failure must not abort the stream — done event must still arrive.
     done_events = [e for e in events if e["t"] == "done"]
     assert done_events, "done event must be emitted even when body edit fails"
+
+
+@pytest.mark.anyio
+async def test_file_issues_immediately_upserts_created_issues() -> None:
+    """upsert_issues is called before the done event so the Ship board is
+    pre-seeded without waiting for the next poller tick."""
+    spec = _make_spec()
+    call_count = 0
+
+    def fake_proc(*_args: object, **_kwargs: object) -> MagicMock:
+        nonlocal call_count
+        call_count += 1
+        return _mock_proc(stdout=_issue_url(1000 + call_count))
+
+    upsert_mock = AsyncMock(return_value=2)
+    with (
+        patch("agentception.readers.issue_creator.ensure_label_exists", new_callable=AsyncMock),
+        patch("asyncio.create_subprocess_exec", side_effect=fake_proc),
+        patch("agentception.readers.issue_creator.upsert_issues", upsert_mock),
+        patch(
+            "agentception.readers.issue_creator.persist_initiative_phases",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.readers.issue_creator.persist_issue_depends_on",
+            new_callable=AsyncMock,
+        ),
+    ):
+        events = await _collect(file_issues(spec))
+
+    # upsert_issues must have been called exactly once, with the two created issues.
+    upsert_mock.assert_awaited_once()
+    call_kwargs = upsert_mock.call_args
+    assert call_kwargs is not None
+    issues_arg: list[object] = call_kwargs.kwargs.get("issues") or call_kwargs.args[0]
+    assert len(issues_arg) == 2, "both created issues must be pre-seeded"
+    for raw in issues_arg:
+        assert isinstance(raw, dict)
+        assert isinstance(raw.get("number"), int)
+        assert raw.get("state") == "open"
+        labels = raw.get("labels")
+        assert isinstance(labels, list) and labels  # at least initiative + phase labels
+
+    # Done event must still arrive.
+    done_events = [e for e in events if e["t"] == "done"]
+    assert done_events, "done event must be emitted after upsert"
+
+
+@pytest.mark.anyio
+async def test_file_issues_upsert_includes_blocked_deps_label() -> None:
+    """When an issue has depends_on and blocked/deps is stamped on GitHub,
+    the immediate upsert must include 'blocked/deps' in its label list."""
+    spec = _make_spec(with_depends_on=True)
+    create_count = 0
+
+    def fake_proc(*args: str, **_kwargs: object) -> MagicMock:
+        nonlocal create_count
+        cmd = list(args)
+        if "create" in cmd:
+            create_count += 1
+            return _mock_proc(stdout=_issue_url(1100 + create_count))
+        if "edit" in cmd:
+            return _mock_proc()
+        return _mock_proc()
+
+    upsert_mock = AsyncMock(return_value=2)
+    with (
+        patch("agentception.readers.issue_creator.ensure_label_exists", new_callable=AsyncMock),
+        patch("agentception.readers.issue_creator.add_label_to_issue", new_callable=AsyncMock),
+        patch("asyncio.create_subprocess_exec", side_effect=fake_proc),
+        patch("agentception.readers.issue_creator.upsert_issues", upsert_mock),
+        patch(
+            "agentception.readers.issue_creator.persist_initiative_phases",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.readers.issue_creator.persist_issue_depends_on",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await _collect(file_issues(spec))
+
+    upsert_mock.assert_awaited_once()
+    call_kwargs = upsert_mock.call_args
+    assert call_kwargs is not None
+    issues_arg: list[object] = call_kwargs.kwargs.get("issues") or call_kwargs.args[0]
+    # The blocked issue must include 'blocked/deps' in its label list.
+    blocked_entries = [
+        raw for raw in issues_arg
+        if isinstance(raw, dict) and "blocked/deps" in (raw.get("labels") or [])
+    ]
+    assert blocked_entries, "blocked issue must carry 'blocked/deps' in the upserted label list"
 
 
 # ── _scoped_label truncation ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- After `file_issues()` creates GitHub issues it now immediately calls `upsert_issues()` with the created issue data before yielding `DoneEvent`, so `ac_issues` is populated without waiting for the next poller tick (up to 5 s gap).
- Tracks the final (post-embedding) body and full label list per issue number so the upsert is accurate.
- Reflects `blocked/deps` label for `depends_on` issues stamped during the same run.
- Fixes pre-existing `test_file_issues_emits_start_event` timeout (missing `enrich_plan_with_codebase_context` mock).
- Adds two new regression tests for the immediate upsert and blocked/deps label inclusion.

## Test plan

- [x] `mypy agentception/ tests/` — zero errors
- [x] `pytest agentception/tests/test_issue_creator.py -v` — 33/33 passed
- [x] `generate.py --check` — no drift