### PR TITLE
docs: make local LLM setup cross-platform (macOS, Linux, Windows)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ GH_REPO=cgcardona/your-repo
 # Required for Phase 1A planning (brain dump → PlanSpec YAML) and all agent runs.
 ANTHROPIC_API_KEY=
 # Optional: use Ollama (local) as LLM backend instead of Anthropic.
-# See docs/guides/local-llm-mlx.md for full Ollama setup.
+# See docs/guides/local-llm.md for full Ollama setup (macOS, Linux, Windows).
 # LLM_PROVIDER=local
 # LOCAL_LLM_BASE_URL=http://host.docker.internal:11434
 # LOCAL_LLM_MODEL=qwen2.5-coder:7b

--- a/README.md
+++ b/README.md
@@ -67,14 +67,17 @@ docker compose exec agentception alembic upgrade head
 open http://localhost:10003
 ```
 
-### Option B — Local models on macOS (free, private)
+### Option B — Local models (free, private)
 
-Run agents entirely on your own hardware with [Ollama](https://ollama.com). No API key, no cloud, no usage bill. Runs on Apple Silicon via Metal — GPU-accelerated.
+Run agents entirely on your own hardware with [Ollama](https://ollama.com). No API key, no cloud, no usage bill. Works on **macOS, Linux, and Windows** — GPU-accelerated on Apple Silicon (Metal), NVIDIA (CUDA), and AMD (ROCm).
 
 ```bash
-# 1. Install Ollama and pull a model
-brew install ollama
-brew services start ollama
+# 1. Install Ollama — https://ollama.com/download
+#    macOS:   brew install ollama && brew services start ollama
+#    Linux:   curl -fsSL https://ollama.com/install.sh | sh
+#    Windows: download the installer from https://ollama.com/download
+
+# Pull a model
 ollama pull qwen2.5-coder:7b      # fast, good quality (~4 GB)
 # ollama pull qwen2.5-coder:32b   # better quality, needs 16 GB+ RAM
 
@@ -99,12 +102,13 @@ HOST_WORKTREES_DIR=/path/to/worktrees
 # 3. Start
 docker compose up -d
 docker compose exec agentception alembic upgrade head
