### PR TITLE
fix: full Cursor decoupling — taxonomy and implementation

### DIFF
--- a/.agentception/agent-command-policy.md
+++ b/.agentception/agent-command-policy.md
@@ -4,6 +4,9 @@ This document defines which shell commands agents may run without confirmation,
 which require caution, and which are forbidden. Every parallel-agent workflow
 reads this policy before executing any command.
 
+> **When using Cursor as the MCP client:** The sections below describe Cursor's
+> allowlist and sandbox. Other MCP clients have their own mechanisms; adapt as needed.
+
 > **Why this exists:** With 5–8 agents running concurrently, per-command
 > confirmation dialogs create severe friction. This policy eliminates that
 > friction for safe commands while preserving human oversight for destructive ones.

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ htmlcov/
 .docker/
 docker-compose.override.yml
 
+# IDE — AgentCeption does not read or write this directory
+.cursor/
+
 # IDE
 .idea/
 .vscode/

--- a/agentception/config.py
+++ b/agentception/config.py
@@ -35,11 +35,9 @@ logger = logging.getLogger(__name__)
 class TaskRunnerChoice(str, enum.Enum):
     """Task runner backend for agent execution.
 
-    Determines which system executes agent tasks:
-    - ``cursor``: Cursor IDE with Composer agent
-    - ``anthropic``: Direct Anthropic API calls (default)
+    Agent tasks are executed by the Cursor-free loop (direct API calls).
+    Currently the only supported value is ``anthropic`` (default).
     """
-    cursor = "cursor"
     anthropic = "anthropic"
 
 
@@ -140,7 +138,7 @@ class AgentCeptionSettings(BaseSettings):
     Inside Docker, ``worktrees_dir`` is the container path (``/worktrees``).
     ``host_worktrees_dir`` is the corresponding path on the developer's machine
     (e.g. ``~/.agentception/worktrees``), used to generate paths that the
-    user can open directly in Cursor.
+    user can open in an IDE on the host.
     Set via ``HOST_WORKTREES_DIR`` in docker-compose.override.yml.
     """
     repo_dir: Path = Path.cwd()
@@ -150,8 +148,8 @@ class AgentCeptionSettings(BaseSettings):
     Inside Docker, ``repo_dir`` is the container path (``/app``).
     ``host_repo_dir`` is the corresponding path on the developer's machine
     (e.g. ``/Users/alice/dev/myproject``), used to generate ``ROLE_FILE``
-    and ``HOST_ROLE_FILE`` paths that Cursor agents running on the host can
-    actually read.  Set via ``HOST_REPO_DIR`` in docker-compose or .env.
+    and ``HOST_ROLE_FILE`` paths that agents running on the host can read.
+    Set via ``HOST_REPO_DIR`` in docker-compose or .env.
     """
     gh_repo: str = "cgcardona/agentception"
     poll_interval_seconds: int = 5
@@ -336,6 +334,11 @@ class AgentCeptionSettings(BaseSettings):
     tools are unavailable in the agent loop.
     """
     ac_task_runner: TaskRunnerChoice = TaskRunnerChoice.anthropic
+    """Task runner backend for agent execution.
+
+    Set via ``AC_TASK_RUNNER`` env var.  Valid value: ``anthropic`` (default).
+    Agent tasks run via the Cursor-free loop (direct Anthropic or local LLM API).
+    """
     ac_min_turn_delay_secs: float = 0.5
     """Minimum seconds between consecutive LLM calls in the agent loop.
 
@@ -346,12 +349,6 @@ class AgentCeptionSettings(BaseSettings):
     if observing 429 rate-limit errors in the logs.
 
     Set via ``AC_MIN_TURN_DELAY_SECS`` env var.
-    """
-    """Task runner backend for agent execution.
-    
-    Set via ``AC_TASK_RUNNER`` env var.  Valid values: ``cursor``, ``anthropic``.
-    Defaults to ``anthropic`` when unset.  Determines which system executes
-    agent tasks — Cursor IDE with Composer agent or direct Anthropic API calls.
     """
     # ── Qdrant / code search ────────────────────────────────────────────────
     qdrant_url: str = "http://agentception-qdrant:6333"

--- a/agentception/db/models.py
+++ b/agentception/db/models.py
@@ -19,7 +19,7 @@ ACPullRequest
     Mirror of a GitHub PR, same hash-diff strategy as ACIssue.
 
 ACAgentMessage
-    One row per message in an agent's Cursor transcript.  Written async so it
+    One row per message in an agent's transcript.  Written async so it
     never blocks the tick loop.  Enables full-text search and heuristics.
 
 ACPipelineSnapshot
@@ -314,7 +314,7 @@ class ACPullRequest(Base):
 
 
 class ACAgentMessage(Base):
-    """One message from a Cursor agent transcript.
+    """One message from an agent transcript.
 
     Written asynchronously so reading + persisting transcripts never blocks
     the 5-second tick loop.  Enables full-text search and ML feature extraction.

--- a/agentception/db/queries/messages.py
+++ b/agentception/db/queries/messages.py
@@ -23,7 +23,8 @@ async def get_agent_thoughts_tail(
     """Return transcript messages for *run_id* with ``sequence_index > after_seq``.
 
     Defaults to thinking + assistant messages — the raw chain-of-thought stream
-    captured from Cursor transcripts by the poller.  Falls back to ``[]`` on error.
+    stored by the agent loop (and optionally ingested from external sources).
+    Falls back to ``[]`` on error.
     """
     try:
         async with get_session() as session:

--- a/agentception/models/__init__.py
+++ b/agentception/models/__init__.py
@@ -395,14 +395,15 @@ class ProjectConfig(BaseModel):
     service was started against — e.g. in a multi-repo setup.
     ``worktrees_dir`` supports ``~`` expansion.
 
-    ``cursor_project_id`` is the Cursor project slug used to locate transcript files.
+    ``ide_project_id`` is an optional client/IDE project slug (e.g. for transcript
+    or workspace lookup in an MCP client). Not used by the server at runtime.
     """
 
     name: str
     gh_repo: str
     repo_dir: str | None = None
     worktrees_dir: str | None = None
