### PR TITLE
feat: add build_block_run, build_resume_run, build_stop_run MCP tools

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -38,9 +38,12 @@ import httpx
 from agentception.types import JsonValue
 from agentception.db.persist import (
     acknowledge_agent_run,
+    block_agent_run,
     cancel_agent_run,
     complete_agent_run,
     persist_agent_event,
+    resume_agent_run,
+    stop_agent_run,
 )
 from agentception.config import settings
 from agentception.db.queries import (
@@ -561,6 +564,81 @@ async def build_cancel_run(run_id: str) -> dict[str, JsonValue]:
         }
     logger.info("✅ build_cancel_run: %r → cancelled", run_id)
     return {"ok": True, "run_id": run_id, "status": "cancelled"}
+
+
+async def build_block_run(run_id: str) -> dict[str, JsonValue]:
+    """Transition an ``implementing`` run to ``blocked``.
+
+    Use this when the agent cannot proceed until a dependency resolves or a
+    human intervenes.  A blocked run can be resumed later via
+    :func:`build_resume_run`.  Only succeeds from ``implementing`` state.
+
+    Args:
+        run_id: The run ID to block.
+
+    Returns:
+        ``{"ok": True, "run_id": run_id, "status": "blocked"}`` on success,
+        ``{"ok": False, "reason": "..."}`` if the run is not implementing.
+    """
+    ok = await block_agent_run(run_id)
+    if not ok:
+        logger.warning("⚠️ build_block_run: %r not found or not in implementing state", run_id)
+        return {
+            "ok": False,
+            "reason": f"Run {run_id!r} not found or not in implementing state",
+        }
+    logger.info("✅ build_block_run: %r → blocked", run_id)
+    return {"ok": True, "run_id": run_id, "status": "blocked"}
+
+
+async def build_resume_run(run_id: str, agent_run_id: str) -> dict[str, JsonValue]:
+    """Transition a ``blocked`` or ``stopped`` run back to ``implementing``.
+
+    Idempotent: if the run is already ``implementing`` and the caller's
+    ``agent_run_id`` matches, the call succeeds so a crashed-and-restarted
+    agent can safely call this on startup.
+
+    Args:
+        run_id:       The run ID to resume.
+        agent_run_id: The caller's own run ID (used for idempotency check).
+
+    Returns:
+        ``{"ok": True, "run_id": run_id, "status": "implementing"}`` on success,
+        ``{"ok": False, "reason": "..."}`` if the run is not resumable.
+    """
+    ok = await resume_agent_run(run_id, agent_run_id)
+    if not ok:
+        logger.warning("⚠️ build_resume_run: %r not resumable", run_id)
+        return {
+            "ok": False,
+            "reason": f"Run {run_id!r} not found or not in a resumable state",
+        }
+    logger.info("✅ build_resume_run: %r → implementing", run_id)
+    return {"ok": True, "run_id": run_id, "status": "implementing"}
+
+
+async def build_stop_run(run_id: str) -> dict[str, JsonValue]:
+    """Transition any active run to ``stopped``.
+
+    Unlike ``build_cancel_run``, a stopped run can be resumed later via
+    :func:`build_resume_run`.
+
+    Args:
+        run_id: The run ID to stop.
+
+    Returns:
+        ``{"ok": True, "run_id": run_id, "status": "stopped"}`` on success,
+        ``{"ok": False, "reason": "..."}`` if already terminal.
+    """
+    ok = await stop_agent_run(run_id)
+    if not ok:
+        logger.warning("⚠️ build_stop_run: %r not found or already terminal", run_id)
+        return {
+            "ok": False,
+            "reason": f"Run {run_id!r} not found or already in a terminal state",
+        }
+    logger.info("✅ build_stop_run: %r → stopped", run_id)
+    return {"ok": True, "run_id": run_id, "status": "stopped"}
 
 
 async def build_spawn_adhoc_child(

--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -55,10 +55,13 @@ from agentception.mcp.types import (
     ToolListResult,
 )
 from agentception.mcp.build_commands import (
+    build_block_run,
     build_cancel_run,
     build_claim_run,
     build_complete_run,
+    build_resume_run,
     build_spawn_adhoc_child,
+    build_stop_run,
 )
 from agentception.mcp.log_tools import (
     log_run_error,
@@ -357,6 +360,59 @@ TOOLS: list[ACToolDef] = [
             "additionalProperties": False,
         },
     ),
+    ACToolDef(
+        name="build_block_run",
+        description=(
+            "Transition an implementing run to blocked. "
+            "Use when the agent cannot proceed until a dependency resolves or a human intervenes. "
+            "A blocked run can be resumed later with build_resume_run. "
+            "Only valid from implementing state."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "The run ID to block."},
+            },
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="build_resume_run",
+        description=(
+            "Transition a blocked or stopped run back to implementing. "
+            "Idempotent: if the run is already implementing with the same agent_run_id, "
+            "the call succeeds so a crashed-and-restarted agent can call this safely on startup."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "The run ID to resume."},
+                "agent_run_id": {
+                    "type": "string",
+                    "description": "The caller's own run ID (used for idempotency check).",
+                },
+            },
+            "required": ["run_id", "agent_run_id"],
+            "additionalProperties": False,
+        },
+    ),
+    ACToolDef(
+        name="build_stop_run",
+        description=(
+            "Transition any active run to stopped (non-terminal — can be resumed). "
+            "Unlike build_cancel_run, a stopped run can be resumed with build_resume_run. "
+            "Valid from any non-terminal state."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "The run ID to stop."},
+            },
+            "required": ["run_id"],
+            "additionalProperties": False,
+        },
+    ),
     # ── Log tools — append-only telemetry, no state change ───────────────────
     ACToolDef(
         name="log_run_step",
@@ -564,6 +620,9 @@ def call_tool(name: str, arguments: dict[str, JsonValue]) -> ACToolResult:
         "build_spawn_adhoc_child",
         "build_complete_run",
         "build_cancel_run",
+        "build_block_run",
+        "build_resume_run",
+        "build_stop_run",
         "log_run_step",
         "log_run_error",
         "github_add_label",
@@ -709,6 +768,51 @@ async def call_tool_async(
                 isError=True,
             )
         result = await build_cancel_run(run_id_arg5)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
+        )
+
+    if name == "build_block_run":
+        run_id_block = arguments.get("run_id")
+        if not isinstance(run_id_block, str) or not run_id_block:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"build_block_run requires a non-empty run_id"}')],
+                isError=True,
+            )
+        result = await build_block_run(run_id_block)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
+        )
+
+    if name == "build_resume_run":
+        run_id_resume = arguments.get("run_id")
+        agent_run_id_resume = arguments.get("agent_run_id")
+        if not isinstance(run_id_resume, str) or not run_id_resume:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"build_resume_run requires a non-empty run_id"}')],
+                isError=True,
+            )
+        if not isinstance(agent_run_id_resume, str) or not agent_run_id_resume:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"build_resume_run requires a non-empty agent_run_id"}')],
+                isError=True,
+            )
+        result = await build_resume_run(run_id_resume, agent_run_id_resume)
+        return ACToolResult(
+            content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
+            isError=not bool(result.get("ok", False)),
+        )
+
+    if name == "build_stop_run":
+        run_id_stop = arguments.get("run_id")
+        if not isinstance(run_id_stop, str) or not run_id_stop:
+            return ACToolResult(
+                content=[ACToolContent(type="text", text='{"error":"build_stop_run requires a non-empty run_id"}')],
+                isError=True,
+            )
+        result = await build_stop_run(run_id_stop)
         return ACToolResult(
             content=[ACToolContent(type="text", text=_tool_result_to_text(result))],
             isError=not bool(result.get("ok", False)),

--- a/agentception/tests/test_mcp_build_commands_pr3.py
+++ b/agentception/tests/test_mcp_build_commands_pr3.py
@@ -1,13 +1,19 @@
-from __future__ import annotations
-
-"""Integration + regression tests for build command MCP tools.
+"""Integration + regression tests for PR 3 new build commands.
 
 Tests:
+- build_block_run:   implementing → blocked
+- build_resume_run:  blocked/stopped → implementing; idempotent restart
 - build_cancel_run:  any active → cancelled; rejects terminal
+- build_stop_run:    any active → stopped; rejects terminal
 
 All tests go through the MCP layer (call_tool_async) to verify end-to-end
 dispatch in addition to the unit tests in test_persist_pending_launch_guard.py.
+
+Regression tests named per spec:
+- test_build_resume_run_idempotent_same_agent_run_id
 """
+
+from __future__ import annotations
 
 import json
 from unittest.mock import AsyncMock, patch
@@ -15,6 +21,143 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from agentception.mcp.server import call_tool_async
+from agentception.tests.conftest import make_create_task_side_effect
+
+
+# ---------------------------------------------------------------------------
+# build_block_run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_block_run_success_via_mcp() -> None:
+    """build_block_run MCP tool returns ok=true when state transition succeeds."""
+    with patch(
+        "agentception.mcp.build_commands.block_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        result = await call_tool_async("build_block_run", {"run_id": "issue-42"})
+
+    assert result["isError"] is False
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is True
+    assert payload["run_id"] == "issue-42"
+    assert payload["status"] == "blocked"
+
+
+@pytest.mark.anyio
+async def test_build_block_run_rejects_wrong_state() -> None:
+    """build_block_run returns isError=True when run is not in implementing state."""
+    with patch(
+        "agentception.mcp.build_commands.block_agent_run",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        result = await call_tool_async("build_block_run", {"run_id": "issue-42"})
+
+    assert result["isError"] is True
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is False
+    assert "reason" in payload
+
+
+@pytest.mark.anyio
+async def test_build_block_run_missing_run_id_returns_error() -> None:
+    """build_block_run returns isError=True when run_id is missing."""
+    result = await call_tool_async("build_block_run", {})
+    assert result["isError"] is True
+
+
+def test_build_block_run_in_tools_list() -> None:
+    """build_block_run is present in the TOOLS registry."""
+    from agentception.mcp.server import TOOLS
+    names = [t["name"] for t in TOOLS]
+    assert "build_block_run" in names
+
+
+# ---------------------------------------------------------------------------
+# build_resume_run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_resume_run_success_via_mcp() -> None:
+    """build_resume_run MCP tool returns ok=true when state transition succeeds."""
+    with patch(
+        "agentception.mcp.build_commands.resume_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        result = await call_tool_async(
+            "build_resume_run",
+            {"run_id": "issue-42", "agent_run_id": "issue-42"},
+        )
+
+    assert result["isError"] is False
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is True
+    assert payload["run_id"] == "issue-42"
+    assert payload["status"] == "implementing"
+
+
+@pytest.mark.anyio
+async def test_build_resume_run_idempotent_same_agent_run_id() -> None:
+    """Regression: build_resume_run with same agent_run_id while already implementing returns ok.
+
+    This is the restart-safe behaviour — an agent that crashes and restarts
+    calls build_resume_run on startup. If the run is already implementing with
+    the same run ID, the call must succeed so the agent can continue work.
+    """
+    with patch(
+        "agentception.mcp.build_commands.resume_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        result = await call_tool_async(
+            "build_resume_run",
+            {"run_id": "issue-42", "agent_run_id": "issue-42"},
+        )
+
+    assert result["isError"] is False
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is True
+
+
+@pytest.mark.anyio
+async def test_build_resume_run_rejects_non_resumable_state() -> None:
+    """build_resume_run returns isError=True when run is not resumable."""
+    with patch(
+        "agentception.mcp.build_commands.resume_agent_run",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        result = await call_tool_async(
+            "build_resume_run",
+            {"run_id": "issue-42", "agent_run_id": "issue-42"},
+        )
+
+    assert result["isError"] is True
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is False
+    assert "reason" in payload
+
+
+@pytest.mark.anyio
+async def test_build_resume_run_missing_args_returns_error() -> None:
+    """build_resume_run returns isError=True when required args are missing."""
+    result = await call_tool_async("build_resume_run", {"run_id": "issue-42"})
+    assert result["isError"] is True
+
+    result2 = await call_tool_async("build_resume_run", {})
+    assert result2["isError"] is True
+
+
+def test_build_resume_run_in_tools_list() -> None:
+    """build_resume_run is present in the TOOLS registry."""
+    from agentception.mcp.server import TOOLS
+    names = [t["name"] for t in TOOLS]
+    assert "build_resume_run" in names
 
 
 # ---------------------------------------------------------------------------
@@ -65,3 +208,294 @@ def test_build_cancel_run_in_tools_list() -> None:
     from agentception.mcp.server import TOOLS
     names = [t["name"] for t in TOOLS]
     assert "build_cancel_run" in names
+
+# ---------------------------------------------------------------------------
+# build_stop_run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_stop_run_success_via_mcp() -> None:
+    """build_stop_run MCP tool returns ok=true when transition succeeds."""
+    with patch(
+        "agentception.mcp.build_commands.stop_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        result = await call_tool_async("build_stop_run", {"run_id": "issue-42"})
+
+    assert result["isError"] is False
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is True
+    assert payload["status"] == "stopped"
+
+
+@pytest.mark.anyio
+async def test_build_stop_run_rejects_terminal_state() -> None:
+    """build_stop_run returns isError=True when run is already terminal."""
+    with patch(
+        "agentception.mcp.build_commands.stop_agent_run",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        result = await call_tool_async("build_stop_run", {"run_id": "issue-42"})
+
+    assert result["isError"] is True
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["ok"] is False
+
+
+@pytest.mark.anyio
+async def test_build_stop_run_missing_run_id_returns_error() -> None:
+    """build_stop_run returns isError=True when run_id is missing."""
+    result = await call_tool_async("build_stop_run", {})
+    assert result["isError"] is True
+
+
+def test_build_stop_run_in_tools_list() -> None:
+    """build_stop_run is present in the TOOLS registry."""
+    from agentception.mcp.server import TOOLS
+    names = [t["name"] for t in TOOLS]
+    assert "build_stop_run" in names
+
+
+# ---------------------------------------------------------------------------
+# Integration: claim → block → resume flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_claim_block_resume_flow() -> None:
+    """Integration: claim → block → resume transitions succeed in sequence."""
+    with patch(
+        "agentception.mcp.build_commands.acknowledge_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        claim_result = await call_tool_async("build_claim_run", {"run_id": "issue-99"})
+
+    assert json.loads(claim_result["content"][0]["text"])["ok"] is True
+
+    with patch(
+        "agentception.mcp.build_commands.block_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        block_result = await call_tool_async("build_block_run", {"run_id": "issue-99"})
+
+    assert json.loads(block_result["content"][0]["text"])["status"] == "blocked"
+
+    with patch(
+        "agentception.mcp.build_commands.resume_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        resume_result = await call_tool_async(
+            "build_resume_run",
+            {"run_id": "issue-99", "agent_run_id": "issue-99"},
+        )
+
+    assert json.loads(resume_result["content"][0]["text"])["status"] == "implementing"
+
+
+@pytest.mark.anyio
+async def test_claim_stop_resume_flow() -> None:
+    """Integration: claim → stop → resume transitions succeed in sequence."""
+    with patch(
+        "agentception.mcp.build_commands.acknowledge_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        await call_tool_async("build_claim_run", {"run_id": "issue-100"})
+
+    with patch(
+        "agentception.mcp.build_commands.stop_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        stop_result = await call_tool_async("build_stop_run", {"run_id": "issue-100"})
+
+    assert json.loads(stop_result["content"][0]["text"])["status"] == "stopped"
+
+    with patch(
+        "agentception.mcp.build_commands.resume_agent_run",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        resume_result = await call_tool_async(
+            "build_resume_run",
+            {"run_id": "issue-100", "agent_run_id": "issue-100"},
+        )
+
+    assert json.loads(resume_result["content"][0]["text"])["status"] == "implementing"
+
+
+# ---------------------------------------------------------------------------
+# Regression: reviewer must not trigger a second reviewer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_reviewer_does_not_redispatch_reviewer() -> None:
+    """When a reviewer calls build_complete_run, no auto-reviewer is dispatched.
+
+    Regression for the infinite reviewer loop: reviewer merges PR → calls
+    build_complete_run → auto_dispatch_reviewer → second reviewer → …
+    """
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="reviewer",
+        ) as mock_role,
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_teardown",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "agentception.mcp.build_commands._is_pr_merged",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_plan_id_for_issue",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "agentception.mcp.build_commands.auto_dispatch_reviewer",
+            new_callable=AsyncMock,
+        ) as mock_dispatch,
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
+        ),
+    ):
+        result = await call_tool_async(
+            "build_complete_run",
+            {
+                "issue_number": 449,
+                "pr_url": "https://github.com/owner/repo/pull/553",
+                "agent_run_id": "issue-449",
+                "grade": "A",
+            },
+        )
+
+    assert json.loads(result["content"][0]["text"])["ok"] is True
+    mock_role.assert_awaited_once_with("issue-449")
+    mock_dispatch.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_implementer_does_redispatch_reviewer() -> None:
+    """When a developer calls build_complete_run, reviewer IS dispatched."""
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="developer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_teardown",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "agentception.mcp.build_commands.auto_dispatch_reviewer",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
+        ) as mock_create_task,
+    ):
+        result = await call_tool_async(
+            "build_complete_run",
+            {
+                "issue_number": 42,
+                "pr_url": "https://github.com/owner/repo/pull/100",
+                "agent_run_id": "issue-42",
+            },
+        )
+
+    assert json.loads(result["content"][0]["text"])["ok"] is True
+    mock_create_task.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_build_complete_run_releases_worktree_before_reviewer() -> None:
+    """Executor worktree is released before the reviewer is dispatched.
+
+    Regression for the "branch already used by worktree" failure: if the
+    executor's worktree still holds feat/issue-N when the reviewer tries to
+    create its own worktree for the same branch, git rejects the second
+    worktree with a fatal error.  build_complete_run must call
+    release_worktree (remove dir + prune refs) first.
+    """
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="developer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_teardown",
+            new_callable=AsyncMock,
+            return_value={"worktree_path": "/worktrees/issue-99", "branch": "feat/issue-99"},
+        ),
+        patch(
+            "agentception.mcp.build_commands.release_worktree",
+            new_callable=AsyncMock,
+        ) as mock_release,
+        patch(
+            "agentception.mcp.build_commands.auto_dispatch_reviewer",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
+        ),
+    ):
+        result = await call_tool_async(
+            "build_complete_run",
+            {
+                "issue_number": 99,
+                "pr_url": "https://github.com/owner/repo/pull/200",
+                "agent_run_id": "issue-99",
+            },
+        )
+
+    assert json.loads(result["content"][0]["text"])["ok"] is True
+    mock_release.assert_awaited_once_with(
+        worktree_path="/worktrees/issue-99",
+        repo_dir=str(__import__("agentception.config", fromlist=["settings"]).settings.repo_dir),
+    )
+


### PR DESCRIPTION
## Summary

- Implements `build_block_run` (implementing → blocked), `build_resume_run` (blocked/stopped → implementing, idempotent), and `build_stop_run` (any active → stopped, resumable) MCP tools in `build_commands.py` and registers them in `server.py`
- Fixes 13 test failures in `test_mcp_build_commands_pr3.py` that referenced these missing functions/tools; also eliminates 2 `RuntimeWarning: coroutine was never awaited` leaks by replacing `patch('asyncio.create_task')` with module-scoped patches using `make_create_task_side_effect()`
- Restores `persist.py` to committed state — local dirty version had removed the stall guard, cross-repo collision fix, `JsonValue` imports, and critical comments

## Test plan

- [x] `mypy agentception/mcp/build_commands.py agentception/mcp/server.py agentception/tests/test_mcp_build_commands_pr3.py` — zero errors
- [x] `pytest agentception/tests/test_mcp_build_commands_pr3.py -W error::RuntimeWarning` — 22 passed, 0 warnings
- [x] `pytest agentception/tests/test_mcp_build_commands_pr3.py agentception/tests/test_build_page_structure.py agentception/tests/test_mcp_http.py -W error::RuntimeWarning` — 45 passed, 0 warnings