### PR TITLE
chore: rename service port from 10003 to 1337

### DIFF
--- a/.agentception/agent-reviewer.md
+++ b/.agentception/agent-reviewer.md
@@ -20,7 +20,7 @@ dispatch for the resulting PR. No manual coordination is needed.
 To trigger a reviewer manually (e.g. for a PR the auto-dispatch missed):
 
 ```bash
-curl -X POST http://localhost:10003/api/dispatch/issue \
+curl -X POST http://localhost:1337/api/dispatch/issue \
   -H "X-API-Key: $AC_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/.agentception/roles/architect.md
+++ b/.agentception/roles/architect.md
@@ -28,7 +28,7 @@ Every architectural artifact (ADR, design doc, RFC) you produce must:
 This repository is a single standalone service:
 
 ```
-agentception/ # AgentCeption — FastAPI + HTMX + Alpine (port 10003)
+agentception/ # AgentCeption — FastAPI + HTMX + Alpine (port 1337)
               #   mcp/        # MCP server for Cursor/Claude tool integration
 ```
 

--- a/.agentception/roles/devops-engineer.md
+++ b/.agentception/roles/devops-engineer.md
@@ -29,7 +29,7 @@ Services in this repo:
 
 | Service | Container | Port |
 |---------|-----------|------|
-| AgentCeption | `agentception` | 10003 |
+| AgentCeption | `agentception` | 1337 |
 | Postgres | `agentception-postgres` | 5433 |
 | Qdrant | `agentception-qdrant` | 6335/6336 |
 | Nginx | `agentception-nginx` | 80/443 |

--- a/.agentception/roles/infrastructure-coordinator.md
+++ b/.agentception/roles/infrastructure-coordinator.md
@@ -40,7 +40,7 @@ You do NOT own:
 
 ## Operating Stack
 
-This codebase runs on Docker Compose locally and is expected to extend to container orchestration at scale. Services: `agentception` (port 10003), `agentception-postgres` (5433), `agentception-qdrant` (6335/6336), `postgres` (5432), `qdrant` (6333/6334), `nginx` (80/443).
+This codebase runs on Docker Compose locally and is expected to extend to container orchestration at scale. Services: `agentception` (port 1337), `agentception-postgres` (5433), `agentception-qdrant` (6335/6336), `postgres` (5432), `qdrant` (6333/6334), `nginx` (80/443).
 
 Dev bind mounts are active — host file edits are instantly visible in containers. Rebuild only when `requirements.txt`, `Dockerfile`, or `entrypoint.sh` change.
 

--- a/.agentception/roles/site-reliability-engineer.md
+++ b/.agentception/roles/site-reliability-engineer.md
@@ -30,7 +30,7 @@ Key AgentCeption services to monitor:
 
 | Service | Container | Port | SLO Owner |
 |---------|-----------|------|-----------|
-| AgentCeption | `agentception` | 10003 | Primary |
+| AgentCeption | `agentception` | 1337 | Primary |
 | Postgres | `agentception-postgres` | 5433 | Data layer |
 | Qdrant | `agentception-qdrant` | 6335 | Vector search |
 | Nginx | `agentception-nginx` | 80/443 | Ingress |

--- a/.cursorrules
+++ b/.cursorrules
@@ -291,7 +291,7 @@ The browser loads **compiled bundles**, not source files directly:
 
 | Service | Container | Port |
 |---------|-----------|------|
-| AgentCeption | `agentception` | 10003 |
+| AgentCeption | `agentception` | 1337 |
 | Postgres | `agentception-postgres` | 5433 |
 | Qdrant | `agentception-qdrant` | 6335/6336 |
 

--- a/.env.example
+++ b/.env.example
@@ -65,7 +65,7 @@ AC_API_KEY=
 
 # ── Service ─────────────────────────────────────────────────────────────────
 # Port the AgentCeption FastAPI app listens on (inside the container).
-PORT=10003
+PORT=1337
 
 # ── Polling / Cache ──────────────────────────────────────────────────────────
 # How often (seconds) the background poller fetches GitHub data.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,11 +120,11 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose.ci.yml \
             up -d proxy agentception
           for i in $(seq 1 18); do
-            curl -sf http://localhost:10003/health && break
+            curl -sf http://localhost:1337/health && break
             sleep 5
           done
-          curl -f http://localhost:10003/health
-          curl -f http://localhost:10003/
+          curl -f http://localhost:1337/health
+          curl -f http://localhost:1337/
 
       - name: Tear down
         if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,4 +116,4 @@ COPY scripts/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["uvicorn", "agentception.app:app", "--host", "0.0.0.0", "--port", "10003"]
+CMD ["uvicorn", "agentception.app:app", "--host", "0.0.0.0", "--port", "1337"]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cp .env.example .env
 # Set ANTHROPIC_API_KEY, GITHUB_TOKEN, GH_REPO, HOST_WORKTREES_DIR
 docker compose up -d
 docker compose exec agentception alembic upgrade head
-open http://localhost:10003
+open http://localhost:1337
 ```
 
 ### Option B — Local models (free, private)