-open http://localhost:10003
+# macOS: open http://localhost:10003
+# Linux/Windows: navigate to http://localhost:10003
 ```
 
 > **Performance tip:** Set `WORKTREE_INDEX_ENABLED=false` in `.env` to skip per-agent code indexing (saves ~2 GB RSS and significant CPU) when running on constrained hardware.
 
-See [docs/guides/local-llm-mlx.md](docs/guides/local-llm-mlx.md) for the full Ollama setup guide and model recommendations.
+See [docs/guides/local-llm.md](docs/guides/local-llm.md) for the full Ollama setup guide and model recommendations.
 
 ---
 
@@ -153,7 +157,7 @@ See [docs/guides/integrate.md](docs/guides/integrate.md) for the full tool refer
 | Guide | What it covers |
 |-------|----------------|
 | [Setup](docs/guides/setup.md) | First-run, Docker, environment variables |
-| [Local LLM / Ollama](docs/guides/local-llm-mlx.md) | Running agents on local hardware with Ollama |
+| [Local LLM / Ollama](docs/guides/local-llm.md) | Running agents on local hardware with Ollama (macOS, Linux, Windows) |
 | [Local LLM Scaling](docs/guides/local-llm-scaling.md) | Multi-agent concurrency and LiteLLM proxy |
 | [MCP Integration](docs/guides/integrate.md) | Cursor / Claude tool integration |
 | [Dispatching Agents](docs/guides/dispatch.md) | How to launch, monitor, and cancel agent runs |

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Step-by-step instructions for humans.
 | [Developer Workflow](guides/developer-workflow.md) | Bind-mount loop, mypy → tests → docs verification order, JS/CSS build pipeline |
 | [Contributing](guides/contributing.md) | Branch naming, commit conventions, PR checklist, code review expectations |
 | [CI](guides/ci.md) | GitHub Actions pipeline — what runs, how to reproduce locally |
-| [Local LLM with MLX](guides/local-llm-mlx.md) | Run the local LLM provider (Qwen/MLX on Apple Silicon): config, env vars, server, probes |
+| [Local LLM / Ollama](guides/local-llm.md) | Run the local LLM provider (Ollama on macOS, Linux, or Windows): config, env vars, server, probes |
 
 ---
 

--- a/docs/architecture/llm-provider-abstraction.md
+++ b/docs/architecture/llm-provider-abstraction.md
@@ -180,7 +180,7 @@ This gives a clean “plug in a model” story: add a new adapter and config val
 6. **Document and test** ✅  
    - **Contract:** [LLM contract and provider abstraction](../reference/llm-contract.md) — entry points, types, provider selection, how to add a provider.  
    - **Tests:** `test_llm.py` and `test_config.py` cover provider selection and adapter behaviour; plan and agent_loop tests use the public API only.  
-   - **Deployment:** [Local LLM with MLX](../guides/local-llm-mlx.md) — config table, how the local adapter works, full MLX runbook; setup and security guides updated for both providers.
+   - **Deployment:** [Local LLM / Ollama](../guides/local-llm.md) — config table, how the local adapter works, Ollama runbook; setup and security guides updated for both providers.
 
 ---
 

--- a/docs/guides/local-llm-scaling.md
+++ b/docs/guides/local-llm-scaling.md
@@ -1,6 +1,6 @@
 # Local LLM Scaling with LiteLLM Proxy
 
-This guide covers the multi-agent scaling architecture for running dozens to hundreds of AgentCeption agents against local models on Apple Silicon. It assumes you have completed the basic [Ollama setup](local-llm-mlx.md) (Phase 1) and now need to scale beyond a single Ollama instance.
+This guide covers the multi-agent scaling architecture for running dozens to hundreds of AgentCeption agents against local models. It assumes you have completed the basic [Ollama setup](local-llm.md) (Phase 1) and now need to scale beyond a single Ollama instance.
 
 ---
 
@@ -44,7 +44,7 @@ Each phase below is independent — implement only as far as your agent count re
 
 ## Phase 1: Single Ollama instance (1–10 agents)
 
-**Already covered in [local-llm-mlx.md](local-llm-mlx.md).** Ollama handles a request queue natively; up to ~5–10 concurrent agents can share one Ollama instance without degradation.
+**Already covered in [local-llm.md](local-llm.md).** Ollama handles a request queue natively; up to ~5–10 concurrent agents can share one Ollama instance without degradation.
 
 Configuration:
 
@@ -308,7 +308,7 @@ curl -s http://localhost:11434/v1/chat/completions \
 
 ## References
 
-- [Local LLM with Ollama setup](local-llm-mlx.md) — Phase 1 runbook.
+- [Local LLM with Ollama setup](local-llm.md) — Phase 1 runbook.
 - [LLM contract and provider abstraction](../reference/llm-contract.md) — AgentCeption's LLM contract.
 - [Ollama](https://ollama.com) — local inference server.
 - [LiteLLM Proxy docs](https://docs.litellm.ai/docs/proxy/quick_start) — full proxy configuration reference.

--- a/docs/guides/local-llm.md
+++ b/docs/guides/local-llm.md
@@ -1,10 +1,21 @@
-# Local LLM with Ollama (and MLX) on Apple Silicon
+# Local LLM with Ollama
 
-This guide explains how to run **Qwen 3.5 35B** (or a quantized variant) locally on macOS and connect it to AgentCeption's **local provider**. **Ollama is the recommended inference backend.** `mlx-openai-server` is documented as a developer-only footnote.
+This guide explains how to run a local inference server and connect it to AgentCeption's **local provider**. **Ollama is the recommended backend.**
 
-**Target hardware:** Apple Silicon Mac (M1/M2/M3/M4) with at least 24 GB unified memory; 48 GB recommended for the 35B 4-bit model.
+AgentCeption works on **macOS, Linux, and Windows** with any [Ollama](https://ollama.com)-compatible server — no API key, no cloud bill, no data leaving your machine.
 
-AgentCeption uses a **provider-agnostic LLM contract**. When the effective provider is **local**, all LLM calls (planning, streaming preview, agent loop) go to your **Chat Completions–compatible** HTTP server on the host instead of Anthropic. Thinking vs content is **normalized by the adapter**: stream chunks always have `type: "thinking"` or `type: "content"`; completion returns only the final answer string. See [LLM contract and provider abstraction](../reference/llm-contract.md) for the full contract and config model.
+**Recommended hardware (any platform):**
+- 8 GB RAM minimum (4B parameter models)
+- 16–24 GB for 9B models (good for real coding tasks)
+- 48 GB+ for 35B models (best planning quality)
+
+GPU acceleration is automatic:
+- **Apple Silicon** — Metal
+- **NVIDIA** — CUDA
+- **AMD** — ROCm
+- **CPU-only** — works, but slower
+
+AgentCeption uses a **provider-agnostic LLM contract**. When the effective provider is **local**, all LLM calls (planning, streaming preview, agent loop) go to your Chat Completions–compatible HTTP server instead of Anthropic. See [LLM contract and provider abstraction](../reference/llm-contract.md) for the full contract and config model.
 
 ### Naming: "OpenAI" in tooling — not OpenAI's cloud
 
@@ -14,7 +25,7 @@ You will see names like **OpenAI-compatible** and the package **`mlx-openai-serv
 |---------------|--------|
 | **OpenAI-compatible / Chat Completions API** | The HTTP shape many tools use: `POST /v1/chat/completions`, JSON body with `messages`, response with `choices[].message`. It is a **wire format** — not a claim that traffic goes to OpenAI Inc. |
 | **Ollama** | Production-grade local inference server. Implements the OpenAI-compatible API. **Recommended.** |
