### PR TITLE
feat: redesign activity feed with SVG icons, relative times, and rich tool-call cards

### DIFF
--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -4,6 +4,8 @@ import {
   appendActivityRow,
   attachActivityFeedHandler,
   getSubtypeIcon,
+  resetFeedStartTime,
+  formatRelativeTime,
   type ActivityMessage,
 } from '../activity_feed';
 
@@ -28,16 +30,16 @@ describe('formatActivitySummary', () => {
     );
   });
 
-  it('formats shell_done exit=0', () => {
+  it('formats shell_done exit=0 with human-readable byte count', () => {
     expect(
       formatActivitySummary('shell_done', { exit_code: 0, stdout_bytes: 10, stderr_bytes: 0 })
-    ).toBe('exit=0 stdout:10B');
+    ).toBe('exit=0  ·  10 B stdout');
   });
 
   it('formats shell_done non-zero exit with error prefix', () => {
     expect(
       formatActivitySummary('shell_done', { exit_code: 1, stdout_bytes: 0, stderr_bytes: 5 })
-    ).toBe('✗ exit=1 stdout:0B');
+    ).toBe('✗ exit=1  ·  0 B stdout');
   });
 
   it('formats file_read', () => {
@@ -48,30 +50,159 @@ describe('formatActivitySummary', () => {
         end_line: 10,
         total_lines: 50,
       })
-    ).toBe('read src/foo.py lines 1–10/50');
+    ).toBe('src/foo.py  ·  1–10 of 50');
   });
 
   it('formats git_push', () => {
-    expect(formatActivitySummary('git_push', { branch: 'feat/944' })).toBe('git push → feat/944');
+    expect(formatActivitySummary('git_push', { branch: 'feat/944' })).toBe('→ feat/944');
   });
 
-  it('formats error with message', () => {
+  it('formats error message without emoji prefix', () => {
     expect(formatActivitySummary('error', { message: 'connection refused' })).toBe(
-      '❌ connection refused'
+      'connection refused'
     );
   });
 
   it('returns subtype for unknown subtype', () => {
     expect(formatActivitySummary('unknown_subtype', {})).toBe('unknown_subtype');
   });
+
+  it('formats llm_iter without ITER prefix — model and turn at front', () => {
+    expect(
+      formatActivitySummary('llm_iter', { model: 'claude-3-5', turns: 2 })
+    ).toBe('claude-3-5  ·  turn 2');
+  });
+
+  it('formats llm_usage as human-readable token counts', () => {
+    expect(
+      formatActivitySummary('llm_usage', { input_tokens: 17524, cache_write: 0, cache_read: 0 })
+    ).toBe('17,524 tokens');
+  });
+
+  it('formats llm_usage includes cached count when non-zero', () => {
+    const result = formatActivitySummary('llm_usage', {
+      input_tokens: 1000,
+      cache_write: 200,
+      cache_read: 50,
+    });
+    expect(result).toContain('1,000 tokens');
+    expect(result).toContain('200 written');
+    expect(result).toContain('50 cached');
+  });
+
+  it('formats llm_done as tool call count', () => {
+    expect(
+      formatActivitySummary('llm_done', { stop_reason: 'tool_calls', tool_call_count: 2 })
+    ).toBe('→ 2 tool calls');
+  });
+});
+
+describe('getSubtypeIcon', () => {
+  it('returns an SVG string for llm_iter', () => {
+    expect(getSubtypeIcon('llm_iter')).toContain('<svg');
+  });
+
+  it('returns an SVG string for llm_usage (tokens icon)', () => {
+    expect(getSubtypeIcon('llm_usage')).toContain('<svg');
+  });
+
+  it('returns an SVG string for llm_reply', () => {
+    expect(getSubtypeIcon('llm_reply')).toContain('<svg');
+  });
+
+  it('returns an SVG string for llm_done', () => {
+    expect(getSubtypeIcon('llm_done')).toContain('<svg');
+  });
+
+  it('returns an SVG string for tool_invoked', () => {
+    expect(getSubtypeIcon('tool_invoked')).toContain('<svg');
+  });
+
+  it('returns an SVG string for github_tool', () => {
+    expect(getSubtypeIcon('github_tool')).toContain('<svg');
+  });
+
+  it('returns an SVG string for file_read', () => {
+    expect(getSubtypeIcon('file_read')).toContain('<svg');
+  });
+
+  it('returns an SVG string for file_replaced', () => {
+    expect(getSubtypeIcon('file_replaced')).toContain('<svg');
+  });
+
+  it('returns an SVG string for file_inserted', () => {
+    expect(getSubtypeIcon('file_inserted')).toContain('<svg');
+  });
+
+  it('returns an SVG string for file_written', () => {
+    expect(getSubtypeIcon('file_written')).toContain('<svg');
+  });
+
+  it('returns an SVG string for shell_start', () => {
+    expect(getSubtypeIcon('shell_start')).toContain('<svg');
+  });
+
+  it('returns an SVG string for shell_done', () => {
+    expect(getSubtypeIcon('shell_done')).toContain('<svg');
+  });
+
+  it('returns an SVG string for git_push', () => {
+    expect(getSubtypeIcon('git_push')).toContain('<svg');
+  });
+
+  it('returns an SVG string for delay', () => {
+    expect(getSubtypeIcon('delay')).toContain('<svg');
+  });
+
+  it('returns an SVG string for error', () => {
+    expect(getSubtypeIcon('error')).toContain('<svg');
+  });
+
+  it('returns an SVG string for unknown subtype', () => {
+    expect(getSubtypeIcon('unknown_subtype')).toContain('<svg');
+  });
+});
+
+describe('formatRelativeTime', () => {
+  beforeEach(() => {
+    resetFeedStartTime();
+  });
+
+  it('returns +0s for the first event', () => {
+    expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('+0s');
+  });
+
+  it('returns +Ns for subsequent events', () => {
+    resetFeedStartTime();
+    formatRelativeTime('2026-03-15T12:00:00Z'); // seed start time
+    expect(formatRelativeTime('2026-03-15T12:00:29Z')).toBe('+29s');
+  });
+
+  it('returns +Mm for minute offsets', () => {
+    resetFeedStartTime();
+    formatRelativeTime('2026-03-15T12:00:00Z');
+    expect(formatRelativeTime('2026-03-15T12:02:00Z')).toBe('+2m');
+  });
+
+  it('returns +MmNs for mixed offsets', () => {
+    resetFeedStartTime();
+    formatRelativeTime('2026-03-15T12:00:00Z');
+    expect(formatRelativeTime('2026-03-15T12:01:05Z')).toBe('+1m5s');
+  });
+
+  it('returns empty string for invalid timestamp', () => {
+    resetFeedStartTime();
+    expect(formatRelativeTime('not-a-date')).toBe('');
+  });
 });
 
 describe('appendActivityRow', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="activity-feed"></div>';
+    resetFeedStartTime();
   });
 