-    cursor_project_id: str | None = None
+    ide_project_id: str | None = None
 
 
 class PipelineConfig(BaseModel):
@@ -468,7 +469,7 @@ class SwitchProjectRequest(BaseModel):
 
 
 class RoleMeta(BaseModel):
-    """Metadata for a managed role or cursor configuration file.
+    """Metadata for a managed role file.
 
     Used by the Role Studio API (AC-301) to describe each file without
     returning full content — callers fetch content separately via GET /api/roles/{slug}.

--- a/agentception/readers/__init__.py
+++ b/agentception/readers/__init__.py
@@ -3,6 +3,6 @@ from __future__ import annotations
 """Readers sub-package for AgentCeption.
 
 Each reader is responsible for collecting raw data from a specific source
-(filesystem worktrees, Cursor transcript files, GitHub API). The poller
+(filesystem worktrees, transcript storage, GitHub API). The poller
 orchestrates them into a unified ``PipelineState``.
 """

--- a/agentception/readers/llm_phase_planner.py
+++ b/agentception/readers/llm_phase_planner.py
@@ -13,8 +13,8 @@ Architecture note
 -----------------
 MCP is NOT involved in this module.  The browser -> AgentCeption -> Anthropic
 loop is entirely self-contained.  MCP enters only after the user approves the
-YAML and a coordinator worktree is spawned -- the coordinator agent (in Cursor)
-calls ``plan_get_labels()`` and similar tools as it files GitHub issues.
+YAML and a coordinator worktree is spawned — the coordinator agent (e.g. in an
+MCP client) calls ``plan_get_labels()`` and similar tools as it files GitHub issues.
 """
 
 import logging

--- a/agentception/routes/roles.py
+++ b/agentception/routes/roles.py
@@ -185,7 +185,7 @@ def _resolve_slug(slug: str) -> str:
     return rel_path
 
 
-@router.get("", summary="List all managed role and cursor files")
+@router.get("", summary="List all managed role files")
 async def list_roles() -> list[RoleMeta]:
     """Return metadata for every file in the managed allowlist.
 

--- a/agentception/routes/ui/agents.py
+++ b/agentception/routes/ui/agents.py
@@ -532,12 +532,10 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
 
     Data sources (in priority order):
     1. In-memory state — live status, branch, issue number from the poller.
-    2. Filesystem transcript — Cursor JSONL file for the full message log.
-    3. Postgres ``ac_agent_runs`` — historical run metadata and status.
-    4. Postgres ``ac_agent_messages`` — stored messages when no transcript
-       file is accessible (e.g. after the worktree is removed).
-    5. Postgres ``ac_agent_events`` — structured MCP events for the timeline.
-    6. GitHub API — issue body, PR checks, PR reviews (fetched in parallel).
+    2. Postgres ``ac_agent_runs`` — historical run metadata and status.
+    3. Postgres ``ac_agent_messages`` — transcript messages (stored by the agent loop).
+    4. Postgres ``ac_agent_events`` — structured MCP events for the timeline.
+    5. GitHub API — issue body, PR checks, PR reviews (fetched in parallel).
 
     Returns HTTP 404 only when the agent is absent from both in-memory state
     and the Postgres history.

--- a/agentception/routes/ui/docs.py
+++ b/agentception/routes/ui/docs.py
@@ -19,7 +19,7 @@ router = APIRouter()
 _AGENTCEPTION_DIR = Path(_settings.repo_dir) / ".agentception"
 
 
-def _scan_cursor_docs() -> list[dict[str, str]]:
+def _scan_agentception_docs() -> list[dict[str, str]]:
     """Auto-discover all markdown files in .agentception/ sorted alphabetically.
 
     Returns a list of {slug, label, file} dicts. Label is derived from the
@@ -41,7 +41,7 @@ def _render_doc(slug: str) -> tuple[str | None, str | None, str | None]:
     Returns (label, content_html, error). ``content_html`` is Markdown
     rendered to safe HTML; ``error`` is set on read failure.
     """
-    docs = _scan_cursor_docs()
+    docs = _scan_agentception_docs()
     doc_meta = next((d for d in docs if d["slug"] == slug), None)
     if doc_meta is None:
         return None, None, f"Unknown doc: {slug}"
@@ -58,7 +58,7 @@ def _render_doc(slug: str) -> tuple[str | None, str | None, str | None]:
 @router.get("/docs", response_class=HTMLResponse)
 async def docs_index(request: Request) -> Response:
     """Redirect to the first available doc."""
-    docs = _scan_cursor_docs()
+    docs = _scan_agentception_docs()
     if docs:
         return RedirectResponse(url=f"/docs/{docs[0]['slug']}", status_code=302)
     raise HTTPException(status_code=404, detail="No .agentception/ docs found")
@@ -80,7 +80,7 @@ async def docs_viewer(request: Request, slug: str) -> HTMLResponse:
             "error": error,
             "available_docs": [
                 {"slug": d["slug"], "label": d["label"]}
-                for d in _scan_cursor_docs()
+                for d in _scan_agentception_docs()
             ],
         },
     )

--- a/agentception/templates/config.html
+++ b/agentception/templates/config.html
@@ -342,9 +342,9 @@
             </div>
 
             <div class="cfg-project-footer">