-| **`mlx-openai-server`** | Developer-preview local MLX server. Single-process, no request queue, KV cache saturates after large generations. **For development and one-off tests only.** |
+| **`mlx-openai-server`** | Developer-preview local MLX server (Apple Silicon only). Single-process, no request queue, KV cache saturates after large generations. **For development and one-off tests only.** |
 
 So: **no OpenAI account or cloud call is required** for the local provider. You are the datacenter; the "OpenAI" wording is only about **request/response shape**, so the same client code can talk to many backends.
 
@@ -35,7 +46,7 @@ When the effective provider is **local**, the following env vars apply. Set them
 |---------|---------|--------|
 | `LOCAL_LLM_BASE_URL` | `http://host.docker.internal:11434` | Base URL of your local Chat Completions–compatible server (no trailing slash). From Docker, use `host.docker.internal` to reach a server on the host. Ollama default port is **11434**. |
 | `LOCAL_LLM_CHAT_PATH` | `/v1/chat/completions` | Path appended to the base URL for chat completions. Ollama exposes this path. |
-| `LOCAL_LLM_MODEL` | *(empty)* | Model name sent in requests. For Ollama, set this to the exact tag (e.g. `qwen3.5:35b-a3b-q4_K_M`). If empty, some servers use their loaded model; Ollama requires a model name. |
+| `LOCAL_LLM_MODEL` | *(empty)* | Model name sent in requests. For Ollama, set this to the exact tag (e.g. `qwen2.5-coder:7b`). If empty, some servers use their loaded model; Ollama requires a model name. |
 | `LOCAL_LLM_MAX_CONTEXT_CHARS` | `12000` | Max characters for the first user message (task briefing) when using the local LLM. Reduces load on small models. |
 | `LOCAL_LLM_MAX_SYSTEM_CHARS` | `6000` | Max characters for the system prompt (role + cognitive arch). Truncation is applied when using the local provider. |
 | `LOCAL_LLM_MAX_TOKENS` | `4096` | Desired max completion tokens per turn (agent loop). Never sent above the ceiling below. |
