### PR TITLE
fix: green full test suite — fix 17 pre-existing test failures

### DIFF
--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -261,7 +261,7 @@
     <template x-if="launchSuccess && launchResult">
       <span class="od-header__launch-ok">
         <template x-if="!startAgentDone && startAgentLoading">
-          <span>⏳ Starting agent…</span>
+          <span class="spinner-inline"></span> Starting agent…
         </template>
         <template x-if="startAgentDone">
           <span>✅ Agent running — <code x-text="launchResult.run_id"></code></span>

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -106,7 +106,13 @@ def _mock_get_session() -> MagicMock:
 class TestRunAgentLoop:
     @pytest.mark.anyio
     async def test_single_turn_stop(self, tmp_path: Path) -> None:
-        """Agent loop completes in one turn when the model returns stop."""
+        """Agent loop exits without calling build_complete_run when model returns stop.
+
+        When the model returns stop_reason=stop without having called
+        create_pull_request + build_complete_run as a tool, the loop logs a
+        warning and exits — it does NOT auto-call build_complete_run because
+        that would leave the run in a broken state (no PR, no commit).
+        """
         worktree = tmp_path / "test-run-1"
         worktree.mkdir()
         task_spec = _make_task_spec(worktree)
@@ -156,10 +162,7 @@ class TestRunAgentLoop:
 
             await run_agent_loop("test-run-1")
 
-        mock_complete.assert_called_once()
-        call_kwargs = mock_complete.call_args.kwargs
-        assert call_kwargs["issue_number"] == 42
-        assert "All done." in call_kwargs["summary"]
+        mock_complete.assert_not_called()
 
     @pytest.mark.anyio
     async def test_tool_call_then_stop(self, tmp_path: Path) -> None:
@@ -220,7 +223,7 @@ class TestRunAgentLoop:
             with patch.object(al, "read_file", return_value=tool_result):
                 await al.run_agent_loop("test-run-1")
 
-        mock_complete.assert_called_once()
+        mock_complete.assert_not_called()
 
     @pytest.mark.anyio
     async def test_mcp_tool_dispatched_to_call_tool_async(self, tmp_path: Path) -> None:

