### PR TITLE
fix: MCP docs and tests — api ref, README, auth docstring, integrate.md, edge-case tests

### DIFF
--- a/agentception/routes/api/mcp.py
+++ b/agentception/routes/api/mcp.py
@@ -33,8 +33,9 @@ Notes
 - No session management: each HTTP request is stateless.
 - No server-sent events: the current MCP surface is request/response only.
   SSE streaming can be added in a future iteration when subscriptions land.
-- No authentication: the endpoint is protected only by network access controls.
-  Add API-key middleware when exposing outside a trusted network.
+- Authentication: when ``AC_API_KEY`` is set, this endpoint is protected by
+  ``ApiKeyMiddleware`` (all ``/api/*`` routes). See the Security guide for
+  client configuration.
 """
 
 from __future__ import annotations

--- a/agentception/tests/test_mcp_http.py
+++ b/agentception/tests/test_mcp_http.py
@@ -180,6 +180,26 @@ class TestMcpHttpBatch:
         assert len(body) == 1
         assert body[0]["id"] == 99
 
+    @pytest.mark.anyio
+    async def test_batch_one_invalid_item_one_valid_returns_mixed_results(self, app: FastAPI) -> None:
+        """Batch with one non-dict item and one valid request returns list of 2: error + success."""
+        batch: list[JsonValue] = [
+            42,
+            _rpc("ping", req_id=1),
+        ]
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=batch)
+        assert r.status_code == 200
+        body = r.json()
+        assert isinstance(body, list)
+        assert len(body) == 2
+        first, second = body[0], body[1]
+        assert "error" in first
+        assert first["error"]["code"] == -32600
+        assert "result" in second
+        assert second["id"] == 1
+        assert second["result"] == {}
+
 
 # ---------------------------------------------------------------------------
 # Error cases
@@ -228,6 +248,47 @@ class TestMcpHttpErrors:
         # handle_request_async will return an error for a non-dict input
         # (it gets wrapped correctly by _handle_single)
         assert r.status_code in (200, 400)
+
+    @pytest.mark.anyio
+    async def test_resources_read_invalid_uri_via_http(self, app: FastAPI) -> None:
+        """resources/read with unknown ac:// URI returns 200 with error in result content."""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                json=_rpc("resources/read", {"uri": "ac://unknown/path"}),
+            )
+        assert r.status_code == 200
+        body = r.json()
+        assert "result" in body
+        result = body["result"]
+        assert "contents" in result
+        contents = result["contents"]
+        assert len(contents) == 1
+        text = contents[0]["text"]
+        payload = json.loads(text)
+        assert "error" in payload
+
+    @pytest.mark.anyio
+    async def test_tools_call_missing_required_arguments_returns_error(self, app: FastAPI) -> None:
+        """tools/call with missing required arguments returns 200 with isError true in result."""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                json=_rpc(
+                    "tools/call",
+                    {"name": "build_claim_run", "arguments": {}},
+                ),
+            )
+        assert r.status_code == 200
+        body = r.json()
+        assert "result" in body
+        result = body["result"]
+        assert result.get("isError") is True
+        content = result.get("content", [])
+        assert len(content) == 1
+        text = content[0]["text"]
+        payload = json.loads(text)
+        assert "error" in payload
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/tests/test_mcp_resources.py
+++ b/agentception/tests/test_mcp_resources.py
@@ -539,6 +539,14 @@ async def test_read_resource_batch_tree_unknown_uri_returns_not_found() -> None:
     assert "error" in payload
 
 
+@pytest.mark.anyio
+async def test_read_resource_batch_tree_malformed_empty_batch_id_returns_not_found() -> None:
+    """ac://batches//tree (empty batch_id) yields only one path segment and returns not-found."""
+    result = await read_resource("ac://batches//tree")
+    payload = _content(result)
+    assert "error" in payload
+
+
 # ---------------------------------------------------------------------------
 # ac://system/dispatcher
 # ---------------------------------------------------------------------------

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,7 @@ agentception/
       cognitive_arch.py → /cognitive-arch, /cognitive-arch/{id}
     api/
       dispatch.py    → /api/dispatch/* (issue, label, context, prompt)
+      mcp.py         → POST /api/mcp (MCP JSON-RPC 2.0)
       runs.py        → /api/runs/* (pending, acknowledge, children, step, …)
       agent_run.py   → /api/runs/{run_id}/execute (Cursor-free dispatch)
       system.py      → /api/system/index-codebase, /api/system/search
@@ -126,7 +127,6 @@ agentception/
   mcp/
     server.py        → MCP tool definitions (plan_*, build_*, …)
     stdio_server.py  → stdio transport for Cursor integration
-    http_server.py   → HTTP Streamable MCP transport (/api/mcp)
   static/
     app.js           → Compiled JS bundle (never edit directly)
     app.css          → Compiled CSS bundle (never edit directly)

--- a/docs/guides/integrate.md
+++ b/docs/guides/integrate.md
@@ -1,6 +1,6 @@
 # Integration Guide
 
-AgentCeption exposes a full [Model Context Protocol](https://modelcontextprotocol.io/) server that Cursor, Claude, and any MCP-compatible client can use to invoke tools, read resources, and fetch prompts directly. The server supports both a **stdio transport** (for Cursor's native MCP panel) and an **HTTP transport** (`POST /api/mcp`, JSON-RPC 2.0).
+AgentCeption exposes a full [Model Context Protocol](https://modelcontextprotocol.io/) server that Cursor, Claude, and any MCP-compatible client can use to **invoke tools** (build, GitHub, plan, log), **read resources** (runs, batches, system state, cognitive arch), and **fetch prompts** (role definitions, task briefings) directly. The server supports both a **stdio transport** (for Cursor's native MCP panel) and an **HTTP transport** (`POST /api/mcp`, JSON-RPC 2.0).
 
 For the complete catalogue of every tool, resource URI, resource template, and prompt — including JSON-RPC error codes — see the reference document:
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -25,6 +25,7 @@ URLs are semantic: each path segment narrows the resource.
 /ship/{initiative}        ← Ship board for a specific initiative
 /api/plan/*               ← Plan pipeline (draft, file, launch)
 /api/dispatch/*           ← Agent dispatch (issue, label, context, prompt)
+/api/mcp                  ← MCP JSON-RPC 2.0 (tools, resources, prompts)
 /api/runs/{run_id}/*      ← Agent run lifecycle (step, blocker, done, …)
 /api/ship/{initiative}/*  ← Ship-level actions (advance phase)
 /api/agents/*             ← Agent pipeline state
@@ -116,6 +117,12 @@ Events and thoughts are merged by `recorded_at` so the client sees the same orde
 ## JSON API Routes
 
 All API routes are prefixed `/api`.
+
+### MCP — `POST /api/mcp`
+
+The [Model Context Protocol](https://modelcontextprotocol.io/) server is exposed over HTTP at `POST /api/mcp`. Clients send JSON-RPC 2.0 requests (single object or batch array); the server returns JSON-RPC 2.0 responses. Supported methods include `initialize`, `ping`, `tools/list`, `tools/call`, `resources/list`, `resources/templates/list`, `resources/read`, `prompts/list`, and `prompts/get`. Notifications (requests without `id`) return `202 Accepted` with no body.
+
+**Authentication:** When `AC_API_KEY` is set, the endpoint is protected by `ApiKeyMiddleware` like all `/api/*` routes. See the [Security Guide](../guides/security.md) and [MCP Reference](mcp.md) for transport details, client configuration, and the full tool/resource/prompt catalogue.
 
 ### Plan pipeline — `/api/plan/*`
 


### PR DESCRIPTION
Addresses the five MCP review gaps:

1. **API reference** — Add `POST /api/mcp` to URL taxonomy and a short MCP section with auth note and links to Security guide and MCP reference.
2. **docs/README** — Fix directory structure: MCP HTTP route lives in `routes/api/mcp.py`, not `mcp/http_server.py`; list `mcp.py` under `routes/api/`.
3. **routes/api/mcp.py** — Docstring now states the endpoint is protected by `ApiKeyMiddleware` when `AC_API_KEY` is set and points to the Security guide.
4. **integrate.md** — Opening paragraph now spells out what the MCP server provides (invoke tools, read resources, fetch prompts).
5. **Edge-case tests** — `test_mcp_http`: batch with one invalid item + one valid request; `resources/read` with invalid URI via HTTP; `tools/call` with missing required args. `test_mcp_resources`: malformed template `ac://batches//tree` returns not-found.