### PR TITLE
fix: add git safe.directory for /app and /worktrees in entrypoint

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -20,7 +20,19 @@ set -euo pipefail
 printf 'nameserver 127.0.0.11\nnameserver 1.1.1.1\nnameserver 8.8.8.8\noptions ndots:0 timeout:3 attempts:1 use-vc\n' \
   > /etc/resolv.conf
 
-# ── 2. Static asset compilation ──────────────────────────────────────────────
+# ── 2. Git safe.directory ────────────────────────────────────────────────────
+# The .git bind-mount is owned by the macOS host user; the container runs as
+# agentception (UID 1001), which has a different UID.  Git 2.35.2+ rejects
+# repositories where the directory owner doesn't match the effective user.
+# Adding /app to the system-wide config (written to /etc/gitconfig) makes it
+# trusted for both root (during this entrypoint) and agentception (after exec).
+# /worktrees/* directories also need coverage because every git-worktree
+# command checks the common git dir at /app, which already resolves via this
+# setting, but individual worktree paths may be traversed by git internally.
+git config --system --add safe.directory /app
+git config --system --add safe.directory /worktrees
+
+# ── 3. Static asset compilation ──────────────────────────────────────────────
 # The bind-mounted source directories appear as root-owned inside the container
 # on macOS/Docker Desktop (VirtioFS maps host UID 0 → container root).
 # Compile as root so we can write to the bind-mounted static output paths.
@@ -32,7 +44,7 @@ sass --style=compressed --no-source-map \
 echo "[entrypoint] building JS bundle …"
 npm run build:js
 
-# ── 3. Database migrations ───────────────────────────────────────────────────
+# ── 4. Database migrations ───────────────────────────────────────────────────
 # Retry once on transient connection failure (Postgres may still be
 # initialising on the first `docker compose up`).
 echo "[entrypoint] running Alembic migrations …"
@@ -42,7 +54,7 @@ alembic -c agentception/alembic.ini upgrade head || {
   alembic -c agentception/alembic.ini upgrade head
 }
 
-# ── 4. Fix ownership of mutable mount points ─────────────────────────────────
+# ── 5. Fix ownership of mutable mount points ─────────────────────────────────
 # /worktrees  — bind-mount of ${HOME}/.agentception/worktrees/agentception on
 #   the host.  On macOS/Docker Desktop (VirtioFS) chown inside the container
 #   propagates to the host as the host user's UID — this is intentional and
@@ -64,7 +76,7 @@ echo "[entrypoint] fixing ownership of FastEmbed cache …"
 mkdir -p /home/agentception/.cache/fastembed
 chown -R agentception:agentception /home/agentception/.cache/fastembed
 
-# ── 5. Drop to non-root user ─────────────────────────────────────────────────
+# ── 6. Drop to non-root user ─────────────────────────────────────────────────
 # gosu is a purpose-built setuid helper (analogous to sudo -u but without the
 # shell overhead).  It sets UID/GID and execs "$@" — typically uvicorn — as
 # PID 1's effective non-root user.  After this line no process in the


### PR DESCRIPTION
## Summary

- The `.git` bind-mount is owned by the macOS host user; the container process runs as `agentception` (UID 1001) which has a different UID. Git 2.35.2+ detects this as "dubious ownership" and refuses to run, causing `git rev-parse origin/dev failed: fatal: detected dubious ownership in repository at '/app'` on every agent dispatch.
- Added `/app` and `/worktrees` to the system git config (`/etc/gitconfig`) during the privileged entrypoint phase via `git config --system --add safe.directory`, so both root (build steps) and the unprivileged `agentception` user (after `gosu` drop) can run git against the mounted repository.

## Test plan

- [x] `docker compose build agentception && docker compose up -d agentception` — succeeds
- [x] `docker compose exec agentception bash -c "git config --system --list | grep safe && git -C /app rev-parse origin/dev"` — prints both safe.directory entries and resolves `origin/dev` cleanly