--- a/agentception/tests/test_agentception_run_conductor.py
+++ b/agentception/tests/test_agentception_run_conductor.py
@@ -65,7 +65,7 @@ async def test_get_conductor_history_status_resolved_from_db(
     ]
 
     with patch(
-        "agentception.db.queries.get_session",
+        "agentception.db.queries.board.get_session",
         return_value=_mock_session_returning(rows),
     ):
         entries = await get_conductor_history(
@@ -89,7 +89,7 @@ async def test_get_conductor_history_reviewing_is_active(tmp_path: Path) -> None
     rows: list[tuple[MagicMock, str | None]] = [(_make_wave("conductor-review"), "reviewing")]
 
     with patch(
-        "agentception.db.queries.get_session",
+        "agentception.db.queries.board.get_session",
         return_value=_mock_session_returning(rows),
     ):
         entries = await get_conductor_history(limit=5, worktrees_dir=tmp_path, host_worktrees_dir=tmp_path)
@@ -105,7 +105,7 @@ async def test_get_conductor_history_no_run_is_completed(tmp_path: Path) -> None
     rows: list[tuple[MagicMock, str | None]] = [(_make_wave("conductor-orphan"), None)]
 
     with patch(
-        "agentception.db.queries.get_session",
+        "agentception.db.queries.board.get_session",
         return_value=_mock_session_returning(rows),
     ):
         entries = await get_conductor_history(limit=5, worktrees_dir=tmp_path, host_worktrees_dir=tmp_path)
@@ -121,7 +121,7 @@ async def test_get_conductor_history_no_fs_access(tmp_path: Path) -> None:
     rows: list[tuple[MagicMock, str | None]] = [(_make_wave("conductor-20260303-100000"), "implementing")]
 
     with patch(
-        "agentception.db.queries.get_session",
+        "agentception.db.queries.board.get_session",
         return_value=_mock_session_returning(rows),
     ), patch("pathlib.Path.exists") as mock_exists:
         await get_conductor_history(limit=5, worktrees_dir=tmp_path, host_worktrees_dir=tmp_path)
@@ -140,7 +140,7 @@ async def test_get_conductor_history_returns_empty_on_db_error(
     mock_session.__aenter__ = AsyncMock(side_effect=RuntimeError("DB unavailable"))
     mock_session.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("agentception.db.queries.get_session", return_value=mock_session):
+    with patch("agentception.db.queries.board.get_session", return_value=mock_session):
         entries = await get_conductor_history(
             limit=5,
             worktrees_dir=tmp_path,

--- a/agentception/tests/test_build_page_structure.py
+++ b/agentception/tests/test_build_page_structure.py
@@ -104,6 +104,7 @@ _BUILD_CTX: dict[str, JsonValue] = {
     "initiative": "test-initiative",
     "initiatives": ["test-initiative"],
     "open_issues": 0,
+    "worktree_index_enabled": False,
     "total_issues": 0,
     "groups": [],
     "figures": [],

--- a/agentception/tests/test_cognitive_arch_in_plan_spec.py
+++ b/agentception/tests/test_cognitive_arch_in_plan_spec.py
@@ -346,13 +346,13 @@ class TestMcpServerCognitiveFigures:
         assert payload.get("role") == "cto"
 
     @pytest.mark.anyio
-    async def test_read_resource_call_tool_redirect_returns_error(self) -> None:
-        """Calling the retired plan_get_cognitive_figures tool returns a redirect error."""
+    async def test_removed_tool_returns_unknown_error(self) -> None:
+        """Calling the removed plan_get_cognitive_figures tool returns an unknown-tool error."""
         result = call_tool("plan_get_cognitive_figures", {})
         assert result["isError"] is True
         payload: JsonValue = json.loads(result["content"][0]["text"])
         assert isinstance(payload, dict)
-        assert "ac://plan/figures/{role}" in str(payload.get("error", ""))
+        assert "Unknown tool" in str(payload.get("error", ""))
 
     @pytest.mark.anyio
     async def test_read_resource_unknown_role_returns_error_in_payload(self, tmp_path: Path) -> None:

--- a/agentception/tests/test_dispatch_variant.py
+++ b/agentception/tests/test_dispatch_variant.py
@@ -18,7 +18,10 @@ async def test_dispatch_passes_prompt_variant_to_task_spec(tmp_path: Path) -> No
     async def mock_persist(**kwargs: str | int | None | bool) -> None:
         captured_kwargs.append(kwargs)
 
-    async def mock_ensure_worktree(path: Path, branch: str, base: str = "origin/dev", reset: bool = False) -> bool:
+    async def mock_ensure_worktree(
+        path: Path, branch: str, base: str = "origin/dev", reset: bool = False,
+        main_repo_dir: Path | None = None,
+    ) -> bool:
         return True
 
     with (
@@ -31,6 +34,7 @@ async def test_dispatch_passes_prompt_variant_to_task_spec(tmp_path: Path) -> No
         patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.asyncio.create_task", return_value=asyncio.Future()),
         patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.assemble_developer_context", new_callable=AsyncMock, return_value=""),
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
     ):
         mock_settings.worktrees_dir = str(tmp_path / "worktrees")
@@ -62,7 +66,10 @@ async def test_dispatch_prompt_variant_defaults_to_none(tmp_path: Path) -> None:
     async def mock_persist(**kwargs: str | int | None | bool) -> None:
         captured_kwargs.append(kwargs)
 
-    async def mock_ensure_worktree(path: Path, branch: str, base: str = "origin/dev", reset: bool = False) -> bool:
+    async def mock_ensure_worktree(
+        path: Path, branch: str, base: str = "origin/dev", reset: bool = False,
+        main_repo_dir: Path | None = None,
+    ) -> bool:
         return True
 
     with (
@@ -75,6 +82,7 @@ async def test_dispatch_prompt_variant_defaults_to_none(tmp_path: Path) -> None:
         patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.asyncio.create_task", return_value=asyncio.Future()),
         patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.assemble_developer_context", new_callable=AsyncMock, return_value=""),
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
     ):
         mock_settings.worktrees_dir = str(tmp_path / "worktrees")

--- a/agentception/tests/test_ensure_helpers.py
+++ b/agentception/tests/test_ensure_helpers.py
@@ -627,6 +627,7 @@ async def test_dispatch_implementer_uses_origin_dev_as_base(tmp_path: Path) -> N
         patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.asyncio.create_task", return_value=asyncio.Future()),
         patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
+        patch("agentception.routes.api.dispatch.assemble_developer_context", new_callable=AsyncMock, return_value=""),
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
     ):
         mock_settings.worktrees_dir = str(tmp_path / "worktrees")

--- a/agentception/tests/test_inspector.py
+++ b/agentception/tests/test_inspector.py
@@ -39,7 +39,7 @@ def _render_build() -> str:
     env.filters["title"] = lambda s: str(s).title()
     env.filters["truncate"] = lambda s, length, killwords, end: str(s)[:length]
 
-    ctx: dict[str, _StubRequest | str | int | list[str] | dict[str, str]] = {
+    ctx: dict[str, _StubRequest | str | int | bool | list[str] | dict[str, str]] = {
         "request": _StubRequest(),
         "repo": "cgcardona/agentception",
         "repo_name": "agentception",
@@ -50,6 +50,7 @@ def _render_build() -> str:
         "groups": [],
         "figures": [],
         "role_figure_map": {},
+        "worktree_index_enabled": False,
     }
     tmpl = env.get_template("build.html")
     return tmpl.render(ctx)


### PR DESCRIPTION
## Summary

- Fix 17 pre-existing test failures across 8 files so the full suite (2027 tests) passes cleanly for the dev→main release merge
- Root causes: stale mock paths after DB module refactoring, missing template context variables, outdated assertions for changed agent loop behavior, missing mocks for model-loading code paths, and leftover retired tool redirect tests

## Test plan

- [x] mypy on all 7 changed test files — 0 errors
- [x] Full test suite: 2027 passed, 0 failed (114s)
- [x] Container healthy