### PR TITLE
feat: scope cascade filter Label → Phase → Ticket in org designer

### DIFF
--- a/agentception/db/queries/board.py
+++ b/agentception/db/queries/board.py
@@ -688,24 +688,37 @@ async def get_label_context(repo: str, initiative_label: str) -> LabelContext:
             )
             rows = result.all()
 
-        phase_counts: dict[str, int] = {}
+        # phase_label → (total_count, blocked_count)
+        phase_counts: dict[str, list[int]] = {}
         issues: list[IssueSummary] = []
 
         for number, title, labels_json_str, _state in rows:
             labels: list[str] = json.loads(labels_json_str or "[]")
             has_initiative = initiative_label in labels
+            is_blocked = "blocked/deps" in labels
 
             # Collect phase sub-labels (e.g. "ac-workflow/5-plan-step-v2")
             for lbl in labels:
                 if lbl.startswith(phase_prefix):
-                    phase_counts[lbl] = phase_counts.get(lbl, 0) + 1
+                    if lbl not in phase_counts:
+                        phase_counts[lbl] = [0, 0]
+                    phase_counts[lbl][0] += 1
+                    if is_blocked:
+                        phase_counts[lbl][1] += 1
 
             # Collect issues directly tagged with the top-level initiative label
             if has_initiative:
-                issues.append(IssueSummary(number=number, title=title or ""))
+                issues.append(IssueSummary(number=number, title=title or "", blocked=is_blocked))
 
         phases: list[PhaseSummary] = sorted(
-            [PhaseSummary(label=lbl, count=cnt) for lbl, cnt in phase_counts.items()],
+            [
+                PhaseSummary(
+                    label=lbl,
+                    count=counts[0],
+                    blocked=counts[0] > 0 and counts[0] == counts[1],
+                )
+                for lbl, counts in phase_counts.items()
+            ],
             key=lambda p: p["label"],
         )
         issues.sort(key=lambda i: i["number"])

--- a/agentception/db/queries/types.py
+++ b/agentception/db/queries/types.py
@@ -499,6 +499,7 @@ class PhaseSummary(TypedDict):
 
     label: str
     count: int
+    blocked: bool  # True when every open issue in the phase carries "blocked/deps"
 
 
 
@@ -507,6 +508,7 @@ class IssueSummary(TypedDict):
 
     number: int
     title: str
+    blocked: bool  # True when the issue carries the "blocked/deps" label
 
 
 

--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -410,6 +410,7 @@ class PhaseSummaryItem(BaseModel):
 
     label: str
     count: int
+    blocked: bool
 
 
 class IssueSummaryItem(BaseModel):
@@ -417,6 +418,7 @@ class IssueSummaryItem(BaseModel):
 
     number: int
     title: str
+    blocked: bool
 
 
 class LabelContextResponse(BaseModel):
