### PR TITLE
fix: close last two bare create_task coroutine leaks in rebase tests

### DIFF
--- a/agentception/tests/test_build_commands_rebase.py
+++ b/agentception/tests/test_build_commands_rebase.py
@@ -198,6 +198,7 @@ async def test_rebase_conflict_returns_error_and_aborts() -> None:
         ),
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
         patch(
             "agentception.mcp.build_commands.Path",
@@ -275,6 +276,7 @@ async def test_no_worktree_path_skips_rebase_and_dispatches_reviewer() -> None:
         ),
         patch(
             "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
         ) as mock_create_task,
     ):
         result = await build_complete_run(


### PR DESCRIPTION
## Summary

- `test_rebase_conflict_returns_error_and_aborts` and `test_no_worktree_path_skips_rebase_and_dispatches_reviewer` both patched `asyncio.create_task` as a bare `MagicMock` without `side_effect`. The `auto_dispatch_reviewer` `AsyncMock` coroutine passed to `create_task` was never closed, leaking into GC and surfacing as a `RuntimeWarning` during `test_build_initiative_tabs.py::test_active_initiative_tab_marked_in_full_page`.
- Added `side_effect=make_create_task_side_effect()` to both patches.

## Test plan

- [x] `mypy agentception/tests/test_build_commands_rebase.py` — zero errors
- [x] `pytest agentception/tests/test_build_commands_rebase.py -W error::RuntimeWarning` — 4 passed, 0 warnings
- [x] Full suite: **2074 passed, 0 warnings**