### PR TITLE
fix: persist FastEmbed ONNX model cache across container rebuilds

### DIFF
--- a/agentception/config.py
+++ b/agentception/config.py
@@ -359,6 +359,17 @@ class AgentCeptionSettings(BaseSettings):
     """
     qdrant_collection: str = "code"
     """Name of the Qdrant collection used for codebase vectors."""
+    fastembed_cache_dir: str = "/home/agentception/.cache/fastembed"
+    """Local filesystem path where FastEmbed stores downloaded ONNX models.
+
+    Must be writable by the ``agentception`` user at runtime.  The Docker
+    Compose stack mounts a named volume (``agentception-fastembed-cache``) here
+    so that the three ONNX models (jina-v2 ~640 MB, BM25, bge-reranker ~280 MB)
+    survive container rebuilds.  Without a persistent mount the models are
+    re-downloaded on every restart, adding ~60 s to the first dispatch.
+
+    Set via ``FASTEMBED_CACHE_DIR`` env var.
+    """
     embed_model: str = "jinaai/jina-embeddings-v2-base-code"
     """FastEmbed model name for generating code chunk embeddings.
 
@@ -368,7 +379,7 @@ class AgentCeptionSettings(BaseSettings):
     (e.g. ``BAAI/bge-small-en-v1.5``) on code retrieval tasks because it
     understands identifier names, type signatures, and code patterns.  The model
     is downloaded from HuggingFace Hub on first use (~640 MB) and cached in
-    ``FASTEMBED_CACHE_DIR`` (default ``/tmp/fastembed_cache``).
+    ``fastembed_cache_dir``.
     """
     embed_model_dim: int = 768
     """Vector dimension produced by ``embed_model``.

--- a/agentception/services/code_indexer.py
+++ b/agentception/services/code_indexer.py
@@ -202,7 +202,10 @@ def _get_model() -> TextEmbedding | None:
         from fastembed import TextEmbedding  # noqa: PLC0415
 
         logger.info("✅ code_indexer — loading embed model: %s", settings.embed_model)
-        _cached_model = TextEmbedding(model_name=settings.embed_model)
+        _cached_model = TextEmbedding(
+            model_name=settings.embed_model,
+            cache_dir=settings.fastembed_cache_dir,
+        )
         _rss_after = _p.memory_info().rss // 1024 // 1024
         logger.warning("📊 _get_model: LOADED embed model RSS_after=%dMB (+%dMB)", _rss_after, _rss_after - _rss_before)
     return _cached_model
@@ -226,7 +229,10 @@ def _get_bm25_model() -> SparseTextEmbedding | None:
         from fastembed.sparse import SparseTextEmbedding  # noqa: PLC0415
 
         logger.info("✅ code_indexer — loading BM25 sparse model: Qdrant/bm25")
-        _bm25_model = SparseTextEmbedding("Qdrant/bm25")
+        _bm25_model = SparseTextEmbedding(
+            "Qdrant/bm25",
+            cache_dir=settings.fastembed_cache_dir,
+        )
         _rss_after = _p.memory_info().rss // 1024 // 1024
         logger.warning("📊 _get_bm25_model: LOADED BM25 RSS_after=%dMB (+%dMB)", _rss_after, _rss_after - _rss_before)
     return _bm25_model
@@ -252,7 +258,10 @@ def _get_rerank_model() -> TextCrossEncoder | None:
         logger.info(
             "✅ code_indexer — loading reranker model: %s", settings.rerank_model
         )
-        _rerank_model = TextCrossEncoder(settings.rerank_model)
+        _rerank_model = TextCrossEncoder(
+            settings.rerank_model,
+            cache_dir=settings.fastembed_cache_dir,
+        )
         _rss_after = _p.memory_info().rss // 1024 // 1024
         logger.warning("📊 _get_rerank_model: LOADED reranker RSS_after=%dMB (+%dMB)", _rss_after, _rss_after - _rss_before)
     return _rerank_model

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,12 +152,14 @@ services:
       # git worktrees created inside the container are immediately visible to
       # processes on the host (e.g. an IDE) at the same absolute path.
       - ${HOME}/.agentception/worktrees/agentception:/worktrees
