### PR TITLE
fix: ab-metrics SQL CAST and poller DNS exponential backoff

### DIFF
--- a/agentception/poller.py
+++ b/agentception/poller.py
@@ -766,13 +766,21 @@ async def polling_loop() -> None:
     Errors inside a single tick are logged and swallowed so one bad GitHub
     response cannot kill the entire dashboard.
 
-    Rate-limit backoff: when GitHub returns a rate-limit error we back off
-    exponentially (60 s → 120 s → 240 s, capped at 300 s) rather than
-    hammering the API on every loop iteration.
+    Backoff policy:
+    - **Rate limit** (GitHub 429/403 rate-limit): exponential backoff
+      60 s → 120 s → 240 s, capped at 300 s.
+    - **Network / DNS error** (``OSError`` including ``socket.gaierror``):
+      exponential backoff 30 s → 60 s → 120 s, capped at 300 s.  DNS blips
+      are transient but hammering a broken network every ``poll_interval``
+      generates noise and burns retries.
+    - **Other**: log at WARNING and sleep one normal poll interval.
     """
     _RATE_LIMIT_BACKOFF_INITIAL: int = 60
     _RATE_LIMIT_BACKOFF_MAX: int = 300
+    _NET_BACKOFF_INITIAL: int = 30
+    _NET_BACKOFF_MAX: int = 300
     _rate_limit_backoff: int = 0  # 0 = not in backoff
+    _net_backoff: int = 0
 
     logger.info(
         "✅ AgentCeption polling loop started (interval=%ds)",
@@ -782,6 +790,7 @@ async def polling_loop() -> None:
         try:
             await tick()
             _rate_limit_backoff = 0  # reset on success
+            _net_backoff = 0
             try:
                 async with get_session() as _reconcile_session:
                     _reconciled = await reconcile_stale_runs(
@@ -803,6 +812,18 @@ async def polling_loop() -> None:
         except asyncio.CancelledError:
             logger.info("✅ Polling loop stopped cleanly")
             return
+        except OSError as exc:
+            # Covers socket.gaierror (DNS), ConnectionRefusedError, etc.
+            if _net_backoff == 0:
+                _net_backoff = _NET_BACKOFF_INITIAL
+            else:
+                _net_backoff = min(_net_backoff * 2, _NET_BACKOFF_MAX)
+            logger.warning(
+                "⚠️  Polling loop network error — backing off %ds before retry: %s",
+                _net_backoff,
+                exc,
+            )
+            await asyncio.sleep(_net_backoff)
         except Exception as exc:
             exc_str = str(exc).lower()
             if "rate limit" in exc_str or "rate_limit" in exc_str:

--- a/agentception/routes/api/ab_metrics.py
+++ b/agentception/routes/api/ab_metrics.py
@@ -75,7 +75,7 @@ LEFT JOIN (
 ) e ON e.agent_run_id = r.id
 WHERE r.role = 'developer'
   AND r.status = 'completed'
-  AND r.spawned_at > NOW() - (:days::integer * INTERVAL '1 day')
+  AND r.spawned_at > NOW() - (CAST(:days AS integer) * INTERVAL '1 day')
 GROUP BY COALESCE(r.prompt_variant, 'control'), r.role
 ORDER BY 1, 2
 """)

