### PR TITLE
feat: show issue # badge on node card when scope === 'issue'

### DIFF
--- a/agentception/static/js/org_designer.ts
+++ b/agentception/static/js/org_designer.ts
@@ -749,6 +749,7 @@ function renderD3(
   container:   HTMLElement,
   figures:     FigureItem[],
   selectedId:  string | null,
+  repo:        string,
   onAdd:       (id: string) => void,
   onRemove:    (id: string) => void,
   onSelect:    (id: string) => void,
@@ -827,7 +828,7 @@ function renderD3(
     .classed('od-node--worker',      (d: D3HierarchyNode) => !!d.data.role && !isCoordinator(d.data.role))
     .classed('od-node--pending',     (d: D3HierarchyNode) => !d.data.role && !d.data.launched)
     .classed('od-node--launched',    (d: D3HierarchyNode) => d.data.launched)
-    .html((d: D3HierarchyNode) => nodeCardHtml(d, figMap, offsetX, offsetY));
+    .html((d: D3HierarchyNode) => nodeCardHtml(d, figMap, repo));
 
   cards.exit().remove();
 
@@ -850,10 +851,24 @@ function renderD3(
 function nodeCardHtml(
   d:      D3HierarchyNode,
   figMap: Map<string, string>,
-  _ox:    number,
-  _oy:    number,
+  repo:   string,
 ): string {
   const node = d.data;
+
+  // Build a scope badge shown on the card (phase label or issue # link).
+  function scopeBadge(): string {
+    if (node.scope === 'phase' && node.scopeLabel) {
+      return `<div class="od-node__scope">⌖ ${node.scopeLabel}</div>`;
+    }
+    if (node.scope === 'issue' && node.scopeIssueNumber != null) {
+      const url = `https://github.com/${repo}/issues/${node.scopeIssueNumber}`;
+      return `<a class="od-node__issue-link" href="${url}" target="_blank" rel="noopener noreferrer"
+                 title="Open issue #${node.scopeIssueNumber} on GitHub"
+                 onclick="event.stopPropagation()"
+               ># ${node.scopeIssueNumber}</a>`;
+    }
+    return '';
+  }
 
   if (node.launched) {
     const removeBtn = d.depth > 0
@@ -862,6 +877,7 @@ function nodeCardHtml(
     return `
       <div class="od-node__tier od-node__tier--launched">✅ launched</div>
       <div class="od-node__role">${roleLabel(node.role)}</div>
+      ${scopeBadge()}
       <div class="od-node__run-id">${node.runId}</div>
       <div class="od-node__actions">
         <button class="od-node__btn od-node__btn--edit" data-id="${node.id}" title="View">edit</button>
@@ -874,9 +890,6 @@ function nodeCardHtml(
   const roleLbl    = configured ? roleLabel(node.role) : '— define role —';
   const figName    = configured
     ? (node.figure ? (figMap.get(node.figure) ?? node.figure) : 'role default')
-    : '';
-  const scopeNote  = node.scope === 'phase' && node.scopeLabel
-    ? `<div class="od-node__scope">⌖ ${node.scopeLabel}</div>`
     : '';
   const removeBtn  = d.depth > 0
     ? `<button class="od-node__btn od-node__btn--remove" data-id="${node.id}" title="Remove">×</button>`
@@ -891,7 +904,7 @@ function nodeCardHtml(
     <div class="od-node__tier od-node__tier--${tier}">${tier}</div>
     <div class="od-node__role${configured ? '' : ' od-node__role--empty'}">${roleLbl}</div>
     ${configured ? `<div class="od-node__figure">${figName}</div>` : ''}
-    ${scopeNote}
+    ${scopeBadge()}
     <div class="od-node__actions">
       ${addBtn}
       <button class="od-node__btn od-node__btn--edit" data-id="${node.id}" title="Edit node">edit</button>
@@ -1468,6 +1481,7 @@ export function orgDesigner(): OrgDesignerComponent {
         this._container,
         this.figures,
         this.selectedNodeId,
+        this.repo,
         id => { this.addChild(id); },
         id => { this.removeNodeById(id); },
         id => { this.selectNodeById(id); },

--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -1686,6 +1686,28 @@ $preset-accents: (
   margin-top: 0.05rem;
 }
 
+.od-node__issue-link {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 0.3rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  background: rgba(52, 211, 153, 0.12);   // emerald tint matching worker border
+  border: 1px solid rgba(52, 211, 153, 0.35);
+  color: #34d399;
+  font-size: 0.67rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  transition: background 0.12s, border-color 0.12s;
+
+  &:hover {
+    background: rgba(52, 211, 153, 0.22);
+    border-color: rgba(52, 211, 153, 0.6);
+    color: #6ee7b7;
+  }
+}
+
 .od-node__actions {
   display: flex;
   gap: 0.3rem;


### PR DESCRIPTION
## Summary
- When a node has scope `'issue'` and an issue number set, the D3 node card now shows a clickable **`# N`** badge linking directly to the GitHub issue
- Badge is visible immediately after setting the issue number in the editor (before launch) and remains after launch
- Clicking the badge opens the issue in a new tab without triggering node selection (`stopPropagation`)
- Uses an emerald tint (matching the worker border color) with a hover state
- `nodeCardHtml` receives `repo` string to build the `https://github.com/{repo}/issues/{N}` URL
- `scopeBadge()` helper consolidates phase label and issue link rendering in one place

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] `npm run build` — both bundles built clean
- [x] `curl -sf http://localhost:1337/health` — `{"status":"ok"}`