@@ -102,8 +102,8 @@ HOST_WORKTREES_DIR=/path/to/worktrees
 # 3. Start
 docker compose up -d
 docker compose exec agentception alembic upgrade head
-# macOS: open http://localhost:10003
-# Linux/Windows: navigate to http://localhost:10003
+# macOS: open http://localhost:1337
+# Linux/Windows: navigate to http://localhost:1337
 ```
 
 > **Performance tip:** Set `WORKTREE_INDEX_ENABLED=false` in `.env` to skip per-agent code indexing (saves ~2 GB RSS and significant CPU) when running on constrained hardware.
@@ -128,7 +128,7 @@ See [docs/guides/local-llm.md](docs/guides/local-llm.md) for the full Ollama set
 
 See [docs/guides/setup.md](docs/guides/setup.md) for the full first-run walkthrough.
 
-> **Security note:** By default all `/api/*` endpoints are unauthenticated. If your machine is on a shared network (office LAN, cloud VM, dev box), set `AC_API_KEY` in `.env` before starting. Without it, anyone who can reach port 10003 can dispatch agents and burn your Anthropic credits. Generate a key with `openssl rand -hex 32`.
+> **Security note:** By default all `/api/*` endpoints are unauthenticated. If your machine is on a shared network (office LAN, cloud VM, dev box), set `AC_API_KEY` in `.env` before starting. Without it, anyone who can reach port 1337 can dispatch agents and burn your Anthropic credits. Generate a key with `openssl rand -hex 32`.
 
 ---
 

--- a/agentception/Dockerfile
+++ b/agentception/Dockerfile
@@ -41,4 +41,4 @@ RUN sass --style=compressed --no-source-map \
     /app/agentception/static/scss/app.scss \
     /app/agentception/static/app.css
 
-CMD ["uvicorn", "agentception.app:app", "--host", "0.0.0.0", "--port", "10003"]
+CMD ["uvicorn", "agentception.app:app", "--host", "0.0.0.0", "--port", "1337"]

--- a/agentception/app.py
+++ b/agentception/app.py
@@ -1,6 +1,6 @@
 """AgentCeption FastAPI application factory.
 
-Entry point: ``uvicorn agentception.app:app --port 10003 --reload``
+Entry point: ``uvicorn agentception.app:app --port 1337 --reload``
 
 Architecture:
 - ``lifespan`` starts the background ``polling_loop`` task from ``poller.py``
@@ -242,7 +242,7 @@ def main() -> None:
 
     Launches the AgentCeption dashboard with uvicorn.  Configure the host and
     port via environment variables ``HOST`` (default ``0.0.0.0``) and
-    ``PORT`` (default ``10003``), or override ``agentception.app:app`` directly
+    ``PORT`` (default ``1337``), or override ``agentception.app:app`` directly
     when running under a production ASGI server.
     """
     import os
@@ -250,7 +250,7 @@ def main() -> None:
     import uvicorn
 
     host = os.environ.get("HOST", "0.0.0.0")
-    port = int(os.environ.get("PORT", "10003"))
+    port = int(os.environ.get("PORT", "1337"))
     uvicorn.run("agentception.app:app", host=host, port=port, reload=False)
 
 

--- a/agentception/services/auto_redispatch.py
+++ b/agentception/services/auto_redispatch.py
@@ -33,7 +33,7 @@ from agentception.readers.github import add_comment_to_issue, get_issue
 logger = logging.getLogger(__name__)
 
 _PR_URL_RE = re.compile(r"/pull/(\d+)")
-_SERVICE_URL = "http://localhost:10003/api/dispatch/issue"
+_SERVICE_URL = "http://localhost:1337/api/dispatch/issue"
 
 # Brief pause after worktree release before touching git/GitHub so git prune
 # has time to flush its ref locks.

--- a/agentception/services/auto_reviewer.py
+++ b/agentception/services/auto_reviewer.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 
 _PR_URL_RE = re.compile(r"/pull/(\d+)")
 
-# Fixed port — the agentception service always binds 10003 inside the container.
-_SERVICE_URL = "http://localhost:10003/api/dispatch/issue"
+# Fixed port — the agentception service always binds 1337 inside the container.
+_SERVICE_URL = "http://localhost:1337/api/dispatch/issue"
 
 # Seconds to wait after build_complete_run before fetching the PR branch.
 # GitHub needs a moment to register the push before the branch is fetchable.

--- a/agentception/tests/test_spawn_child.py
+++ b/agentception/tests/test_spawn_child.py
@@ -60,7 +60,7 @@ async def test_spawn_child_forwards_cognitive_arch_without_resolving() -> None:
         mock_settings.host_worktrees_dir = MagicMock()
         mock_settings.host_worktrees_dir.__truediv__ = lambda s, x: MagicMock(__str__=lambda _: f"/host/worktrees/{x}")
         mock_settings.repo_dir = "/repo"
-        mock_settings.ac_url = "http://localhost:10003"
+        mock_settings.ac_url = "http://localhost:1337"
 
         # Mock git commands — rev-parse and worktree add both succeed
         git_proc = AsyncMock()
@@ -106,7 +106,7 @@ async def test_spawn_child_resolves_arch_when_not_provided() -> None:
         mock_settings.host_worktrees_dir = MagicMock()
         mock_settings.host_worktrees_dir.__truediv__ = lambda s, x: MagicMock(__str__=lambda _: f"/host/worktrees/{x}")
         mock_settings.repo_dir = "/repo"
-        mock_settings.ac_url = "http://localhost:10003"
+        mock_settings.ac_url = "http://localhost:1337"
 
         git_proc = AsyncMock()
         git_proc.returncode = 0
@@ -165,7 +165,7 @@ async def test_cognitive_arch_propagates_to_leaf() -> None:
         mock_settings_1.host_worktrees_dir = MagicMock()
         mock_settings_1.host_worktrees_dir.__truediv__ = lambda s, x: MagicMock(__str__=lambda _: f"/host/worktrees/{x}")
         mock_settings_1.repo_dir = "/repo"
-        mock_settings_1.ac_url = "http://localhost:10003"
+        mock_settings_1.ac_url = "http://localhost:1337"
 
         git_proc = AsyncMock()
         git_proc.returncode = 0
@@ -208,7 +208,7 @@ async def test_cognitive_arch_propagates_to_leaf() -> None:
         mock_settings_2.host_worktrees_dir = MagicMock()
         mock_settings_2.host_worktrees_dir.__truediv__ = lambda s, x: MagicMock(__str__=lambda _: f"/host/worktrees/{x}")
         mock_settings_2.repo_dir = "/repo"
-        mock_settings_2.ac_url = "http://localhost:10003"
+        mock_settings_2.ac_url = "http://localhost:1337"
 
         git_proc_2 = AsyncMock()
         git_proc_2.returncode = 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   # ==========================================================================
   # AgentCeption — multi-agent orchestration dashboard
-  # Port 10003 — the AgentCeption service port.
+  # Port 1337 — the AgentCeption service port.
   # ==========================================================================
   agentception:
     build:
@@ -49,7 +49,7 @@ services:
       - DAC_OVERRIDE
       - FOWNER
     ports:
-      - "127.0.0.1:10003:10003"
+      - "127.0.0.1:1337:1337"
     environment:
       # Run as agentception (non-root). HOME must be writable so HuggingFace/fastembed
       # can write ~/.cache/huggingface/token and model files; using /root causes
@@ -183,7 +183,7 @@ services:
       proxy:
         condition: service_started
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:10003/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:1337/health"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docs/README.md
+++ b/docs/README.md
@@ -161,7 +161,7 @@ scripts/
 
 | Service | Container | Port |
 |---------|-----------|------|
-| AgentCeption | `agentception` | 10003 |
+| AgentCeption | `agentception` | 1337 |
 | Postgres | `agentception-postgres` | 5433 |
 | Qdrant | `agentception-qdrant` | 6335 / 6336 |
 

--- a/docs/agent-tree-protocol.md
+++ b/docs/agent-tree-protocol.md
@@ -159,7 +159,7 @@ BATCH_ID      = "label-AC-UI-0-20260303T200000Z-a1b2"
 PARENT_RUN_ID = ""                  # empty for root; set by spawner for all other tiers
 
 # ── Callbacks ─────────────────────────────────────────────────────────────────
-AC_URL        = "http://localhost:10003"
+AC_URL        = "http://localhost:1337"
 # ROLE_FILE is the container-side path; HOST_ROLE_FILE is the host-side path.
 # Cursor agents running on the developer's machine should use HOST_ROLE_FILE.
 ROLE_FILE     = "<container-repo-root>/.agentception/roles/cto.md"
@@ -180,7 +180,7 @@ BRANCH        = "feat/issue-42"
 WORKTREE      = "$HOME/.agentception/worktrees/agentception/issue-42"
 BATCH_ID      = "label-AC-UI-0-20260303T200000Z-a1b2"
 PARENT_RUN_ID = "label-AC-UI-0-CRITICAL-BUGS-20260303T200000Z-a1b2"
-AC_URL        = "http://localhost:10003"
+AC_URL        = "http://localhost:1337"
 ROLE_FILE     = "<container-repo-root>/.agentception/roles/python-developer.md"
 HOST_ROLE_FILE = "<host-repo-root>/.agentception/roles/python-developer.md"
 ```
@@ -199,7 +199,7 @@ BRANCH        = ""
 WORKTREE      = "$HOME/.agentception/worktrees/agentception/pr-99"
 BATCH_ID      = "label-AC-UI-0-20260303T200000Z-a1b2"
 PARENT_RUN_ID = "issue-42-20260303T200100Z-c3d4"  # ← worker that spawned this reviewer
-AC_URL        = "http://localhost:10003"
+AC_URL        = "http://localhost:1337"
 ROLE_FILE     = "<container-repo-root>/.agentception/roles/reviewer.md"
 HOST_ROLE_FILE = "<host-repo-root>/.agentception/roles/reviewer.md"
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ agentception/
 
 | Service    | Purpose                                 | Port  |
 |------------|-----------------------------------------|-------|
-| agentception | FastAPI application                   | 10003 |
+| agentception | FastAPI application                   | 1337 |
 | postgres   | Persistent store (runs, phases, issues) | 5433  |
 | qdrant     | Vector store (semantic search)          | 6335  |
 

--- a/docs/cognitive-arch-audit.md
+++ b/docs/cognitive-arch-audit.md
@@ -172,7 +172,7 @@ RUN_ID:      {run_id}
 SCOPE_TYPE:  label
 SCOPE_VALUE: {scope_value}
 GH_REPO:     {gh_repo}
-AC_URL:      http://localhost:10003
+AC_URL:      http://localhost:1337
 ```
 
 For leaf agents, the briefing is similarly arch-free.  The agent must read `COGNITIVE_ARCH` from its `ac://runs/{run_id}/context` on its own — which coordinator role files do (as part of STEP 0) but leaf role files do not (for the intro announcement).

--- a/docs/guides/agent-loop.md
+++ b/docs/guides/agent-loop.md
@@ -110,14 +110,14 @@ Before agents can use semantic search, the codebase must be indexed. Indexing ru
 ### Trigger indexing
 
 ```bash
-curl -X POST http://localhost:10003/api/system/index-codebase
+curl -X POST http://localhost:1337/api/system/index-codebase
 # → 202 Accepted {"ok": true, "message": "Codebase indexing started in the background."}
 ```
 
 If `AC_API_KEY` is set:
 
 ```bash
-curl -X POST http://localhost:10003/api/system/index-codebase \
+curl -X POST http://localhost:1337/api/system/index-codebase \
   -H "Authorization: Bearer your-key"
 ```
 
@@ -143,7 +143,7 @@ Directories skipped entirely: `.git` `__pycache__` `node_modules` `.venv` `venv`
 ### Search the index directly
 
 ```bash
-curl "http://localhost:10003/api/system/search?q=anthropic+api+key&n=5"
+curl "http://localhost:1337/api/system/search?q=anthropic+api+key&n=5"
 ```
 
 Returns:
@@ -180,7 +180,7 @@ The `POST /api/runs/{run_id}/execute` endpoint dispatches an agent run using the
 ### HTTP request
 
 ```bash
-curl -X POST http://localhost:10003/api/runs/{run_id}/execute \
+curl -X POST http://localhost:1337/api/runs/{run_id}/execute \
   -H "Authorization: Bearer your-key"
 ```
 
@@ -243,7 +243,7 @@ FetchMcpResource(server="user-agentception", uri="ac://runs/{run_id}/events")
 Or directly:
 
 ```bash
-curl http://localhost:10003/api/runs/{run_id}/step
+curl http://localhost:1337/api/runs/{run_id}/step
 ```
 
 ---
@@ -260,11 +260,11 @@ Expected output:
 
 ```
 ══ AgentCeption Smoke Test — Cursor-Free Agent Loop ══
-  AgentCeption: http://127.0.0.1:10003
+  AgentCeption: http://127.0.0.1:1337
   Qdrant:       http://127.0.0.1:6335
 
 ─── Step 1: AgentCeption health check ───
-  OK — AgentCeption at http://127.0.0.1:10003 is healthy
+  OK — AgentCeption at http://127.0.0.1:1337 is healthy
 ─── Step 2: Qdrant connectivity ───
   OK — Qdrant at http://127.0.0.1:6335 is reachable
 ─── Step 3: Trigger codebase indexing ───

--- a/docs/guides/ci.md
+++ b/docs/guides/ci.md
@@ -53,7 +53,7 @@ docker compose -f docker-compose.yml -f docker-compose.ci.yml \
 
 # Smoke test
 docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --wait
-curl -f http://localhost:10003/health
+curl -f http://localhost:1337/health
 docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v
 ```
 

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -139,7 +139,7 @@ docker compose exec agentception sh -c \
 
 # 4. Smoke test (from the host)
 docker compose up -d --wait
-curl -f http://localhost:10003/health
+curl -f http://localhost:1337/health
 ```
 
 > **Dev bind mounts are active.** `docker-compose.override.yml` bind-mounts `agentception/`, `tests/`, `scripts/`, and `pyproject.toml` into the container. Host file edits are instantly visible — no rebuild needed for code changes. Only rebuild (`docker compose build agentception && docker compose up -d`) when `requirements.txt`, `Dockerfile`, or `entrypoint.sh` change.

--- a/docs/guides/dispatch.md
+++ b/docs/guides/dispatch.md
@@ -60,7 +60,7 @@ at the end — you never need to dispatch it manually.
 ### Implementation dispatch (the one you call)
 
 ```bash
-curl -s -X POST http://localhost:10003/api/dispatch/issue \
+curl -s -X POST http://localhost:1337/api/dispatch/issue \
   -H "Content-Type: application/json" \
   -d '{
     "issue_number": 35,
@@ -78,7 +78,7 @@ curl -s -X POST http://localhost:10003/api/dispatch/issue \
 ### Manual PR reviewer dispatch (rare — auto-fires on completion normally)
 
 ```bash
-curl -s -X POST http://localhost:10003/api/dispatch/issue \
+curl -s -X POST http://localhost:1337/api/dispatch/issue \
   -H "Content-Type: application/json" \
   -d '{
     "issue_number": 35,
@@ -94,7 +94,7 @@ If the PR branch does **not** follow the `feat/issue-{N}` convention, pass
 `pr_branch` explicitly:
 
 ```bash
-curl -s -X POST http://localhost:10003/api/dispatch/issue \
+curl -s -X POST http://localhost:1337/api/dispatch/issue \
   -H "Content-Type: application/json" \
   -d '{
     "issue_number": 35,
@@ -176,7 +176,7 @@ Stops all active agents, removes all worktrees, clears all `agent/wip` labels,
 and resets all active DB runs to `failed`. **Idempotent.**
 
 ```bash
-curl -s -X POST http://localhost:10003/api/control/reset-build \
+curl -s -X POST http://localhost:1337/api/control/reset-build \
   -H "Content-Type: application/json" | python3 -m json.tool
 ```
 
@@ -244,7 +244,7 @@ git push origin --delete feat/issue-35
 ## Re-dispatching a failed run
 
 ```bash
-curl -s -X POST http://localhost:10003/api/dispatch/issue \
+curl -s -X POST http://localhost:1337/api/dispatch/issue \
   -H "Content-Type: application/json" \
   -d '{"issue_number": 35, "issue_title": "...", "issue_body": "...", "role": "developer", "repo": "cgcardona/agentception"}'
 ```

--- a/docs/guides/dispatcher-walkthrough.md
+++ b/docs/guides/dispatcher-walkthrough.md
@@ -112,7 +112,7 @@ docker compose up -d
 
 ## Step 6 — Check the Ship board
 
-1. In your browser, open the Ship page (e.g. `http://localhost:10003/ship/...` for your project/initiative).
+1. In your browser, open the Ship page (e.g. `http://localhost:1337/ship/...` for your project/initiative).
 2. Refresh the page.
 3. You should see:
    - The run(s) no longer stuck in “Mission Control Idle”

--- a/docs/guides/local-llm-scaling.md
+++ b/docs/guides/local-llm-scaling.md
@@ -180,7 +180,7 @@ curl -s http://localhost:4000/v1/chat/completions \
   }'
 
 # Confirm AgentCeption reaches local model through proxy
-curl -s http://localhost:10003/api/local-llm/hello
+curl -s http://localhost:1337/api/local-llm/hello
 ```
 
 ---

--- a/docs/guides/local-llm.md
+++ b/docs/guides/local-llm.md
@@ -171,7 +171,7 @@ docker compose exec agentception curl -s http://host.docker.internal:11434/v1/ch
   -d '{"model":"qwen2.5-coder:7b","messages":[{"role":"user","content":"Say hi"}],"temperature":0,"max_tokens":16,"stream":false}'
 
 # Confirm AgentCeption reaches the local model
-curl -s http://localhost:10003/api/local-llm/hello
+curl -s http://localhost:1337/api/local-llm/hello
 # Expect: {"ok": true, "reply": "..."}
 ```
 
@@ -197,7 +197,7 @@ When Ollama is running, point the agent at it so it uses the local model instead
 3. **Probe the local model (no agent):**
 
    ```bash
-   curl -s http://localhost:10003/api/local-llm/hello
+   curl -s http://localhost:1337/api/local-llm/hello
    ```
 
    You should get `{"ok": true, "reply": "..."}`. If you get 502, the container cannot reach Ollama; check `host.docker.internal` and that Ollama is running on the host.
@@ -205,7 +205,7 @@ When Ollama is running, point the agent at it so it uses the local model instead
 4. **Optional: run an agent that says "hello world":**
 
    ```bash
-   curl -s -X POST http://localhost:10003/api/local-llm/hello-agent
+   curl -s -X POST http://localhost:1337/api/local-llm/hello-agent
    ```
 
    Returns `{"run_id": "local-hello-<uuid>", "status": "implementing"}`. Watch with `python3 scripts/watch_run.py local-hello-<uuid>`.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -20,7 +20,7 @@ Two transports are available — both speak the same JSON-RPC 2.0 protocol:
 | Transport | Entry point | Best for |
 |-----------|-------------|----------|
 | **stdio** | `docker compose exec -T agentception python -m agentception.mcp.stdio_server` | IDE sessions (e.g. Cursor, VS Code) |
-| **HTTP** | `POST http://localhost:10003/api/mcp` | Web agents, CI/CD, curl, Anthropic remote MCP |
+| **HTTP** | `POST http://localhost:1337/api/mcp` | Web agents, CI/CD, curl, Anthropic remote MCP |
 
 The HTTP transport follows the [MCP 2025-03-26 Streamable HTTP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports/): single or batch JSON-RPC request bodies, JSON responses. Notifications (requests without `id`) return `202 Accepted`.
 
@@ -41,7 +41,7 @@ When `AC_API_KEY` is configured, the HTTP MCP client must include the key:
 {
   "mcpServers": {
     "agentception": {
-      "url": "http://localhost:10003/api/mcp",
+      "url": "http://localhost:1337/api/mcp",
       "headers": {
         "Authorization": "Bearer your-generated-key-here"
       }
@@ -158,7 +158,7 @@ starting agents, advancing phase gates) always require an explicit human confirm
 {
   "mcpServers": {
     "agentception": {
-      "url": "http://localhost:10003/api/mcp",
+      "url": "http://localhost:1337/api/mcp",
       "autoApprove": [
         "plan_validate_spec",
         "plan_validate_manifest",
@@ -186,7 +186,7 @@ starting agents, advancing phase gates) always require an explicit human confirm
 
 - Resource reads (`FetchMcpResource`), prompt fetches, and observability tool calls happen without interruption.
 - `build_spawn_adhoc_child` and `plan_advance_phase` always require explicit confirmation — a mis-fire creates real GitHub issues and running agent processes that are hard to undo.
-- The HTTP endpoint is available at `http://localhost:10003/api/mcp` once containers are running.
+- The HTTP endpoint is available at `http://localhost:1337/api/mcp` once containers are running.
 
 ## Available tools, resources, and prompts
 

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -39,7 +39,7 @@ LLM calls are made by `agentception/services/llm.py` through a **provider-agnost
 
 ## AgentCeption HTTP Service
 
-The service listens on port `10003` bound to `127.0.0.1` by default (configured in `docker-compose.yml`). It is not reachable from the network without explicit port-forwarding or a reverse proxy. For a local developer machine, this is the only protection required.
+The service listens on port `1337` bound to `127.0.0.1` by default (configured in `docker-compose.yml`). It is not reachable from the network without explicit port-forwarding or a reverse proxy. For a local developer machine, this is the only protection required.
 
 ### API Key Authentication
 
@@ -82,7 +82,7 @@ Cursor's MCP client automatically sends `Authorization: Bearer <key>` when confi
 {
   "mcpServers": {
     "agentception": {
-      "url": "http://localhost:10003/api/mcp",
+      "url": "http://localhost:1337/api/mcp",
       "headers": {
         "Authorization": "Bearer your-generated-key-here"
       }
@@ -123,7 +123,7 @@ The Docker service itself speaks plain HTTP. For public-facing deployments, term
 
 ```caddy
 your.domain.example {
-    reverse_proxy localhost:10003
+    reverse_proxy localhost:1337
 }
 ```
 
@@ -140,7 +140,7 @@ server {
     ssl_certificate_key /path/to/privkey.pem;
 
     location / {
-        proxy_pass http://127.0.0.1:10003;
+        proxy_pass http://127.0.0.1:1337;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -45,7 +45,7 @@ Open `.env` and fill in the required values:
 | `WORKTREES_DIR` | Optional | Container-internal path that maps to `HOST_WORKTREES_DIR`. Add a matching volume in `docker-compose.override.yml` if you change this. | Default: `/worktrees` |
 | `HOST_REPO_DIR` | Optional | Absolute path to the repo on the host. Persisted to the DB context row so agents can resolve role files. Override in .env when the repo is outside the default Docker mount. | Default: unset |
 | `REPO_DIR` | Optional | Absolute path to the cloned agentception repo on the host. Used for git operations inside the container. | Default: `/app` (the container working directory) |
-| `PORT` | Optional | Port the FastAPI app listens on. | Default: `10003` |
+| `PORT` | Optional | Port the FastAPI app listens on. | Default: `1337` |
 | `LOG_LEVEL` | Optional | Log verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`. | Default: `INFO` |
 | `AC_PIPELINE_STALL_THRESHOLD_MINUTES` | Optional | Minutes of DB-heartbeat silence before a worker agent is promoted to `STALLED`. Stored in `PipelineConfig.stall_threshold_minutes`; also settable via `pipeline-config.json`. | Default: `30` |
 
@@ -85,7 +85,7 @@ This starts three services:
 
 | Container | Host port | Purpose |
 |-----------|-----------|---------|
-| `agentception` | 10003 | FastAPI dashboard + API |
+| `agentception` | 1337 | FastAPI dashboard + API |
 | `agentception-postgres` | 5433 | Persistent database (to avoid collision with other local Postgres instances) |
 | `agentception-qdrant` | 6335 / 6336 | Vector store for semantic search |
 
@@ -122,17 +122,17 @@ If postgres is still starting, wait 5 seconds and retry.
 
 ## Step 6 — Verify the dashboard
 
-Open [http://localhost:10003](http://localhost:10003) in your browser. You should see the AgentCeption dashboard with **Build**, **Org Chart**, and **Cognitive Architecture** pages all rendering.
+Open [http://localhost:1337](http://localhost:1337) in your browser. You should see the AgentCeption dashboard with **Build**, **Org Chart**, and **Cognitive Architecture** pages all rendering.
 
 Quick smoke test from the command line:
 
 ```bash
 # Basic health ping
-curl -f http://localhost:10003/health
+curl -f http://localhost:1337/health
 # → {"status":"ok"}
 
 # Detailed health snapshot (uptime, memory, worktree count, GitHub API latency)
-curl -f http://localhost:10003/api/health/detailed
+curl -f http://localhost:1337/api/health/detailed
 # → {"uptime_seconds":..., "memory_rss_mb":..., "active_worktree_count":0, "github_api_latency_ms":...}
 ```
 
@@ -145,7 +145,7 @@ Both should return HTTP 200.
 The Cursor-free agent loop uses a Qdrant vector index to give agents `@Codebase`-style semantic search without Cursor. Trigger indexing with a single API call:
 
 ```bash
-curl -X POST http://localhost:10003/api/system/index-codebase
+curl -X POST http://localhost:1337/api/system/index-codebase
 # → {"ok": true, "message": "Codebase indexing started in the background."}
 ```
 
@@ -158,7 +158,7 @@ docker compose logs -f agentception | grep code_indexer
 Verify the index is populated:
 
 ```bash
-curl "http://localhost:10003/api/system/search?q=anthropic+api+key&n=3"
+curl "http://localhost:1337/api/system/search?q=anthropic+api+key&n=3"
 # → {"ok": true, "query": "anthropic api key", "n_results": 3, "matches": [...]}
 ```
 
@@ -167,7 +167,7 @@ Re-index after significant code changes (e.g. after merging a large PR).
 If `AC_API_KEY` is set, include it:
 
 ```bash
-curl -X POST http://localhost:10003/api/system/index-codebase \
+curl -X POST http://localhost:1337/api/system/index-codebase \
   -H "Authorization: Bearer your-key"
 ```
 
@@ -222,12 +222,12 @@ grep DB_PASSWORD .env   # should show a non-empty value
 
 This indicates a mismatch between pip and the build backend. Make sure your local `pyproject.toml` uses `build-backend = "setuptools.build_meta"` (not `setuptools.backends.legacy:build`). Pull the latest `main` — this was fixed in [#970](https://github.com/cgcardona/agentception/pull/970).
 
-**Port 10003 already in use**
+**Port 1337 already in use**
 
 Another service is occupying that port. Stop it, or change the host port in `docker-compose.yml`:
 ```yaml
 ports:
-  - "127.0.0.1:10004:10003"   # use 10004 on the host instead
+  - "127.0.0.1:10004:1337"   # use 10004 on the host instead
 ```
 
 **Alembic migration fails with "connection refused"**

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-All endpoints are served by the AgentCeption container on port 10003. Every browser page and MCP tool call resolves to one of these routes.
+All endpoints are served by the AgentCeption container on port 1337. Every browser page and MCP tool call resolves to one of these routes.
 
 ## Authentication
 

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -139,7 +139,7 @@ The HTTP transport is available at `POST /api/mcp` once the containers are runni
 {
   "mcpServers": {
     "agentception": {
-      "url": "http://localhost:10003/api/mcp",
+      "url": "http://localhost:1337/api/mcp",
       "headers": {
         "Authorization": "Bearer your-generated-key-here"
       }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 /**
  * Playwright E2E configuration.
  *
- * Targets the AgentCeption server running in Docker at localhost:10003.
+ * Targets the AgentCeption server running in Docker at localhost:1337.
  * Start the stack first:  docker compose up -d
  *
  * Run all E2E tests:      npm run test:e2e
@@ -21,7 +21,7 @@ export default defineConfig({
   workers: process.env['CI'] ? 1 : undefined,
   reporter: [['html', { open: 'never' }], ['list']],
   use: {
-    baseURL: 'http://localhost:10003',
+    baseURL: 'http://localhost:1337',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',

--- a/scripts/gen_prompts/templates/roles/architect.md.j2
+++ b/scripts/gen_prompts/templates/roles/architect.md.j2
@@ -27,7 +27,7 @@ Every architectural artifact (ADR, design doc, RFC) you produce must:
 This repository is a single standalone service:
 
 ```
-agentception/ # AgentCeption — FastAPI + HTMX + Alpine (port 10003)
+agentception/ # AgentCeption — FastAPI + HTMX + Alpine (port 1337)
               #   mcp/        # MCP server for Cursor/Claude tool integration
 ```
 

--- a/scripts/gen_prompts/templates/roles/devops-engineer.md.j2
+++ b/scripts/gen_prompts/templates/roles/devops-engineer.md.j2
@@ -28,7 +28,7 @@ Services in this repo:
 
 | Service | Container | Port |
 |---------|-----------|------|
-| AgentCeption | `agentception` | 10003 |
+| AgentCeption | `agentception` | 1337 |
 | Postgres | `agentception-postgres` | 5433 |
 | Qdrant | `agentception-qdrant` | 6335/6336 |
 | Nginx | `agentception-nginx` | 80/443 |

--- a/scripts/gen_prompts/templates/roles/infrastructure-coordinator.md.j2
+++ b/scripts/gen_prompts/templates/roles/infrastructure-coordinator.md.j2
@@ -39,7 +39,7 @@ You do NOT own:
 
 ## Operating Stack
 
-This codebase runs on Docker Compose locally and is expected to extend to container orchestration at scale. Services: `agentception` (port 10003), `agentception-postgres` (5433), `agentception-qdrant` (6335/6336), `postgres` (5432), `qdrant` (6333/6334), `nginx` (80/443).
+This codebase runs on Docker Compose locally and is expected to extend to container orchestration at scale. Services: `agentception` (port 1337), `agentception-postgres` (5433), `agentception-qdrant` (6335/6336), `postgres` (5432), `qdrant` (6333/6334), `nginx` (80/443).
 
 Dev bind mounts are active — host file edits are instantly visible in containers. Rebuild only when `requirements.txt`, `Dockerfile`, or `entrypoint.sh` change.
 

--- a/scripts/gen_prompts/templates/roles/site-reliability-engineer.md.j2
+++ b/scripts/gen_prompts/templates/roles/site-reliability-engineer.md.j2
@@ -29,7 +29,7 @@ Key AgentCeption services to monitor:
 
 | Service | Container | Port | SLO Owner |
 |---------|-----------|------|-----------|
-| AgentCeption | `agentception` | 10003 | Primary |
+| AgentCeption | `agentception` | 1337 | Primary |
 | Postgres | `agentception-postgres` | 5433 | Data layer |
 | Qdrant | `agentception-qdrant` | 6335 | Vector search |
 | Nginx | `agentception-nginx` | 80/443 | Ingress |

--- a/scripts/search_benchmark.py
+++ b/scripts/search_benchmark.py
@@ -27,7 +27,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 
-BASE_URL = "http://localhost:10003"
+BASE_URL = "http://localhost:1337"
 
 
 @dataclass(frozen=True)

--- a/scripts/smoke_test_agent_loop.py
+++ b/scripts/smoke_test_agent_loop.py
@@ -7,7 +7,7 @@ Validates the full Cursor-replacement pipeline:
   4. FastEmbed model download + embedding round-trip
 
 This script communicates with a running AgentCeption container at
-http://127.0.0.1:10003.  Start the stack with ``docker compose up -d``
+http://127.0.0.1:1337.  Start the stack with ``docker compose up -d``
 before running:
 
     python3 scripts/smoke_test_agent_loop.py
@@ -26,7 +26,7 @@ import urllib.error
 import urllib.request
 from typing import TypedDict
 
-BASE_URL = "http://127.0.0.1:10003"
+BASE_URL = "http://127.0.0.1:1337"
 QDRANT_URL = "http://127.0.0.1:6335"
 
 


### PR DESCRIPTION
## Summary
- Replaces every reference to port `10003` with `1337` across 40 files: Dockerfiles, docker-compose, CI workflow, app entrypoint, scripts, all docs, tests, and derived `.agentception` role prompts
- Zero remaining `10003` references confirmed via grep
- Health check confirmed passing: `curl -sf http://localhost:1337/health` → `{"status":"ok"}`

## Test plan
- [x] `docker compose build agentception` succeeded
- [x] `curl -sf http://localhost:1337/health` → `{"status":"ok"}`
- [x] `mypy agentception/ tests/` → 0 errors
- [x] `generate.py --check` → 0 drift
- [x] 40 tests pass (test_spawn_child, test_agentception_poller, test_ab_metrics)