### PR TITLE
fix: colour Mission Control bolt yellow

### DIFF
--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -79,7 +79,7 @@ body:has(.build-layout) nav.topnav {
     width: 10px;
     height: 16px;
     flex-shrink: 0;
-    opacity: 0.85;
+    fill: #f59e0b;
   }
 
   &__repo {


### PR DESCRIPTION
Sets `.build-header__bolt { fill: #f59e0b }` so the lightning bolt in the Mission Control header renders amber-yellow instead of inheriting the dark text color.