-              <span class="cfg-project-cursor-id"
-                    x-show="project.cursor_project_id"
-                    x-text="'cursor: ' + project.cursor_project_id"></span>
+              <span class="cfg-project-ide-id"
+                    x-show="project.ide_project_id"
+                    x-text="'Project ID: ' + project.ide_project_id"></span>
               <button class="btn btn-secondary btn-sm"
                       type="button"
                       :disabled="config.active_project === project.name || projectSaving === project.name"

--- a/agentception/templates/settings.html
+++ b/agentception/templates/settings.html
@@ -80,11 +80,6 @@
       </div>
 
       <div class="settings-row">
-        <dt class="settings-label">Cursor projects directory</dt>
-        <dd class="settings-value settings-value--mono">{{ settings.cursor_projects_dir }}</dd>
-      </div>
-
-      <div class="settings-row">
         <dt class="settings-label">Database URL</dt>
         <dd class="settings-value settings-value--mono">
           {% if settings.database_url %}

--- a/agentception/templates/transcripts.html
+++ b/agentception/templates/transcripts.html
@@ -186,7 +186,7 @@
   {% elif not error %}
   <div class="card">
     <p class="text-muted empty-state">
-      No transcripts found. Make sure the Cursor projects directory is mounted correctly.
+      No transcripts found. Check that the database is populated and the service can read transcript data.
     </p>
   </div>
   {% endif %}

--- a/agentception/tests/test_agentception_pipeline_config.py
+++ b/agentception/tests/test_agentception_pipeline_config.py
@@ -77,7 +77,7 @@ async def test_read_pipeline_config_reads_file_when_present(tmp_path: Path) -> N
 @pytest.mark.anyio
 async def test_write_pipeline_config_persists(tmp_path: Path) -> None:
     """write_pipeline_config writes the config to disk and returns it."""
-    config_file = tmp_path / ".cursor" / "pipeline-config.json"
+    config_file = tmp_path / ".agentception" / "pipeline-config.json"
     config = PipelineConfig(
         coordinator_limits=_COORD_LIMITS,
         pool_size=4,
@@ -245,7 +245,7 @@ async def test_settings_reads_active_project(tmp_path: Path) -> None:
                 "gh_repo": "cgcardona/agentception",
                 "repo_dir": str(tmp_path),
                 "worktrees_dir": "~/.agentception/worktrees/agentception",
-                "cursor_project_id": "Users-example-dev-cgcardona-example-project",
+                "ide_project_id": "Users-example-dev-cgcardona-example-project",
                 "active_labels_order": [],
             },
             {
@@ -253,7 +253,7 @@ async def test_settings_reads_active_project(tmp_path: Path) -> None:
                 "gh_repo": "acme/other",
                 "repo_dir": str(tmp_path / "other"),
                 "worktrees_dir": str(tmp_path / "other-worktrees"),
-                "cursor_project_id": "other-project-id",
+                "ide_project_id": "other-project-id",
                 "active_labels_order": [],
             },
         ],
@@ -282,7 +282,7 @@ async def test_switch_project_updates_config(tmp_path: Path) -> None:
                 "gh_repo": "cgcardona/agentception",
                 "repo_dir": "/dev/example-project",
                 "worktrees_dir": "~/.agentception/worktrees/agentception",
-                "cursor_project_id": "example-project-id",
+                "ide_project_id": "example-project-id",
                 "active_labels_order": [],
             },
             {
@@ -290,7 +290,7 @@ async def test_switch_project_updates_config(tmp_path: Path) -> None:
                 "gh_repo": "acme/other",
                 "repo_dir": "/dev/other",
                 "worktrees_dir": "~/.agentception/worktrees/other",
-                "cursor_project_id": "other-id",
+                "ide_project_id": "other-id",
                 "active_labels_order": [],
             },
         ],
@@ -320,7 +320,7 @@ async def test_switch_project_rejects_unknown_name(tmp_path: Path) -> None:
                 "gh_repo": "cgcardona/agentception",
                 "repo_dir": "/dev/example-project",
                 "worktrees_dir": "~/.agentception/worktrees/agentception",
-                "cursor_project_id": "example-project-id",
+                "ide_project_id": "example-project-id",
                 "active_labels_order": [],
             },
         ],

--- a/agentception/tests/test_config.py
+++ b/agentception/tests/test_config.py
@@ -12,7 +12,7 @@ Covers:
     when the file is well-formed.
   - AgentCeptionSettings.reload() mirrors the validator's behaviour and
     handles every error path gracefully.
-  - AC_TASK_RUNNER env var is parsed correctly and defaults to anthropic.
+  - AC_TASK_RUNNER env var is parsed correctly (anthropic only) and defaults to anthropic.
 
 Run targeted:
     pytest agentception/tests/test_config.py -v
