### PR TITLE
fix: uncomment A/B metrics panel div in build.html

### DIFF
--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -185,7 +185,6 @@
   </div>{# /.build-columns #}
 
   <!-- ── A/B metrics panel (HTMX polled every 30s) ───────────────────────────── -->
-  <!--
   <div id="ab-metrics-panel"
        class="build-ab-metrics"
        hx-get="/api/metrics/ab"
@@ -194,7 +193,6 @@
        hx-swap="innerHTML">
     <p class="loading-placeholder">Loading A/B metrics…</p>
   </div>
-  -->
 
 </div>{# /.build-layout #}
 


### PR DESCRIPTION
## Root Cause

The `<div id="ab-metrics-panel">` in `build.html` was wrapped in an HTML comment (`<!-- ... -->`), so `HTMLParser` (Python's stdlib parser used in the test) skips its content entirely — `handle_starttag` is never called for content inside comments. This left `parser.found` as `{}`, failing:

```
assert parser.found.get("id") == "ab-metrics-panel"
AssertionError: assert None == 'ab-metrics-panel'
```

The route (`/api/metrics/ab`), router registration (`routes/api/__init__.py` line 60), and partial template (`partials/_ab_metrics.html`) were all correctly wired — only the HTML comment wrapper needed removal.

## Fix

Remove the `<!-- ... -->` wrapping the panel div. The div and its HTMX polling attributes (`hx-get`, `hx-trigger="load, every 30s"`, etc.) are now live in the page.

## Verification

```
pytest tests/test_ab_metrics_panel.py -v
3 passed in 0.54s
```