### PR TITLE
fix: use #fff for text on opaque colored buttons in light mode

### DIFF
--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -1287,7 +1287,7 @@ $_sw-gap: 0.5rem;
 
   &--launch {
     background: var(--grad-accent);
-    color: var(--text-primary);
+    color: #fff;
     box-shadow: 0 2px 12px var(--accent-glow-strong);
     &:hover:not(:disabled) {
       background: linear-gradient(135deg, var(--accent), var(--accent-bright));
@@ -1342,7 +1342,7 @@ $_sw-gap: 0.5rem;
 
 .od-header__btn--save-confirm {
   background: var(--accent-hover);
-  color: var(--text-primary);
+  color: #fff;
   border: none;
   &:disabled { opacity: 0.3; cursor: not-allowed; }
   &:hover:not(:disabled) { background: var(--accent); }
@@ -2047,7 +2047,7 @@ $preset-accents: (
 
   &--apply {
     background: var(--grad-accent);
-    color: var(--text-primary);
+    color: #fff;
     box-shadow: 0 2px 10px var(--accent-glow-strong);
     &:hover:not(:disabled) {
       background: linear-gradient(135deg, var(--accent), var(--accent-bright));
@@ -2091,7 +2091,7 @@ $preset-accents: (
 
   &--active {
     background: var(--accent-hover);
-    color: var(--text-primary);
+    color: #fff;
   }
 }
 

--- a/agentception/static/scss/pages/_plan.scss
+++ b/agentception/static/scss/pages/_plan.scss
@@ -66,12 +66,12 @@
 }
 
 .plan-step--active {
-  .plan-step-bubble { background: var(--accent-bright); color: var(--text-primary); }
+  .plan-step-bubble { background: var(--accent-bright); color: #fff; }
   .plan-step-label  { color: var(--accent-bright); }
 }
 
 .plan-step--done {
-  .plan-step-bubble { background: var(--success); color: var(--text-primary); }
+  .plan-step-bubble { background: var(--success); color: #fff; }
   .plan-step-label  { color: var(--success); }
 }
 
@@ -217,7 +217,7 @@
 .plan-options-badge {
   font-size: .72rem;
   background: var(--accent);
-  color: var(--text-primary);
+  color: #fff;
   border-radius: 3px;
   padding: .05rem .35rem;
 }


### PR DESCRIPTION
## Summary

- Fix dark text on buttons with solid colored backgrounds (purple gradient, accent fills) in light mode
- Reverts 7 specific cases from `var(--text-primary)` back to `#fff` — the token resolves to dark navy in light mode, which is unreadable on opaque purple/green fills
- Affected: launch button, apply button, save-confirm button, mode toggle active state, plan step bubbles (active/done), options badge

## Test plan

- [ ] Visual QA: org designer header buttons in light mode — launch, save-confirm, mode toggle should have white text
- [ ] Visual QA: plan page step bubbles in light mode — numbered circles should have white text on colored backgrounds