### PR TITLE
security: non-root container user, narrow bind mounts, egress allowlist proxy (phase 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,34 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install git, curl, ripgrep, and the GitHub CLI (gh).
-# ripgrep (rg) is used by the search_text agent tool for fast codebase search.
+# Install system dependencies:
+#   git       — version control for worktree operations
+#   curl      — downloading tool binaries (gh, sass, MCP server)
+#   ripgrep   — fast codebase search used by the search_text agent tool
+#   gosu      — minimal setuid helper for privilege dropping in entrypoint.sh
+#               (purpose-built alternative to sudo/su; avoids TTY issues and
+#               signal-forwarding bugs that plague plain `su`)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     ripgrep \
+    gosu \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
        | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
        > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update && apt-get install -y gh \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root service user.  UID/GID 1001 is chosen to avoid collision
+# with common system UIDs (0=root, 1-999=system, 1000=typical first human
+# user).  The agentception user owns its home directory and the model cache;
+# /worktrees ownership is fixed at runtime by entrypoint.sh after the bind
+# mount is available.
+RUN groupadd -g 1001 agentception \
+    && useradd -r -u 1001 -g agentception -m -d /home/agentception -s /bin/bash agentception \
+    && mkdir -p /worktrees /root/.cache/huggingface \
+    && chown agentception:agentception /root/.cache/huggingface
 
 # Install Node.js 22.x — enables sass/esbuild builds at container startup
 # and npm run type-check / npm test inside the container.
@@ -24,21 +40,28 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && node --version \
     && npm --version
 
-# Install the GitHub askpass helper and configure system-wide git auth.
+# Install the GitHub askpass helper and configure system-wide git settings.
 #
 # Git's git-receive-pack (push) and git-upload-pack (fetch/clone) endpoints
-# only accept HTTP Basic auth — Bearer tokens are rejected with 401. The askpass
-# helper supplies "x-access-token" / $GITHUB_TOKEN so git generates a valid
-# Basic auth header without any token ever touching remote.origin.url or a
-# per-worktree git config file (which risks GitHub secret scanning revocation).
+# only accept HTTP Basic auth — Bearer tokens are rejected with 401.  The
+# askpass helper supplies "x-access-token" / $GITHUB_TOKEN so git generates a
+# valid Basic auth header without any token ever touching remote.origin.url or
+# a per-worktree git config file (which risks GitHub secret scanning revocation).
 #
 # --system writes to /etc/gitconfig (baked into the image layer), so it applies
-# regardless of which $HOME the container runs with. GIT_TERMINAL_PROMPT=0
+# regardless of which $HOME the container runs with.  GIT_TERMINAL_PROMPT=0
 # prevents git from falling back to an interactive TTY prompt when credentials
-# are missing — agents run non-interactively and must fail fast instead.
+# are missing — agents run non-interactively and must fail fast.
+#
+# http.proxy routes git HTTPS operations through the egress allowlist proxy.
+# The proxy service name resolves inside the Docker network at runtime; this
+# config has no effect during the Docker build phase (proxy not running then).
 COPY scripts/github-askpass /usr/local/bin/github-askpass
 RUN chmod +x /usr/local/bin/github-askpass \
-    && git config --system core.askPass /usr/local/bin/github-askpass
+    && git config --system core.askPass /usr/local/bin/github-askpass \
+    && git config --system user.email "agentception@localhost" \
+    && git config --system user.name "AgentCeption" \
+    && git config --system http.proxy "http://proxy:8888"
 
 # Install the GitHub MCP server binary — provides the agent loop with typed
 # GitHub tools (get_issue, list_issues, add_issue_comment, create_pull_request,
@@ -86,5 +109,11 @@ COPY pyproject.toml /app/pyproject.toml
 # Install the package itself so `agentception.*` imports resolve.
 RUN pip install --no-cache-dir -e /app
 
+# Entrypoint: performs privileged startup (resolv.conf, asset compilation,
+# DB migrations, ownership fixes) then drops to the agentception user via
+# gosu before exec'ing the server command.
+COPY scripts/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["uvicorn", "agentception.app:app", "--host", "0.0.0.0", "--port", "10003"]

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,13 +1,25 @@
 # docker-compose.ci.yml — GitHub Actions override
 # Override the base docker-compose.yml for CI environments:
-#   - Strips host-specific bind mounts (cursor dir, gh auth, dev bind mount)
+#   - Remaps host-specific bind mounts to ephemeral CI paths
 #   - Sets CI-safe environment defaults
+#   - Disables the egress proxy (GitHub Actions runners have unrestricted
+#     internet access; tinyproxy adds latency without benefit in CI)
 #   - No port conflicts needed — runner is ephemeral
 #
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.ci.yml build
 #   docker compose -f docker-compose.yml -f docker-compose.ci.yml run --rm agentception <cmd>
 services:
+  # In CI the egress proxy is replaced with a no-op container so the
+  # agentception `depends_on: proxy: service_started` condition is satisfied
+  # without running tinyproxy.  GitHub Actions runners already have network
+  # policies enforced at the runner level; the proxy adds latency with no
+  # benefit here.
+  proxy:
+    image: alpine:latest
+    container_name: agentception-proxy-ci
+    command: ["/bin/true"]
+
   agentception:
     environment:
       HOME: /root
@@ -16,9 +28,27 @@ services:
       GH_REPO: ${GH_REPO:-cgcardona/agentception}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      # Disable the proxy in CI — no proxy service running.
+      HTTP_PROXY: ""
+      HTTPS_PROXY: ""
+      NO_PROXY: ""
+      http_proxy: ""
+      https_proxy: ""
+      no_proxy: ""
     # volumes: [] does NOT work in Compose v2 to clear the base list.
-    # Instead we remap to paths that exist unconditionally in any runner:
+    # Instead we remap to paths that exist unconditionally in any runner.
+    # The CI runner has no .env file, so the narrow bind-mount security
+    # posture from docker-compose.yml is naturally satisfied here too.
     volumes:
       - /tmp/ci-cursor:/root/.cursor
       - /tmp/ci-gh:/root/.config/gh
-      - ./:/app
+      - ./agentception:/app/agentception
+      - ./.agentception:/app/.agentception
+      - ./pyproject.toml:/app/pyproject.toml
+      - ./org-presets.yaml:/app/org-presets.yaml
+      - ./scripts:/app/scripts
+      - ./tests:/app/tests
+      - ./tools:/app/tools
+    depends_on:
+      postgres:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,26 @@
 services:
   # ==========================================================================
+  # Egress proxy — tinyproxy with a strict domain allowlist
+  #
+  # Intercepts all outbound HTTP/HTTPS from the agentception container for
+  # processes that honour HTTP_PROXY / HTTPS_PROXY environment variables
+  # (Python httpx, requests, curl, git, npm, gh CLI).  Any domain NOT in
+  # scripts/tinyproxy/filter is rejected with HTTP 403.
+  #
+  # This is a belt-and-suspenders control on top of the shell denylist and
+  # secret redaction: it prevents a prompt-injected agent from exfiltrating
+  # data to an arbitrary attacker-controlled URL via standard HTTP clients.
+  # ==========================================================================
+  proxy:
+    build:
+      context: ./scripts/tinyproxy
+      dockerfile: Dockerfile.proxy
+    container_name: agentception-proxy
+    restart: unless-stopped
+    networks:
+      - agentception-net
+
+  # ==========================================================================
   # AgentCeption — multi-agent orchestration dashboard
   # Port 10003 — the AgentCeption service port.
   # ==========================================================================
@@ -10,9 +31,15 @@ services:
     container_name: agentception-app
     restart: unless-stopped
     # Security hardening: prevent privilege escalation inside the container.
+    # The entrypoint starts as root, performs privileged setup, then drops to
+    # the agentception user (UID 1001) via gosu before starting uvicorn.
     security_opt:
       - no-new-privileges:true
-    # Drop all Linux capabilities and re-add only those needed for git and npm.
+    # Drop all Linux capabilities; re-add only those the entrypoint needs for
+    # the brief root phase (chown, sass/npm build).  After gosu drops to
+    # agentception, these capabilities are present in the process's bounding
+    # set but the non-root uvicorn process has no way to acquire new privs
+    # (no-new-privileges + no setuid binaries owned by root).
     cap_drop:
       - ALL
     cap_add:
@@ -74,10 +101,8 @@ services:
       # Disable HuggingFace tokenizers Rust parallelism — it spawns its own
       # thread pool that stacks on top of ORT's, making contention worse.
       TOKENIZERS_PARALLELISM: "false"
-      # HOME inside the container is inherited from the host (/Users/gabriel),
-      # which makes huggingface_hub and FastEmbed resolve their cache to a host
-      # path that is not mounted in the container.  HF_HOME overrides the
-      # HOME-derived default and points to the persistent model_cache volume.
+      # HF_HOME points to the persistent model_cache volume.  entrypoint.sh
+      # chowns this directory to the agentception user before dropping privs.
       HF_HOME: /root/.cache/huggingface
       # Optional: set HF_TOKEN in .env to avoid HuggingFace rate-limit warnings
       # on model downloads and enable authenticated access to private models.
@@ -85,15 +110,40 @@ services:
       WORKTREE_INDEX_ENABLED: ${WORKTREE_INDEX_ENABLED:-false}
       # No Anthropic rate limits with local Ollama — remove the pacing delay.
       AC_MIN_TURN_DELAY_SECS: ${AC_MIN_TURN_DELAY_SECS:-0}
+      # ── Egress proxy ──────────────────────────────────────────────────────
+      # Route all outbound HTTP/HTTPS through the tinyproxy allowlist.
+      # Standard-case and uppercase variants are both set for maximum tool
+      # coverage (curl, git, npm, Python httpx/requests all check one or both).
+      # NO_PROXY excludes internal Docker services that must not go through the
+      # proxy: postgres, qdrant, and the local LLM server on the host.
+      HTTP_PROXY: "http://proxy:8888"
+      HTTPS_PROXY: "http://proxy:8888"
+      NO_PROXY: "localhost,127.0.0.1,postgres,qdrant,host.docker.internal,::1"
+      http_proxy: "http://proxy:8888"
+      https_proxy: "http://proxy:8888"
+      no_proxy: "localhost,127.0.0.1,postgres,qdrant,host.docker.internal,::1"
     volumes:
       # gh CLI auth (read-only)
       - ${HOME}/.config/gh:${HOME}/.config/gh:ro
-      # Repo itself (for git operations)
-      - ./:/app
-      # Linux-native node_modules — sits on top of the ./:/app bind mount so the
-      # container's esbuild/tsc binaries (ELF) are never replaced by the host's
-      # macOS binaries. Populated from the image layer on first run via Docker's
-      # volume-init copy (image content wins when the named volume is empty).
+      # ── Narrow bind mounts (belt-and-suspenders for credential isolation) ──
+      # Instead of mounting the full repo root (./:/app) — which would expose
+      # .env, docker-compose secrets, and .git — we mount only the directories
+      # the container actually needs at runtime.  The .env file (which holds
+      # ANTHROPIC_API_KEY, GITHUB_TOKEN, DB_PASSWORD, etc.) is intentionally
+      # excluded.  Credentials reach the container only via environment
+      # variables, never via the filesystem.
+      - ./agentception:/app/agentception
+      - ./.agentception:/app/.agentception
+      - ./pyproject.toml:/app/pyproject.toml
+      - ./org-presets.yaml:/app/org-presets.yaml
+      - ./scripts:/app/scripts
+      - ./tests:/app/tests
+      - ./tools:/app/tools
+      # Linux-native node_modules — sits on top of the agentception bind mount
+      # so the container's esbuild/tsc binaries (ELF) are never replaced by the
+      # host's macOS binaries.  Populated from the image layer on first run via
+      # Docker's volume-init copy (image content wins when the named volume is
+      # empty).
       - node_modules:/app/node_modules
       # Agent worktrees: bind-mount the host directory into the container so that
       # git worktrees created inside the container are immediately visible to Cursor
@@ -121,17 +171,14 @@ services:
       - "host.docker.internal:host-gateway"
     networks:
       - agentception-net
-    command: >
-      sh -c 'printf "nameserver 127.0.0.11\nnameserver 1.1.1.1\nnameserver 8.8.8.8\noptions ndots:0 timeout:3 attempts:1 use-vc\n" > /etc/resolv.conf &&
-      cd /app &&
-      sass --style=compressed --no-source-map agentception/static/scss/app.scss agentception/static/app.css &&
-      npm run build:js &&
-      (alembic -c agentception/alembic.ini upgrade head ||
-        (echo "[startup] alembic failed, retrying in 5s" && sleep 5 && alembic -c agentception/alembic.ini upgrade head)) &&
-      exec uvicorn agentception.app:app --host 0.0.0.0 --port 10003'
+    # The startup command is the entrypoint's $@ argument — uvicorn.
+    # All privileged setup (resolv.conf, sass/npm builds, alembic, chown) is
+    # handled by /entrypoint.sh before gosu drops to the agentception user.
     depends_on:
       postgres:
         condition: service_healthy
+      proxy:
+        condition: service_started
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:10003/health"]
       interval: 30s

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -17,7 +17,10 @@ AgentCeption is an orchestration engine that calls external APIs, executes shell
 | File tool path sandbox | **Enforced** | Reads restricted to worktree + repo root; writes restricted to worktree only |
 | Prompt injection | **Hardened** | System prompt explicitly warns agents to treat repo content as untrusted |
 | Agent wall-clock timeout | **Enforced** | `AGENT_MAX_WALL_SECONDS` (default 2 h) cancels runaway loops |
-| Docker container privileges | **Hardened** | `no-new-privileges`, capability drop, minimal capability re-add |
+| Docker container user | **Hardened** | `entrypoint.sh` drops from root → UID 1001 (`agentception`) via `gosu` before starting uvicorn |
+| Docker container privileges | **Hardened** | `no-new-privileges`, `cap_drop: ALL`, minimal capability re-add |
+| Repo bind mount | **Hardened** | Only source subdirectories mounted; `.env` and secrets are never present in the container filesystem |
+| Egress proxy | **Enforced** | `tinyproxy` sidecar with strict domain allowlist; all agent HTTP/HTTPS goes through it |
 | Qdrant (vector store) | **Localhost-only by default** | Docker binds to `127.0.0.1:6335` |
 
 ---
@@ -277,26 +280,104 @@ services:
 
 ## Docker Container Hardening
 
-`docker-compose.yml` applies container security hardening:
+### Non-root process user
+
+`scripts/entrypoint.sh` implements a two-phase startup:
+
+1. **Root phase** — writes `/etc/resolv.conf`, compiles SCSS/JS assets, runs Alembic migrations, and fixes ownership of mutable mount points (`/worktrees`, `/root/.cache/huggingface`).
+2. **Unprivileged phase** — `exec gosu agentception "$@"` drops to UID 1001 (`agentception` user) for the long-running `uvicorn` process. Every Python coroutine, agent loop iteration, and tool call runs as this non-root user.
+
+`gosu` is a purpose-built setuid helper (analogous to `sudo -u` but signal-transparent and without shell overhead). After the `exec`, no process in the container runs as root.
+
+The `agentception` user is created in the Dockerfile:
+
+```dockerfile
+RUN groupadd -g 1001 agentception \
+    && useradd -r -u 1001 -g agentception -m -d /home/agentception -s /bin/bash agentception
+```
+
+### Capability model
 
 ```yaml
 security_opt:
   - no-new-privileges:true   # prevents privilege escalation via setuid binaries
 cap_drop:
-  - ALL                      # drop all capabilities
+  - ALL                      # drop all capabilities at the container level
 cap_add:
-  - CHOWN                    # needed for file ownership operations
-  - SETGID
-  - SETUID
-  - DAC_OVERRIDE
-  - FOWNER
+  - CHOWN                    # needed for entrypoint chown of /worktrees and model cache
+  - SETGID                   # needed for gosu to switch GID
+  - SETUID                   # needed for gosu to switch UID
+  - DAC_OVERRIDE             # needed for sass/npm writes during root phase
+  - FOWNER                   # needed for git operations in worktrees
 ```
 
-**Remaining risks to be aware of:**
+After gosu drops to UID 1001, these capabilities remain in the bounding set but `no-new-privileges` prevents the non-root process from using `SETUID`/`SETGID` to re-acquire root.
 
-- The container runs as `root` (no `USER` directive in the Dockerfile). For production deployments, create a non-root user and switch to it.
-- `./:/app` bind-mounts the full repository (including `.env`) into the container. The file-tool path sandbox prevents agents from reading `/app/.env` via tool calls, but a shell command like `cat /app/.env` would succeed. The secret-redaction layer strips credential values from shell output before they reach the agent.
-- The container has full internet access. Network egress restrictions (e.g. iptables rules or an egress proxy) are recommended for high-security deployments.
+### Narrow bind mounts (`.env` isolation)
+
+Instead of mounting the full repository root (`./:/app`) — which would expose `.env`, `docker-compose.yml` secrets, `.git`, and other sensitive files — only the directories the container needs at runtime are mounted:
+
+```yaml
+volumes:
+  - ./agentception:/app/agentception   # Python source, templates, static
+  - ./.agentception:/app/.agentception # generated role prompt files
+  - ./pyproject.toml:/app/pyproject.toml
+  - ./org-presets.yaml:/app/org-presets.yaml
+  - ./scripts:/app/scripts
+  - ./tests:/app/tests
+  - ./tools:/app/tools
+```
+
+**Not mounted** (intentionally excluded):
+
+| File / Directory | Why excluded |
+|-----------------|-------------|
+| `.env` | Contains `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `DB_PASSWORD` |
+| `docker-compose*.yml` | Contains environment variable references to secrets |
+| `.git/` | Contains git objects and config (no runtime need) |
+| `Dockerfile` | Build-time artifact; no runtime need |
+| `node_modules/` | Served from a named volume (ELF binaries); never from the host |
+| `AGENTS.md`, `README.md` | Documentation; no runtime need |
+
+Credentials reach the container **only via environment variables** (injected from the host shell or Docker secrets), never via the filesystem.
+
+---
+
+## Egress Proxy
+
+A `tinyproxy` sidecar container (`agentception-proxy`) enforces a domain allowlist for all outbound HTTP/HTTPS traffic from the `agentception` container.
+
+### How it works
+
+The `agentception` container has `HTTP_PROXY=http://proxy:8888` and `HTTPS_PROXY=http://proxy:8888` set. Every HTTP/HTTPS client that honours these environment variables — including Python `httpx`, `requests`, `curl`, `git`, `npm`, and the `gh` CLI — routes its connections through tinyproxy. For HTTPS, tinyproxy handles the `CONNECT` method: it checks the target hostname against the allowlist, then opens a transparent TCP tunnel if allowed (the TLS payload is never inspected).
+
+If the target domain is NOT in the allowlist, tinyproxy returns `HTTP 403 Filtered` and the connection is refused before a single byte of data leaves the Docker network.
+
+### Allowed domains
+
+| Domain pattern | Purpose |
+|---------------|---------|
+| `api.anthropic.com` | LLM API calls |
+| `api.github.com`, `github.com`, `*.githubusercontent.com`, `codeload.github.com` | GitHub API, git push/fetch, gh CLI |
+| `registry.npmjs.org`, `cdn.jsdelivr.net` | NPM package installs |
+| `huggingface.co`, `cdn-lfs*.huggingface.co`, `cdn-lfs-us-1.hf.co` | ONNX model downloads (first run) |
+| `files.pythonhosted.org`, `pypi.org` | pip installs in agent worktrees |
+| `1.1.1.1`, `cloudflare.com` | Cloudflare DNS |
+
+The allowlist lives in `scripts/tinyproxy/filter` (one regex per line). Review and audit every addition.
+
+### Bypass configuration
+
+`NO_PROXY=localhost,127.0.0.1,postgres,qdrant,host.docker.internal,::1` exempts internal Docker services from proxy routing. Connections to `postgres` (SQLAlchemy) and `qdrant` (vector store) are direct; they do not go through tinyproxy.
+
+### Limitation
+
+Tinyproxy intercepts only processes that honour `*_PROXY` environment variables. A process that opens a raw TCP socket without consulting the proxy env vars would bypass the allowlist. This vector is mitigated by:
+1. The shell denylist (blocks `/dev/tcp`, `nc -e`, reverse shells)
+2. The fact that uvicorn and all agent code use standard HTTP client libraries
+3. The non-root user reducing the surface area for privilege escalation
+
+For a fully locked-down deployment, combine the proxy with host-level iptables rules that drop traffic from the container's Docker network to anything other than `proxy:8888`.
 
 ---
 
@@ -309,12 +390,19 @@ This is an internal developer tool, not a multi-tenant SaaS. The threat model is
 | Attacker on the same machine | `AC_API_KEY` |
 | Attacker on the network (public server) | `AC_API_KEY` + TLS reverse proxy |
 | Agent loop runs destructive commands | Shell denylist |
-| Agent escapes worktree to read secrets | File-tool path sandbox |
-| Agent reads secrets via shell command | Secret redaction layer strips values from output |
+| Agent escapes worktree to read secrets via file tool | File-tool path sandbox |
+| Agent reads secrets via shell command | Secret redaction layer strips values from all shell output |
+| `.env` accessible inside container | Narrow bind mounts exclude `.env` — it never exists in the container filesystem |
+| Agent exfiltrates data to attacker-controlled URL | Egress proxy allowlist rejects non-allowlisted domains |
+| Agent escapes container, gains root | Non-root process user (UID 1001) + `no-new-privileges` |
 | LLM intercepts your API key in transit | HTTPS (httpx enforces TLS) |
-| Code chunks contain secrets | Indexer skips `.env`, `override.yml`; see note above |
+| Code chunks contain secrets | Indexer skips `.env`, `override.yml` |
 | Prompt injection via malicious repo content | System-prompt security contract + agent instruction hierarchy |
 | Runaway agent loop (cost explosion) | Hard iteration limit + wall-clock timeout |
-| Privilege escalation in container | `no-new-privileges` + capability drop |
+| Container privilege escalation | `no-new-privileges` + `cap_drop: ALL` + minimal caps |
 
-Prompt injection (malicious content in indexed files influencing agent behavior) is partially mitigated by the explicit security contract in the system prompt. The agent is instructed to treat all repository content as untrusted data and to ignore instructions embedded in it. Additionally, reviewing agent steps in the Build dashboard before they complete provides human oversight.
+**Residual risks (accepted for a developer tool):**
+
+- Raw TCP socket connections (bypassing `*_PROXY` env vars) are not blocked at the network level. Mitigated by the shell denylist.
+- Agents can still read environment variables from the process environment via Python (`os.environ`). The secret redaction layer strips these from shell tool output; direct Python access within the agent's own process is harder to intercept. Mitigation: secrets are injected per-run and never baked into the image.
+- The container still has outbound access to the allowlisted domains. A compromised agent could exfiltrate data to `api.github.com` (e.g. by creating a GitHub issue). This is a residual risk inherent to any agent that needs to push code and create PRs.

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Container entrypoint.  Runs as root, performs privileged setup, then drops
+# to the non-root `agentception` user (UID 1001) for the long-running server
+# process.  All code executed after the exec is fully unprivileged.
+#
+# Belt-and-suspenders design:
+#   1. Privileged phase (root): write resolv.conf, compile static assets,
+#      run DB migrations, chown mutable volumes.
+#   2. Unprivileged phase: exec gosu → agentception → "$@" (uvicorn by default).
+#
+# This pattern follows the Docker best practice of keeping the PID-1 server
+# process non-root even when container setup requires transient root access.
+set -euo pipefail
+
+# ── 1. DNS resolver ──────────────────────────────────────────────────────────
+# Override the Docker embedded resolver with Cloudflare + Google DNS.
+# Docker's embedded DNS sometimes returns dead GitHub nodes; 1.1.1.1 avoids
+# that by performing its own health-aware routing.  We write this before any
+# network operations so all subsequent calls use the correct resolvers.
+printf 'nameserver 127.0.0.11\nnameserver 1.1.1.1\nnameserver 8.8.8.8\noptions ndots:0 timeout:3 attempts:1 use-vc\n' \
+  > /etc/resolv.conf
+
+# ── 2. Static asset compilation ──────────────────────────────────────────────
+# The bind-mounted source directories appear as root-owned inside the container
+# on macOS/Docker Desktop (VirtioFS maps host UID 0 → container root).
+# Compile as root so we can write to the bind-mounted static output paths.
+cd /app
+echo "[entrypoint] compiling SCSS …"
+sass --style=compressed --no-source-map \
+  agentception/static/scss/app.scss agentception/static/app.css
+
+echo "[entrypoint] building JS bundle …"
+npm run build:js
+
+# ── 3. Database migrations ───────────────────────────────────────────────────
+# Retry once on transient connection failure (Postgres may still be
+# initialising on the first `docker compose up`).
+echo "[entrypoint] running Alembic migrations …"
+alembic -c agentception/alembic.ini upgrade head || {
+  echo "[entrypoint] alembic failed, retrying in 5 s …"
+  sleep 5
+  alembic -c agentception/alembic.ini upgrade head
+}
+
+# ── 4. Fix ownership of mutable mount points ─────────────────────────────────
+# /worktrees  — bind-mount of ${HOME}/.agentception/worktrees/agentception on
+#   the host.  On macOS/Docker Desktop (VirtioFS) chown inside the container
+#   propagates to the host as the host user's UID — this is intentional and
+#   safe.  The agentception user must be able to create git worktree
+#   directories here.
+echo "[entrypoint] fixing ownership of /worktrees …"
+chown agentception:agentception /worktrees
+
+# /root/.cache/huggingface — named volume (agentception-model-cache).
+#   FastEmbed downloads ONNX models on first dispatch; the agentception user
+#   must be able to write to this directory.
+echo "[entrypoint] fixing ownership of model cache …"
+chown -R agentception:agentception /root/.cache/huggingface
+
+# ── 5. Drop to non-root user ─────────────────────────────────────────────────
+# gosu is a purpose-built setuid helper (analogous to sudo -u but without the
+# shell overhead).  It sets UID/GID and execs "$@" — typically uvicorn — as
+# PID 1's effective non-root user.  After this line no process in the
+# container runs as root.
+echo "[entrypoint] dropping privileges → agentception (uid=$(id -u agentception))"
+exec gosu agentception "$@"

--- a/scripts/tinyproxy/Dockerfile.proxy
+++ b/scripts/tinyproxy/Dockerfile.proxy
@@ -1,0 +1,15 @@
+FROM debian:bookworm-slim
+
+# Install tinyproxy from Debian's official repo — no third-party base images.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tinyproxy \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
+COPY filter         /etc/tinyproxy/filter
+
+EXPOSE 8888
+
+# Run tinyproxy in the foreground so Docker captures its logs and detects crashes.
+CMD ["tinyproxy", "-d", "-c", "/etc/tinyproxy/tinyproxy.conf"]

--- a/scripts/tinyproxy/filter
+++ b/scripts/tinyproxy/filter
@@ -1,0 +1,38 @@
+# Tinyproxy domain allowlist — regular expressions matched against HOST:PORT
+# (for HTTPS CONNECT tunnels) and full URL (for plain HTTP requests).
+#
+# FilterDefaultDeny Yes means: if a domain does NOT match any pattern here,
+# tinyproxy returns HTTP 403 Forbidden and the connection is refused.
+#
+# Keep this list minimal.  Every addition increases the potential exfiltration
+# surface.  Audit any new addition before merging.
+
+# ── Anthropic API (LLM calls) ────────────────────────────────────────────────
+api\.anthropic\.com
+
+# ── GitHub (API, git push/fetch, gh CLI, GitHub MCP server) ──────────────────
+api\.github\.com
+github\.com
+objects\.githubusercontent\.com
+codeload\.github\.com
+raw\.githubusercontent\.com
+uploads\.github\.com
+
+# ── NPM registry (JavaScript package installs and agent npm commands) ─────────
+registry\.npmjs\.org
+cdn\.jsdelivr\.net
+
+# ── HuggingFace (ONNX model downloads — jina-v2, BM25, bge-reranker) ─────────
+# First-run download only; subsequent runs serve from the model_cache volume.
+huggingface\.co
+cdn-lfs\.huggingface\.co
+cdn-lfs-us-1\.huggingface\.co
+cdn-lfs-us-1\.hf\.co
+
+# ── Python Package Index (pip install inside agent worktrees) ─────────────────
+files\.pythonhosted\.org
+pypi\.org
+
+# ── Cloudflare DNS-over-HTTPS (used when ndots resolution falls back) ─────────
+1\.1\.1\.1
+cloudflare\.com

--- a/scripts/tinyproxy/tinyproxy.conf
+++ b/scripts/tinyproxy/tinyproxy.conf
@@ -1,0 +1,36 @@
+# tinyproxy.conf -- AgentCeption egress proxy
+#
+# Restricts outbound HTTP/HTTPS from the agentception container to a
+# known-good allowlist of upstream services.  Any domain NOT in
+# scripts/tinyproxy/filter is rejected with HTTP 403.
+#
+# Limitation: only intercepts traffic from processes that honour *_PROXY env
+# vars (Python httpx/requests, curl, git, npm, gh CLI).  Raw TCP connections
+# that bypass proxy env vars are mitigated by the shell denylist instead.
+
+# Listen on all interfaces so other containers on the Docker network can reach us.
+Port 8888
+Listen 0.0.0.0
+
+# Keep at 600 for long-running SSE / streaming API responses.
+Timeout 600
+
+MaxClients 32
+
+# Allow connections from any container on the agentception-net Docker network.
+Allow 0.0.0.0/0
+
+# Domain allowlist (FilterDefaultDeny + Filter = allowlist mode).
+# FilterType ere: extended regular expressions for pattern matching.
+# FilterURLs On: match against HOST:PORT in CONNECT (HTTPS tunnels) and URL
+#   in plain HTTP -- so the host portion is always inspected.
+# FilterCaseSensitive Off: case-insensitive domain matching.
+# FilterDefaultDeny Yes: reject anything NOT matched by the filter file.
+Filter "/etc/tinyproxy/filter"
+FilterURLs On
+FilterType ere
+FilterCaseSensitive Off
+FilterDefaultDeny Yes
+
+# Log to stdout so Docker captures it -- no file needed.
+LogLevel Warning


### PR DESCRIPTION
## Summary

Phase 2 of the security hardening audit — addresses the three residual risks identified at the end of phase 1:

### 1. Non-root process user (`scripts/entrypoint.sh` + `Dockerfile`)

- Creates `agentception` user UID/GID 1001 in the Dockerfile via `useradd -r -u 1001`
- Installs `gosu` (purpose-built privilege-drop helper, signal-transparent unlike `su`)
- `scripts/entrypoint.sh` implements a two-phase startup:
  - **Root phase**: writes `/etc/resolv.conf`, compiles SCSS/JS, runs Alembic migrations, `chown`s `/worktrees` and model cache to `agentception:agentception`
  - **Unprivileged phase**: `exec gosu agentception "$@"` — uvicorn runs as PID 1 with UID 1001; `no-new-privileges` prevents any re-acquisition of root
- git system config adds `user.email`/`user.name` and `http.proxy` for worktree commit operations
- **Verified**: `/proc/1/status` shows `Uid: 1001` in the running container

### 2. Narrow bind mounts — `.env` never enters the container

- Replaces `./:/app` with explicit per-directory mounts: `agentception/`, `.agentception/`, `pyproject.toml`, `org-presets.yaml`, `scripts/`, `tests/`, `tools/`
- `.env`, `docker-compose*.yml`, `.git/`, `Dockerfile`, and all other sensitive files are **intentionally excluded**
- Credentials reach the container only via environment variables, never the filesystem
- **Verified**: `/app/.env` is absent in the running container
- `docker-compose.ci.yml` updated with matching narrow mounts + no-op proxy for CI

### 3. Egress allowlist proxy (`scripts/tinyproxy/`)

- `scripts/tinyproxy/Dockerfile.proxy`: builds a `tinyproxy` image from `debian:bookworm-slim` (no third-party base images)
- `scripts/tinyproxy/tinyproxy.conf`: `FilterDefaultDeny Yes` + `FilterURLs On`; domains NOT in the allowlist are TCP-rejected at the CONNECT stage
- `scripts/tinyproxy/filter`: allowlist covers `api.anthropic.com`, `*.github.com`, npm registry, HuggingFace, PyPI, Cloudflare DNS
- `agentception` service routes all HTTP/HTTPS through `http://proxy:8888` via `HTTP_PROXY`/`HTTPS_PROXY` env vars + git `http.proxy` system config
- `NO_PROXY` exempts internal Docker services: postgres, qdrant, host.docker.internal
- **Verified**: `httpx.ProxyError` for `malicious-exfil-server.io`; HTTP 200 for `api.github.com`

## Test plan

- [x] `mypy agentception/ tests/` — zero errors
- [x] `pytest test_shell_tools.py test_agent_loop.py` — 131/131 passed
- [x] `generate.py --check` — no drift
- [x] Live verification: PID 1 = UID 1001, `/app/.env` absent, egress proxy blocks unlisted domains
- [x] Both Docker images build cleanly (`docker compose build`)