-  it('appends a row with data-subtype, summary, and time', () => {
+  it('appends a row with data-subtype, summary, and relative time', () => {
     const msg: ActivityMessage = {
       t: 'activity',
       subtype: 'shell_done',
@@ -82,10 +213,21 @@ describe('appendActivityRow', () => {
     const row = document.querySelector('.activity-feed__row');
     expect(row).not.toBeNull();
     expect(row?.getAttribute('data-subtype')).toBe('shell_done');
-    expect(row?.querySelector('.activity-feed__summary')?.textContent).toBe('exit=0 stdout:5B');
+    expect(row?.querySelector('.activity-feed__summary')?.textContent).toBe('exit=0  ·  5 B stdout');
     expect(row?.querySelector('.activity-feed__ts')?.getAttribute('datetime')).toBe(
       '2026-03-13T14:30:00Z'
     );
+  });
+
+  it('icon element contains an SVG', () => {
+    appendActivityRow({
+      t: 'activity',
+      subtype: 'shell_done',
+      payload: { exit_code: 0, stdout_bytes: 5, stderr_bytes: 0 },
+      recorded_at: '',
+    });
+    const icon = document.querySelector('.activity-feed__icon');
+    expect(icon?.innerHTML).toContain('<svg');
   });
 
   it('sets data-exit-nonzero on shell_done rows with non-zero exit', () => {
@@ -122,75 +264,10 @@ describe('appendActivityRow', () => {
   });
 });
 
-describe('getSubtypeIcon', () => {
-  it('returns brain emoji for llm_iter', () => {
-    expect(getSubtypeIcon('llm_iter')).toBe('🧠');
-  });
-
-  it('returns brain emoji for llm_usage', () => {
-    expect(getSubtypeIcon('llm_usage')).toBe('🧠');
-  });
-
-  it('returns brain emoji for llm_reply', () => {
-    expect(getSubtypeIcon('llm_reply')).toBe('🧠');
-  });
-
-  it('returns brain emoji for llm_done', () => {
-    expect(getSubtypeIcon('llm_done')).toBe('🧠');
-  });
-
-  it('returns gear emoji for tool_invoked', () => {
-    expect(getSubtypeIcon('tool_invoked')).toBe('⚙️');
-  });
-
-  it('returns gear emoji for github_tool', () => {
-    expect(getSubtypeIcon('github_tool')).toBe('⚙️');
-  });
-
-  it('returns eye emoji for file_read', () => {
-    expect(getSubtypeIcon('file_read')).toBe('👁️');
-  });
-
-  it('returns pencil emoji for file_replaced', () => {
-    expect(getSubtypeIcon('file_replaced')).toBe('✏️');
-  });
-
-  it('returns pencil emoji for file_inserted', () => {
-    expect(getSubtypeIcon('file_inserted')).toBe('✏️');
-  });
-
-  it('returns pencil emoji for file_written', () => {
-    expect(getSubtypeIcon('file_written')).toBe('✏️');
-  });
-
-  it('returns dollar sign for shell_start', () => {
-    expect(getSubtypeIcon('shell_start')).toBe('$');
-  });
-
-  it('returns dollar sign for shell_done', () => {
-    expect(getSubtypeIcon('shell_done')).toBe('$');
-  });
-
-  it('returns up arrow for git_push', () => {
-    expect(getSubtypeIcon('git_push')).toBe('⬆️');
-  });
-
-  it('returns hourglass for delay', () => {
-    expect(getSubtypeIcon('delay')).toBe('⏳');
-  });
-
-  it('returns cross mark for error', () => {
-    expect(getSubtypeIcon('error')).toBe('❌');
-  });
-
-  it('returns bullet for unknown subtype', () => {
-    expect(getSubtypeIcon('unknown_subtype')).toBe('•');
-  });
-});
-
 describe('attachActivityFeedHandler', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="activity-feed"></div>';
+    resetFeedStartTime();
   });
 
   it('appends a row when msg.t === "activity"', () => {

--- a/agentception/static/js/__tests__/event_card.test.ts
+++ b/agentception/static/js/__tests__/event_card.test.ts
@@ -24,6 +24,14 @@ describe('attachEventCardHandler', () => {
     expect(card?.querySelector('.event-card__text')?.textContent).toBe('Step 2');
   });
 
+  it('renders step_start icon as SVG', () => {
+    const src = makeSource();
+    attachEventCardHandler(src);
+    dispatch(src, { t: 'event', event_type: 'step_start', payload: { step: 'Step 1' }, recorded_at: '' });
+    const icon = document.querySelector('.event-card__icon');
+    expect(icon?.innerHTML).toContain('<svg');
+  });
+
   it('renders done card with summary text', () => {
     const src = makeSource();
     attachEventCardHandler(src);
@@ -31,13 +39,20 @@ describe('attachEventCardHandler', () => {
     expect(document.querySelector('.event-card__text')?.textContent).toBe('All green');
   });
 
-  it('renders blocker card with correct data-event-type and icon', () => {
+  it('renders done icon as SVG', () => {
+    const src = makeSource();
+    attachEventCardHandler(src);
+    dispatch(src, { t: 'event', event_type: 'done', payload: { summary: 'ok' }, recorded_at: '' });
+    expect(document.querySelector('.event-card__icon')?.innerHTML).toContain('<svg');
+  });
+
+  it('renders blocker card with correct data-event-type and SVG icon', () => {
     const src = makeSource();
     attachEventCardHandler(src);
     dispatch(src, { t: 'event', event_type: 'blocker', payload: { description: 'Missing dep' }, recorded_at: '' });
     const card = document.querySelector('.event-card');
     expect(card?.getAttribute('data-event-type')).toBe('blocker');
-    expect(card?.querySelector('.event-card__icon')?.textContent).toBe('🚧');
+    expect(card?.querySelector('.event-card__icon')?.innerHTML).toContain('<svg');
   });
 
   it('ignores non-event SSE messages', () => {
@@ -54,29 +69,29 @@ describe('attachEventCardHandler', () => {
     expect(document.querySelector('.event-card')).toBeNull();
   });
 
-  it('renders message card with 💬 icon and message text', () => {
+  it('renders message card with SVG icon and message text', () => {
     const src = makeSource();
     attachEventCardHandler(src);
     dispatch(src, { t: 'event', event_type: 'message', payload: { message: 'Branch created' }, recorded_at: '' });
     const card = document.querySelector('.event-card');
     expect(card).not.toBeNull();
     expect(card?.getAttribute('data-event-type')).toBe('message');
-    expect(card?.querySelector('.event-card__icon')?.textContent).toBe('💬');
+    expect(card?.querySelector('.event-card__icon')?.innerHTML).toContain('<svg');
     expect(card?.querySelector('.event-card__text')?.textContent).toBe('Branch created');
   });
 
-  it('renders error card with ❌ icon and error text', () => {
+  it('renders error card with SVG icon and error text', () => {
     const src = makeSource();
     attachEventCardHandler(src);
     dispatch(src, { t: 'event', event_type: 'error', payload: { error: 'Rate limit hit' }, recorded_at: '' });
     const card = document.querySelector('.event-card');
     expect(card).not.toBeNull();
     expect(card?.getAttribute('data-event-type')).toBe('error');
-    expect(card?.querySelector('.event-card__icon')?.textContent).toBe('❌');
+    expect(card?.querySelector('.event-card__icon')?.innerHTML).toContain('<svg');
     expect(card?.querySelector('.event-card__text')?.textContent).toBe('Rate limit hit');
   });
 
-  it('renders decision card with 💡 icon', () => {
+  it('renders decision card with SVG icon and composed text', () => {
     const src = makeSource();
     attachEventCardHandler(src);
     dispatch(src, {
@@ -86,7 +101,7 @@ describe('attachEventCardHandler', () => {
       recorded_at: '',
     });
     const card = document.querySelector('.event-card');
-    expect(card?.querySelector('.event-card__icon')?.textContent).toBe('💡');
+    expect(card?.querySelector('.event-card__icon')?.innerHTML).toContain('<svg');
     expect(card?.querySelector('.event-card__text')?.textContent).toBe('Use TypeScript — type safety');
   });
 });

--- a/agentception/static/js/__tests__/tool_call_card.test.ts
+++ b/agentception/static/js/__tests__/tool_call_card.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { attachToolCallHandler } from "../tool_call_card";
+import { attachToolCallHandler, parseArgPreview, formatResultPreview, svgForTool } from "../tool_call_card";
 
 function makeSource(): EventTarget & EventSource {
   return new EventTarget() as EventTarget & EventSource;
@@ -9,53 +9,178 @@ function dispatch(src: EventTarget, data: object): void {
   src.dispatchEvent(new MessageEvent("message", { data: JSON.stringify(data) }));
 }
 
+describe("svgForTool", () => {
+  it("returns an SVG string for search_codebase", () => {
+    expect(svgForTool("search_codebase")).toContain("<svg");
+  });
+
+  it("returns an SVG string for read_file", () => {
+    expect(svgForTool("read_file")).toContain("<svg");
+  });
+
+  it("returns an SVG string for write_file", () => {
+    expect(svgForTool("write_file")).toContain("<svg");
+  });
+
+  it("returns an SVG string for run_command", () => {
+    expect(svgForTool("run_command")).toContain("<svg");
+  });
+
+  it("returns an SVG string for git_commit", () => {
+    expect(svgForTool("git_commit")).toContain("<svg");
+  });
+
+  it("returns an SVG string for unknown tool", () => {
+    expect(svgForTool("some_custom_tool")).toContain("<svg");
+  });
+});
+
+describe("parseArgPreview", () => {
+  it("parses valid JSON", () => {
+    const result = parseArgPreview('{"path": "src/foo.py"}');
+    expect(result).toBe("path=src/foo.py");
+  });
+
+  it("parses Python dict notation (single quotes)", () => {
+    const result = parseArgPreview("{'path': 'src/bar.py', 'encoding': 'utf-8'}");
+    expect(result).toContain("path=src/bar.py");
+    expect(result).toContain("encoding=utf-8");
+  });
+
+  it("handles Python True/False/None", () => {
+    const result = parseArgPreview("{'flag': True, 'val': None}");
+    expect(result).toContain("flag=true");
+    expect(result).toContain("val=null");
+  });
+
+  it("returns raw string when parse fails", () => {
+    const raw = "definitely not dict or json";
+    expect(parseArgPreview(raw)).toBe(raw);
+  });
+
+  it("returns empty string for empty args", () => {
+    expect(parseArgPreview("{}")).toBe("");
+    expect(parseArgPreview("")).toBe("");
+  });
+
+  it("truncates long values", () => {
+    const longVal = "x".repeat(100);
+    const result = parseArgPreview(JSON.stringify({ key: longVal }));
+    expect(result).toContain("key=");
+    expect(result.length).toBeLessThan(150);
+  });
+});
+
+describe("formatResultPreview", () => {
+  it("returns plain string content", () => {
+    expect(formatResultPreview('"hello world"')).toBe("hello world");
+  });
+
+  it("returns item count for arrays", () => {
+    expect(formatResultPreview("[1, 2, 3]")).toBe("[3 items]");
+  });
+
+  it("surfaces error from ok=false objects", () => {
+    expect(formatResultPreview('{"ok": false, "error": "rate limit"}')).toBe("error: rate limit");
+  });
+
+  it("formats object key=value pairs", () => {
+    const result = formatResultPreview('{"total": 10, "done": 5}');
+    expect(result).toContain("total: 10");
+    expect(result).toContain("done: 5");
+  });
+
+  it("returns raw string for non-JSON", () => {
+    expect(formatResultPreview("plain text output")).toBe("plain text output");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(formatResultPreview("")).toBe("");
+  });
+});
+
 describe("attachToolCallHandler", () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="activity-feed"></div>';
   });
 
-  it("renders tool_call card with correct icon for search_codebase", () => {
+  it("renders tool_call card with SVG icon for search_codebase", () => {
     const src = makeSource();
     attachToolCallHandler(src);
     dispatch(src, { t: "tool_call", tool_name: "search_codebase", args_preview: "foo", recorded_at: "" });
     const icon = document.querySelector(".tool-call-card__icon");
-    expect(icon?.textContent).toBe("🔍");
+    expect(icon?.innerHTML).toContain("<svg");
   });
 
-  it("renders tool_call card with correct icon for git_commit", () => {
+  it("renders tool_call card with SVG icon for git_commit", () => {
     const src = makeSource();
     attachToolCallHandler(src);
     dispatch(src, { t: "tool_call", tool_name: "git_commit", args_preview: "msg", recorded_at: "" });
     const icon = document.querySelector(".tool-call-card__icon");
-    expect(icon?.textContent).toBe("🌿");
+    expect(icon?.innerHTML).toContain("<svg");
   });
 
-  it("renders tool_call card with fallback icon for unknown tool", () => {
+  it("renders tool_call card with SVG icon for unknown tool", () => {
     const src = makeSource();
     attachToolCallHandler(src);
     dispatch(src, { t: "tool_call", tool_name: "some_custom_tool", args_preview: "x", recorded_at: "" });
     const icon = document.querySelector(".tool-call-card__icon");
-    expect(icon?.textContent).toBe("🔧");
+    expect(icon?.innerHTML).toContain("<svg");
   });
 
-  it("appends result preview to matching card on tool_result event", () => {
+  it("sets data-tool-category on the card", () => {
+    const src = makeSource();
+    attachToolCallHandler(src);
+    dispatch(src, { t: "tool_call", tool_name: "read_file", args_preview: "", recorded_at: "" });
+    const card = document.querySelector(".tool-call-card");
+    expect(card?.getAttribute("data-tool-category")).toBe("file-read");
+  });
+
+  it("renders parsed args as a separate div", () => {
+    const src = makeSource();
+    attachToolCallHandler(src);
+    dispatch(src, {
+      t: "tool_call",
+      tool_name: "read_file",
+      args_preview: "{'path': 'src/foo.py'}",
+      recorded_at: "",
+    });
+    const args = document.querySelector(".tool-call-card__args");
+    expect(args).not.toBeNull();
+    expect(args?.textContent).toContain("path=src/foo.py");
+  });
+
+  it("appends formatted result preview to matching card on tool_result event", () => {
     const src = makeSource();
     attachToolCallHandler(src);
     dispatch(src, { t: "tool_call", tool_name: "bash", args_preview: "ls", recorded_at: "" });
-    dispatch(src, { t: "tool_result", tool_name: "bash", result_preview: "file.py", recorded_at: "" });
+    dispatch(src, {
+      t: "tool_result",
+      tool_name: "bash",
+      result_preview: '"file.py\nlib.py"',
+      recorded_at: "",
+    });
     const result = document.querySelector(".tool-call-card__result");
-    expect(result?.textContent).toBe("file.py");
+    expect(result).not.toBeNull();
+    expect(result?.textContent).toContain("file.py");
     // Result is a child of the matching card, not appended separately.
     const card = document.querySelector('.tool-call-card[data-tool="bash"]');
     expect(card?.contains(result)).toBe(true);
+    // Card gets the has-result modifier class
+    expect(card?.classList.contains("tool-call-card--has-result")).toBe(true);
   });
 
   it("appends standalone result card when no matching tool card exists", () => {
     const src = makeSource();
     attachToolCallHandler(src);
-    dispatch(src, { t: "tool_result", tool_name: "orphan_tool", result_preview: "output", recorded_at: "" });
+    dispatch(src, {
+      t: "tool_result",
+      tool_name: "orphan_tool",
+      result_preview: '"output"',
+      recorded_at: "",
+    });
     const card = document.querySelector('.tool-call-card[data-tool="orphan_tool"]');
     expect(card).not.toBeNull();
-    expect(card?.querySelector(".tool-call-card__result")?.textContent).toBe("output");
+    expect(card?.querySelector(".tool-call-card__result")?.textContent).toContain("output");
   });
 });

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -9,6 +9,8 @@
  * the bottom — reading old content is never interrupted.
  */
 
+import * as icons from './icons';
+
 /** SSE activity message shape from the inspector stream. */
 export interface ActivityMessage {
   t: 'activity';
@@ -34,6 +36,18 @@ function num(p: Record<string, unknown>, key: string): number {
   return 0;
 }
 
+/** Format a byte count as human-readable: 0 B, 1.2 KB, 3.4 MB. */
+function fmtBytes(b: number): string {
+  if (b < 1024) return `${b} B`;
+  if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`;
+  return `${(b / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** Format a number with thousands separators. */
+function fmtNum(n: number): string {
+  return n.toLocaleString();
+}
+
 /**
  * Returns true when the feed scroll position is within 80px of the bottom.
  * Used to decide whether appending a new row should auto-scroll.
@@ -56,79 +70,114 @@ export function formatActivitySummary(subtype: string, payload: Record<string, u
     case 'shell_done': {
       const code = num(p, 'exit_code');
       const prefix = code !== 0 ? `✗ exit=${code}` : `exit=${code}`;
-      return `${prefix} stdout:${num(p, 'stdout_bytes')}B`;
+      return `${prefix}  ·  ${fmtBytes(num(p, 'stdout_bytes'))} stdout`;
     }
-    case 'file_read':
-      return `read ${str(p, 'path')} lines ${num(p, 'start_line')}–${num(p, 'end_line')}/${num(p, 'total_lines')}`.trim();
+    case 'file_read': {
+      const path = str(p, 'path');
+      const s = num(p, 'start_line');
+      const e = num(p, 'end_line');
+      const t = num(p, 'total_lines');
+      return `${path}  ·  ${s}–${e} of ${t}`;
+    }
     case 'file_replaced':
-      return `replaced ${str(p, 'path')} (${num(p, 'replacement_count')}×)`.trim();
+      return `${str(p, 'path')}  ·  ${num(p, 'replacement_count')} replacement${num(p, 'replacement_count') === 1 ? '' : 's'}`.trim();
     case 'file_inserted':
       return `inserted ${str(p, 'path')}`.trim();
     case 'file_written':
-      return `wrote ${str(p, 'path')} ${num(p, 'byte_count')}B`.trim();
+      return `${str(p, 'path')}  ·  ${fmtBytes(num(p, 'byte_count'))}`.trim();
     case 'git_push':
-      return `git push → ${str(p, 'branch')}`.trim();
+      return `→ ${str(p, 'branch')}`.trim();
     case 'github_tool':
-      return `🐙 ${str(p, 'tool_name')} ${str(p, 'arg_preview')}`.trim();
-    case 'llm_iter':
-      return `ITER ${num(p, 'iteration')} model=${str(p, 'model')} turns=${num(p, 'turns')}`.trim();
-    case 'llm_usage':
-      return `in=${num(p, 'input_tokens')} cw=${num(p, 'cache_write')} cr=${num(p, 'cache_read')}`;
+      return `${str(p, 'tool_name')} ${str(p, 'arg_preview')}`.trim();
+    case 'llm_iter': {
+      const model = str(p, 'model') || 'unknown';
+      const turns = num(p, 'turns');
+      return `${model}  ·  turn ${turns}`;
+    }
+    case 'llm_usage': {
+      const inp = num(p, 'input_tokens');
+      const cw  = num(p, 'cache_write');
+      const cr  = num(p, 'cache_read');
+      const parts: string[] = [`${fmtNum(inp)} tokens`];
+      if (cw > 0) parts.push(`${fmtNum(cw)} written`);
+      if (cr > 0) parts.push(`${fmtNum(cr)} cached`);
+      return parts.join('  ·  ');
+    }
     case 'llm_reply':
-      return `(${num(p, 'chars')}ch) ${str(p, 'text_preview')}`.trim();
-    case 'llm_done':
-      return `${str(p, 'stop_reason')} → ${num(p, 'tool_call_count')} tool calls`.trim();
+      return `(${fmtNum(num(p, 'chars'))} ch)  ${str(p, 'text_preview')}`.trim();
+    case 'llm_done': {
+      const count = num(p, 'tool_call_count');
+      if (count > 0) return `→ ${count} tool call${count === 1 ? '' : 's'}`;
+      return str(p, 'stop_reason') || 'done';
+    }
     case 'delay':
-      return `⏳ ${num(p, 'secs')}s`;
+      return `${num(p, 'secs')}s pause`;
     case 'error':
-      return `❌ ${str(p, 'message')}`.trim();
+      return str(p, 'message') || 'error';
     default:
       return subtype || 'activity';
   }
 }
 
 /**
- * Map activity subtype to icon character.
- * Pure function with switch statement for explicit subtype mapping.
+ * Map activity subtype to an SVG icon string (set via innerHTML).
+ * All returned strings are hardcoded static SVG — never user data.
  */
 export function getSubtypeIcon(subtype: string): string {
   switch (subtype) {
     case 'llm_iter':
-    case 'llm_usage':
     case 'llm_reply':
     case 'llm_done':
-      return '🧠';
+      return icons.llm;
+    case 'llm_usage':
+      return icons.tokens;
     case 'tool_invoked':
     case 'github_tool':
-      return '⚙️';
+      return icons.arrow;
     case 'file_read':
-      return '👁️';
+      return icons.eye;
     case 'file_replaced':
     case 'file_inserted':
     case 'file_written':
-      return '✏️';
+      return icons.pencil;
     case 'shell_start':
     case 'shell_done':
-      return '$';
+      return icons.terminal;
     case 'git_push':
-      return '⬆️';
+      return icons.gitPush;
     case 'delay':
-      return '⏳';
+      return icons.clock;
     case 'error':
-      return '❌';
+      return icons.xCircle;
     default:
-      return '•';
+      return icons.dot;
   }
 }
 
-/** Format recorded_at (ISO8601) to HH:MM:SS. */
-function formatTime(recordedAt: string): string {
+// ── Relative timestamp ─────────────────────────────────────────────────────────
+
+/** ISO timestamp (ms) of the first event appended in this feed session. */
+let feedStartMs: number | null = null;
+
+/** Reset the feed start time — call when the feed is cleared or a new run begins. */
+export function resetFeedStartTime(): void {
+  feedStartMs = null;
+}
+
+/** Format recorded_at as a relative offset from the first feed event: +0s, +1m5s, … */
+export function formatRelativeTime(recordedAt: string): string {
   try {
-    const d = new Date(recordedAt);
-    const h = d.getHours();
-    const m = d.getMinutes();
-    const s = d.getSeconds();
-    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+    const t = new Date(recordedAt).getTime();
+    if (Number.isNaN(t)) return '';
+    if (feedStartMs === null) {
+      feedStartMs = t;
+      return '+0s';
+    }
+    const delta = Math.max(0, Math.round((t - feedStartMs) / 1000));
+    if (delta < 60) return `+${delta}s`;
+    const m = Math.floor(delta / 60);
+    const s = delta % 60;
+    return s > 0 ? `+${m}m${s}s` : `+${m}m`;
   } catch {
     return '';
   }
@@ -137,6 +186,7 @@ function formatTime(recordedAt: string): string {
 /**
  * Create a single activity row and append it to #activity-feed.
  * One SSE message → one DOM append. No innerHTML with payload data.
+ * Icon column uses innerHTML with hardcoded SVG strings from icons.ts.
  */
 export function appendActivityRow(msg: ActivityMessage): void {
   const feed = document.getElementById('activity-feed');
@@ -148,16 +198,18 @@ export function appendActivityRow(msg: ActivityMessage): void {
 
   // Mark non-zero shell exits for CSS error highlighting
   if (msg.subtype === 'shell_done') {
-    const code = num(msg.payload, 'exit_code');
+    const code = typeof msg.payload['exit_code'] === 'number' ? msg.payload['exit_code'] : 0;
     if (code !== 0) {
       row.dataset['exitNonzero'] = 'true';
     }
   }
 
+  // Icon: hardcoded SVG via innerHTML (safe — getSubtypeIcon returns only static strings)
   const icon = document.createElement('span');
   icon.className = 'activity-feed__icon';
   icon.setAttribute('aria-hidden', 'true');
-  icon.textContent = getSubtypeIcon(msg.subtype);
+  // eslint-disable-next-line no-unsanitized/property
+  icon.innerHTML = getSubtypeIcon(msg.subtype);
 
   const summary = document.createElement('span');
   summary.className = 'activity-feed__summary';
@@ -165,8 +217,9 @@ export function appendActivityRow(msg: ActivityMessage): void {
 
   const ts = document.createElement('time');
   ts.className = 'activity-feed__ts';
-  ts.textContent = formatTime(msg.recorded_at);
+  ts.textContent = formatRelativeTime(msg.recorded_at);
   ts.setAttribute('datetime', msg.recorded_at);
+  ts.setAttribute('title', msg.recorded_at);
 
   row.appendChild(icon);
   row.appendChild(summary);

--- a/agentception/static/js/event_card.ts
+++ b/agentception/static/js/event_card.ts
@@ -3,12 +3,14 @@
  *
  * Handled event_types:
  *   step_start  ▶  agent begins a named step
- *   blocker     🚧  agent is stalled on external dependency
- *   decision    💡  agent made an architectural choice
- *   done        ✅  agent declared work complete
+ *   blocker     ⚠  agent is stalled on external dependency
+ *   decision    ⚡  agent made an architectural choice
+ *   done        ✓  agent declared work complete
  *   message     💬  free-form agent note (log_run_message)
- *   error       ❌  structured MCP error (log_run_error)
+ *   error       ✕  structured MCP error (log_run_error)
  */
+
+import * as icons from './icons';
 
 interface EventSseMessage {
   t: 'event';
@@ -20,12 +22,12 @@ interface EventSseMessage {
 type AnySseMessage = EventSseMessage | { t: string };
 
 const EVENT_ICONS: Record<string, string> = {
-  step_start: '▶',
-  blocker:    '🚧',
-  decision:   '💡',
-  done:       '✅',
-  message:    '💬',
-  error:      '❌',
+  step_start: icons.stepStart,
+  blocker:    icons.blocker,
+  decision:   icons.decision,
+  done:       icons.checkmark,
+  message:    icons.speech,
+  error:      icons.xCircle,
 };
 
 const RENDERABLE = new Set(['step_start', 'blocker', 'decision', 'done', 'message', 'error']);
@@ -63,10 +65,12 @@ export function attachEventCardHandler(source: EventSource): void {
     card.className = 'event-card';
     card.dataset['eventType'] = m.event_type;
 
+    // Icon: hardcoded SVG via innerHTML (safe — EVENT_ICONS contains only static strings)
     const icon = document.createElement('span');
     icon.className = 'event-card__icon';
     icon.setAttribute('aria-hidden', 'true');
-    icon.textContent = EVENT_ICONS[m.event_type] ?? '•';
+    // eslint-disable-next-line no-unsanitized/property
+    icon.innerHTML = EVENT_ICONS[m.event_type] ?? icons.dot;
 
     const text = document.createElement('span');
     text.className = 'event-card__text';

--- a/agentception/static/js/icons.ts
+++ b/agentception/static/js/icons.ts
@@ -1,0 +1,163 @@
+/**
+ * icons.ts — inline SVG strings for the activity feed and event cards.
+ *
+ * All icons are hardcoded static strings using a 14×14 viewBox with
+ * stroke-based paths.  They inherit `currentColor` so they theme
+ * automatically in both light and dark mode.
+ *
+ * Usage: `element.innerHTML = icons.llm;`
+ * Safety: never interpolate user-supplied data into these strings.
+ */
+
+const ATTRS =
+  'xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none" ' +
+  'stroke="currentColor" stroke-width="1.5" stroke-linecap="round" ' +
+  'stroke-linejoin="round" aria-hidden="true"';
+
+function s(body: string): string {
+  return `<svg ${ATTRS}>${body}</svg>`;
+}
+
+// ── Activity-feed row icons ────────────────────────────────────────────────────
+
+/** Spark / sun rays — LLM activity */
+export const llm = s(
+  '<circle cx="7" cy="7" r="2"/>' +
+  '<line x1="7" y1="0.5" x2="7" y2="3"/>' +
+  '<line x1="7" y1="11" x2="7" y2="13.5"/>' +
+  '<line x1="0.5" y1="7" x2="3" y2="7"/>' +
+  '<line x1="11" y1="7" x2="13.5" y2="7"/>' +
+  '<line x1="2.64" y1="2.64" x2="4.41" y2="4.41"/>' +
+  '<line x1="9.59" y1="9.59" x2="11.36" y2="11.36"/>' +
+  '<line x1="2.64" y1="11.36" x2="4.41" y2="9.59"/>' +
+  '<line x1="9.59" y1="4.41" x2="11.36" y2="2.64"/>',
+);
+
+/** Rising bars — token usage */
+export const tokens = s(
+  '<rect x="1" y="9" width="3" height="4" rx="0.5"/>' +
+  '<rect x="5.5" y="5.5" width="3" height="7.5" rx="0.5"/>' +
+  '<rect x="10" y="2" width="3" height="11" rx="0.5"/>',
+);
+
+/** Arrow right — tool invoked / action */
+export const arrow = s(
+  '<line x1="2" y1="7" x2="12" y2="7"/>' +
+  '<polyline points="8.5,3.5 12,7 8.5,10.5"/>',
+);
+
+/** Eye — file read */
+export const eye = s(
+  '<path d="M1 7s2.5-4.5 6-4.5S13 7 13 7s-2.5 4.5-6 4.5S1 7 1 7"/>' +
+  '<circle cx="7" cy="7" r="2"/>',
+);
+
+/** Pencil — file write */
+export const pencil = s(
+  '<path d="M10.5 1.5l2 2L4 12H2v-2L10.5 1.5z"/>' +
+  '<line x1="8.5" y1="3.5" x2="10.5" y2="5.5"/>',
+);
+
+/** Terminal prompt — shell */
+export const terminal = s(
+  '<polyline points="2,4.5 6,7 2,9.5"/>' +
+  '<line x1="8" y1="10" x2="12" y2="10"/>',
+);
+
+/** Arrow up + branch nodes — git push */
+export const gitPush = s(
+  '<line x1="7" y1="1" x2="7" y2="9"/>' +
+  '<polyline points="4,4 7,1 10,4"/>' +
+  '<circle cx="4" cy="12" r="1.5"/>' +
+  '<circle cx="10" cy="12" r="1.5"/>' +
+  '<path d="M4 10.5V10a3 3 0 0 1 6 0v0.5"/>',
+);
+
+/** Clock — delay */
+export const clock = s(
+  '<circle cx="7" cy="7" r="6"/>' +
+  '<polyline points="7,4 7,7 9.5,9"/>',
+);
+
+/** X-circle — error */
+export const xCircle = s(
+  '<circle cx="7" cy="7" r="6"/>' +
+  '<line x1="4.5" y1="4.5" x2="9.5" y2="9.5"/>' +
+  '<line x1="9.5" y1="4.5" x2="4.5" y2="9.5"/>',
+);
+
+/** Small filled dot — default / unknown */
+export const dot = s(
+  '<circle cx="7" cy="7" r="2" fill="currentColor" stroke="none"/>',
+);
+
+// ── Tool-call-card icons ───────────────────────────────────────────────────────
+
+/** Magnifying glass — search tools */
+export const search = s(
+  '<circle cx="5.5" cy="5.5" r="4"/>' +
+  '<line x1="8.5" y1="8.5" x2="12" y2="12"/>',
+);
+
+/** Document with fold — file tools */
+export const fileDoc = s(
+  '<path d="M3 1h6.5L12 3.5V13a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1z"/>' +
+  '<polyline points="9.5,1 9.5,4 12,4"/>',
+);
+
+/** Wrench — generic tool */
+export const wrench = s(
+  '<path d="M11 2a3 3 0 0 0-2.94 3.65L3 10.5l.5.5.5.5L9.35 6.94A3 3 0 1 0 11 2z"/>',
+);
+
+/** Git branch — git tools */
+export const gitBranch = s(
+  '<circle cx="4" cy="3.5" r="1.5"/>' +
+  '<circle cx="4" cy="11" r="1.5"/>' +
+  '<circle cx="10" cy="9" r="1.5"/>' +
+  '<line x1="4" y1="5" x2="4" y2="9.5"/>' +
+  '<path d="M4 9.5a3.5 3.5 0 0 0 3.5 2H10"/>',
+);
+
+/** GitHub mark (filled) — GitHub tools */
+export const gitHub =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="currentColor" aria-hidden="true">' +
+  '<path d="M7 .5a6.5 6.5 0 0 0-2.056 12.67c.326.06.446-.14.446-.31V11.79' +
+  'c-1.8.39-2.18-.87-2.18-.87-.294-.75-.72-.95-.72-.95-.588-.402.044-.394.044-.394' +
+  '.65.046.993.669.993.669.579.99 1.518.704 1.888.538.058-.418.226-.704.41-.866' +
+  'C3.634 9.71 2.1 9.14 2.1 6.556c0-.708.252-1.286.667-1.739' +
+  '-.067-.164-.29-.823.064-1.714 0 0 .544-.174 1.784.665A6.21 6.21 0 0 1 7 3.551' +
+  'a6.21 6.21 0 0 1 1.615.217c1.24-.839 1.784-.665 1.784-.665' +
+  '.354.891.13 1.55.064 1.714.415.453.667 1.031.667 1.739' +
+  'C11.13 9.14 9.58 9.71 7.81 9.882c.233.201.44.597.44 1.203v1.783' +
+  'c0 .172.118.373.446.31A6.5 6.5 0 0 0 7 .5z"/></svg>';
+
+// ── Event-card icons ───────────────────────────────────────────────────────────
+
+/** Filled play triangle — step_start */
+export const stepStart =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" ' +
+  'fill="currentColor" aria-hidden="true">' +
+  '<polygon points="3,2 12,7 3,12"/></svg>';
+
+/** Warning triangle with exclamation — blocker */
+export const blocker = s(
+  '<path d="M6.14 2.5l-5 8.66A1 1 0 0 0 2 12.83h10' +
+  'a1 1 0 0 0 .86-1.67l-5-8.66a1 1 0 0 0-1.72 0z"/>' +
+  '<line x1="7" y1="5.5" x2="7" y2="8"/>' +
+  '<circle cx="7" cy="10.3" r="0.6" fill="currentColor" stroke="none"/>',
+);
+
+/** Lightning bolt — decision */
+export const decision = s(
+  '<polygon points="8.5,1 5,7.5 7.5,7.5 5.5,13 10,6.5 7.5,6.5"/>',
+);
+
+/** Checkmark — done */
+export const checkmark = s('<polyline points="2,7 5.5,10.5 12,4"/>');
+
+/** Speech bubble — message */
+export const speech = s(
+  '<path d="M1 2h12a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H9l-2 2-2-2H1' +
+  'a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1z"/>',
+);

--- a/agentception/static/js/tool_call_card.ts
+++ b/agentception/static/js/tool_call_card.ts
@@ -8,7 +8,12 @@
  * On tool_call: appends a div.tool-call-card to #activity-feed.
  * On tool_result: annotates the most recent matching .tool-call-card[data-tool]
  *   with result text; falls back to a standalone card if none found.
+ *
+ * arg_preview comes from the backend as str(args)[:120] — Python dict notation.
+ * We parse it into readable key=value pairs before display.
  */
+
+import * as icons from './icons';
 
 interface ToolCallSseMessage {
   t: "tool_call";
@@ -26,74 +31,180 @@ interface ToolResultSseMessage {
 
 type SseMessage = ToolCallSseMessage | ToolResultSseMessage | { t: string };
 
-const TOOL_ICONS: ReadonlyMap<string, string> = new Map([
-  ["search_codebase", "🔍"],
-  ["search_text", "🔍"],
-  ["grep_search", "🔍"],
-  ["read_file", "📄"],
-  ["read_file_lines", "📄"],
-  ["list_directory", "📄"],
-  ["write_file", "✏️"],
-  ["replace_in_file", "✏️"],
-  ["create_file", "✏️"],
-  ["shell_exec", "🖥"],
-  ["run_command", "🖥"],
-]);
+// ── Tool categorisation ────────────────────────────────────────────────────────
 
-function iconForTool(toolName: string): string {
-  const direct = TOOL_ICONS.get(toolName);
-  if (direct !== undefined) return direct;
-  if (toolName.startsWith("git_")) return "🌿";
-  return "🔧";
+type ToolCategory = 'search' | 'file-read' | 'file-write' | 'shell' | 'git' | 'github' | 'default';
+
+function categoriseTool(toolName: string): ToolCategory {
+  if (/^(search_codebase|search_text|grep_search|find_files?)$/.test(toolName)) return 'search';
+  if (/^(read_file|read_file_lines|list_directory|get_file_contents)$/.test(toolName)) return 'file-read';
+  if (/^(write_file|replace_in_file|create_file|delete_file|create_or_update_file)$/.test(toolName)) return 'file-write';
+  if (/^(shell_exec|run_command|execute_command|bash)$/.test(toolName)) return 'shell';
+  if (toolName.startsWith('git_')) return 'git';
+  return 'default';
 }
 
+// ── SVG icons ─────────────────────────────────────────────────────────────────
+
+/** Return the SVG icon string for a given tool name. */
+export function svgForTool(toolName: string): string {
+  const category = categoriseTool(toolName);
+  switch (category) {
+    case 'search':    return icons.search;
+    case 'file-read': return icons.fileDoc;
+    case 'file-write':return icons.pencil;
+    case 'shell':     return icons.terminal;
+    case 'git':       return icons.gitBranch;
+    case 'github':    return icons.gitHub;
+    default:          return icons.wrench;
+  }
+}
+
+// ── Arg formatting ─────────────────────────────────────────────────────────────
+
+/**
+ * Parse the backend's args_preview (Python dict str() notation, truncated at
+ * 120 chars) into a readable "key=value  ·  key=value" string.
+ */
+export function parseArgPreview(raw: string): string {
+  if (!raw || raw === '{}' || raw === '') return '';
+
+  let parsed: Record<string, unknown> | null = null;
+
+  // 1. Try JSON directly.
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    // 2. Convert Python dict notation → JSON and retry.
+    try {
+      const json = raw
+        .replace(/'/g, '"')
+        .replace(/\bTrue\b/g, 'true')
+        .replace(/\bFalse\b/g, 'false')
+        .replace(/\bNone\b/g, 'null');
+      parsed = JSON.parse(json) as Record<string, unknown>;
+    } catch {
+      // 3. Return raw with a truncation marker if it was cut off.
+      return raw.length >= 120 ? raw.slice(0, 117) + '…' : raw;
+    }
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return raw;
+  }
+
+  const entries = Object.entries(parsed);
+  if (entries.length === 0) return '';
+
+  return entries
+    .map(([k, v]) => {
+      const raw = typeof v === 'string' ? v : JSON.stringify(v);
+      const val = raw.length > 70 ? raw.slice(0, 67) + '…' : raw;
+      return `${k}=${val}`;
+    })
+    .join('  ·  ');
+}
+
+// ── Result formatting ──────────────────────────────────────────────────────────
+
+/** Format result_preview (JSON string from backend) into a human-readable line. */
+export function formatResultPreview(preview: string): string {
+  if (!preview) return '';
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(preview);
+  } catch {
+    const t = preview.trim();
+    return t.length > 240 ? t.slice(0, 237) + '…' : t;
+  }
+
+  if (typeof parsed === 'string') {
+    const t = parsed.trim();
+    return t.length > 240 ? t.slice(0, 237) + '…' : t;
+  }
+  if (Array.isArray(parsed)) {
+    return `[${parsed.length} item${parsed.length === 1 ? '' : 's'}]`;
+  }
+  if (parsed !== null && typeof parsed === 'object') {
+    const obj = parsed as Record<string, unknown>;
+    // Surface errors immediately.
+    if ('ok' in obj && !obj['ok']) {
+      const msg = typeof obj['error'] === 'string' ? obj['error'] : 'unknown error';
+      return `error: ${msg}`;
+    }
+    // Show up to 4 key=value pairs.
+    return Object.entries(obj)
+      .slice(0, 4)
+      .map(([k, v]) => {
+        const raw = typeof v === 'string' ? v : JSON.stringify(v);
+        return `${k}: ${raw.length > 50 ? raw.slice(0, 47) + '…' : raw}`;
+      })
+      .join('  ·  ');
+  }
+  return String(parsed).slice(0, 240);
+}
+
+// ── DOM builders ───────────────────────────────────────────────────────────────
+
 function buildToolCallCard(toolName: string, argsPreview: string): HTMLElement {
-  const card = document.createElement("div");
-  card.className = "tool-call-card";
-  card.dataset["tool"] = toolName;
+  const card = document.createElement('div');
+  card.className = 'tool-call-card';
+  card.dataset['tool'] = toolName;
+  card.dataset['toolCategory'] = categoriseTool(toolName);
 
-  const icon = document.createElement("span");
-  icon.className = "tool-call-card__icon";
-  icon.setAttribute("aria-hidden", "true");
-  icon.textContent = iconForTool(toolName);
+  // Header: icon + tool name
+  const header = document.createElement('div');
+  header.className = 'tool-call-card__header';
 
-  const name = document.createElement("span");
-  name.className = "tool-call-card__name";
+  const icon = document.createElement('span');
+  icon.className = 'tool-call-card__icon';
+  icon.setAttribute('aria-hidden', 'true');
+  // eslint-disable-next-line no-unsanitized/property
+  icon.innerHTML = svgForTool(toolName);
+
+  const name = document.createElement('span');
+  name.className = 'tool-call-card__name';
   name.textContent = toolName;
 
-  const args = document.createElement("span");
-  args.className = "tool-call-card__args";
-  args.textContent = argsPreview;
+  header.appendChild(icon);
+  header.appendChild(name);
+  card.appendChild(header);
 
-  card.appendChild(icon);
-  card.appendChild(name);
-  card.appendChild(args);
+  // Args row (may be empty)
+  const formattedArgs = parseArgPreview(argsPreview);
+  if (formattedArgs) {
+    const args = document.createElement('div');
+    args.className = 'tool-call-card__args';
+    args.textContent = formattedArgs;
+    card.appendChild(args);
+  }
+
   return card;
 }
 
 function appendResult(feed: HTMLElement, toolName: string, resultPreview: string): void {
-  const result = document.createElement("div");
-  result.className = "tool-call-card__result";
-  result.textContent = resultPreview;
+  const result = document.createElement('div');
+  result.className = 'tool-call-card__result';
+  result.textContent = formatResultPreview(resultPreview);
 
   // Find most recent matching card (last in DOM order).
-  // Use attribute selector with escaped value when CSS.escape is available,
-  // otherwise fall back to iterating all tool-call-cards.
   let target: HTMLElement | null = null;
-  const escapedName = typeof CSS !== "undefined" && typeof CSS.escape === "function"
-    ? CSS.escape(toolName)
-    : null;
+  const escapedName =
+    typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+      ? CSS.escape(toolName)
+      : null;
+
   if (escapedName !== null) {
     const cards = feed.querySelectorAll<HTMLElement>(
       `.tool-call-card[data-tool="${escapedName}"]`,
     );
     target = cards.length > 0 ? (cards[cards.length - 1] ?? null) : null;
   } else {
-    // Fallback: iterate in reverse to find the last matching card.
-    const allCards = feed.querySelectorAll<HTMLElement>(".tool-call-card");
+    const allCards = feed.querySelectorAll<HTMLElement>('.tool-call-card');
     for (let i = allCards.length - 1; i >= 0; i--) {
       const card = allCards[i];
-      if (card !== undefined && card.dataset["tool"] === toolName) {
+      if (card !== undefined && card.dataset['tool'] === toolName) {
         target = card;
         break;
       }
@@ -102,25 +213,28 @@ function appendResult(feed: HTMLElement, toolName: string, resultPreview: string
 
   if (target !== null) {
     target.appendChild(result);
+    target.classList.add('tool-call-card--has-result');
   } else {
     // Standalone fallback card.
-    const fallback = document.createElement("div");
-    fallback.className = "tool-call-card tool-call-card--result-only";
-    fallback.dataset["tool"] = toolName;
+    const fallback = document.createElement('div');
+    fallback.className = 'tool-call-card tool-call-card--result-only';
+    fallback.dataset['tool'] = toolName;
     fallback.appendChild(result);
     feed.appendChild(fallback);
   }
 }
+
+// ── Public handler ─────────────────────────────────────────────────────────────
 
 /**
  * Register handlers on `source` that append ToolCallCards to `#activity-feed`.
  * The `#activity-feed` element must exist in the DOM before this is called.
  */
 export function attachToolCallHandler(source: EventSource): void {
-  const feed = document.getElementById("activity-feed");
+  const feed = document.getElementById('activity-feed');
   if (!feed) return;
 
-  source.addEventListener("message", (evt: MessageEvent<string>) => {
+  source.addEventListener('message', (evt: MessageEvent<string>) => {
     let msg: SseMessage;
     try {
       msg = JSON.parse(evt.data) as SseMessage;
@@ -128,13 +242,13 @@ export function attachToolCallHandler(source: EventSource): void {
       return;
     }
 
-    if (msg.t === "tool_call") {
+    if (msg.t === 'tool_call') {
       const m = msg as ToolCallSseMessage;
       feed.appendChild(buildToolCallCard(m.tool_name, m.args_preview));
       return;
     }
 
-    if (msg.t === "tool_result") {
+    if (msg.t === 'tool_result') {
       const m = msg as ToolResultSseMessage;
       appendResult(feed, m.tool_name, m.result_preview);
     }

--- a/agentception/static/scss/pages/_activity-feed.scss
+++ b/agentception/static/scss/pages/_activity-feed.scss
@@ -1,17 +1,18 @@
 // ── Activity feed row (SSE activity messages) ─────────────────────────────────
 //
 // Terminal-style log: icon | content (grows) | timestamp (right-aligned).
-// Rows are compact (24px line-height) to maximise visible history.
+// Rows are compact to maximise visible history.
+// Icons are 11×11 inline SVG inheriting currentColor.
 
 .activity-feed__row {
   display: grid;
-  grid-template-columns: 1.1rem 1fr auto;
-  align-items: baseline;
-  gap: 0 0.45rem;
-  padding: 0.05rem 0.75rem 0.05rem 0.5rem;
+  grid-template-columns: 1.25rem 1fr auto;
+  align-items: center;
+  gap: 0 0.4rem;
+  padding: 0.075rem 0.75rem 0.075rem 0.5rem;
   min-height: 22px;
   font-size: 0.695rem;
-  line-height: 1.9;
+  line-height: 1.8;
   color: rgba(255, 255, 255, 0.5);
   border-left: 2px solid transparent;
   transition: background 0.08s;
@@ -30,9 +31,13 @@
   &[data-subtype="delay"]       { border-left-color: #f59e0b; opacity: 0.55; }
   &[data-subtype="error"]       { border-left-color: #ef4444; color: #fca5a5; }
 
-  // LLM rows are slightly brighter — they carry the key iteration signal
+  // llm_iter: iteration milestone — slightly elevated, model name prominent
   &[data-subtype="llm_iter"] {
-    color: rgba(167, 139, 250, 0.85);
+    color: rgba(167, 139, 250, 0.9);
+    padding-top: 0.2rem;
+    padding-bottom: 0.15rem;
+    border-left-width: 3px;
+    font-weight: 500;
   }
 
   &[data-subtype="llm_usage"] {
@@ -43,7 +48,7 @@
   &[data-subtype="file_replaced"],
   &[data-subtype="file_inserted"],
   &[data-subtype="file_written"] {
-    color: rgba(52, 211, 153, 0.8);
+    color: rgba(52, 211, 153, 0.85);
   }
 
   // Non-zero shell exit: error tint
@@ -54,10 +59,22 @@
   }
 
   .activity-feed__icon {
-    font-size: 0.7rem;
-    line-height: 1.9;
-    opacity: 0.7;
-    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.65;
+    flex-shrink: 0;
+
+    svg {
+      width: 11px;
+      height: 11px;
+      flex-shrink: 0;
+    }
+  }
+
+  // llm_iter icon slightly brighter to match the elevated row
+  &[data-subtype="llm_iter"] .activity-feed__icon {
+    opacity: 0.85;
   }
 
   .activity-feed__summary {
@@ -66,16 +83,56 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     font-family: var(--font-mono);
-    font-size: 0.68rem;
+    font-size: 0.675rem;
     letter-spacing: 0.01em;
   }
 
   .activity-feed__ts {
-    font-size: 0.6rem;
+    font-size: 0.58rem;
     font-variant-numeric: tabular-nums;
     color: rgba(255, 255, 255, 0.2);
     font-family: var(--font-mono);
     white-space: nowrap;
-    padding-left: 0.5rem;
+    padding-left: 0.4rem;
+    letter-spacing: 0.02em;
+  }
+}
+
+// ── Light mode overrides ───────────────────────────────────────────────────────
+
+[data-theme="light"] .activity-feed__row {
+  color: rgba(0, 0, 0, 0.55);
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.03);
+  }
+
+  &[data-subtype^="shell"] { border-left-color: #9ca3af; }
+
+  &[data-subtype="llm_iter"] {
+    color: rgba(109, 40, 217, 0.9);
+  }
+
+  &[data-subtype="llm_usage"] {
+    color: rgba(109, 40, 217, 0.6);
+  }
+
+  &[data-subtype="file_replaced"],
+  &[data-subtype="file_inserted"],
+  &[data-subtype="file_written"] {
+    color: rgba(5, 150, 105, 0.85);
+  }
+
+  &[data-subtype="error"] {
+    color: #dc2626;
+  }
+
+  &[data-subtype="shell_done"][data-exit-nonzero] {
+    background: rgba(239, 68, 68, 0.05);
+    color: #dc2626;
+  }
+
+  .activity-feed__ts {
+    color: rgba(0, 0, 0, 0.3);
   }
 }

--- a/agentception/static/scss/pages/_event-card.scss
+++ b/agentception/static/scss/pages/_event-card.scss
@@ -4,6 +4,7 @@
 //
 // These cards live inside the dark terminal #activity-feed container and act
 // as section dividers (step_start) or highlighted lifecycle markers.
+// Icons are 11×11 inline SVG inheriting currentColor.
 
 .event-card {
   display: flex;
@@ -18,13 +19,13 @@
 
   // Step start: full-width section divider
   &[data-event-type='step_start'] {
-    margin-top: 0.4rem;
-    padding-top: 0.35rem;
-    padding-bottom: 0.2rem;
+    margin-top: 0.5rem;
+    padding-top: 0.4rem;
+    padding-bottom: 0.25rem;
     border-top: 1px solid rgba(255, 255, 255, 0.06);
     border-left: none;
-    color: rgba(255, 255, 255, 0.35);
-    font-size: 0.62rem;
+    color: rgba(255, 255, 255, 0.4);
+    font-size: 0.63rem;
     font-weight: 700;
     letter-spacing: 0.1em;
     text-transform: uppercase;
@@ -36,8 +37,9 @@
     }
 
     .event-card__icon {
-      color: rgba(255, 255, 255, 0.2);
-      font-size: 0.55rem;
+      color: rgba(255, 255, 255, 0.3);
+      // Slightly smaller play triangle
+      svg { width: 9px; height: 9px; }
     }
   }
 
@@ -73,7 +75,14 @@
   &__icon {
     flex-shrink: 0;
     opacity: 0.8;
-    font-size: 0.75rem;
+    display: flex;
+    align-items: center;
+
+    svg {
+      width: 11px;
+      height: 11px;
+      flex-shrink: 0;
+    }
   }
 
   &__text {
@@ -82,5 +91,45 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+}
+
+// ── Light mode overrides ───────────────────────────────────────────────────────
+// Replace hardcoded rgba(255,255,255,…) values that disappear on a light bg.
+
+[data-theme="light"] .event-card {
+  color: rgba(0, 0, 0, 0.55);
+
+  &[data-event-type='step_start'] {
+    border-top-color: rgba(0, 0, 0, 0.08);
+    color: rgba(0, 0, 0, 0.4);
+
+    .event-card__icon {
+      color: rgba(0, 0, 0, 0.25);
+    }
+  }
+
+  &[data-event-type='blocker'] {
+    color: #92400e;
+    background: rgba(245, 158, 11, 0.08);
+  }
+
+  &[data-event-type='decision'] {
+    color: #0369a1;
+  }
+
+  &[data-event-type='done'] {
+    color: #065f46;
+    background: rgba(16, 185, 129, 0.07);
+  }
+
+  &[data-event-type='message'] {
+    border-left-color: rgba(0, 0, 0, 0.12);
+    color: rgba(0, 0, 0, 0.5);
+  }
+
+  &[data-event-type='error'] {
+    color: #dc2626;
+    background: rgba(239, 68, 68, 0.06);
   }
 }

--- a/agentception/static/scss/pages/_tool-call-card.scss
+++ b/agentception/static/scss/pages/_tool-call-card.scss
@@ -1,58 +1,121 @@
 // ── Tool call card ────────────────────────────────────────────────────────────
 // Shows tool invocations and their results inline.
-// tool_call:   icon · name · args preview
-// tool_result: result preview appended below, separated by subtle rule
+//
+// Structure:
+//   .tool-call-card
+//     .tool-call-card__header     (flex row: icon + name)
+//       .tool-call-card__icon
+//       .tool-call-card__name
+//     .tool-call-card__args       (optional — formatted key=value pairs)
+//     .tool-call-card__result     (appended on tool_result SSE)
+//
+// Left-border color is driven by [data-tool-category].
 
 .tool-call-card {
   border-left: 3px solid var(--accent-blue, #4dabf7);
   border-radius: 0 var(--radius-xs, 4px) var(--radius-xs, 4px) 0;
-  padding: 0.25rem 0.5rem 0.25rem 0.625rem;
+  padding: 0.3rem 0.5rem 0.3rem 0.625rem;
   display: flex;
-  flex-direction: row;
-  align-items: baseline;
-  gap: 0.4rem;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 0.15rem;
   max-width: 100%;
   overflow-x: hidden;
-  word-break: break-word;
+
+  // Category-driven border colors
+  &[data-tool-category="search"]     { border-left-color: #4dabf7; }
+  &[data-tool-category="file-read"]  { border-left-color: #60a5fa; }
+  &[data-tool-category="file-write"] { border-left-color: #34d399; }
+  &[data-tool-category="shell"]      { border-left-color: #f59e0b; }
+  &[data-tool-category="git"]        { border-left-color: #a78bfa; }
+  &[data-tool-category="github"]     { border-left-color: #818cf8; }
+  &[data-tool-category="default"]    { border-left-color: #6b7280; }
+
+  // Result separator — shown only when a result is present
+  &--has-result .tool-call-card__args {
+    padding-bottom: 0.15rem;
+  }
+
+  &--result-only {
+    border-left-color: var(--border-subtle, #2a2a2a);
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
 
   &__icon {
     flex-shrink: 0;
-    opacity: 0.8;
-    line-height: 1;
+    opacity: 0.7;
+    display: flex;
+    align-items: center;
+
+    svg {
+      width: 11px;
+      height: 11px;
+      flex-shrink: 0;
+    }
   }
 
   &__name {
     font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
-    font-size: 0.75rem;
+    font-size: 0.72rem;
     font-weight: 600;
     color: var(--accent-bright, #a78bfa);
     white-space: nowrap;
   }
 
+  // Category-tinted name color
+  &[data-tool-category="search"]     &__name { color: #7dd3fc; }
+  &[data-tool-category="file-read"]  &__name { color: #93c5fd; }
+  &[data-tool-category="file-write"] &__name { color: #6ee7b7; }
+  &[data-tool-category="shell"]      &__name { color: #fcd34d; }
+  &[data-tool-category="git"]        &__name { color: #c4b5fd; }
+  &[data-tool-category="github"]     &__name { color: #a5b4fc; }
+
   &__args {
     font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
-    font-size: 0.7rem;
+    font-size: 0.67rem;
     color: var(--text-muted, #888);
-    word-break: break-all;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 100%;
+    word-break: break-word;
+    padding-left: 1.45rem; // align under tool name (icon width + gap)
+    line-height: 1.55;
+    opacity: 0.9;
   }
 
   &__result {
-    flex-basis: 100%;
     font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
-    font-size: 0.7rem;
-    color: var(--text-muted, #888);
-    padding: 0.2rem 0 0 1.4rem;
-    margin-top: 0.15rem;
-    border-top: 1px solid var(--border-subtle, #2a2a2a);
+    font-size: 0.67rem;
+    color: rgba(255, 255, 255, 0.35);
+    padding: 0.25rem 0 0 1.45rem;
+    margin-top: 0.05rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
     word-break: break-word;
     white-space: pre-wrap;
+    line-height: 1.5;
+
+    // Subtle leading arrow to indicate "result of ↑"
+    &::before {
+      content: '↳ ';
+      opacity: 0.4;
+    }
+  }
+}
+
+// ── Light mode overrides ───────────────────────────────────────────────────────
+
+[data-theme="light"] .tool-call-card {
+  &__args {
+    color: rgba(0, 0, 0, 0.5);
+  }
+
+  &__result {
+    color: rgba(0, 0, 0, 0.45);
+    border-top-color: rgba(0, 0, 0, 0.08);
   }
 
   &--result-only {
-    border-left-color: var(--border-subtle, #2a2a2a);
+    border-left-color: rgba(0, 0, 0, 0.1);
   }
 }


### PR DESCRIPTION
## Summary

- **SVG icons everywhere** — new `icons.ts` module with 14×14 stroke-based SVGs replacing all emoji. Icons inherit `currentColor` so they theme automatically in light and dark mode.
- **llm_iter row decluttered** — drops the redundant "ITER N" prefix; formats as `model · turn N` so the model name leads the line.
- **Human-readable formatting** — `llm_usage` now shows `17,524 tokens · 0 cached`; `shell_done` shows `10 B stdout`; `file_read` shows `path · 1–10 of 50`.
- **Feed-relative timestamps** — absolute `HH:MM:SS` replaced with `+0s`, `+29s`, `+1m5s` deltas from the first event in the session.
- **Rich tool-call cards** — args_preview is parsed from Python dict notation into `key=value · key=value` pairs; tools are categorised (search/file-read/file-write/shell/git/github) with matching left-border and name colours; results show with a `↳` prefix.
- **SCSS polish** — icon column uses flex+SVG sizing; `llm_iter` rows are slightly elevated (font-weight 500, wider border, brighter icon); tool-call-card layout switched to column with `__header` + `__args` + `__result`.

## Test plan

- [x] `tsc --noEmit` — zero errors
- [x] 75/75 unit tests green (`activity_feed`, `tool_call_card`, `event_card`)
- [x] `npm run build` — JS 444 KB, CSS compiled cleanly
- [x] `generate.py --check` — no drift