### PR TITLE
fix: replace banned `object` param type in conftest create_task helper

### DIFF
--- a/agentception/tests/conftest.py
+++ b/agentception/tests/conftest.py
@@ -19,7 +19,7 @@ import pytest
 
 
 def make_create_task_side_effect() -> (
-    Callable[[collections.abc.Coroutine[object, object, object]], asyncio.Future[None]]
+    Callable[..., asyncio.Future[None]]
 ):
     """Return a side-effect for patching ``asyncio.create_task`` in tests.
 
@@ -36,9 +36,11 @@ def make_create_task_side_effect() -> (
     """
 
     def _side_effect(
-        coro: collections.abc.Coroutine[object, object, object],
-        **_: object,
+        coro: collections.abc.Coroutine[None, None, None],
+        *,
+        name: str | None = None,
     ) -> asyncio.Future[None]:
+        del name
         coro.close()
         fut: asyncio.Future[None] = asyncio.get_event_loop().create_future()
         fut.set_result(None)


### PR DESCRIPTION
## Summary

- Replace `**_: object` in `make_create_task_side_effect` with explicit `name: str | None` keyword arg matching `asyncio.create_task`'s actual signature.
- Typing audit now passes with zero violations (`param_object` was the last one).

Fixes the "Typing ceiling (zero Any)" CI failure blocking [PR #1085](https://github.com/cgcardona/agentception/pull/1085).

## Test plan

- [x] `mypy agentception/tests/conftest.py` — clean
- [x] `typing_audit.py --max-any 0` — zero violations