### PR TITLE
feat: replace emoji with inline SVGs in nav, header, and phase board

### DIFF
--- a/agentception/static/scss/_foundation.scss
+++ b/agentception/static/scss/_foundation.scss
@@ -233,6 +233,9 @@ nav.topnav {
 
 /* Brand */
 a.brand, nav.topnav .brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
   font-size: 0.9375rem;
   font-weight: 700;
   letter-spacing: -0.01em;
@@ -246,6 +249,15 @@ a.brand, nav.topnav .brand {
   margin-right: 0.5rem;
   flex-shrink: 0;
   text-decoration: none;
+}
+
+/* Brand lightning bolt — solid accent, not subject to text-fill gradient */
+.brand__bolt {
+  width: 12px;
+  height: 18px;
+  flex-shrink: 0;
+  /* SVG fill bypasses -webkit-text-fill-color; use explicit fill */
+  fill: #a78bfa;
 }
 
 a.brand:hover, nav.topnav .brand:hover {

--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -65,11 +65,21 @@ body:has(.build-layout) nav.topnav {
   }
 
   &__title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
     font-size: 1rem;
     font-weight: 700;
     color: var(--text-primary);
     letter-spacing: -0.02em;
     margin: 0;
+  }
+
+  &__bolt {
+    width: 10px;
+    height: 16px;
+    flex-shrink: 0;
+    opacity: 0.85;
   }
 
   &__repo {
@@ -241,10 +251,24 @@ body:has(.build-layout) nav.topnav {
 // ── Phase row elements (icon, label, progress badge, gate, buttons, chevron) ──
 
 .build-phase__icon {
-  font-size: 0.8125rem;
-  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
+  width: 1rem;
+
+  svg {
+    width: 13px;
+    height: 13px;
+    flex-shrink: 0;
+  }
 }
+
+// Phase icon colors driven by row state class on the parent swimlane row
+.build-swimlane__row--complete .build-phase__icon { color: #34d399; }
+.build-swimlane__row--locked   .build-phase__icon { color: #f59e0b; }
+.build-swimlane__row--empty    .build-phase__icon { color: var(--text-faint); }
+.build-swimlane__row--active   .build-phase__icon { color: var(--text-muted); }
 
 .build-phase__label {
   font-size: 0.75rem;
@@ -2045,6 +2069,10 @@ $preset-accents: (
   background-position: right 0.75rem center;
   padding-right: 2rem;
 
+  [data-theme="light"] & {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='rgba(0,0,0,0.4)'/%3E%3C/svg%3E");
+  }
+
   option, optgroup { background: var(--bg-elevated); color: var(--text-primary); }
   option:disabled, &__opt--blocked { color: var(--text-faint); }
   &:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-glow); }
@@ -2305,6 +2333,12 @@ $preset-accents: (
   &::-webkit-scrollbar       { width: 4px; }
   &::-webkit-scrollbar-track { background: transparent; }
   &::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.12); border-radius: 2px; }
+
+  [data-theme="light"] & {
+    scrollbar-color: rgba(0,0,0,0.15) transparent;
+
+    &::-webkit-scrollbar-thumb { background: rgba(0,0,0,0.15); }
+  }
 }
 
 // ── Start agent block (pending_launch state) ──────────────────────────────────

--- a/agentception/static/scss/pages/_pipeline.scss
+++ b/agentception/static/scss/pages/_pipeline.scss
@@ -97,12 +97,21 @@
 /* ── Gate badge ─────────────────────────────────────────────── */
 
 .phase-gate-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   font-size: 0.65rem;
   font-weight: 700;
   padding: 0.15rem 0.45rem;
   border-radius: 999px;
   white-space: nowrap;
   flex-shrink: 0;
+
+  svg {
+    width: 10px;
+    height: 10px;
+    flex-shrink: 0;
+  }
 
   &--ready {
     background: var(--success-dim);

--- a/agentception/templates/_build_board.html
+++ b/agentception/templates/_build_board.html
@@ -205,7 +205,15 @@
     <div class="build-swimlane__phase-label" @click="open = !open">
       <div class="build-swimlane__phase-label-top">
         <span class="build-phase__icon">
-          {%- if group.complete %}✅{%- elif group.locked %}🔒{%- elif not group.issues %}○{%- else %}🔓{%- endif %}
+          {%- if group.complete -%}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="2,7 5.5,10.5 12,4"/></svg>
+          {%- elif group.locked -%}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="6.5" width="10" height="6.5" rx="1.5"/><path d="M4.5 6.5V4.5a2.5 2.5 0 0 1 5 0v2"/></svg>
+          {%- elif not group.issues -%}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><circle cx="7" cy="7" r="5"/></svg>
+          {%- else -%}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="6.5" width="10" height="6.5" rx="1.5"/><path d="M4.5 6.5V4.5a2.5 2.5 0 0 1 4.5-1.6"/></svg>
+          {%- endif -%}
         </span>
         <span class="build-phase__label">{{ phase_slug }}</span>
         <span class="build-phase__chevron" :class="{ 'build-phase__chevron--open': open }">›</span>

--- a/agentception/templates/base.html
+++ b/agentception/templates/base.html
@@ -34,7 +34,12 @@
       hx-on::after-request="const hdr = event.detail.xhr.getResponseHeader('HX-Trigger'); if (hdr) { try { const triggers = JSON.parse(hdr); if (triggers.toast) window.dispatchEvent(new CustomEvent('toast', { detail: triggers.toast })); } catch(e) {} }">
 
   <nav class="topnav" role="navigation" aria-label="Main navigation">
-    <span class="brand">⚡ Agentception</span>
+    <span class="brand">
+      <svg class="brand__bolt" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 16" aria-hidden="true">
+        <polygon points="6,0 0,9 5,9 3,16 10,7 5,7"/>
+      </svg>
+      Agentception
+    </span>
 
     {# ── Primary nav: Plan → Ship ────────────────────────────────────────── #}
     <a href="/plan" class="nav-cta {% if request.url.path == '/' or request.url.path.startswith('/plan') %}active{% endif %}">Plan</a>

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -16,7 +16,12 @@
   <div class="build-subnav">
     <header class="build-header">
       <div class="build-header__left">
-        <h1 class="build-header__title">⚡ Mission Control</h1>
+        <h1 class="build-header__title">
+          <svg class="build-header__bolt" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 16" fill="currentColor" aria-hidden="true">
+            <polygon points="6,0 0,9 5,9 3,16 10,7 5,7"/>
+          </svg>
+          Mission Control
+        </h1>
         <span class="build-header__repo">{{ repo }}</span>
       </div>
       <div class="build-header__right">

--- a/agentception/templates/partials/phase_lanes.html
+++ b/agentception/templates/partials/phase_lanes.html
@@ -26,9 +26,13 @@
         ></span>
         <span class="phase-lane__name">{{ lane.label }}</span>
         <span class="phase-gate-badge phase-gate-badge--{{ lane.gate_status }}">
-          {% if lane.gate_status == 'waiting' %}🔒 Waiting
-          {% elif lane.gate_status == 'ready' %}🟢 Ready
-          {% else %}✅ Done{% endif %}
+          {%- if lane.gate_status == 'waiting' -%}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="6.5" width="10" height="6.5" rx="1.5"/><path d="M4.5 6.5V4.5a2.5 2.5 0 0 1 5 0v2"/></svg> Waiting
+          {%- elif lane.gate_status == 'ready' -%}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><circle cx="7" cy="7" r="5"/><circle cx="7" cy="7" r="2" fill="currentColor" stroke="none"/></svg> Ready
+          {%- else -%}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="2,7 5.5,10.5 12,4"/></svg> Done
+          {%- endif -%}
         </span>
       </div>
 


### PR DESCRIPTION
## Summary

- **Brand nav** — `⚡ Agentception` bolt replaced with a 12×18 filled polygon SVG. Uses explicit `fill: #a78bfa` so it isn't transparent under the `-webkit-text-fill-color` gradient clip that styles the text. Brand gains `display: inline-flex` + `gap` for clean icon/text alignment.
- **Mission Control header** — `⚡ Mission Control` replaced with the same bolt SVG styled via `.build-header__bolt`; title gains `display: inline-flex` for vertical centering.
- **Phase board state icons** — `✅` / `🔒` / `○` / `🔓` replaced with stroke-based SVGs (checkmark, lock, empty-circle, open-lock). Icons inherit `currentColor` and are colored by parent swimlane state class: complete=green, locked=amber, empty=faint, active=muted.
- **Phase gate badges** — `🔒 Waiting` / `🟢 Ready` / `✅ Done` replaced with matching inline SVGs inside the pill badge. Badge gains `display: inline-flex` + `gap` + `svg` sizing.

## Test plan

- [x] `npm run build:css` — clean
- [ ] Visual check: nav bolt, Mission Control header, phase board icons, gate badges