### PR TITLE
feat: add dark/light mode toggle to top nav

### DIFF
--- a/agentception/static/js/app.ts
+++ b/agentception/static/js/app.ts
@@ -29,6 +29,7 @@
  *   transcripts.js  🟡 — transcriptBrowser, transcriptDetail
  *   templates.js    🟡 — exportPanel, importPanel, envSandbox
  *   api.js          🟡 — apiEndpoint
+ *   theme_toggle.ts ✅ — themeToggle
  */
 
 'use strict';
@@ -40,6 +41,7 @@ import { controlsKill } from './controls.ts';
 import { buildPage, renderMd } from './build.ts';
 import { planForm } from './plan.ts';
 import { orgDesigner } from './org_designer.ts';
+import { themeToggle } from './theme_toggle.ts';
 
 // ── Legacy JS modules (converted when their pages are reactivated) ───────────
 import {
@@ -68,6 +70,7 @@ Object.assign(window as unknown as Record<string, unknown>, {
   renderMd,
   planForm,
   orgDesigner,
+  themeToggle,
   // JS modules (untyped until converted)
   pipelineDashboard, agentCard, phaseSwitcher, pipelineControl,
   sweepControl, waveControl, conductorModal, scalingAdvisor, prViolations,

--- a/agentception/static/js/theme_toggle.ts
+++ b/agentception/static/js/theme_toggle.ts
@@ -1,0 +1,36 @@
+/**
+ * Alpine.js component for toggling dark / light mode.
+ *
+ * Reads the initial theme from the `data-theme` attribute on `<html>`
+ * (set by the inline FOUC-prevention script in base.html) and provides
+ * a reactive `dark` boolean plus a `toggle()` method.
+ *
+ * Preference is persisted to `localStorage` under the key `ac_theme`.
+ */
+
+interface ThemeToggleState {
+  dark: boolean;
+  readonly label: string;
+  toggle(): void;
+}
+
+const STORAGE_KEY = 'ac_theme';
+
+export function themeToggle(): ThemeToggleState {
+  const current = document.documentElement.getAttribute('data-theme') ?? 'dark';
+
+  return {
+    dark: current === 'dark',
+
+    get label(): string {
+      return this.dark ? 'Switch to light mode' : 'Switch to dark mode';
+    },
+
+    toggle(): void {
+      this.dark = !this.dark;
+      const next = this.dark ? 'dark' : 'light';
+      document.documentElement.setAttribute('data-theme', next);
+      localStorage.setItem(STORAGE_KEY, next);
+    },
+  };
+}

--- a/agentception/static/scss/_foundation.scss
+++ b/agentception/static/scss/_foundation.scss
@@ -89,6 +89,55 @@
   --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+/* ── Light Theme Overrides ───────────────────────────────────── */
+
+[data-theme="light"] {
+  --bg-void:      #f0f2f7;
+  --bg-base:      #f8f9fc;
+  --bg-surface:   #ffffff;
+  --bg-elevated:  #ffffff;
+  --bg-overlay:   #e8ebf2;
+  --bg-glass:     rgba(255, 255, 255, 0.82);
+
+  --border-subtle:  #e2e6ef;
+  --border-default: #d0d5e0;
+  --border-strong:  #b0b8c9;
+  --border: var(--border-default);
+
+  --text-primary:   #1a1d27;
+  --text-secondary: #484e5e;
+  --text-muted:     #6b7280;
+  --text-faint:     #9ca3af;
+
+  --accent:              #7c3aed;
+  --accent-bright:       #6d28d9;
+  --accent-dim:          #ede9fe;
+  --accent-hover:        #8b5cf6;
+  --accent-glow:         rgba(124, 58, 237, 0.10);
+  --accent-glow-strong:  rgba(124, 58, 237, 0.20);
+
+  --success-dim:    rgba(16, 217, 160, 0.08);
+  --success-border: rgba(16, 217, 160, 0.25);
+  --success-glow:   rgba(16, 217, 160, 0.10);
+
+  --warning-dim:    rgba(251, 191, 36, 0.08);
+  --warning-border: rgba(251, 191, 36, 0.25);
+  --warning-glow:   rgba(251, 191, 36, 0.10);
+
+  --danger-dim:     rgba(244, 63, 94, 0.08);
+  --danger-border:  rgba(244, 63, 94, 0.25);
+  --danger-glow:    rgba(244, 63, 94, 0.10);
+
+  --info-dim:       rgba(56, 189, 248, 0.08);
+  --info-border:    rgba(56, 189, 248, 0.25);
+
+  --shadow-sm:   0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-md:   0 4px 16px rgba(0, 0, 0, 0.10);
+  --shadow-lg:   0 12px 40px rgba(0, 0, 0, 0.12);
+  --shadow-glow: 0 0 24px var(--accent-glow);
+  --shadow-glow-strong: 0 0 36px var(--accent-glow-strong);
+}
+
 /* ── Reset ────────────────────────────────────────────────────── */
 
 *, *::before, *::after {
@@ -249,6 +298,27 @@ nav.topnav a.active {
 .project-switcher__select:focus {
   outline: none;
   border-color: var(--accent);
+}
+
+/* ── Theme toggle ────────────────────────────────────────────── */
+
+.theme-toggle {
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 1.125rem;
+  line-height: 1;
+  padding: 0.25rem 0.45rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  flex-shrink: 0;
+}
+
+.theme-toggle:hover {
+  color: var(--accent-bright);
+  border-color: var(--accent);
+  background: var(--accent-glow);
 }
 
 /* ── Main content ─────────────────────────────────────────────── */

--- a/agentception/templates/base.html
+++ b/agentception/templates/base.html
@@ -1,9 +1,14 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{% block title %}Agentception — The Singularity Is Here{% endblock %}</title>
+
+  <!-- Theme — set data-theme before first paint to prevent FOUC -->
+  <script>
+    (function(){var t=localStorage.getItem('ac_theme');if(!t)t=matchMedia('(prefers-color-scheme:light)').matches?'light':'dark';document.documentElement.setAttribute('data-theme',t)})();
+  </script>
 
   <!-- Inline SVG favicon — no 404 on /favicon.ico -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='8' fill='%238b5cf6'/><text x='50%25' y='56%25' dominant-baseline='middle' text-anchor='middle' font-size='18' font-family='monospace' fill='white'>⚡</text></svg>" />
@@ -79,6 +84,15 @@
         </template>
       </select>
     </div>
+
+    <button class="theme-toggle"
+            x-data="themeToggle()"
+            @click="toggle()"
+            :aria-label="label"
+            :title="label">
+      <span x-show="dark" x-cloak>&#9788;</span>
+      <span x-show="!dark" x-cloak>&#9790;</span>
+    </button>
   </nav>
 
   <main id="main-content" role="main">


### PR DESCRIPTION
## Summary

- Add a dark/light mode toggle button (sun/moon icons) to the right side of the top nav bar.
- Add FOUC-prevention inline script in `<head>` that reads `localStorage` or `prefers-color-scheme` before first paint, preventing any flash of unstyled/wrong-theme content.
- Add `[data-theme="light"]` CSS custom property overrides in `_foundation.scss` covering backgrounds, borders, text, accents, semantic colors, and shadows.
- Add `themeToggle()` Alpine.js component (`theme_toggle.ts`) with reactive `dark` boolean, `toggle()` method, and `localStorage` persistence under `ac_theme`.

## Test plan

- [x] `tsc --noEmit` — zero errors
- [x] `npm run build` — JS and CSS bundles compile
- [x] `generate.py --check` — no drift
- [ ] Manual: click toggle in nav, verify theme switches between dark and light
- [ ] Manual: refresh page, verify preference is remembered
- [ ] Manual: clear `ac_theme` from localStorage, verify OS preference is respected