@@ -83,30 +94,39 @@ Ollama is the recommended local inference backend. It is production-grade:
 ### Install Ollama
 
 ```bash
-# macOS (via Homebrew)
-brew install ollama
+# macOS (Homebrew)
+brew install ollama && brew services start ollama
 
-# Or download from https://ollama.com/download
+# Linux (one-line installer)
+curl -fsSL https://ollama.com/install.sh | sh
+
+# Windows
+# Download the installer from https://ollama.com/download
 ```
 
 ### Pull a model
 
 ```bash
-# Qwen 3.5 35B (MoE, 4-bit) — requires ~20 GB unified memory for weights
+# Qwen 2.5 Coder 7B — fast, good quality (~4 GB), works on 8 GB+ RAM
+ollama pull qwen2.5-coder:7b
+
+# Qwen 3.5 35B (MoE, 4-bit) — best quality; requires ~20 GB RAM for weights
 ollama pull qwen3.5:35b-a3b-q4_K_M
 
-# Qwen 3.5 9B (4-bit) — for 16–24 GB Macs
+# Qwen 3.5 9B (4-bit) — good for real coding tasks, 16–24 GB RAM
 ollama pull qwen3.5:9b
 
-# Qwen 3.5 4B (4-bit) — for 8–16 GB Macs
+# Qwen 3.5 4B (4-bit) — for 8–16 GB RAM
 ollama pull qwen3.5:4b
 ```
 
 ### Start the Ollama server
 
 ```bash
-# Start in the background (listens on 0.0.0.0:11434 by default)
+# macOS/Linux: start in the background (listens on 0.0.0.0:11434 by default)
 ollama serve
+
+# Windows: Ollama runs as a system service after installation; no manual start needed.
 ```
 
 Ollama binds to `0.0.0.0:11434` by default, so Docker containers reach it at `host.docker.internal:11434`.
@@ -119,7 +139,7 @@ In `.env`:
 LLM_PROVIDER=local
 LOCAL_LLM_BASE_URL=http://host.docker.internal:11434
 LOCAL_LLM_CHAT_PATH=/v1/chat/completions
-LOCAL_LLM_MODEL=qwen3.5:35b-a3b-q4_K_M
+LOCAL_LLM_MODEL=qwen2.5-coder:7b
 LOCAL_LLM_COMPLETION_TOKEN_CEILING=8192
 LOCAL_LLM_MAX_CONTEXT_CHARS=24000
 LOCAL_LLM_MAX_SYSTEM_CHARS=12000
@@ -139,7 +159,7 @@ docker compose restart agentception
 curl -s http://localhost:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "qwen3.5:35b-a3b-q4_K_M",
+    "model": "qwen2.5-coder:7b",
     "messages": [{"role": "user", "content": "Reply with exactly: hello world"}],
     "temperature": 0.0,
     "max_tokens": 32,
@@ -149,7 +169,7 @@ curl -s http://localhost:11434/v1/chat/completions \
 # From inside Docker
 docker compose exec agentception curl -s http://host.docker.internal:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"model":"qwen3.5:35b-a3b-q4_K_M","messages":[{"role":"user","content":"Say hi"}],"temperature":0,"max_tokens":16,"stream":false}'
+  -d '{"model":"qwen2.5-coder:7b","messages":[{"role":"user","content":"Say hi"}],"temperature":0,"max_tokens":16,"stream":false}'
 
 # Confirm AgentCeption reaches the local model
 curl -s http://localhost:10003/api/local-llm/hello
@@ -197,10 +217,11 @@ When Ollama is running, point the agent at it so it uses the local model instead
 
 ---
 
-## Model choice by Mac RAM
+## Model choice by available RAM
 
-| Mac RAM (unified) | Model | Ollama tag | Notes |
-|-------------------|-------|------------|-------|
+| RAM | Model | Ollama tag | Notes |
+|-----|-------|------------|-------|
+| 8–16 GB | Qwen 2.5 Coder 7B | `qwen2.5-coder:7b` | Fast; good for coding tasks |
 | 8–16 GB | Qwen 3.5 4B | `qwen3.5:4b` | Fast; limited context |
 | 16–24 GB | Qwen 3.5 9B | `qwen3.5:9b` | Good for real coding tasks |
 | 48 GB+ | Qwen 3.5 35B (MoE) | `qwen3.5:35b-a3b-q4_K_M` | Best quality; preferred for planning |
@@ -213,7 +234,7 @@ LOCAL_LLM_MAX_CONTEXT_CHARS=24000
 LOCAL_LLM_MAX_SYSTEM_CHARS=12000
 LOCAL_LLM_MAX_TOKENS=8192
 
