### PR TITLE
fix: live org tree TypeError + Cursor-like inspector terminal log

### DIFF
--- a/agentception/static/js/org_designer.ts
+++ b/agentception/static/js/org_designer.ts
@@ -652,10 +652,14 @@ function renderLiveD3(
     .x((d: D3HierarchyNode) => d.x + offsetX)
     .y((d: D3HierarchyNode) => d.y + offsetY + NODE_H);
 
+  // d.data here is LiveOrgNode (D3 hierarchy wraps LiveOrgNode); the actual
+  // RunTreeNodeRow is one level deeper at d.data.data.
   svg.selectAll('.od-link')
     .data((d3Root as unknown as D3HierarchyNode).links() as unknown as D3HierarchyNode[], (d: D3HierarchyNode) => {
       const lnk = d as unknown as D3HierarchyLink;
-      return `${lnk.source?.data?.id}-${lnk.target?.data?.id}`;
+      const srcId = (lnk.source?.data as unknown as LiveOrgNode | undefined)?.data?.id ?? '';
+      const tgtId = (lnk.target?.data as unknown as LiveOrgNode | undefined)?.data?.id ?? '';
+      return `${srcId}-${tgtId}`;
     })
     .join('path')
     .attr('class', 'od-link')
@@ -663,7 +667,7 @@ function renderLiveD3(
 
   const descendants = (d3Root as unknown as D3HierarchyNode).descendants();
   const cards = cardLayer.selectAll('.od-node')
-    .data(descendants, (d: D3HierarchyNode) => d.data.id);
+    .data(descendants, (d: D3HierarchyNode) => (d.data as unknown as LiveOrgNode).data.id);
 
   const entered = cards.enter().append('div').attr('class', 'od-node od-node--live');
   const all     = entered.merge(cards);
@@ -672,15 +676,15 @@ function renderLiveD3(
     .style('left', (d: D3HierarchyNode) => `${d.x + offsetX - NODE_W / 2}px`)
     .style('top',  (d: D3HierarchyNode) => `${d.y + offsetY}px`)
     .classed('od-node--coordinator', (d: D3HierarchyNode) => {
-      const row = d.data as unknown as RunTreeNodeRow;
+      const row = (d.data as unknown as LiveOrgNode).data;
       return !!row.role && isCoordinator(row.role);
     })
     .classed('od-node--worker', (d: D3HierarchyNode) => {
-      const row = d.data as unknown as RunTreeNodeRow;
+      const row = (d.data as unknown as LiveOrgNode).data;
       return !!row.role && !isCoordinator(row.role);
     })
     .html((d: D3HierarchyNode) => {
-      const row = d.data as unknown as RunTreeNodeRow;
+      const row = (d.data as unknown as LiveOrgNode).data;
       return liveNodeCardHtml(row, repo, initiative);
     });
 

--- a/agentception/static/scss/pages/_activity-feed.scss
+++ b/agentception/static/scss/pages/_activity-feed.scss
@@ -1,65 +1,81 @@
 // ── Activity feed row (SSE activity messages) ─────────────────────────────────
+//
+// Terminal-style log: icon | content (grows) | timestamp (right-aligned).
+// Rows are compact (24px line-height) to maximise visible history.
 
 .activity-feed__row {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.2rem 0.5rem;
-  font-size: 0.75rem;
-  color: var(--text-secondary, #888);
-  max-width: 100%;
-  overflow-x: hidden;
-  word-break: break-word;
-  border-left: 3px solid transparent;
-  border-radius: 0 var(--radius-xs, 4px) var(--radius-xs, 4px) 0;
-  transition: background 0.12s;
+  display: grid;
+  grid-template-columns: 1.1rem 1fr auto;
+  align-items: baseline;
+  gap: 0 0.45rem;
+  padding: 0.05rem 0.75rem 0.05rem 0.5rem;
+  min-height: 22px;
+  font-size: 0.695rem;
+  line-height: 1.9;
+  color: rgba(255, 255, 255, 0.5);
+  border-left: 2px solid transparent;
+  transition: background 0.08s;
 
   &:hover {
-    background: var(--bg-hover);
+    background: rgba(255, 255, 255, 0.03);
   }
 
   // Color-coded left border by event category
-  &[data-subtype^="llm"]   { border-left-color: var(--accent-purple, #9b6dff); }
-  &[data-subtype^="file"]  { border-left-color: var(--accent-green,  #3ecf8e); }
-  &[data-subtype="tool"],
+  &[data-subtype^="llm"]   { border-left-color: #7c3aed; }
+  &[data-subtype^="file"]  { border-left-color: #10b981; }
   &[data-subtype="tool_invoked"],
-  &[data-subtype="github_tool"] { border-left-color: var(--accent-orange, #f5a623); }
-  &[data-subtype^="shell"] { border-left-color: var(--text-muted, #6a8aaa); }
-  &[data-subtype="git_push"]    { border-left-color: var(--accent-blue, #4dabf7); }
-  &[data-subtype="delay"]       { border-left-color: var(--warning, #f5a623); opacity: 0.7; }
-  &[data-subtype="error"]       { border-left-color: var(--error, #e53e3e); }
+  &[data-subtype="github_tool"] { border-left-color: #f59e0b; }
+  &[data-subtype^="shell"] { border-left-color: #4b5563; }
+  &[data-subtype="git_push"]    { border-left-color: #38bdf8; }
+  &[data-subtype="delay"]       { border-left-color: #f59e0b; opacity: 0.55; }
+  &[data-subtype="error"]       { border-left-color: #ef4444; color: #fca5a5; }
 
-  // Non-zero shell exit: override border to error red and tint background
+  // LLM rows are slightly brighter — they carry the key iteration signal
+  &[data-subtype="llm_iter"] {
+    color: rgba(167, 139, 250, 0.85);
+  }
+
+  &[data-subtype="llm_usage"] {
+    color: rgba(167, 139, 250, 0.5);
+  }
+
+  // File writes are highlighted
+  &[data-subtype="file_replaced"],
+  &[data-subtype="file_inserted"],
+  &[data-subtype="file_written"] {
+    color: rgba(52, 211, 153, 0.8);
+  }
+
+  // Non-zero shell exit: error tint
   &[data-subtype="shell_done"][data-exit-nonzero] {
-    border-left-color: var(--error, #e53e3e);
-    background: rgba(229, 62, 62, 0.06);
-    color: var(--error, #e53e3e);
+    border-left-color: #ef4444;
+    background: rgba(239, 68, 68, 0.06);
+    color: #fca5a5;
   }
 
   .activity-feed__icon {
-    flex-shrink: 0;
-    line-height: 1;
-    &[aria-hidden='true'] {
-      opacity: 0.7;
-    }
+    font-size: 0.7rem;
+    line-height: 1.9;
+    opacity: 0.7;
+    text-align: center;
   }
 
   .activity-feed__summary {
-    flex: 1;
     min-width: 0;
-    white-space: nowrap;
     overflow: hidden;
+    white-space: nowrap;
     text-overflow: ellipsis;
     font-family: var(--font-mono);
-    font-size: 0.7rem;
+    font-size: 0.68rem;
+    letter-spacing: 0.01em;
   }
 
   .activity-feed__ts {
-    flex-shrink: 0;
-    font-size: 0.65rem;
+    font-size: 0.6rem;
     font-variant-numeric: tabular-nums;
-    color: var(--text-faint, #555);
+    color: rgba(255, 255, 255, 0.2);
     font-family: var(--font-mono);
-    opacity: 0.8;
+    white-space: nowrap;
+    padding-left: 0.5rem;
   }
 }

--- a/agentception/static/scss/pages/_event-card.scss
+++ b/agentception/static/scss/pages/_event-card.scss
@@ -1,58 +1,79 @@
 // ── Event card ────────────────────────────────────────────────────────────────
 // Structured MCP lifecycle events: step_start, blocker, decision, done,
 // message (free-form agent note), error (structured MCP error).
+//
+// These cards live inside the dark terminal #activity-feed container and act
+// as section dividers (step_start) or highlighted lifecycle markers.
 
 .event-card {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  padding: 0.25rem 0.5rem;
-  border-left: 3px solid var(--text-muted, #6a8aaa);
-  border-radius: 0 var(--radius-xs, 4px) var(--radius-xs, 4px) 0;
-  font-size: 0.75rem;
-  color: var(--text-secondary, #aaa);
-  max-width: 100%;
-  overflow-x: hidden;
-  word-break: break-word;
+  padding: 0.1rem 0.75rem;
+  font-size: 0.695rem;
+  color: rgba(255, 255, 255, 0.5);
+  font-family: var(--font-mono);
+  border-left: 2px solid transparent;
+  line-height: 1.9;
 
+  // Step start: full-width section divider
   &[data-event-type='step_start'] {
-    border-left-color: var(--text-muted, #6a8aaa);
-    color: var(--text-secondary, #aaa);
+    margin-top: 0.4rem;
+    padding-top: 0.35rem;
+    padding-bottom: 0.2rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    border-left: none;
+    color: rgba(255, 255, 255, 0.35);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+
+    // First step_start has no top separator
+    &:first-child {
+      margin-top: 0;
+      border-top: none;
+    }
+
+    .event-card__icon {
+      color: rgba(255, 255, 255, 0.2);
+      font-size: 0.55rem;
+    }
   }
 
   &[data-event-type='blocker'] {
-    border-left-color: var(--warning, #f5a623);
-    color: var(--warning, #f5a623);
-    background: rgba(245, 166, 35, 0.05);
+    border-left-color: #f59e0b;
+    color: #fcd34d;
+    background: rgba(245, 158, 11, 0.06);
   }
 
   &[data-event-type='decision'] {
-    border-left-color: var(--accent-blue, #4dabf7);
-    color: var(--text-secondary, #aaa);
+    border-left-color: #38bdf8;
+    color: rgba(186, 230, 253, 0.75);
   }
 
   &[data-event-type='done'] {
-    border-left-color: var(--success, #3ecf8e);
-    color: var(--success, #3ecf8e);
+    border-left-color: #10b981;
+    color: #6ee7b7;
     font-weight: 600;
-    font-size: 0.8rem;
-    background: rgba(62, 207, 142, 0.05);
+    background: rgba(16, 185, 129, 0.06);
   }
 
   &[data-event-type='message'] {
-    border-left-color: var(--border-default, #444);
-    color: var(--text-secondary, #aaa);
+    border-left-color: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.45);
   }
 
   &[data-event-type='error'] {
-    border-left-color: var(--error, #e53e3e);
-    color: var(--error, #e53e3e);
-    background: rgba(229, 62, 62, 0.05);
+    border-left-color: #ef4444;
+    color: #fca5a5;
+    background: rgba(239, 68, 68, 0.07);
   }
 
   &__icon {
     flex-shrink: 0;
-    opacity: 0.85;
+    opacity: 0.8;
+    font-size: 0.75rem;
   }
 
   &__text {

--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -679,7 +679,7 @@ body:has(.build-layout) nav.topnav {
   overflow: hidden;
   position: sticky;
   top: 64px;
-  max-height: calc(100vh - 80px);
+  height: calc(100vh - 80px);
 
   // ── Empty state ─────────────────────────────────────────────────────────────
   &__empty {
@@ -720,7 +720,8 @@ body:has(.build-layout) nav.topnav {
   &__content {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    flex: 1;
+    min-height: 0; // required so flex children can scroll rather than expanding
     overflow: hidden;
   }
 
@@ -882,14 +883,47 @@ body:has(.build-layout) nav.topnav {
   &__stream-status {
     padding: 0.3rem 0.875rem;
     font-size: 0.6rem;
-    color: var(--text-faint);
+    color: rgba(255, 255, 255, 0.25);
     margin: 0;
-    border-top: 1px solid var(--border-subtle);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    background: #09090f;
     font-family: var(--font-mono);
     flex-shrink: 0;
     letter-spacing: 0.04em;
 
     &--live { color: var(--success); }
+  }
+
+  &__chat {
+    flex-shrink: 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    background: #09090f;
+  }
+
+  &__agent-actions {
+    padding: 0.45rem 0.75rem;
+  }
+
+  &__stop-btn {
+    font-size: 0.68rem;
+    font-weight: 600;
+    font-family: var(--font-mono);
+    padding: 0.3rem 0.7rem;
+    border-radius: 5px;
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    background: rgba(239, 68, 68, 0.08);
+    color: #fca5a5;
+    cursor: pointer;
+    letter-spacing: 0.04em;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+
+    &:hover:not(:disabled) {
+      background: rgba(239, 68, 68, 0.18);
+      border-color: rgba(239, 68, 68, 0.6);
+      color: #f87171;
+    }
+
+    &:disabled { opacity: 0.4; cursor: not-allowed; }
   }
 }
 
@@ -2232,15 +2266,22 @@ $preset-accents: (
   &--off { color: rgba(134,239,172,0.7); }
 }
 
-// ── Activity feed container ───────────────────────────────────────────────────
+// ── Activity feed container — terminal-style scrollable log ──────────────────
 
 .build-inspector__activity {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.5rem 0;
+  flex: 1;
+  min-height: 0; // without this the flex child never scrolls — it just expands
   overflow-y: auto;
-  flex: 1 1 auto;
+  padding: 0;
+  background: #09090f;
+  font-family: var(--font-mono);
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255,255,255,0.1) transparent;
+
+  &::-webkit-scrollbar       { width: 4px; }
+  &::-webkit-scrollbar-track { background: transparent; }
+  &::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.12); border-radius: 2px; }
 }
 
 // ── Start agent block (pending_launch state) ──────────────────────────────────


### PR DESCRIPTION
## Summary

- **Bug fix**: Agent Org live view crashed with `TypeError: Cannot read properties of undefined (reading 'length')` — D3 `hierarchy<LiveOrgNode>` stores `LiveOrgNode` at `d.data`, but five callbacks in `renderLiveD3` cast it directly to `RunTreeNodeRow`, accessing `.id`/`.role` on the wrong level. Fixed by going through `(d.data as LiveOrgNode).data` at all five sites (link key, card key, `classed×2`, `html`).
- **Inspector redesign**: The right-column inspector panel was compressing instead of scrolling because `max-height` without `height` meant `height: 100%` on `__content` never bounded the flex tree; `min-height: 0` was missing throughout. Converted to a full-height sticky Cursor-like terminal log with dark background, compact monospace rows, color-coded 2px left borders, and step headers as subtle section dividers.

## Test plan
- [ ] Open Agent Org live view while an agent is running — tree renders without console errors
- [ ] Open any active issue in the Build inspector — panel fills viewport height and activity feed scrolls smoothly as events stream in
- [ ] Verify LLM rows are purple-tinted, file writes are green, errors are red, step headers appear as thin uppercase dividers
- [ ] Stop button shows red-tinted styling; stream-status bar matches the dark terminal background