### PR TITLE
fix: eliminate last two RuntimeWarning and DeprecationWarning sources

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -2294,7 +2294,7 @@ def _auto_track_file_write(rel_path: str, worktree_path: Path) -> None:
         already_tracked = any(e.path == rel_path for e in current if isinstance(e, FileEditEvent))
         if not already_tracked:
             current.append(FileEditEvent(
-                timestamp=datetime.datetime.utcnow(),
+                timestamp=datetime.datetime.now(datetime.UTC),
                 path=rel_path,
                 diff="",
                 lines_omitted=0,

--- a/agentception/tests/test_build_commands_rebase.py
+++ b/agentception/tests/test_build_commands_rebase.py
@@ -350,6 +350,7 @@ async def test_rebase_succeeds_with_empty_worktree_path_dict() -> None:
         ),
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
     ):
         result = await build_complete_run(


### PR DESCRIPTION
## Summary

- `test_build_commands_rebase.py`: `test_rebase_succeeds_with_empty_worktree_path_dict` was patching `asyncio.create_task` as a plain `MagicMock`, leaving the `auto_dispatch_reviewer` coroutine unclosed; GC triggered `RuntimeWarning` in later unrelated tests (`test_build_page_structure` / `test_ensure_helpers`). Fixed with `side_effect=make_create_task_side_effect()`.
- `agent_loop.py:2297`: replaced `datetime.datetime.utcnow()` with `datetime.datetime.now(datetime.UTC)` to eliminate the `DeprecationWarning` that appeared across 7 `test_agent_loop.py` tests.

## Test plan

- [x] `mypy agentception/services/agent_loop.py agentception/tests/test_build_commands_rebase.py` — zero errors
- [x] `pytest test_build_commands_rebase.py test_build_page_structure.py test_ensure_helpers.py::test_dispatch_reviewer_pr_branch_override_respected -W error::RuntimeWarning -W error::DeprecationWarning` — 9 passed, 0 warnings
- [x] `pytest test_agent_loop.py (two representative tests) -W error::DeprecationWarning` — 2 passed, 0 warnings