### PR TITLE
fix: resolve test failure and AsyncMock coroutine warnings across test suite

### DIFF
--- a/agentception/tests/conftest.py
+++ b/agentception/tests/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """conftest.py for agentception tests.
 
 Deliberately minimal — no Postgres, no Qdrant, no Redis.
@@ -10,11 +8,43 @@ Run the full agentception suite:
     docker compose exec agentception pytest agentception/tests/ -v
 """
 
+from __future__ import annotations
+
 import asyncio
-from collections.abc import AsyncGenerator, Generator
+import collections.abc
+from collections.abc import AsyncGenerator, Callable, Generator
 from unittest.mock import patch
 
 import pytest
+
+
+def make_create_task_side_effect() -> (
+    Callable[[collections.abc.Coroutine[object, object, object]], asyncio.Future[None]]
+):
+    """Return a side-effect for patching ``asyncio.create_task`` in tests.
+
+    When ``asyncio.create_task`` is mocked the coroutine passed to it is never
+    scheduled, so Python emits ``RuntimeWarning: coroutine … was never awaited``
+    during garbage collection.  This helper closes the incoming coroutine
+    immediately (suppressing the warning) and returns a resolved Future so any
+    code that reads the return value of ``create_task`` still gets a valid object.
+
+    Usage::
+
+        patch("some.module.asyncio.create_task",
+              side_effect=make_create_task_side_effect())
+    """
+
+    def _side_effect(
+        coro: collections.abc.Coroutine[object, object, object],
+        **_: object,
+    ) -> asyncio.Future[None]:
+        coro.close()
+        fut: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        fut.set_result(None)
+        return fut
+
+    return _side_effect
 
 
 async def _noop_polling_loop() -> None:

--- a/agentception/tests/test_build_commands.py
+++ b/agentception/tests/test_build_commands.py
@@ -14,6 +14,8 @@ Run targeted:
 import pytest
 from unittest.mock import AsyncMock, patch
 
+from agentception.tests.conftest import make_create_task_side_effect
+
 
 @pytest.mark.anyio
 async def test_reviewer_worktree_released_after_failing_grade() -> None:
@@ -64,6 +66,7 @@ async def test_reviewer_worktree_released_after_failing_grade() -> None:
         ),
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
         patch("agentception.mcp.build_commands.settings") as mock_settings,
     ):
@@ -122,6 +125,7 @@ async def test_reviewer_worktree_torn_down_after_passing_grade() -> None:
         ),
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
         patch(
             "agentception.mcp.build_commands._is_pr_merged",
@@ -199,6 +203,7 @@ async def test_redispatch_fires_after_failing_grade() -> None:
         ) as mock_redispatch,
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
         patch("agentception.mcp.build_commands.settings") as mock_settings,
     ):
@@ -277,6 +282,7 @@ async def test_redispatch_skipped_after_passing_grade() -> None:
         ) as mock_teardown,
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
         patch(
             "agentception.mcp.build_commands._is_pr_merged",
@@ -350,6 +356,7 @@ async def test_build_complete_run_rejects_empty_grade_from_reviewer() -> None:
         ) as mock_teardown,
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
     ):
         result = await build_complete_run(
@@ -429,6 +436,7 @@ async def test_build_complete_run_accepted_with_valid_pr_url() -> None:
         ),
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ),
     ):
         result = await build_complete_run(
@@ -486,6 +494,7 @@ async def test_implementer_completion_fails_when_release_worktree_returns_false(
         ) as mock_reviewer,
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
         patch(
             "agentception.mcp.build_commands._rebase_and_push_worktree",
@@ -546,6 +555,7 @@ async def test_build_complete_run_rejects_whitespace_grade_from_reviewer() -> No
         ) as mock_teardown,
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
     ):
         result = await build_complete_run(
@@ -603,7 +613,7 @@ async def test_done_event_payload_includes_grade_for_reviewer() -> None:
             "agentception.mcp.build_commands.teardown_agent_worktree",
             new_callable=AsyncMock,
         ),
