### PR TITLE
fix: repurpose A/B metrics widget as Developer Run Health

### DIFF
--- a/agentception/routes/api/ab_metrics.py
+++ b/agentception/routes/api/ab_metrics.py
@@ -1,10 +1,10 @@
-"""A/B metrics API — per-prompt-variant aggregates for developer runs.
+"""Developer Run Health API — aggregate KPIs for completed developer runs.
 
-Read-only endpoint for comparing control vs treatment (e.g. prompt_variant)
-without changing dispatch or prompts. Used when ready to analyse A/B experiments.
-
-When the request includes the HTMX header ``HX-Request: true``, returns an HTML
-partial (table) for in-place swap; otherwise returns JSON.
+Read-only endpoint that surfaces pass rate, iteration count, and token usage
+for developer runs grouped by ``prompt_variant`` (NULL = baseline).  Used as
+a health dashboard on the Build page.  When the request includes the HTMX
+header ``HX-Request: true``, returns an HTML partial for in-place swap;
+otherwise returns JSON.
 """
 
 from __future__ import annotations

--- a/agentception/static/scss/pages/_ab_metrics.scss
+++ b/agentception/static/scss/pages/_ab_metrics.scss
@@ -1,4 +1,33 @@
-// ── A/B metrics panel (Mission Control build page) ─────────────────────────────
+// ── Developer Run Health panel (Mission Control build page) ──────────────────
+
+.dev-health-panel {
+  &__title {
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+    margin: 0 0 0.5rem;
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  &__window {
+    font-size: 0.68rem;
+    font-weight: 400;
+    text-transform: none;
+    letter-spacing: 0;
+    color: var(--muted);
+    opacity: 0.6;
+  }
+}
+
+.dev-health {
+  &__good { color: #34d399; font-weight: 600; }
+  &__warn { color: #fbbf24; font-weight: 600; }
+  &__bad  { color: #f87171; font-weight: 600; }
+}
 
 .ab-metrics {
   width: 100%;

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -184,14 +184,14 @@
     </aside>
   </div>{# /.build-columns #}
 
-  <!-- ── A/B metrics panel (HTMX polled every 30s) ───────────────────────────── -->
+  <!-- ── Developer Run Health panel (HTMX polled every 30s) ─────────────────── -->
   <div id="ab-metrics-panel"
        class="build-ab-metrics"
        hx-get="/api/metrics/ab"
        hx-trigger="load, every 30s"
        hx-target="#ab-metrics-panel"
        hx-swap="innerHTML">
-    <p class="loading-placeholder">Loading A/B metrics…</p>
+    <p class="loading-placeholder">Loading developer run health…</p>
   </div>
 
 </div>{# /.build-layout #}

--- a/agentception/templates/partials/_ab_metrics.html
+++ b/agentception/templates/partials/_ab_metrics.html
@@ -1,26 +1,36 @@
-<table class="ab-metrics">
-  <thead>
+<div class="dev-health-panel">
+  <h3 class="dev-health-panel__title">
+    Developer Run Health
+    <span class="dev-health-panel__window">last 7 days · completed developer runs</span>
+  </h3>
+  <table class="ab-metrics">
+    <thead>
+      <tr>
+        <th>Runs</th>
+        <th>Pass Rate</th>
+        <th>Passed</th>
+        <th>Failed</th>
+        <th>Avg Iters</th>
+        <th>Avg Input Tokens</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for v in variants %}
     <tr>
-      <th>Variant</th>
-      <th>Runs</th>
-      <th>Avg Iters</th>
-      <th>Pass Rate</th>
-      <th>Avg Tokens</th>
+      <td>{{ v.runs }}</td>
+      <td class="{% if v.pass_rate >= 0.5 %}dev-health__good{% elif v.pass_rate > 0 %}dev-health__warn{% else %}dev-health__bad{% endif %}">
+        {{ "%.0f%%"|format(v.pass_rate * 100) }}
+      </td>
+      <td class="dev-health__good">{{ v.passed }}</td>
+      <td class="{% if v.failed > 0 %}dev-health__bad{% endif %}">{{ v.failed }}</td>
+      <td>{{ "%.1f"|format(v.avg_iterations) }}</td>
+      <td>{{ (v.avg_input_tokens / 1000000) | round(2) }}M</td>
     </tr>
-  </thead>
-  <tbody>
-  {% for v in variants %}
-  <tr>
-    <td>{{ v.variant }}</td>
-    <td>{{ v.runs }}</td>
-    <td>{{ "%.1f"|format(v.avg_iterations) }}</td>
-    <td>{{ "%.0f%%"|format(v.pass_rate * 100) }}</td>
-    <td>{{ v.avg_input_tokens | int }}</td>
-  </tr>
-  {% else %}
-  <tr>
-    <td colspan="5" class="no-data">No completed runs in the last 7 days.</td>
-  </tr>
-  {% endfor %}
-  </tbody>
-</table>
+    {% else %}
+    <tr>
+      <td colspan="6" class="no-data">No completed developer runs in the last 7 days.</td>
+    </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
## Summary
- Drops the `Variant` column (always `'control'`, adds no signal since nothing sets `prompt_variant`)
- Adds a clear **Developer Run Health** heading with a "last 7 days" subtitle
- Adds **Passed** and **Failed** columns alongside the pass rate percentage
- Color-codes pass rate: green ≥ 50%, amber > 0%, red = 0%
- Formats avg input tokens as `1.52M` instead of raw integer
- Updates loading placeholder and HTML comment in `build.html`
- Updates route module docstring to reflect actual purpose
- SCSS: `dev-health-panel` heading styles, `dev-health__good/warn/bad` color classes

## Test plan
- [x] `curl -H 'HX-Request: true' http://localhost:1337/api/metrics/ab` returns correct HTML with new structure
- [x] `npm run build:css` clean
- [x] `curl -sf http://localhost:1337/health` → `{"status":"ok"}`