--- a/agentception/tests/test_agentception_poller.py
+++ b/agentception/tests/test_agentception_poller.py
@@ -998,3 +998,88 @@ async def test_stamp_missing_blocked_deps_skips_when_no_candidates() -> None:
 
     closed_mock.assert_not_awaited()
     add_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# polling_loop() — network / DNS error backoff
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_polling_loop_oserror_triggers_backoff() -> None:
+    """OSError (socket.gaierror, connection refused, DNS failure) triggers
+    exponential backoff instead of sleeping at the normal poll interval.
+
+    Regression: [Errno -2] Name or service not known was being logged as a
+    plain 'Polling loop error' with no backoff, causing the poller to hammer
+    an unreachable GitHub API on every poll cycle.
+    """
+    import socket
+
+    sleep_calls: list[float] = []
+    call_count = 0
+
+    async def fake_tick() -> None:
+        nonlocal call_count
+        call_count += 1
+        # First call raises a DNS error; second call cancels the loop.
+        if call_count == 1:
+            raise socket.gaierror(-2, "Name or service not known")
+        raise asyncio.CancelledError
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    with (
+        patch("agentception.poller.tick", side_effect=fake_tick),
+        patch("agentception.poller.asyncio.sleep", side_effect=fake_sleep),
+        patch("agentception.poller.settings") as mock_settings,
+    ):
+        mock_settings.poll_interval_seconds = 5
+        mock_settings.stale_run_threshold_minutes = 60
+        try:
+            await polling_loop()
+        except asyncio.CancelledError:
+            pass
+
+    # The backoff sleep must be the initial net-error backoff (30 s), not the
+    # normal poll interval (5 s).
+    assert len(sleep_calls) >= 1
+    assert sleep_calls[0] == 30, (
+        f"Expected 30 s net backoff on OSError, got {sleep_calls[0]} s"
+    )
+
+
+@pytest.mark.anyio
+async def test_polling_loop_oserror_backoff_doubles_on_repeat() -> None:
+    """Second consecutive OSError doubles the backoff sleep."""
+    import socket
+
+    sleep_calls: list[float] = []
+    call_count = 0
+
+    async def fake_tick() -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise socket.gaierror(-2, "Name or service not known")
+        raise asyncio.CancelledError
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    with (
+        patch("agentception.poller.tick", side_effect=fake_tick),
+        patch("agentception.poller.asyncio.sleep", side_effect=fake_sleep),
+        patch("agentception.poller.settings") as mock_settings,
+    ):
+        mock_settings.poll_interval_seconds = 5
+        mock_settings.stale_run_threshold_minutes = 60
+        try:
+            await polling_loop()
+        except asyncio.CancelledError:
+            pass
+
+    assert len(sleep_calls) >= 2
+    assert sleep_calls[0] == 30, f"First backoff should be 30 s, got {sleep_calls[0]}"
+    assert sleep_calls[1] == 60, f"Second backoff should be 60 s, got {sleep_calls[1]}"

--- a/tests/test_ab_metrics.py
+++ b/tests/test_ab_metrics.py
@@ -148,3 +148,20 @@ async def test_ab_metrics_days_clamped(client: AsyncClient) -> None:
     """days=0 is clamped to 1 (Query(ge=1)); invalid values return 422."""
     response = await client.get("/metrics/ab", params={"days": 0})
     assert response.status_code == 422
+
+
+def test_ab_metrics_sql_uses_cast_not_double_colon() -> None:
+    """Regression: asyncpg rejects :param::type syntax in textual SQL.
+
+    The named parameter :days must be written as CAST(:days AS integer) so
+    asyncpg does not see the :: cast operator as part of the parameter name.
+    """
+    from agentception.routes.api.ab_metrics import _AB_QUERY
+
+    sql = str(_AB_QUERY)
+    assert "CAST(:days AS integer)" in sql, (
+        "SQL must use CAST(:days AS integer) — asyncpg misparses :days::integer"
+    )
+    assert ":days::integer" not in sql, (
+        "Found :days::integer in SQL — this causes asyncpg PostgresSyntaxError"
+    )


### PR DESCRIPTION
Fixes two recurring log errors visible in the terminal.

## AB Metrics SQL (`PostgresSyntaxError`)

asyncpg's textual SQL parser misparses `:days::integer` — it sees the `::` cast operator immediately after a named bind parameter and raises `syntax error at or near ":"`. Fix: replace with `CAST(:days AS integer)` which is unambiguous.

**Regression test:** `test_ab_metrics_sql_uses_cast_not_double_colon` asserts the SQL string never contains `:days::integer`.

## Poller DNS Backoff (`[Errno -2] Name or service not known`)

`socket.gaierror` (DNS failure) is a subclass of `OSError`. The existing handler only caught rate-limit strings and fell through to the generic branch — log and sleep one normal poll interval — causing the poller to hammer an unreachable `api.github.com` on every cycle and flood the logs.

Fix: add an `except OSError` handler before the generic `except Exception` that backs off exponentially (30 s → 60 s → 120 s, capped at 300 s), matching the rate-limit backoff policy.

**Regression tests:** `test_polling_loop_oserror_triggers_backoff`, `test_polling_loop_oserror_backoff_doubles_on_repeat`.

mypy + pytest 40/40 green.