### PR TITLE
fix: remove duplicate SCSS blocks from main merge

### DIFF
--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -887,7 +887,6 @@ body:has(.build-layout) nav.topnav {
     margin: 0;
     border-top: 1px solid rgba(255, 255, 255, 0.06);
     background: var(--bg-void);
-    background: #09090f;
     font-family: var(--font-mono);
     flex-shrink: 0;
     letter-spacing: 0.04em;
@@ -899,7 +898,6 @@ body:has(.build-layout) nav.topnav {
     flex-shrink: 0;
     border-top: 1px solid rgba(255, 255, 255, 0.06);
     background: var(--bg-void);
-    background: #09090f;
   }
 
   &__agent-actions {
@@ -915,9 +913,6 @@ body:has(.build-layout) nav.topnav {
     border: 1px solid var(--danger-border);
     background: var(--danger-dim);
     color: var(--danger);
-    border: 1px solid rgba(239, 68, 68, 0.3);
-    background: rgba(239, 68, 68, 0.08);
-    color: #fca5a5;
     cursor: pointer;
     letter-spacing: 0.04em;
     transition: background 0.15s, border-color 0.15s, color 0.15s;
@@ -926,9 +921,6 @@ body:has(.build-layout) nav.topnav {
       background: var(--danger-border);
       border-color: var(--danger);
       color: var(--danger);
-      background: rgba(239, 68, 68, 0.18);
-      border-color: rgba(239, 68, 68, 0.6);
-      color: #f87171;
     }
 
     &:disabled { opacity: 0.4; cursor: not-allowed; }
@@ -1960,7 +1952,6 @@ $preset-accents: (
   padding: 0.65rem 0.875rem;
   border-radius: 8px;
   border: 1.5px solid var(--border-subtle);
-  border: 1.5px solid $od-border;
   cursor: pointer;
   transition: border-color 0.15s, background 0.15s;
 
@@ -1972,12 +1963,6 @@ $preset-accents: (
     border-color: var(--accent);
     background: var(--accent-glow);
     box-shadow: 0 0 0 1px var(--accent-dim) inset;
-  &:hover { border-color: $od-border-hi; background: $od-surface-hi; }
-
-  &--active {
-    border-color: #7c3aed;
-    background: rgba(124, 58, 237, 0.12);
-    box-shadow: 0 0 0 1px rgba(124, 58, 237, 0.25) inset;
   }
 
   &__text {
@@ -1989,14 +1974,12 @@ $preset-accents: (
       font-size: 0.8rem;
       font-weight: 700;
       color: var(--text-primary);
-      color: #fff;
     }
 
     em {
       font-style: normal;
       font-size: 0.64rem;
       color: var(--text-faint);
-      color: rgba(255,255,255,0.38);
     }
   }
 }
@@ -2021,13 +2004,6 @@ $preset-accents: (
 
   &:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-glow); }
   &::placeholder { color: var(--text-faint); }
-  border: 1.5px solid $od-border;
-  background: rgba(255,255,255,0.04);
-  color: #fff;
-  transition: border-color 0.15s;
-
-  &:focus { outline: none; border-color: #7c3aed; box-shadow: 0 0 0 2px rgba(124,58,237,0.25); }
-  &::placeholder { color: rgba(255,255,255,0.25); }
 
   &--issue {
     width: 100%;
@@ -2077,36 +2053,6 @@ $preset-accents: (
 .od-scope-empty {
   font-size: 0.7rem;
   color: var(--text-faint);
-  margin: 0;
-  padding: 0.25rem 0;
-  font-style: italic;
-}
-
-// Scope cascade pickers (Phase dropdown, Ticket dropdown)
-.od-scope-select {
-  font-size: 0.78rem;
-  padding: 0.5rem 0.625rem;
-  border-radius: 7px;
-  border: 1.5px solid $od-border;
-  background: rgba(255,255,255,0.04);
-  color: #fff;
-  width: 100%;
-  cursor: pointer;
-  transition: border-color 0.15s;
-  appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='rgba(255,255,255,0.35)'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 0.75rem center;
-  padding-right: 2rem;
-
-  option, optgroup { background: #1a1a2e; color: #fff; }
-  option:disabled, &__opt--blocked { color: rgba(255,255,255,0.28); }
-  &:focus { outline: none; border-color: #7c3aed; box-shadow: 0 0 0 2px rgba(124,58,237,0.25); }
-}
-
-.od-scope-empty {
-  font-size: 0.7rem;
-  color: rgba(255,255,255,0.35);
   margin: 0;
   padding: 0.25rem 0;
   font-style: italic;
@@ -2351,7 +2297,6 @@ $preset-accents: (
   overflow-y: auto;
   padding: 0;
   background: var(--bg-void);
-  background: #09090f;
   font-family: var(--font-mono);
   scroll-behavior: smooth;
   scrollbar-width: thin;


### PR DESCRIPTION
## Summary

- Removes duplicate SCSS blocks created by the auto-merge of `main` into `dev` (PR #1094)
- The merge interleaved old hardcoded color blocks alongside new tokenized versions, creating: duplicate `.od-scope-select` and `.od-scope-empty` blocks, stale `$od-*` variable references, duplicate `background`/`color`/`border` declarations, and a missing closing brace that broke sass compilation
- Net result: 55 lines deleted, zero functional changes

## Test plan

- [x] `sass` compiles clean
- [x] No remaining `$od-*` references
- Fixes CI failure on release PR #1093