-# Qwen 3.5 4B (8–16 GB) — more conservative
+# Qwen 3.5 4B / Qwen 2.5 Coder 7B (8–16 GB) — more conservative
 LOCAL_LLM_MAX_CONTEXT_CHARS=12000
 LOCAL_LLM_MAX_SYSTEM_CHARS=6000
 LOCAL_LLM_MAX_TOKENS=4096
@@ -221,40 +242,34 @@ LOCAL_LLM_MAX_TOKENS=4096
 
 ---
 
-## Capturing resource usage (CPU, GPU, Neural Engine)
+## Capturing resource usage
 
-Use **Activity Monitor** for a quick view, or **powermetrics** for detailed, script-friendly logs.
+### macOS — Activity Monitor and powermetrics
 
-### Activity Monitor
+Use **Activity Monitor** for a quick visual view: Window → CPU History, GPU History.
 
-1. Open **Activity Monitor** (Applications → Utilities).
-2. Window → **CPU History**, **GPU History** (if available).
-3. Run your inference in a terminal; watch **CPU**, **Memory**, and **GPU** during the run.
-
-### powermetrics (command line)
-
-Requires `sudo`. Sample every 1 second, 60 samples (~1 minute), and write to a file:
+For scripted logs, use **powermetrics** (requires `sudo`):
 
 ```bash
+# Sample every 1 second, 60 samples (~1 minute)
 sudo powermetrics -i 1000 -n 60 -o powermetrics_run.txt -s cpu_power,gpu_power,ane_power
 ```
 
-Then start your inference in another terminal. When the run finishes, stop powermetrics (Ctrl+C if running in foreground). The file will contain CPU, GPU, and ANE (Neural Engine) power estimates.
+Useful samplers: `cpu_power`, `gpu_power`, `ane_power` (Apple Neural Engine), `all`.
 
-**Useful samplers:**
-
-- `cpu_power` — CPU usage and power
-- `gpu_power` — GPU
-- `ane_power` — Apple Neural Engine
-- `all` — everything (noisier, larger output)
-
-**Example (minimal, 10 samples at 2 s):**
+### Linux — nvidia-smi / rocm-smi
 
 ```bash
-sudo powermetrics -i 2000 -n 10 -o ~/mlx_resource_run.txt -s cpu_power,gpu_power,ane_power
+# NVIDIA
+watch -n 1 nvidia-smi
+
+# AMD
+watch -n 1 rocm-smi
 ```
 
-Open `~/mlx_resource_run.txt` after the run to inspect CPU/GPU/ANE utilization during inference.
+### Windows
+
+Use **Task Manager → Performance** for a quick view, or install **GPU-Z** / **HWiNFO** for detailed GPU metrics.
 
 ---
 
@@ -274,7 +289,7 @@ These work for any OpenAI-compatible backend (Ollama or otherwise). Replace the 
 curl -s http://localhost:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "qwen3.5:35b-a3b-q4_K_M",
