### PR TITLE
fix: use agentception home for HuggingFace cache (fix download permission)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # mount is available.
 RUN groupadd -g 1001 agentception \
     && useradd -r -u 1001 -g agentception -m -d /home/agentception -s /bin/bash agentception \
-    && mkdir -p /worktrees /root/.cache/huggingface \
-    && chown agentception:agentception /root/.cache/huggingface
+    && mkdir -p /worktrees /home/agentception/.cache/huggingface \
+    && chown -R agentception:agentception /home/agentception/.cache
 
 # Install Node.js 22.x — enables sass/esbuild builds at container startup
 # and npm run type-check / npm test inside the container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,10 @@ services:
     ports:
       - "127.0.0.1:10003:10003"
     environment:
-      HOME: ${HOME}
+      # Run as agentception (non-root). HOME must be writable so HuggingFace/fastembed
+      # can write ~/.cache/huggingface/token and model files; using /root causes
+      # [Errno 13] Permission denied when the process is non-root.
+      HOME: /home/agentception
       # Database: inject via .env (DATABASE_URL=postgresql+asyncpg://...)
       DATABASE_URL: "postgresql+asyncpg://agentception:${DB_PASSWORD}@postgres:5432/agentception"
       # gh CLI / git repo settings — override via .env or docker-compose.override.yml
@@ -101,9 +104,9 @@ services:
       # Disable HuggingFace tokenizers Rust parallelism — it spawns its own
       # thread pool that stacks on top of ORT's, making contention worse.
       TOKENIZERS_PARALLELISM: "false"
-      # HF_HOME points to the persistent model_cache volume.  entrypoint.sh
-      # chowns this directory to the agentception user before dropping privs.
-      HF_HOME: /root/.cache/huggingface
+      # HF_HOME under agentception's home so downloads and token file are writable.
+      # entrypoint.sh chowns the mounted model_cache volume here before dropping privs.
+      HF_HOME: /home/agentception/.cache/huggingface
       # Optional: set HF_TOKEN in .env to avoid HuggingFace rate-limit warnings
       # on model downloads and enable authenticated access to private models.
       HF_TOKEN: ${HF_TOKEN:-}
@@ -123,8 +126,8 @@ services:
       https_proxy: "http://proxy:8888"
       no_proxy: "localhost,127.0.0.1,postgres,qdrant,host.docker.internal,::1"
     volumes:
-      # gh CLI auth (read-only)
-      - ${HOME}/.config/gh:${HOME}/.config/gh:ro
+      # gh CLI auth (read-only). Container HOME is /home/agentception.
+      - ${HOME}/.config/gh:/home/agentception/.config/gh:ro
       # ── Narrow bind mounts (belt-and-suspenders for credential isolation) ──
       # Instead of mounting the full repo root (./:/app) — which would expose
       # .env, docker-compose secrets, and .git — we mount only the directories
@@ -154,7 +157,7 @@ services:
       # are re-downloaded from HuggingFace on every restart, adding ~50s to the
       # first dispatch after each restart.  With the volume they are loaded from
       # disk on first use (~5–10s) and stay warm for the lifetime of the volume.
-      - model_cache:/root/.cache/huggingface
+      - model_cache:/home/agentception/.cache/huggingface
     # Use Cloudflare DNS instead of Docker's embedded resolver.
     # Docker's embedded DNS caches whichever node it gets first, and GitHub
     # occasionally has dead nodes in rotation (e.g. 140.82.116.6) that refuse

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -284,7 +284,7 @@ services:
 
 `scripts/entrypoint.sh` implements a two-phase startup:
 
-1. **Root phase** — writes `/etc/resolv.conf`, compiles SCSS/JS assets, runs Alembic migrations, and fixes ownership of mutable mount points (`/worktrees`, `/root/.cache/huggingface`).
+1. **Root phase** — writes `/etc/resolv.conf`, compiles SCSS/JS assets, runs Alembic migrations, and fixes ownership of mutable mount points (`/worktrees`, `/home/agentception/.cache/huggingface`).
 2. **Unprivileged phase** — `exec gosu agentception "$@"` drops to UID 1001 (`agentception` user) for the long-running `uvicorn` process. Every Python coroutine, agent loop iteration, and tool call runs as this non-root user.
 
 `gosu` is a purpose-built setuid helper (analogous to `sudo -u` but signal-transparent and without shell overhead). After the `exec`, no process in the container runs as root.

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -51,11 +51,11 @@ alembic -c agentception/alembic.ini upgrade head || {
 echo "[entrypoint] fixing ownership of /worktrees …"
 chown agentception:agentception /worktrees
 
-# /root/.cache/huggingface — named volume (agentception-model-cache).
+# /home/agentception/.cache/huggingface — named volume (agentception-model-cache).
 #   FastEmbed downloads ONNX models on first dispatch; the agentception user
-#   must be able to write to this directory.
+#   must be able to write here (and to the hub token file under it).
 echo "[entrypoint] fixing ownership of model cache …"
-chown -R agentception:agentception /root/.cache/huggingface
+chown -R agentception:agentception /home/agentception/.cache/huggingface
 
 # ── 5. Drop to non-root user ─────────────────────────────────────────────────
 # gosu is a purpose-built setuid helper (analogous to sudo -u but without the


### PR DESCRIPTION
Fixes [Errno 13] Permission denied: '/root/.cache/huggingface/token' when fastembed downloads models.

- Set `HOME=/home/agentception` and `HF_HOME` under it so fastembed/hub can write token and model files when running as non-root.
- Mount model_cache at `/home/agentception/.cache/huggingface`; update Dockerfile and entrypoint chown.
- Mount gh config at explicit `/home/agentception/.config/gh` (read-only).
- Update docs/guides/security.md for new cache path.

Verification: mypy, typing_audit, full pytest, generate.py --check — all pass.