-      # Persist FastEmbed / HuggingFace model files across container restarts.
-      # Without this volume the three ONNX models (jina-v2, BM25, bge-reranker)
-      # are re-downloaded from HuggingFace on every restart, adding ~50s to the
-      # first dispatch after each restart.  With the volume they are loaded from
-      # disk on first use (~5–10s) and stay warm for the lifetime of the volume.
+      # Persist HuggingFace hub files (tokens, metadata) across container restarts.
       - model_cache:/home/agentception/.cache/huggingface
+      # Persist FastEmbed ONNX models across container restarts.
+      # Without this volume the three ONNX models (jina-v2 ~640 MB, BM25, bge-reranker ~280 MB)
+      # are re-downloaded from HuggingFace on every restart, adding ~60 s to the
+      # first dispatch after each restart.  With the volume they are loaded from
+      # disk on first use (~5–10 s) and stay warm for the lifetime of the volume.
+      - fastembed_cache:/home/agentception/.cache/fastembed
     # Use Cloudflare DNS instead of Docker's embedded resolver.
     # Docker's embedded DNS caches whichever node it gets first, and GitHub
     # occasionally has dead nodes in rotation (e.g. 140.82.116.6) that refuse
@@ -236,6 +238,8 @@ volumes:
     name: agentception-qdrant-data
   model_cache:
     name: agentception-model-cache
+  fastembed_cache:
+    name: agentception-fastembed-cache
   node_modules:
     name: agentception-node-modules
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -52,10 +52,17 @@ echo "[entrypoint] fixing ownership of /worktrees …"
 chown agentception:agentception /worktrees
 
 # /home/agentception/.cache/huggingface — named volume (agentception-model-cache).
-#   FastEmbed downloads ONNX models on first dispatch; the agentception user
-#   must be able to write here (and to the hub token file under it).
-echo "[entrypoint] fixing ownership of model cache …"
+#   HuggingFace Hub token file and metadata; the agentception user must be able
+#   to write here.
+echo "[entrypoint] fixing ownership of HuggingFace cache …"
 chown -R agentception:agentception /home/agentception/.cache/huggingface
+
+# /home/agentception/.cache/fastembed — named volume (agentception-fastembed-cache).
+#   FastEmbed downloads ONNX models here on first dispatch; the agentception user
+#   must be able to write here.
+echo "[entrypoint] fixing ownership of FastEmbed cache …"
+mkdir -p /home/agentception/.cache/fastembed
+chown -R agentception:agentception /home/agentception/.cache/fastembed
 
 # ── 5. Drop to non-root user ─────────────────────────────────────────────────
 # gosu is a purpose-built setuid helper (analogous to sudo -u but without the


### PR DESCRIPTION
## Summary

- `FASTEMBED_CACHE_DIR` was documented in a config comment but never implemented as a `Settings` field, so the env var was a no-op and FastEmbed always defaulted to `/tmp/fastembed_cache` — wiped on every container rebuild, causing the three ONNX models (~900 MB total) to be re-downloaded on every restart
- All three model constructors (`TextEmbedding`, `SparseTextEmbedding`, `TextCrossEncoder`) now receive `cache_dir=settings.fastembed_cache_dir`
- A new `agentception-fastembed-cache` named Docker volume is mounted at `/home/agentception/.cache/fastembed` so models survive rebuilds
- `entrypoint.sh` now `mkdir -p` + `chown`s the fastembed cache before dropping to the non-root user

## Test plan

- [x] `mypy agentception/config.py agentception/services/code_indexer.py` — zero errors
- [x] `docker compose build && docker compose up -d` — new volume `agentception-fastembed-cache` created cleanly
- [x] Logs confirm `[entrypoint] fixing ownership of FastEmbed cache …` runs before privilege drop
- [x] `curl http://localhost:1337/health` → `{"status":"ok"}`
- [ ] After first planning run that triggers codebase enrichment, verify ONNX model loads from `/home/agentception/.cache/fastembed` and not `/tmp`
- [ ] Rebuild container again (`docker compose build && docker compose up -d`) and confirm model loads from volume without re-downloading