+    "model": "qwen2.5-coder:7b",
     "messages": [
       {"role": "system", "content": "You are a helpful assistant."},
       {"role": "user", "content": "Reply with exactly: hello world"}
@@ -290,16 +305,16 @@ curl -s http://localhost:11434/v1/chat/completions \
 ```bash
 docker compose exec agentception curl -s http://host.docker.internal:11434/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"model":"qwen3.5:35b-a3b-q4_K_M","messages":[{"role":"user","content":"Say hi"}],"temperature":0,"max_tokens":64,"stream":false}'
+  -d '{"model":"qwen2.5-coder:7b","messages":[{"role":"user","content":"Say hi"}],"temperature":0,"max_tokens":64,"stream":false}'
 ```
 
 If the host call works but the Docker call fails, check that Ollama is not bound only to `127.0.0.1`. Ollama binds to `0.0.0.0` by default, so this should work without extra config.
 
 ---
 
-## Developer footnote: mlx-openai-server
+## Apple Silicon: MLX (developer footnote)
 
-`mlx-openai-server` is a developer preview tool. It is **not suitable for multi-agent workloads** because:
+`mlx-openai-server` is an Apple Silicon–only developer preview tool. It is **not suitable for multi-agent workloads** because:
 
 - Single-process, no request queue — one request at a time
 - No KV cache management — cache saturates after a large generation (~4000 tok); subsequent requests hang until server restart
@@ -308,7 +323,7 @@ If the host call works but the Docker call fails, check that Ollama is not bound
 
 Use it only for one-off tests or model exploration on a Mac that does not have Ollama installed. If you must use it, set `LOCAL_LLM_COMPLETION_TOKEN_CEILING=4096` and expect to restart it between large generations.
 
-**Quick start (mlx-openai-server, developer use only):**
+**Quick start (mlx-openai-server, developer use only, Apple Silicon):**
 
 ```bash
 pip install -U mlx-openai-server
@@ -361,5 +376,5 @@ After the run, verify: `docker compose exec agentception pytest agentception/tes
 - [Local LLM Scaling](local-llm-scaling.md) — multi-agent scaling with LiteLLM Proxy and multiple Ollama instances.
 - [LLM contract and provider abstraction](../reference/llm-contract.md) — AgentCeption's LLM contract, provider selection, and how to add a provider.
 - [Ollama](https://ollama.com) — local inference server (recommended).
-- [mlx-community/Qwen3.5-35B-A3B-4bit](https://huggingface.co/mlx-community/Qwen3.5-35B-A3B-4bit) — 4-bit quantized Qwen 3.5 35B for MLX.
+- [mlx-community/Qwen3.5-35B-A3B-4bit](https://huggingface.co/mlx-community/Qwen3.5-35B-A3B-4bit) — 4-bit quantized Qwen 3.5 35B for MLX (Apple Silicon only).
 - [powermetrics(1)](https://keith.github.io/xcode-man-pages/powermetrics.1.html) — macOS power and usage sampling.

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -31,7 +31,7 @@ LLM calls are made by `agentception/services/llm.py` through a **provider-agnost
 
 **Anthropic provider (default):** All requests go to `https://api.anthropic.com/v1/messages` over HTTPS. `httpx` enforces TLS; there is no HTTP fallback. Your API key is sent in the `Authorization: Bearer <key>` header. The key is never logged.
 
-**Local provider:** When `LLM_PROVIDER=local`, all LLM traffic is between AgentCeption and your Ollama server on the host. No data is sent to Anthropic. Use a private base URL (e.g. `http://host.docker.internal:11434`); see [Local LLM / Ollama guide](local-llm-mlx.md).
+**Local provider:** When `LLM_PROVIDER=local`, all LLM traffic is between AgentCeption and your Ollama server on the host. No data is sent to Anthropic. Use a private base URL (e.g. `http://host.docker.internal:11434`); see [Local LLM / Ollama guide](local-llm.md).
 
 **What you must do for Anthropic:** Set `ANTHROPIC_API_KEY` when using the anthropic provider. For local, set `LLM_PROVIDER=local` and configure `LOCAL_LLM_BASE_URL` (and optional caps).
 

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -37,7 +37,7 @@ Open `.env` and fill in the required values:
 | `GH_REPO` | **Yes** | The `owner/repo` this AgentCeption instance orchestrates. | Your GitHub repo |
 | `GITHUB_TOKEN` | Optional | GitHub PAT with `repo` + `issues` scope. If you have `~/.config/gh` configured (via `gh auth login`), the container volume-mounts it and you can leave this blank. | [github.com/settings/tokens](https://github.com/settings/tokens) |
 | `ANTHROPIC_API_KEY` | Optional | Anthropic API key. Required when using the **anthropic** LLM provider (default). Used for Phase 1A planning and the agent loop. Without it the service starts, but planning and agent execution are unavailable when `LLM_PROVIDER=anthropic`. | [console.anthropic.com](https://console.anthropic.com/) |
-| `LLM_PROVIDER` | Optional | Which LLM backend to use: `anthropic` (default) or `local`. When `local`, all LLM calls go to an Ollama-compatible server on the host (see [Local LLM guide](local-llm-mlx.md)). | Default: `anthropic` |
+| `LLM_PROVIDER` | Optional | Which LLM backend to use: `anthropic` (default) or `local`. When `local`, all LLM calls go to an Ollama-compatible server on the host (see [Local LLM guide](local-llm.md)). | Default: `anthropic` |
 | `AC_API_KEY` | Optional | Shared secret for authenticating all `/api/*` requests. Leave empty for local-only deployments. Required when exposing the service on a shared server or the public internet. | Generate with `python3 -c "import secrets; print(secrets.token_urlsafe(32))"` |
 | `QDRANT_URL` | Optional | Internal Qdrant REST endpoint. | Default: `http://agentception-qdrant:6333` |
 | `QDRANT_COLLECTION` | Optional | Qdrant collection for code vectors. | Default: `code` |
@@ -49,7 +49,7 @@ Open `.env` and fill in the required values:
 | `LOG_LEVEL` | Optional | Log verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`. | Default: `INFO` |
 | `AC_PIPELINE_STALL_THRESHOLD_MINUTES` | Optional | Minutes of DB-heartbeat silence before a worker agent is promoted to `STALLED`. Stored in `PipelineConfig.stall_threshold_minutes`; also settable via `pipeline-config.json`. | Default: `30` |
 
-**Local LLM (free, private):** To run agents entirely on your own hardware using [Ollama](https://ollama.com), set `LLM_PROVIDER=local` and configure `LOCAL_LLM_BASE_URL` and `LOCAL_LLM_MODEL`. See [Local LLM / Ollama guide](local-llm-mlx.md) for the full setup walkthrough (model recommendations, performance tips) and [LLM contract and provider abstraction](../reference/llm-contract.md) for the config model.
+**Local LLM (free, private):** To run agents entirely on your own hardware using [Ollama](https://ollama.com), set `LLM_PROVIDER=local` and configure `LOCAL_LLM_BASE_URL` and `LOCAL_LLM_MODEL`. See [Local LLM / Ollama guide](local-llm.md) for the full setup walkthrough (model recommendations, performance tips) and [LLM contract and provider abstraction](../reference/llm-contract.md) for the config model.
 
 Minimal `.env` that works for a basic smoke test (no LLM features):
 

--- a/docs/reference/llm-contract.md
+++ b/docs/reference/llm-contract.md
@@ -89,6 +89,6 @@ To add a new backend (e.g. OpenAI, Azure, or another API):
 | Doc | Content |
 |-----|--------|
 | [LLM provider abstraction (architecture)](../architecture/llm-provider-abstraction.md) | Rationale, options, target architecture, implementation steps. |
-| [Local LLM with MLX (deployment)](../guides/local-llm-mlx.md) | End-to-end local provider setup: config, env vars, MLX server, probes. |
+| [Local LLM / Ollama (deployment)](../guides/local-llm.md) | End-to-end local provider setup: config, env vars, Ollama, probes. |
 | [Type contracts — LLM Service Types](type-contracts.md#llm-service-types) | TypedDict and function signatures in detail. |
 | [Setup](../guides/setup.md) | First-run env vars; optional local LLM subsection. |


### PR DESCRIPTION
Removes the Mac-only framing from the local LLM docs. The Ollama integration was never actually Apple-only — this was just documentation scope creep.

## Changes

- **README Option B**: re-titled from "Local models on macOS" to "Local models"; adds macOS/Linux/Windows Ollama install instructions; notes GPU acceleration per platform (Metal, CUDA, ROCm).
- **`docs/guides/local-llm-mlx.md` → `local-llm.md`**: removes Apple Silicon framing from title and intro; adds Linux (`curl` installer) and Windows (download page) install steps; renames "Model choice by Mac RAM" to "Model choice by available RAM"; resource monitoring section now covers macOS (`powermetrics`), Linux (`nvidia-smi`/`rocm-smi`), and Windows (Task Manager/GPU-Z); MLX content stays but is explicitly labelled as Apple Silicon-only footnote.
- **8 reference sites updated**: `.env.example`, `docs/README.md`, `docs/guides/setup.md`, `security.md`, `local-llm-scaling.md`, `docs/reference/llm-contract.md`, `docs/architecture/llm-provider-abstraction.md`.

No Python, TypeScript, or config changes — docs only.