### PR TITLE
fix: OrgNodeSpec missing 'issue' scope + readable 422 error messages

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -64,8 +64,9 @@ class OrgNodeSpec(BaseModel):
     id: str
     role: str
     figure: str = ""
-    scope: Literal["full_initiative", "phase"] = "full_initiative"
+    scope: Literal["full_initiative", "phase", "issue"] = "full_initiative"
     scope_label: str = ""
+    scope_issue_number: int | None = None
     children: list["OrgNodeSpec"] = []
 
 

--- a/agentception/static/js/org_designer.ts
+++ b/agentception/static/js/org_designer.ts
@@ -168,8 +168,16 @@ interface DispatchResponse {
   status: string;
 }
 
+interface FastApiValidationError {
+  msg: string;
+  loc: string[];
+  type: string;
+}
+
 interface DispatchError {
-  detail?: string;
+  // FastAPI returns detail as a string for application errors,
+  // or as an array of validation error objects for 422 responses.
+  detail?: string | FastApiValidationError[];
 }
 
 // ── Live mode types (from GET /api/org/batches and SSE /api/org/live) ─────────
@@ -1524,7 +1532,14 @@ export function orgDesigner(): OrgDesignerComponent {
         });
         const data = await res.json() as DispatchResponse | DispatchError;
         if (!res.ok) {
-          this.launchError = (data as DispatchError).detail ?? `Error ${res.status}`;
+          const errData = data as DispatchError;
+          const detail = errData.detail;
+          if (Array.isArray(detail)) {
+            // FastAPI 422 validation errors — format as readable list.
+            this.launchError = detail.map(e => e.msg).join('; ') || `Error ${res.status}`;
+          } else {
+            this.launchError = detail ?? `Error ${res.status}`;
+          }
         } else {
           const dispatched    = data as DispatchResponse;
           this.launchResult   = dispatched;


### PR DESCRIPTION
## Summary

- `OrgNodeSpec.scope` was `Literal["full_initiative", "phase"]` — it did not include `"issue"`, so any dispatch with the new Ticket scope picker caused Pydantic to 422 the request immediately
- The frontend displayed `[object Object]` because FastAPI's 422 `detail` is an array of validation error objects, not a string, and `DispatchError.detail` was typed as `string`
- `scope_issue_number` field was also missing from `OrgNodeSpec` entirely

## Test plan

- [x] `mypy agentception/routes/api/dispatch.py` — zero errors
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build:js` — clean bundle
- [x] `curl /health` — ok
- [ ] Select Ticket scope, pick a ticket from the dropdown, click Launch — should no longer 422
- [ ] Trigger a real validation error and confirm the message is readable text, not `[object Object]`