-        patch("agentception.mcp.build_commands.asyncio.create_task"),
+        patch("agentception.mcp.build_commands.asyncio.create_task", side_effect=make_create_task_side_effect()),
         patch(
             "agentception.mcp.build_commands._is_pr_merged",
             new_callable=AsyncMock,
@@ -710,6 +720,7 @@ async def test_build_complete_run_blocks_grade_a_when_pr_not_merged() -> None:
         ),
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
     ):
         result = await build_complete_run(
@@ -765,6 +776,7 @@ async def test_build_complete_run_allows_grade_a_when_pr_merged() -> None:
         ),
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
     ):
         result = await build_complete_run(

--- a/agentception/tests/test_build_commands_rebase.py
+++ b/agentception/tests/test_build_commands_rebase.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Unit tests for the rebase-onto-dev logic inside build_complete_run.
 
 The non-reviewer (implementer) path of build_complete_run:
@@ -25,11 +23,15 @@ Run targeted:
     pytest agentception/tests/test_build_commands_rebase.py -v
 """
 
+from __future__ import annotations
+
 import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from agentception.tests.conftest import make_create_task_side_effect
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +114,7 @@ async def test_rebase_succeeds_force_pushes_and_dispatches_reviewer() -> None:
         ),
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+             side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
     ):
         result = await build_complete_run(

--- a/agentception/tests/test_dispatch_variant.py
+++ b/agentception/tests/test_dispatch_variant.py
@@ -5,6 +5,8 @@ import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+from agentception.tests.conftest import make_create_task_side_effect
+
 import pytest
 
 
@@ -32,7 +34,7 @@ async def test_dispatch_passes_prompt_variant_to_task_spec(tmp_path: Path) -> No
         patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", side_effect=mock_persist),
         patch("agentception.routes.api.dispatch.acknowledge_agent_run", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
-        patch("agentception.routes.api.dispatch.asyncio.create_task", return_value=asyncio.Future()),
+        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=make_create_task_side_effect()),
         patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.assemble_developer_context", new_callable=AsyncMock, return_value=""),
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
@@ -80,7 +82,7 @@ async def test_dispatch_prompt_variant_defaults_to_none(tmp_path: Path) -> None:
         patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", side_effect=mock_persist),
         patch("agentception.routes.api.dispatch.acknowledge_agent_run", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
-        patch("agentception.routes.api.dispatch.asyncio.create_task", return_value=asyncio.Future()),
+        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=make_create_task_side_effect()),
         patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.assemble_developer_context", new_callable=AsyncMock, return_value=""),
         patch("agentception.routes.api.dispatch.settings") as mock_settings,

--- a/agentception/tests/test_ensure_helpers.py
+++ b/agentception/tests/test_ensure_helpers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import collections.abc
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -11,28 +10,7 @@ import pytest
 
 from agentception.readers.git import _symlink_frontend_resources, ensure_branch, ensure_worktree
 from agentception.readers.github import ensure_pull_request
-
-
-def _make_create_task_side_effect() -> collections.abc.Callable[
-    [collections.abc.Coroutine[object, object, object]], asyncio.Future[None]
-]:
-    """Return a side-effect for patching asyncio.create_task.
-
-    Closes the coroutine passed to create_task so that the
-    'coroutine never awaited' RuntimeWarning is suppressed in tests that mock
-    the entire agent loop — the mock coroutine is intentionally not run.
-    """
-
-    def _side_effect(
-        coro: collections.abc.Coroutine[object, object, object],
-        **_: object,
-    ) -> asyncio.Future[None]:
-        coro.close()
-        fut: asyncio.Future[None] = asyncio.get_event_loop().create_future()
-        fut.set_result(None)
-        return fut
-
-    return _side_effect
+from agentception.tests.conftest import make_create_task_side_effect
 
 
 # ---------------------------------------------------------------------------
@@ -602,7 +580,7 @@ async def test_dispatch_reviewer_fetches_pr_branch_and_uses_it_as_base(tmp_path:
         patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.acknowledge_agent_run", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
-        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=_make_create_task_side_effect()),
+        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=make_create_task_side_effect()),
         patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
     ):
@@ -648,7 +626,7 @@ async def test_dispatch_implementer_uses_origin_dev_as_base(tmp_path: Path) -> N
         patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.acknowledge_agent_run", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
-        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=_make_create_task_side_effect()),
+        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=make_create_task_side_effect()),
         patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.assemble_developer_context", new_callable=AsyncMock, return_value=""),
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
@@ -704,7 +682,7 @@ async def test_dispatch_reviewer_pr_branch_override_respected(tmp_path: Path) ->
         patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.acknowledge_agent_run", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
-        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=_make_create_task_side_effect()),
+        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=make_create_task_side_effect()),
         patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
     ):
@@ -806,7 +784,7 @@ async def test_dispatch_resets_stale_working_memory_on_redispatch(tmp_path: Path
         patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.acknowledge_agent_run", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
-        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=_make_create_task_side_effect()),
+        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=make_create_task_side_effect()),
         patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.assemble_developer_context", new_callable=AsyncMock, return_value=""),
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
@@ -1057,7 +1035,7 @@ async def test_dispatch_agent_seeds_next_steps_from_ac_items(tmp_path: Path) -> 
         patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.acknowledge_agent_run", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
-        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=_make_create_task_side_effect()),
+        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=make_create_task_side_effect()),
         patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
     ):
@@ -1124,7 +1102,7 @@ async def test_dispatch_agent_reviewer_does_not_seed_ac_items(tmp_path: Path) ->
         patch("agentception.routes.api.dispatch.persist_agent_run_dispatch", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.acknowledge_agent_run", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.run_agent_loop", new_callable=AsyncMock),
-        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=_make_create_task_side_effect()),
+        patch("agentception.routes.api.dispatch.asyncio.create_task", side_effect=make_create_task_side_effect()),
         patch("agentception.routes.api.dispatch._index_worktree", new_callable=AsyncMock),
         patch("agentception.routes.api.dispatch.settings") as mock_settings,
     ):

--- a/agentception/tests/test_label_context_and_dispatch.py
+++ b/agentception/tests/test_label_context_and_dispatch.py
@@ -228,8 +228,8 @@ def test_label_context_returns_empty_lists_when_no_db_data(
 
 def test_label_context_returns_phases_and_issues(client: TestClient) -> None:
     mock_ctx = {
-        "phases": [{"label": "ac-workflow/5-plan-step-v2", "count": 3}],
-        "issues": [{"number": 42, "title": "Fix the thing"}],
+        "phases": [{"label": "ac-workflow/5-plan-step-v2", "count": 3, "blocked": False}],
+        "issues": [{"number": 42, "title": "Fix the thing", "blocked": False}],
     }
     with patch(
         "agentception.routes.api.dispatch.get_label_context",
@@ -244,7 +244,9 @@ def test_label_context_returns_phases_and_issues(client: TestClient) -> None:
     data = res.json()
     assert data["phases"][0]["label"] == "ac-workflow/5-plan-step-v2"
     assert data["phases"][0]["count"] == 3
+    assert data["phases"][0]["blocked"] is False
     assert data["issues"][0]["number"] == 42
+    assert data["issues"][0]["blocked"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **KeyError fix**: `test_label_context_returns_phases_and_issues` was mocking `get_label_context` with data missing the `blocked` field, which the route now reads. Added `blocked: False` to both phases and issues in the mock and asserted on the field in the response.
- **Coroutine warning fix**: Added `make_create_task_side_effect()` to `conftest.py` and applied it wherever `asyncio.create_task` is patched with a plain `MagicMock`. When `AsyncMock`-patched functions (`run_agent_loop`, `auto_dispatch_reviewer`, `teardown_agent_worktree`, `auto_redispatch_after_rejection`) are called, their coroutine is passed to the mocked `create_task` which ignores it — the coroutine is never closed and emits `RuntimeWarning` at GC time. The helper closes the coroutine immediately and returns a resolved `Future`.
- Replaced the local `_make_create_task_side_effect` helper in `test_ensure_helpers.py` with the shared conftest version.

## Test plan
- [x] `pytest test_label_context_and_dispatch.py test_dispatch_variant.py test_ensure_helpers.py test_build_commands.py test_build_commands_rebase.py -W error::RuntimeWarning` → 82 passed, 0 warnings