### PR TITLE
fix: move lone-worker warning out of header row into dedicated strip

### DIFF
--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -1341,6 +1341,31 @@ $od-pending-color:#4b5563;  // gray for unconfigured
   color: #f87171;
 }
 
+// ── Lone-worker warning strip — full-width bar below the header ────────────────
+
+.od-warn-strip {
+  flex-shrink: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.6rem 1.5rem;
+  background: rgba(217, 119, 6, 0.12);
+  border-bottom: 1px solid rgba(217, 119, 6, 0.3);
+  color: #fbbf24;
+
+  &__icon {
+    flex-shrink: 0;
+    font-size: 0.85rem;
+    line-height: 1.5;
+  }
+
+  &__text {
+    font-size: 0.75rem;
+    line-height: 1.5;
+    color: rgba(251, 191, 36, 0.9);
+  }
+}
+
 // ── Preset picker ─────────────────────────────────────────────────────────────
 
 // ── Preset palette (accent colours per template) ──────────────────────────────

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -302,22 +302,25 @@
       </button>
     </template>
 
-    {# Launch button + lone-worker warning — design canvas only #}
+    {# Launch button — design canvas only #}
     <template x-if="!presetsOpen && !liveMode">
-      <span class="od-header__launch-group">
-        <template x-if="loneWorkerWarning">
-          <span class="od-header__lone-worker-warn" x-text="loneWorkerWarning"></span>
-        </template>
-        <button class="od-header__btn od-header__btn--launch"
-                :disabled="!launchReady"
-                @click="launch()"
-                x-text="launching ? 'Launching…' : (startAgentLoading ? 'Starting agent…' : launchPreviewText)">
-        </button>
-      </span>
+      <button class="od-header__btn od-header__btn--launch"
+              :disabled="!launchReady"
+              @click="launch()"
+              x-text="launching ? 'Launching…' : (startAgentLoading ? 'Starting agent…' : launchPreviewText)">
+      </button>
     </template>
 
     <button class="od-header__btn od-header__btn--close" @click="close()">✕ Close</button>
   </div>
+
+  {# Lone-worker warning strip — below header, design canvas only #}
+  <template x-if="!presetsOpen && !liveMode && loneWorkerWarning">
+    <div class="od-warn-strip">
+      <span class="od-warn-strip__icon">⚠️</span>
+      <span class="od-warn-strip__text" x-text="loneWorkerWarning.replace(/^⚠️\s*/, '')"></span>
+    </div>
+  </template>
 
   {# ── Sessions tab — shown in live mode when multiple batches exist ──────── #}
   <template x-if="liveMode && activeBatches.length > 1">


### PR DESCRIPTION
The `loneWorkerWarning` message was sitting inside `.od-header` (a single-line flex row) alongside the title, badge, save/preset buttons, launch button, and close button. The long text stretched the row and broke the layout.

## Changes

- **`build.html`**: Remove `od-header__launch-group` wrapper; pull the lone-worker warning entirely out of the header row; add a new `od-warn-strip` element that renders just below the header (between header and canvas) when the warning is active. Launch button stays in the header row alone.
- **`_inspector-layout.scss`**: Add `.od-warn-strip` with amber background/border and icon/text sub-elements. The strip flexes to full width naturally inside the OD panel column.

mypy + pytest 38/38 green.