### PR TITLE
fix: add missing columns to A/B metrics test mocks

### DIFF
--- a/tests/test_ab_metrics.py
+++ b/tests/test_ab_metrics.py
@@ -28,7 +28,7 @@ async def client() -> AsyncGenerator[AsyncClient, None]:
 
 
 def _mock_result_two_rows() -> list[dict[str, JsonValue]]:
-    """Two rows: control and streamlined."""
+    """Two rows: control and streamlined — all columns from _AB_QUERY."""
     return [
         {
             "variant": "control",
@@ -36,10 +36,20 @@ def _mock_result_two_rows() -> list[dict[str, JsonValue]]:
             "runs": 10,
             "avg_iterations": 5.2,
             "avg_input_tokens": 50000.0,
+            "avg_output_tokens": 12000.0,
+            "avg_cache_read_tokens": 3000.0,
+            "avg_cache_write_tokens": 1500.0,
             "total_tokens": 520000,
+            "avg_duration_secs": 180.0,
+            "retry_count": 2,
             "pass_rate": 0.8,
             "passed": 8,
             "failed": 2,
+            "grade_a": 5,
+            "grade_b": 3,
+            "grade_c": 1,
+            "grade_d": 1,
+            "grade_f": 0,
         },
         {
             "variant": "streamlined",
@@ -47,10 +57,20 @@ def _mock_result_two_rows() -> list[dict[str, JsonValue]]:
             "runs": 10,
             "avg_iterations": 4.1,
             "avg_input_tokens": 42000.0,
+            "avg_output_tokens": 10000.0,
+            "avg_cache_read_tokens": 2500.0,
+            "avg_cache_write_tokens": 1200.0,
             "total_tokens": 410000,
+            "avg_duration_secs": 150.0,
+            "retry_count": 1,
             "pass_rate": 0.9,
             "passed": 9,
             "failed": 1,
+            "grade_a": 7,
+            "grade_b": 2,
+            "grade_c": 1,
+            "grade_d": 0,
+            "grade_f": 0,
         },
     ]
 

--- a/tests/test_ab_metrics_panel.py
+++ b/tests/test_ab_metrics_panel.py
@@ -64,10 +64,20 @@ async def test_ab_metrics_htmx_returns_html(client: AsyncClient) -> None:
             "runs": 5,
             "avg_iterations": 4.0,
             "avg_input_tokens": 1000.0,
+            "avg_output_tokens": 500.0,
+            "avg_cache_read_tokens": 200.0,
+            "avg_cache_write_tokens": 100.0,
             "total_tokens": 5000,
+            "avg_duration_secs": 120.0,
+            "retry_count": 0,
             "pass_rate": 0.8,
             "passed": 4,
             "failed": 1,
+            "grade_a": 3,
+            "grade_b": 1,
+            "grade_c": 1,
+            "grade_d": 0,
+            "grade_f": 0,
         },
     ]
 
@@ -91,7 +101,7 @@ async def test_ab_metrics_htmx_returns_html(client: AsyncClient) -> None:
 
     assert response.status_code == 200
     assert "text/html" in response.headers.get("content-type", "")
-    assert '<table class="ab-metrics">' in response.text
+    assert '<div class="drh">' in response.text
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Add all missing SQL result columns (`retry_count`, `avg_output_tokens`, `avg_cache_read_tokens`, `avg_cache_write_tokens`, `avg_duration_secs`, `grade_a`–`grade_f`) to the mock data in `test_ab_metrics.py` and `test_ab_metrics_panel.py`. Without them, the route handler raises `KeyError: 'retry_count'`.
- Update the HTMX assertion from the old `<table class="ab-metrics">` to the current `<div class="drh">` template structure.

Fixes the 2 test failures blocking [PR #1085](https://github.com/cgcardona/agentception/pull/1085) (dev → main release).

## Test plan

- [x] `pytest tests/test_ab_metrics.py tests/test_ab_metrics_panel.py -v` — all 8 pass
- [x] `mypy tests/test_ab_metrics.py tests/test_ab_metrics_panel.py` — clean