@@ -413,13 +413,6 @@ def test_ac_task_runner_defaults_to_anthropic(tmp_path: Path, monkeypatch: pytes
     monkeypatch.delenv("AC_TASK_RUNNER", raising=False)
     s = _make_settings(tmp_path)
     assert s.ac_task_runner == TaskRunnerChoice.anthropic
-
-
-def test_ac_task_runner_cursor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """When AC_TASK_RUNNER=cursor, ac_task_runner is TaskRunnerChoice.cursor."""
-    monkeypatch.setenv("AC_TASK_RUNNER", "cursor")
-    s = _make_settings(tmp_path)
-    assert s.ac_task_runner == TaskRunnerChoice.cursor
 
 
 def test_ac_task_runner_anthropic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/agentception/tests/test_git_reader.py
+++ b/agentception/tests/test_git_reader.py
@@ -30,7 +30,7 @@ _SHOULD_NOT_MATCH = [
     "dev",
     "main",
     "feature/something",
-    "fix/something",        # Cursor fix branches are NOT agent branches
+    "fix/something",        # fix/* branches are NOT agent branches
     "feat/issue-1",         # removed — legacy naming, no longer used
     "feat/issue-42",
     "feat/brain-dump-foo",  # removed — legacy naming, no longer used

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -39,8 +39,8 @@ services:
     # Instead we remap to paths that exist unconditionally in any runner.
     # The CI runner has no .env file, so the narrow bind-mount security
     # posture from docker-compose.yml is naturally satisfied here too.
+    # AgentCeption does not use .cursor/; only gh CLI auth is remapped.
     volumes:
-      - /tmp/ci-cursor:/root/.cursor
       - /tmp/ci-gh:/root/.config/gh
       - ./agentception:/app/agentception
       - ./.agentception:/app/.agentception

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,11 +59,11 @@ services:
       REPO_DIR: ${REPO_DIR:-/app}
       WORKTREES_DIR: ${WORKTREES_DIR:-/worktrees}
       # Host-side path to the worktrees directory.  Persisted to the DB context row
-      # so spawned Cursor agents (running on the host) can find the worktree at
+      # so agents running on the host can find the worktree at
       # the same path the container created it.  Must match the worktrees volume mount.
       HOST_WORKTREES_DIR: ${HOST_WORKTREES_DIR:-${HOME}/.agentception/worktrees/agentception}
       # Host-side path to the repository root — persisted to the DB context row
-      # so Cursor agents (on the host) can resolve role files.
+      # so agents on the host can resolve role files.
       # Override via HOST_REPO_DIR in .env when the repo is not at the default.
       HOST_REPO_DIR: ${HOST_REPO_DIR:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
@@ -146,8 +146,8 @@ services:
       # empty).
       - node_modules:/app/node_modules
       # Agent worktrees: bind-mount the host directory into the container so that
-      # git worktrees created inside the container are immediately visible to Cursor
-      # agents running on the host at the same absolute path.
+      # git worktrees created inside the container are immediately visible to
+      # processes on the host (e.g. an IDE) at the same absolute path.
       - ${HOME}/.agentception/worktrees/agentception:/worktrees
       # Persist FastEmbed / HuggingFace model files across container restarts.
       # Without this volume the three ONNX models (jina-v2, BM25, bge-reranker)

--- a/docs/cursor-agent-spawning.md
+++ b/docs/cursor-agent-spawning.md
@@ -1,5 +1,7 @@
 # Cursor Agent Spawning — Empirical Reference
 
+> **Legacy:** Agents now run via the Cursor-free loop (Anthropic/local LLM API). This document is historical.
+>
 > Ground truth derived from live stress tests run 2026-03-03.  
 > No inherited assumptions. Everything here was directly observed.
 >

--- a/docs/guides/ci.md
+++ b/docs/guides/ci.md
@@ -63,7 +63,7 @@ docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v
 
 The CI override strips host-specific bind mounts that don't exist on GitHub Actions runners:
 
-- Removes the `~/.cursor` mount (Cursor is not installed on runners)
-- Removes the `~/.config/gh` mount (gh CLI auth is handled via `GITHUB_TOKEN`)
-- Remaps paths to runner-safe locations (`/root`, `/tmp`)
-- Sets `REPO_DIR=/app` (the built image already has the code at `/app`)
+- No `~/.cursor` mount — AgentCeption does not read or write the IDE config directory.
+- Remaps `~/.config/gh` to a runner-safe path (gh CLI auth is handled via `GITHUB_TOKEN`).
+- Remaps paths to runner-safe locations (`/root`, `/tmp`).
+- Sets `REPO_DIR=/app` (the built image already has the code at `/app`).

--- a/docs/guides/dispatcher-walkthrough.md
+++ b/docs/guides/dispatcher-walkthrough.md
@@ -1,6 +1,6 @@
-# Dispatcher walkthrough — run agents from Cursor (step-by-step)
+# Dispatcher walkthrough — run agents from an MCP client (step-by-step)
 
-This guide gets you from “Mission Control Idle” to agents running on the Ship board by configuring Cursor to act as the **Dispatcher**: it claims pending runs and starts the agent loop. Follow every step in order.
+This guide gets you from “Mission Control Idle” to agents running on the Ship board by configuring an MCP client to act as the **Dispatcher** (this doc uses Cursor as the example): it claims pending runs and starts the agent loop. Follow every step in order.
 
 ---
 

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -109,7 +109,7 @@ The stdio MCP server communicates over a Docker exec pipe — no TCP socket, no 
 
 ### HTTP transport (`POST /api/mcp`)
 
-The HTTP MCP transport is served at `/api/mcp` — a path under `/api/`, so it is protected by `ApiKeyMiddleware` when `AC_API_KEY` is set. Configure the key in Cursor's `mcp.json` as shown above.
+The HTTP MCP transport is served at `/api/mcp` — a path under `/api/`, so it is protected by `ApiKeyMiddleware` when `AC_API_KEY` is set. Configure the key in your MCP client's config (e.g. Cursor's `mcp.json`) as shown in the setup guide.
 
 **How it works technically:** The HTTP transport follows the [MCP 2025-03-26 Streamable HTTP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports/). Anthropic's remote MCP integration (currently in beta) can also call this endpoint directly — Claude running on Anthropic's infrastructure sends tool calls to your `POST /api/mcp` endpoint, which executes them locally and returns results. This is the mechanism that enables the Cursor-free agent loop without losing MCP capability.
 

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -175,9 +175,9 @@ See the [Cursor-Free Agent Loop guide](agent-loop.md) for full documentation.
 
 ---
 
-## Step 8 — Configure Cursor MCP (optional)
+## Step 8 — Configure MCP client (optional, e.g. Cursor)
 
-To use AgentCeption tools from Cursor, add to `~/.cursor/mcp.json`:
+To use AgentCeption tools from an MCP client (e.g. Cursor), add the server to your client's config. For Cursor, that is `~/.cursor/mcp.json`:
 
 ```json
 {
@@ -258,13 +258,13 @@ This prevents Git from text-merging compiled frontend bundles (app.css, app.css.
 
 ---
 
-## Step N — Cursor MCP setup (one-time)
+## Step N — MCP client setup (one-time, e.g. Cursor)
 
-AgentCeption exposes its planning and dispatch tools over MCP. Cursor must be configured to connect to it and, ideally, to run those tools without prompting you on every call.
+AgentCeption exposes its planning and dispatch tools over MCP. Configure your MCP client to connect to it and, ideally, to run those tools without prompting on every call. The following uses Cursor as the example client.
 
-### Connecting Cursor to AgentCeption
+### Connecting your MCP client to AgentCeption
 
-Add the following to your `~/.cursor/mcp.json` (create the file if it does not exist):
+For Cursor: add the following to your `~/.cursor/mcp.json` (create the file if it does not exist):
 
 ```json
 {

--- a/docs/plan-spec.md
+++ b/docs/plan-spec.md
@@ -22,7 +22,7 @@ User brain dump (free text)
   CodeMirror editor  ←── user reviews and edits
         │
         ▼  POST /api/plan/launch
-   Coordinator agent (Cursor / MCP)
+   Coordinator agent (MCP client, e.g. Cursor)
         │  creates GitHub issues from each PlanIssue
         ▼
   GitHub Issues tagged by phase label

--- a/docs/plans/agent-speedup.md
+++ b/docs/plans/agent-speedup.md
@@ -190,13 +190,13 @@ Uses `context_files` to inject:
 
 | Step | Phase | Owner | Status |
 |------|-------|-------|--------|
-| Update `search_codebase` tool description | 0A | Cursor | ⬜ |
-| Add batching + search-first rules to `worker-base.md.j2` | 0B/0C | Cursor | ⬜ |
-| Regenerate `.agentception/*.md` | 0 | Cursor | ⬜ |
-| PR: Phase 0 | 0 | Cursor | ⬜ |
-| `asyncio.gather` in `_dispatch_tool_calls` | 1A | Cursor | ⬜ |
-| PR: Phase 1 | 1 | Cursor | ⬜ |
-| `context_files` in `AdhocRunRequest` | 2A/2B/2C | Cursor | ⬜ |
-| PR: Phase 2 | 2 | Cursor | ⬜ |
-| Redispatch #36 | 4 | Cursor | ⬜ |
+| Update `search_codebase` tool description | 0A | MCP/IDE | ⬜ |
+| Add batching + search-first rules to `worker-base.md.j2` | 0B/0C | MCP/IDE | ⬜ |
+| Regenerate `.agentception/*.md` | 0 | MCP/IDE | ⬜ |
+| PR: Phase 0 | 0 | MCP/IDE | ⬜ |
+| `asyncio.gather` in `_dispatch_tool_calls` | 1A | MCP/IDE | ⬜ |
+| PR: Phase 1 | 1 | MCP/IDE | ⬜ |
+| `context_files` in `AdhocRunRequest` | 2A/2B/2C | MCP/IDE | ⬜ |
+| PR: Phase 2 | 2 | MCP/IDE | ⬜ |
+| Redispatch #36 | 4 | MCP/IDE | ⬜ |
 | Worktree indexing on spawn | 3A/3B/3C | AgentCeption | ⬜ |

--- a/docs/reference/cursor-decoupling-taxonomy.md
+++ b/docs/reference/cursor-decoupling-taxonomy.md
@@ -1,0 +1,159 @@
+# Cursor decoupling — taxonomy and action plan
+
+AgentCeption is **LLM-agnostic** and does not launch or depend on Cursor for agent execution. All agent runs use the Cursor-free loop (Anthropic, Ollama, or other backends). This document is a full sweep of every Cursor reference in the codebase and a taxonomy for decoupling.
+
+**Principles:**
+
+- **Keep (acceptable):** Cursor as one possible *client* for MCP (like Claude Desktop). Docs can say "e.g. Cursor" where they explain where users put `mcp.json`. Project files `.cursorrules` / `.cursorignore` are IDE-specific and live in the repo; we don't depend on them at runtime.
+- **Remove or reword:** Any code path, config, or doc that implies Cursor is required or that we read/write the `.cursor/` directory. No `TaskRunnerChoice.cursor`, no `cursor_project_id` in our data model unless we generalize it. No naming that suggests ".cursor" is our config location.
+
+---
+
+## 1. Taxonomy
+
+| Tier | Description | Action |
+|------|-------------|--------|
+| **A. Runtime / config coupling** | Code or config that reads/writes `.cursor/` or branches on "Cursor" as execution backend | **Remove or generalize** |
+| **B. Data model / API** | Fields or endpoints named after Cursor (e.g. `cursor_project_id`, "cursor files") | **Rename or drop** |
+| **C. Naming / comments** | Function or variable names, docstrings, or comments that say "cursor" but mean ".agentception" or "IDE" | **Rename / reword** |
+| **D. Documentation — MCP client** | Docs that tell users to edit `~/.cursor/mcp.json` or "restart Cursor" | **Keep as "e.g. Cursor"** — MCP is client-agnostic; Cursor is one client |
+| **D. Documentation — Cursor-specific** | Docs that describe Cursor sandbox, allowlist, or internal DB (agent-command-policy, dispatcher walkthrough) | **Move to optional "Cursor as MCP client"** or generalize to "MCP client" |
+| **E. Project files** | `.cursorrules`, `.cursorignore`, repo-owned `.cursor/mcp.json` | **Keep** `.cursorrules`/`.cursorignore`; **do not** rely on `.cursor/` in app code; optional: add `.cursor/` to `.gitignore` if we don't want to track `mcp.json` |
+| **F. Third-party / false positives** | `.venv`, pip, rich, DOM "cursor" (CSS/UI) | **Ignore** |
+
+---
+
+## 2. Full inventory by tier
+
+### A. Runtime / config coupling (remove or generalize)
+
+| Location | Current | Action |
+|----------|---------|--------|
+| `agentception/config.py` | `TaskRunnerChoice.cursor` / `TaskRunnerChoice.anthropic`; docstring says "Cursor IDE with Composer agent" | **Remove** `TaskRunnerChoice.cursor` and all references. Default is `anthropic`; no other runner in code. |
+| `agentception/config.py` | `ac_task_runner: TaskRunnerChoice` field and `AC_TASK_RUNNER` env | **Remove** `ac_task_runner` and `AC_TASK_RUNNER` if no code path uses `cursor`; else keep enum as `anthropic` only (or rename to execution backend later). |
+| `agentception/tests/test_config.py` | Tests for `AC_TASK_RUNNER=cursor` and invalid value | **Remove** cursor test; keep anthropic default and invalid-value test. |
+| `scripts/debug_loop.py` | Comment "TaskRunnerChoice (enum: cursor \| anthropic)" | **Update** to describe actual backends (e.g. anthropic only, or current enum). |
+| `docker-compose.ci.yml` | Volume `- /tmp/ci-cursor:/root/.cursor` | **Remove** volume. No app code should read `.cursor`; CI doesn't need a dummy dir. |
+| `docs/guides/ci.md` | "Removes the `~/.cursor` mount" | **Reword** to state we don't mount or use `.cursor` in CI. |
+
+**Verification:** Grep for `ac_task_runner`, `TaskRunnerChoice`, `AC_TASK_RUNNER` — no execution path branches on them; only config default and tests reference them.
+
+---
+
+### B. Data model / API (rename or drop)
+
+| Location | Current | Action |
+|----------|---------|--------|
+| `agentception/models/__init__.py` | `ProjectConfig.cursor_project_id`: "Cursor project slug used to locate transcript files" | **Rename** to `ide_project_id` or `transcript_project_id` (generic), or **deprecate** if transcripts are DB-only and this is unused. |
+| `agentception/routes/roles.py` | Summary "List all managed role and **cursor** files" | **Change** to "List all managed role files" (allowlist is only `.agentception/roles/*.md`). |
+| `agentception/models/__init__.py` | `RoleMeta` docstring "managed role or **cursor configuration** file" | **Change** to "managed role file". |
+| `agentception/templates/config.html` | Shows `project.cursor_project_id` as "cursor: …" | **Rename** to `ide_project_id` / "Project ID" or remove if we drop the field. |
+| `agentception/tests/test_agentception_pipeline_config.py` | Test data uses `cursor_project_id` | **Rename** to chosen field name or remove from test payloads if field is deprecated. |
+| `docs/reference/type-contracts.md` | Documents `cursor_project_id` and `TaskRunnerChoice` | **Update** to match renames/removals. |
+
+**Verification:** No API or UI says "cursor" as a required concept. Transcript resolution is either DB-only or uses a generic "project id" for any IDE.
+
+---
+
+### C. Naming / comments (rename or reword)
+
+| Location | Current | Action |
+|----------|---------|--------|
+| `agentception/routes/ui/docs.py` | `_scan_cursor_docs()` — scans `.agentception/*.md` | **Rename** to `_scan_agentception_docs()` or `_scan_docs()`. |
+| `agentception/config.py` | `ac_dir` docstring "not in ``.cursor/``, which belongs to the IDE" | **Keep** — clarifies we don't use .cursor; no change. |
+| `agentception/config.py` | Docstrings for `host_worktrees_dir` / `host_repo_dir` saying "open in Cursor" / "Cursor agents on the host" | **Reword** to "agents running on the host" or "IDE on the host". |
+| `agentception/readers/__init__.py` | "Cursor transcript files" | **Change** to "transcript storage" or "DB transcript records". |
+| `agentception/readers/llm_phase_planner.py` | "coordinator agent (in Cursor)" | **Change** to "coordinator agent (e.g. in an MCP client)". |
+| `agentception/routes/api/agent_run.py` | "Cursor-free agent loop" | **Keep** — describes the architecture (no Cursor dependency). |
+| `agentception/routes/ui/agents.py` | "Filesystem transcript — Cursor JSONL file" in docstring | **Update** to "Postgres ``ac_agent_messages``" as primary; remove Cursor JSONL mention if no longer used. |
+| `agentception/db/models.py` | "One row per message in a Cursor transcript" / "Cursor agent transcript" | **Change** to "agent transcript" or "agent message". |
+| `agentception/db/queries/messages.py` | "captured from Cursor transcripts by the poller" | **Change** to "captured from agent runs" or "stored by the agent loop". |
+| `docker-compose.yml` | Comments "spawned Cursor agents" / "Cursor agents (on the host)" | **Reword** to "agents running on the host" or "IDE on the host". |
+| `agentception/tests/test_git_reader.py` | "Cursor fix branches are NOT agent branches" | **Change** to "fix/something branches are NOT agent branches" (remove "Cursor"). |
+| `tools/typing_audit.py` | "Checks every rule from .cursorrules and AGENTS.md" | **Keep** — .cursorrules is a file path, not a Cursor dependency. |
+
+---
+
+### D. Documentation — MCP client (keep, optionally generalize)
+
+These refer to Cursor as **one** MCP client. Keep as-is or add "e.g. Cursor".
+
+| Location | Current | Action |
+|----------|---------|--------|
+| `docs/guides/setup.md` | Step 8 / N: "Configure Cursor MCP", `~/.cursor/mcp.json`, "restart Cursor", Cursor bug workaround | **Keep** section; title can be "Configure MCP client (e.g. Cursor)". |
+| `docs/guides/dispatcher-walkthrough.md` | Entire doc: run dispatcher from Cursor, `~/.cursor/mcp.json`, allowlist, Cursor bug | **Keep**; add one line that any MCP client can be used; Cursor is the documented example. |
+| `docs/guides/mcp.md` | "e.g. `~/.cursor/mcp.json` for Cursor, or the equivalent for your IDE" | **Keep** — already client-agnostic. |
+| `docs/reference/mcp.md` | MCP server reference | **No change** — no Cursor-specific logic. |
+| `README.md` | "MCP Integration (Cursor / Claude)" | **Keep** or "MCP Integration (e.g. Cursor, Claude)". |
+| `docs/README.md` | "Connect Cursor / Claude", "Cursor-Free Agent Loop" | **Keep**; "Cursor-Free" is accurate. |
+| `docs/guides/security.md` | "Configure the key in Cursor's mcp.json" | **Reword** to "Configure the key in your MCP client's config (e.g. Cursor's mcp.json)". |
+
+---
+
+### D. Documentation — Cursor-specific behavior (optional "Cursor as client" appendix)
+
+| Location | Current | Action |
+|----------|---------|--------|
+| `.agentception/agent-command-policy.md` | Describes Cursor tiers, sandbox, allowlist, `Cmd+Shift+J`, `.cursor/sandbox.json` | **Move** to a doc like `docs/guides/mcp-client-cursor.md` or keep in .agentception with a note: "When using Cursor as the MCP client, …". Do not remove — useful for Cursor users. |
+| `docs/cursor-agent-spawning.md` | Historical "Cursor Agent Spawning" | **Keep** as historical; add one-line note at top: "Legacy; agents now run via Cursor-free loop." |
+| `docs/plan-spec.md` | "Coordinator agent (Cursor / MCP)" | **Change** to "Coordinator agent (MCP client, e.g. Cursor)". |
+| `docs/plans/agent-speedup.md` | Table "Cursor" as owner | **Change** to "MCP / IDE" or "Human" if it's about who runs tasks. |
+
+---
+
+### E. Project files (keep; do not depend on .cursor in app)
+
+| Location | Current | Action |
+|----------|---------|--------|
+| `.cursorrules` | Agent rules for Cursor IDE | **Keep** — project convention; no app dependency. |
+| `.cursorignore` | Ignore patterns for Cursor | **Keep**. |
+| `.cursor/mcp.json` | Example/local MCP config in repo | **Optional:** Add `.cursor/` to `.gitignore` so each dev uses their own; or keep as committed example. Do **not** read this path in application code. |
+
+---
+
+### F. False positives (ignore)
+
+| Location | Reason |
+|----------|--------|
+| `agentception/static/js/thought_block.ts` | DOM "cursor" (blinking cursor in UI). |
+| `agentception/static/js/org_chart_tree.ts` | CSS `cursor: pointer`. |
+| `.venv-mlx/`, `pip/_vendor/rich/` | Third-party code; "cursor" is terminal/UI. |
+| `agentception/static/scss/**` | Comment "transcript" only. |
+
+---
+
+## 3. Summary table
+
+| Category | Count (approx) | Action |
+|----------|----------------|--------|
+| A. Runtime/config | 6 | Remove `TaskRunnerChoice.cursor`, `AC_TASK_RUNNER` usage; remove CI `.cursor` volume. |
+| B. Data/API | 6 | Rename/drop `cursor_project_id`; fix "cursor files" in roles API/docs. |
+| C. Naming/comments | 12+ | Rename `_scan_cursor_docs`; reword "Cursor" in docstrings/comments to "IDE" or "MCP client". |
+| D. Docs (MCP client) | 7 | Keep; optionally add "e.g. Cursor". |
+| D. Docs (Cursor-specific) | 4 | Keep as optional Cursor-as-client material. |
+| E. Project files | 3 | Keep `.cursorrules` / `.cursorignore`; don't read `.cursor/` in app. |
+| F. False positives | — | Ignore. |
+
+---
+
+## 4. Recommended implementation order
+
+1. **A (runtime):** Remove `TaskRunnerChoice.cursor`, `AC_TASK_RUNNER` parsing for `cursor`, and the CI volume. Grep for any use of `ac_task_runner == TaskRunnerChoice.cursor` and delete.
+2. **B (data):** Rename `cursor_project_id` → `ide_project_id` (or similar) across models, API, UI, tests, and type-contracts; or remove if transcripts are DB-only and this is unused. Fix roles API summary and RoleMeta docstring.
+3. **C (naming):** Rename `_scan_cursor_docs` → `_scan_agentception_docs`; reword all "Cursor" in config/reader/route/db comments to "IDE" or "MCP client" where appropriate.
+4. **Docs:** Pass over D items (add "e.g. Cursor" where needed; move Cursor-specific behavior to optional guide).
+5. **E:** Confirm no code reads `.cursor/`; add `.cursor/` to `.gitignore` if desired.
+
+After this, the only remaining "Cursor" mentions are: (1) MCP client docs ("e.g. Cursor"), (2) optional Cursor-as-client guide, (3) project files `.cursorrules` / `.cursorignore`, and (4) historical cursor-agent-spawning doc. No runtime or config coupling remains.
+
+---
+
+## 5. Completed (decoupling applied)
+
+All items above have been implemented:
+
+- **A:** Removed `TaskRunnerChoice.cursor`; kept `anthropic` only. Removed CI volume `/tmp/ci-cursor:/root/.cursor`. Updated `docs/guides/ci.md`.
+- **B:** Renamed `cursor_project_id` → `ide_project_id` in models, templates, tests, and type-contracts. Updated roles API summary and `RoleMeta` docstring. Test `test_write_pipeline_config_persists` now uses `.agentception/` for the config path.
+- **C:** Renamed `_scan_cursor_docs` → `_scan_agentception_docs`. Reworded config/readers/routes/db/docker-compose comments and docstrings. Updated `templates/transcripts.html` empty state. Removed stale "Cursor projects directory" row from `settings.html`.
+- **D:** Setup and dispatcher-walkthrough titles/descriptions generalized to "MCP client (e.g. Cursor)". Security guide reworded. `cursor-agent-spawning.md` legacy note added. `plan-spec.md` and `agent-speedup.md` updated. `.agentception/agent-command-policy.md` prefixed with "When using Cursor as the MCP client" note.
+- **E:** Confirmed no application code reads `.cursor/`. Added `.cursor/` to `.gitignore`.

--- a/docs/reference/type-contracts.md
+++ b/docs/reference/type-contracts.md
@@ -339,7 +339,7 @@ The canonical `AgentStatus` in `agentception/workflow/status.py` includes two ad
 | `gh_repo` | `str` | required | GitHub `owner/repo` string |
 | `repo_dir` | `str \| None` | `None` | Override for the local repo path |
 | `worktrees_dir` | `str \| None` | `None` | Override for worktrees directory |
-| `cursor_project_id` | `str \| None` | `None` | Cursor project slug for transcripts |
+| `ide_project_id` | `str \| None` | `None` | Optional IDE/client project slug (e.g. for transcript lookup) |
 
 #### `PipelineConfig`
 
@@ -664,12 +664,11 @@ Produced by the LLM coordinator after enriching a `PlanSpec` with full issue bod
 
 #### `TaskRunnerChoice`
 
-`str, Enum` — Task runner backend for agent execution.
+`str, Enum` — Task runner backend for agent execution. Agent tasks run via the Cursor-free loop.
 
 | Value | Description |
 |-------|-------------|
-| `"cursor"` | Cursor IDE with Composer agent |
-| `"anthropic"` | Direct Anthropic API calls (default) |
+| `"anthropic"` | Direct Anthropic (or local LLM) API calls (default) |
 
 #### `LLMProviderChoice`
 
@@ -694,7 +693,7 @@ Key fields (not exhaustive — see `config.py` for the full list):
 | `gh_repo` | `str` | `GH_REPO` | GitHub `owner/repo` string |
 | `ac_api_key` | `str \| None` | `AC_API_KEY` | API key for agent callback authentication |
 | `anthropic_api_key` | `str \| None` | `ANTHROPIC_API_KEY` | Anthropic API key |
-| `ac_task_runner` | `TaskRunnerChoice` | `AC_TASK_RUNNER` | Agent execution backend |
+| `ac_task_runner` | `TaskRunnerChoice` | `AC_TASK_RUNNER` | Agent execution backend (currently ``anthropic`` only) |
 | `llm_provider` | `LLMProviderChoice` | `LLM_PROVIDER` | LLM provider selection |
 | `database_url` | `str` | `DATABASE_URL` | PostgreSQL connection string |
 | `qdrant_url` | `str` | `QDRANT_URL` | Qdrant vector DB URL |
@@ -1626,7 +1625,7 @@ AgentCeption
 │   └── HealthSnapshot               — BaseModel: system metrics for /api/health/detailed
 │
 ├── Config (agentception/config.py)
-│   ├── TaskRunnerChoice             — str Enum: cursor | anthropic
+│   ├── TaskRunnerChoice             — str Enum: anthropic (Cursor-free loop)
 │   ├── LLMProviderChoice            — str Enum: anthropic | local
 │   └── AgentCeptionSettings         — BaseSettings: env-var config
 │

--- a/scripts/debug_loop.py
+++ b/scripts/debug_loop.py
@@ -28,14 +28,14 @@ Implement the TaskRunner protocol — issue #267.
 
 `agentception/services/task_runner.py` does not exist yet. Create it.
 `agentception/services/__init__.py` is currently empty — export `TaskRunner` from it.
-`agentception/config.py` already defines `TaskRunnerChoice` (enum: cursor | anthropic)
+`agentception/config.py` already defines `TaskRunnerChoice` (currently ``anthropic`` only)
 and the `ac_task_runner` setting — you do not need to touch config.py.
 
 ## What to do
 
 1. Read `agentception/services/__init__.py` to see its current state.
    Read `agentception/config.py` around `TaskRunnerChoice` to understand
-   the existing config wiring (grep for TaskRunnerChoice).
+   the existing config wiring.
 
 2. Create `agentception/services/task_runner.py` with:
    - `from __future__ import annotations` as the first line


### PR DESCRIPTION
Implements the full sweep from `docs/reference/cursor-decoupling-taxonomy.md`.

- **A (runtime):** Removed `TaskRunnerChoice.cursor`; kept `anthropic` only. Removed CI volume `/tmp/ci-cursor:/root/.cursor`. Updated `docs/guides/ci.md`.
- **B (data):** Renamed `cursor_project_id` → `ide_project_id` in models, templates, tests, type-contracts. Roles API summary and RoleMeta docstring updated. Test config path uses `.agentception/`.
- **C (naming):** `_scan_cursor_docs` → `_scan_agentception_docs`. Reworded config/readers/routes/db/docker comments. Transcripts empty state and removed stale Cursor projects row from settings.
- **D (docs):** Setup and dispatcher titles generalized to MCP client (e.g. Cursor). Security guide, cursor-agent-spawning legacy note, plan-spec, agent-speedup. agent-command-policy prefixed with Cursor-as-client note.
- **E:** `.cursor/` added to `.gitignore`; confirmed no app code reads `.cursor/`.