@@ -436,16 +438,22 @@ async def get_label_context_route(
     Response shape::
 
         {
-          "phases": [{"label": "ac-workflow/5-plan-step-v2", "count": 3}, ...],
-          "issues": [{"number": 108, "title": "..."}, ...]
+          "phases": [{"label": "ac-workflow/5-plan-step-v2", "count": 3, "blocked": false}, ...],
+          "issues": [{"number": 108, "title": "...", "blocked": false}, ...]
         }
 
     Falls back to empty lists when the initiative has no recorded data yet.
     """
     ctx = await get_label_context(repo=repo, initiative_label=label)
     return LabelContextResponse(
-        phases=[PhaseSummaryItem(label=p["label"], count=p["count"]) for p in ctx["phases"]],
-        issues=[IssueSummaryItem(number=i["number"], title=i["title"]) for i in ctx["issues"]],
+        phases=[
+            PhaseSummaryItem(label=p["label"], count=p["count"], blocked=p["blocked"])
+            for p in ctx["phases"]
+        ],
+        issues=[
+            IssueSummaryItem(number=i["number"], title=i["title"], blocked=i["blocked"])
+            for i in ctx["issues"]
+        ],
     )
 
 

--- a/agentception/static/js/org_designer.ts
+++ b/agentception/static/js/org_designer.ts
@@ -143,11 +143,18 @@ interface ApiPresetDetail extends ApiPresetSummary {
 interface PhaseItem {
   label: string;
   count: number;
+  blocked: boolean;
+}
+
+interface IssueItem {
+  number: number;
+  title: string;
+  blocked: boolean;
 }
 
 interface ContextResponse {
   phases: PhaseItem[];
-  issues: Array<{ number: number; title: string }>;
+  issues: IssueItem[];
 }
 
 interface DispatchResponse {
@@ -948,6 +955,7 @@ interface OrgDesignerComponent {
   editScopeLabel: string;
   editScopeIssueNumber: number | null;
   phases: PhaseItem[];
+  issues: IssueItem[];
 
   // ── Submission
   launching: boolean;
@@ -1052,6 +1060,7 @@ export function orgDesigner(): OrgDesignerComponent {
     editScopeLabel:       '',
     editScopeIssueNumber: null,
     phases:               [],
+    issues:               [],
 
     // ── Submission state ──────────────────────────────────────────────────────
     launching:    false,
@@ -1131,10 +1140,10 @@ export function orgDesigner(): OrgDesignerComponent {
     get loneWorkerWarning(): string {
       if (!this._root || !this._root.role) return '';
       if (isCoordinator(this._root.role)) return '';
-      // When scoped to a specific issue the user has made an explicit choice — no warning.
-      if (this._root.scope === 'issue') return '';
+      // When scoped to a specific issue or phase the user has made an explicit choice — no warning.
+      if (this._root.scope === 'issue' || this._root.scope === 'phase') return '';
       if (this._root.scope !== 'full_initiative') return '';
-      return `⚠️ "${roleLabel(this._root.role)}" is a worker, not a coordinator. Workers don't pick up tickets automatically. Add a coordinator (e.g. CTO) as the root, or set scope to "Specific Issue".`;
+      return `⚠️ "${roleLabel(this._root.role)}" is a worker, not a coordinator. Workers don't pick up tickets automatically. Add a coordinator (e.g. CTO) as the root, or set scope to "Phase" or "Ticket".`;
     },
 
     get isRootSelected(): boolean {
@@ -1330,9 +1339,10 @@ export function orgDesigner(): OrgDesignerComponent {
         if (res.ok) {
           const data = await res.json() as ContextResponse;
           this.phases = data.phases ?? [];
+          this.issues = data.issues ?? [];
         }
       } catch {
-        // Non-critical — scope picker just won't show phases.
+        // Non-critical — scope picker just won't show phases or issues.
       }
     },
 

--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -1971,6 +1971,36 @@ $preset-accents: (
   &:focus { outline: none; border-color: #7c3aed; box-shadow: 0 0 0 2px rgba(124,58,237,0.25); }
 }
 
+// Scope cascade pickers (Phase dropdown, Ticket dropdown)
+.od-scope-select {
+  font-size: 0.78rem;
+  padding: 0.5rem 0.625rem;
+  border-radius: 7px;
+  border: 1.5px solid $od-border;
+  background: rgba(255,255,255,0.04);
+  color: #fff;
+  width: 100%;
+  cursor: pointer;
+  transition: border-color 0.15s;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='rgba(255,255,255,0.35)'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  padding-right: 2rem;
+
+  option, optgroup { background: #1a1a2e; color: #fff; }
+  option:disabled, &__opt--blocked { color: rgba(255,255,255,0.28); }
+  &:focus { outline: none; border-color: #7c3aed; box-shadow: 0 0 0 2px rgba(124,58,237,0.25); }
+}
+
+.od-scope-empty {
+  font-size: 0.7rem;
+  color: rgba(255,255,255,0.35);
+  margin: 0;
+  padding: 0.25rem 0;
+  font-style: italic;
+}
+
 .od-editor__actions {
   display: flex;
   gap: 0.625rem;

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -490,28 +490,66 @@
                   <label class="od-scope-opt" :class="{'od-scope-opt--active': editScope === 'full_initiative'}">
                     <input type="radio" x-model="editScope" value="full_initiative">
                     <span class="od-scope-opt__text">
-                      <strong>Full Initiative</strong>
-                      <em>Coordinator sweeps all open tickets</em>
+                      <strong>Label</strong>
+                      <em>Coordinator sweeps all tickets in the initiative</em>
+                    </span>
+                  </label>
+                  <label class="od-scope-opt" :class="{'od-scope-opt--active': editScope === 'phase'}">
+                    <input type="radio" x-model="editScope" value="phase">
+                    <span class="od-scope-opt__text">
+                      <strong>Phase</strong>
+                      <em>Target all tickets in a specific phase</em>
                     </span>
                   </label>
                   <label class="od-scope-opt" :class="{'od-scope-opt--active': editScope === 'issue'}">
                     <input type="radio" x-model="editScope" value="issue">
                     <span class="od-scope-opt__text">
-                      <strong>Specific Issue</strong>
+                      <strong>Ticket</strong>
                       <em>Target a single ticket directly</em>
                     </span>
                   </label>
                 </div>
-                <template x-if="editScope === 'issue'">
+
+                {# Phase picker — dropdown of phases, blocked ones disabled #}
+                <template x-if="editScope === 'phase'">
                   <div class="od-editor__issue-row">
-                    <label class="od-editor__label">Issue #</label>
-                    <input type="number"
-                           class="od-editor__input od-editor__input--issue"
-                           x-model.number="editScopeIssueNumber"
-                           placeholder="e.g. 42"
-                           min="1">
+                    <label class="od-editor__label">Phase</label>
+                    <select class="od-scope-select"
+                            x-model="editScopeLabel">
+                      <option value="" disabled>— select a phase —</option>
+                      <template x-for="ph in phases" :key="ph.label">
+                        <option :value="ph.label"
+                                :disabled="ph.blocked"
+                                :class="{'od-scope-select__opt--blocked': ph.blocked}"
+                                x-text="ph.label + (ph.blocked ? ' (blocked)' : '') + ' · ' + ph.count + ' open'"></option>
+                      </template>
+                    </select>
+                    <template x-if="phases.length === 0">
+                      <p class="od-scope-empty">No phases found for this initiative.</p>
+                    </template>
                   </div>
                 </template>
+
+                {# Ticket picker — dropdown of issues, blocked ones disabled #}
+                <template x-if="editScope === 'issue'">
+                  <div class="od-editor__issue-row">
+                    <label class="od-editor__label">Ticket</label>
+                    <select class="od-scope-select"
+                            x-model.number="editScopeIssueNumber">
+                      <option value="" disabled>— select a ticket —</option>
+                      <template x-for="iss in issues" :key="iss.number">
+                        <option :value="iss.number"
+                                :disabled="iss.blocked"
+                                :class="{'od-scope-select__opt--blocked': iss.blocked}"
+                                x-text="'#' + iss.number + ' — ' + (iss.title.length > 52 ? iss.title.slice(0, 52) + '…' : iss.title) + (iss.blocked ? ' (blocked)' : '')"></option>
+                      </template>
+                    </select>
+                    <template x-if="issues.length === 0">
+                      <p class="od-scope-empty">No tickets found for this initiative.</p>
+                    </template>
+                  </div>
+                </template>
+
               </div>
             </template>
 


### PR DESCRIPTION
## Summary

- Extends the org designer scope picker from 2 flat options to a 3-level cascade: **Label** (all tickets in the initiative) → **Phase** (specific phase sub-label) → **Ticket** (single issue)
- Blocked phases and tickets — identified by the `blocked/deps` label — are displayed grayed out and `disabled` so users can't dispatch against stuck work
- Backend context API (`GET /api/dispatch/context`) now returns a `blocked` flag for each phase and issue

## Test plan

- [x] `mypy agentception/db/queries/types.py agentception/db/queries/board.py agentception/routes/api/dispatch.py` — zero errors
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — clean JS + CSS bundles
- [x] `docker compose restart agentception` + `curl /health` → `{"status":"ok"}`
- [ ] Open Build page, select root node, verify 3 scope options appear (Label / Phase / Ticket)
- [ ] Select Phase → confirm phase dropdown populates from initiative context; blocked phases appear grayed + disabled
- [ ] Select Ticket → confirm issue dropdown populates; blocked issues appear grayed + disabled
- [ ] Apply edit, launch — verify `scope_label` or `scope_issue_number` flows to dispatch correctly