### PR TITLE
docs: Add Quick health check section after Step 6

### DIFF
--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -140,6 +140,22 @@ Both should return HTTP 200.
 
 ---
 
+## Quick health check
+
+Verify the service is running with these curl commands:
+
+```bash
+# Basic health ping
+curl -f http://localhost:1337/health
+# → {"status":"ok"}
+
+# Detailed health snapshot (uptime, memory, worktree count, GitHub API latency)
+curl -f http://localhost:1337/api/health/detailed
+# → {"uptime_seconds":..., "memory_rss_mb":..., "active_worktree_count":0, "github_api_latency_ms":...}
+```
+
+---
+
 ## Step 7 — Index the codebase for semantic search (optional)
 
 The Cursor-free agent loop uses a Qdrant vector index to give agents `@Codebase`-style semantic search without Cursor. Trigger indexing with a single API call:


### PR DESCRIPTION
## Summary

Addresses issue #1071 by adding a "Quick health check" section immediately after Step 6 in the setup guide.

## Changes

- Added dedicated "Quick health check" section with curl commands for `/health` and `/api/health/detailed` endpoints
- Improves discoverability of health endpoints for users following the setup guide
- Section appears right after Step 6 verification, making it easy to find

## Testing

Verified the markdown renders correctly and the curl commands are properly formatted.