### PR TITLE
feat: polish activity feed — humanized names, compact args, nested indent

### DIFF
--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -18,31 +18,56 @@ function dispatch(src: EventTarget, data: object): void {
 }
 
 describe('formatActivitySummary', () => {
-  it('formats tool_invoked', () => {
+  it('formats tool_invoked with humanized name (unparseable args falls back to name only)', () => {
+    // 'echo ok' is not a Python dict — falls back to name only (no arg summary)
     expect(
       formatActivitySummary('tool_invoked', { tool_name: 'run_command', arg_preview: 'echo ok' })
-    ).toBe('→ run_command echo ok');
+    ).toBe('Run command');
   });
 
-  it('formats shell_start', () => {
+  it('formats tool_invoked with compact arg summary when args are parseable', () => {
+    const result = formatActivitySummary('tool_invoked', {
+      tool_name: 'read_file',
+      arg_preview: "{'path': 'src/foo.py'}",
+    });
+    // humanized name + primary arg value
+    expect(result).toContain('Read file');
+    expect(result).toContain('src/foo.py');
+  });
+
+  it('formats github_tool with humanized name', () => {
+    const result = formatActivitySummary('github_tool', {
+      tool_name: 'create_pull_request',
+      arg_preview: "{'title': 'My PR'}",
+    });
+    expect(result).toContain('Open PR');
+  });
+
+  it('formats shell_start as the command preview without $ prefix', () => {
     expect(formatActivitySummary('shell_start', { cmd_preview: 'echo hi', cwd: '/app' })).toBe(
-      '$ echo hi'
+      'echo hi'
     );
   });
 
-  it('formats shell_done exit=0 with human-readable byte count', () => {
+  it('formats shell_done exit=0 with byte count only', () => {
     expect(
       formatActivitySummary('shell_done', { exit_code: 0, stdout_bytes: 10, stderr_bytes: 0 })
-    ).toBe('exit=0  ·  10 B stdout');
+    ).toBe('10 B');
   });
 
-  it('formats shell_done non-zero exit with error prefix', () => {
+  it('formats shell_done exit=0 with no output as "ok"', () => {
+    expect(
+      formatActivitySummary('shell_done', { exit_code: 0, stdout_bytes: 0, stderr_bytes: 0 })
+    ).toBe('ok');
+  });
+
+  it('formats shell_done non-zero exit with code and output size', () => {
     expect(
       formatActivitySummary('shell_done', { exit_code: 1, stdout_bytes: 0, stderr_bytes: 5 })
-    ).toBe('✗ exit=1  ·  0 B stdout');
+    ).toBe('exit 1  ·  0 B out');
   });
 
-  it('formats file_read', () => {
+  it('formats file_read with short path', () => {
     expect(
       formatActivitySummary('file_read', {
         path: 'src/foo.py',
@@ -53,11 +78,22 @@ describe('formatActivitySummary', () => {
     ).toBe('src/foo.py  ·  1–10 of 50');
   });
 
-  it('formats git_push', () => {
-    expect(formatActivitySummary('git_push', { branch: 'feat/944' })).toBe('→ feat/944');
+  it('strips ac://runs prefix from file_read paths', () => {
+    const result = formatActivitySummary('file_read', {
+      path: 'ac://runs/run-abc123/agentception/config.py',
+      start_line: 1,
+      end_line: 5,
+      total_lines: 50,
+    });
+    expect(result).not.toContain('ac://runs');
+    expect(result).toContain('config.py');
   });
 
-  it('formats error message without emoji prefix', () => {
+  it('formats git_push as branch name only (icon provides the arrow)', () => {
+    expect(formatActivitySummary('git_push', { branch: 'feat/944' })).toBe('feat/944');
+  });
+
+  it('formats error message', () => {
     expect(formatActivitySummary('error', { message: 'connection refused' })).toBe(
       'connection refused'
     );
@@ -67,7 +103,7 @@ describe('formatActivitySummary', () => {
     expect(formatActivitySummary('unknown_subtype', {})).toBe('unknown_subtype');
   });
 
-  it('formats llm_iter without ITER prefix — model and turn at front', () => {
+  it('formats llm_iter — model and turn at front', () => {
     expect(
       formatActivitySummary('llm_iter', { model: 'claude-3-5', turns: 2 })
     ).toBe('claude-3-5  ·  turn 2');
@@ -90,10 +126,16 @@ describe('formatActivitySummary', () => {
     expect(result).toContain('50 cached');
   });
 
-  it('formats llm_done as tool call count', () => {
+  it('suppresses llm_done when tool calls follow (returns empty string)', () => {
     expect(
       formatActivitySummary('llm_done', { stop_reason: 'tool_calls', tool_call_count: 2 })
-    ).toBe('→ 2 tool calls');
+    ).toBe('');
+  });
+
+  it('shows llm_done stop reason when no tool calls', () => {
+    expect(
+      formatActivitySummary('llm_done', { stop_reason: 'end_turn', tool_call_count: 0 })
+    ).toBe('end_turn');
   });
 });
 
@@ -168,8 +210,14 @@ describe('formatRelativeTime', () => {
     resetFeedStartTime();
   });
 
-  it('returns +0s for the first event', () => {
-    expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('+0s');
+  it('returns "now" for the first event', () => {
+    expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('now');
+  });
+
+  it('returns "now" for a second event at the same timestamp', () => {
+    resetFeedStartTime();
+    formatRelativeTime('2026-03-15T12:00:00Z');
+    expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('now');
   });
 
   it('returns +Ns for subsequent events', () => {
@@ -213,7 +261,7 @@ describe('appendActivityRow', () => {
     const row = document.querySelector('.activity-feed__row');
     expect(row).not.toBeNull();
     expect(row?.getAttribute('data-subtype')).toBe('shell_done');
-    expect(row?.querySelector('.activity-feed__summary')?.textContent).toBe('exit=0  ·  5 B stdout');
+    expect(row?.querySelector('.activity-feed__summary')?.textContent).toBe('5 B');
     expect(row?.querySelector('.activity-feed__ts')?.getAttribute('datetime')).toBe(
       '2026-03-13T14:30:00Z'
     );
@@ -252,6 +300,16 @@ describe('appendActivityRow', () => {
     expect(row?.hasAttribute('data-exit-nonzero')).toBe(false);
   });
 
+  it('does NOT append a row for llm_done when tool calls follow', () => {
+    appendActivityRow({
+      t: 'activity',
+      subtype: 'llm_done',
+      payload: { stop_reason: 'tool_calls', tool_call_count: 3 },
+      recorded_at: '',
+    });
+    expect(document.querySelector('.activity-feed__row')).toBeNull();
+  });
+
   it('does nothing when #activity-feed is missing', () => {
     document.body.innerHTML = '';
     appendActivityRow({
@@ -282,7 +340,7 @@ describe('attachActivityFeedHandler', () => {
     const row = document.querySelector('.activity-feed__row');
     expect(row).not.toBeNull();
     expect(row?.getAttribute('data-subtype')).toBe('github_tool');
-    expect(row?.querySelector('.activity-feed__summary')?.textContent).toContain('create_pull_request');
+    expect(row?.querySelector('.activity-feed__summary')?.textContent).toContain('Open PR');
   });
 
   it('ignores non-activity messages', () => {

--- a/agentception/static/js/__tests__/format_utils.test.ts
+++ b/agentception/static/js/__tests__/format_utils.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+  humanizeTool,
+  shortenPath,
+  parseArgsRaw,
+  formatArgsCompact,
+  formatArgsFull,
+  parseArgPreview,
+  formatResultPreview,
+} from '../format_utils';
+
+describe('humanizeTool', () => {
+  it('maps known tool names to human labels', () => {
+    expect(humanizeTool('read_file')).toBe('Read file');
+    expect(humanizeTool('run_command')).toBe('Run command');
+    expect(humanizeTool('write_file')).toBe('Write file');
+    expect(humanizeTool('replace_in_file')).toBe('Edit file');
+    expect(humanizeTool('search_codebase')).toBe('Search');
+    expect(humanizeTool('create_pull_request')).toBe('Open PR');
+    expect(humanizeTool('merge_pull_request')).toBe('Merge PR');
+  });
+
+  it('prefixes git_ tools with "Git"', () => {
+    expect(humanizeTool('git_commit')).toBe('Git commit');
+    expect(humanizeTool('git_push')).toBe('Git push');
+    expect(humanizeTool('git_checkout')).toBe('Git checkout');
+  });
+
+  it('falls back to capitalised underscore-split for unknown tools', () => {
+    expect(humanizeTool('custom_tool')).toBe('Custom tool');
+    expect(humanizeTool('some_long_tool_name')).toBe('Some long tool name');
+  });
+});
+
+describe('shortenPath', () => {
+  it('strips ac://runs/{id}/ prefix', () => {
+    expect(shortenPath('ac://runs/run-abc123/agentception/config.py')).not.toContain('ac://runs');
+    expect(shortenPath('ac://runs/run-abc123/agentception/config.py')).toContain('config.py');
+  });
+
+  it('strips /app/ prefix', () => {
+    const result = shortenPath('/app/agentception/routes/build.py');
+    expect(result).not.toContain('/app/');
+    expect(result).toContain('build.py');
+  });
+
+  it('leaves short relative paths unchanged', () => {
+    expect(shortenPath('src/foo.py')).toBe('src/foo.py');
+    expect(shortenPath('agentception/config.py')).toBe('agentception/config.py');
+  });
+
+  it('abbreviates deep paths to last 2 components', () => {
+    const result = shortenPath('a/b/c/d/e/f/file.ts');
+    expect(result).toContain('f/file.ts');
+    expect(result).toContain('…/');
+  });
+});
+
+describe('parseArgsRaw', () => {
+  it('parses valid JSON object', () => {
+    expect(parseArgsRaw('{"path": "src/foo.py"}')).toEqual({ path: 'src/foo.py' });
+  });
+
+  it('parses Python dict single-quote notation', () => {
+    const result = parseArgsRaw("{'command': 'gh issue view 1'}");
+    expect(result).toEqual({ command: 'gh issue view 1' });
+  });
+
+  it('handles Python True/False/None', () => {
+    const result = parseArgsRaw("{'flag': True, 'val': None}");
+    expect(result).toEqual({ flag: true, val: null });
+  });
+
+  it('returns null for empty/empty-dict input', () => {
+    expect(parseArgsRaw('')).toBeNull();
+    expect(parseArgsRaw('{}')).toBeNull();
+  });
+
+  it('returns null for unparseable strings', () => {
+    expect(parseArgsRaw('definitely not a dict')).toBeNull();
+    expect(parseArgsRaw('echo hello')).toBeNull();
+  });
+});
+
+describe('formatArgsCompact', () => {
+  it('shows path value for path-primary tools', () => {
+    expect(formatArgsCompact({ path: 'src/foo.py' })).toBe('src/foo.py');
+  });
+
+  it('shows command value for command-primary tools', () => {
+    expect(formatArgsCompact({ command: 'gh issue view 1071' })).toBe('gh issue view 1071');
+  });
+
+  it('strips ac://runs prefix from path values', () => {
+    const result = formatArgsCompact({ path: 'ac://runs/run-abc/agentception/config.py' });
+    expect(result).not.toContain('ac://runs');
+    expect(result).toContain('config.py');
+  });
+
+  it('uses first non-noise key when no primary key exists', () => {
+    const result = formatArgsCompact({ owner: 'acme', repo: 'myapp' });
+    expect(result).toContain('owner:');
+    expect(result).toContain('acme');
+  });
+
+  it('returns empty string for empty object', () => {
+    expect(formatArgsCompact({})).toBe('');
+  });
+});
+
+describe('formatArgsFull', () => {
+  it('returns key=value pairs joined by ·', () => {
+    const result = formatArgsFull({ path: 'src/foo.py', encoding: 'utf-8' });
+    expect(result).toContain('path=');
+    expect(result).toContain('encoding=utf-8');
+    expect(result).toContain('  ·  ');
+  });
+
+  it('applies path shortening to path values', () => {
+    const result = formatArgsFull({ path: 'ac://runs/run-abc/agentception/config.py' });
+    expect(result).not.toContain('ac://runs');
+    expect(result).toContain('config.py');
+  });
+
+  it('returns empty string for empty object', () => {
+    expect(formatArgsFull({})).toBe('');
+  });
+});
+
+describe('parseArgPreview (convenience wrapper)', () => {
+  it('parses JSON and returns full key=value display', () => {
+    expect(parseArgPreview('{"path": "src/foo.py"}')).toBe('path=src/foo.py');
+  });
+
+  it('parses Python dict and returns full display', () => {
+    const result = parseArgPreview("{'path': 'src/bar.py', 'encoding': 'utf-8'}");
+    expect(result).toContain('path=src/bar.py');
+    expect(result).toContain('encoding=utf-8');
+  });
+
+  it('returns raw string when unparseable', () => {
+    expect(parseArgPreview('just a plain string')).toBe('just a plain string');
+  });
+
+  it('returns empty string for empty/empty-dict', () => {
+    expect(parseArgPreview('')).toBe('');
+    expect(parseArgPreview('{}')).toBe('');
+  });
+
+  it('truncates long values', () => {
+    const longVal = 'x'.repeat(100);
+    const result = parseArgPreview(JSON.stringify({ key: longVal }));
+    expect(result).toContain('key=');
+    expect(result.length).toBeLessThan(150);
+  });
+});
+
+describe('formatResultPreview', () => {
+  it('returns plain string content', () => {
+    expect(formatResultPreview('"hello world"')).toBe('hello world');
+  });
+
+  it('returns item count for arrays', () => {
+    expect(formatResultPreview('[1, 2, 3]')).toBe('[3 items]');
+    expect(formatResultPreview('[42]')).toBe('[1 item]');
+  });
+
+  it('surfaces error from ok=false objects', () => {
+    expect(formatResultPreview('{"ok": false, "error": "rate limit"}')).toBe('error: rate limit');
+  });
+
+  it('formats object key=value pairs', () => {
+    const result = formatResultPreview('{"total": 10, "done": 5}');
+    expect(result).toContain('total: 10');
+    expect(result).toContain('done: 5');
+  });
+
+  it('returns raw string for non-JSON', () => {
+    expect(formatResultPreview('plain text output')).toBe('plain text output');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(formatResultPreview('')).toBe('');
+  });
+});

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -10,6 +10,7 @@
  */
 
 import * as icons from './icons';
+import { humanizeTool, parseArgsRaw, formatArgsCompact, shortenPath } from './format_utils';
 
 /** SSE activity message shape from the inspector stream. */
 export interface ActivityMessage {
@@ -64,31 +65,40 @@ export function formatActivitySummary(subtype: string, payload: Record<string, u
   const p = payload ?? {};
   switch (subtype) {
     case 'tool_invoked':
-      return `→ ${str(p, 'tool_name')} ${str(p, 'arg_preview')}`.trim();
+    case 'github_tool': {
+      // Icon already provides the arrow — no need for `→` text prefix.
+      const toolName = str(p, 'tool_name');
+      const argPreview = str(p, 'arg_preview');
+      const label = humanizeTool(toolName);
+      const parsed = parseArgsRaw(argPreview);
+      const argSummary = parsed !== null ? formatArgsCompact(parsed) : '';
+      return argSummary ? `${label}  ·  ${argSummary}` : label;
+    }
     case 'shell_start':
-      return `$ ${str(p, 'cmd_preview')}`.trim();
+      return str(p, 'cmd_preview') || 'shell';
     case 'shell_done': {
       const code = num(p, 'exit_code');
-      const prefix = code !== 0 ? `✗ exit=${code}` : `exit=${code}`;
-      return `${prefix}  ·  ${fmtBytes(num(p, 'stdout_bytes'))} stdout`;
+      const bytes = num(p, 'stdout_bytes');
+      if (code !== 0) return `exit ${code}  ·  ${fmtBytes(bytes)} out`;
+      return bytes > 0 ? fmtBytes(bytes) : 'ok';
     }
     case 'file_read': {
-      const path = str(p, 'path');
+      const path = shortenPath(str(p, 'path'));
       const s = num(p, 'start_line');
       const e = num(p, 'end_line');
       const t = num(p, 'total_lines');
       return `${path}  ·  ${s}–${e} of ${t}`;
     }
-    case 'file_replaced':
-      return `${str(p, 'path')}  ·  ${num(p, 'replacement_count')} replacement${num(p, 'replacement_count') === 1 ? '' : 's'}`.trim();
+    case 'file_replaced': {
+      const n = num(p, 'replacement_count');
+      return `${shortenPath(str(p, 'path'))}  ·  ${n} replacement${n === 1 ? '' : 's'}`;
+    }
     case 'file_inserted':
-      return `inserted ${str(p, 'path')}`.trim();
+      return shortenPath(str(p, 'path'));
     case 'file_written':
-      return `${str(p, 'path')}  ·  ${fmtBytes(num(p, 'byte_count'))}`.trim();
+      return `${shortenPath(str(p, 'path'))}  ·  ${fmtBytes(num(p, 'byte_count'))}`;
     case 'git_push':
-      return `→ ${str(p, 'branch')}`.trim();
-    case 'github_tool':
-      return `${str(p, 'tool_name')} ${str(p, 'arg_preview')}`.trim();
+      return str(p, 'branch') || 'push';
     case 'llm_iter': {
       const model = str(p, 'model') || 'unknown';
       const turns = num(p, 'turns');
@@ -107,7 +117,8 @@ export function formatActivitySummary(subtype: string, payload: Record<string, u
       return `(${fmtNum(num(p, 'chars'))} ch)  ${str(p, 'text_preview')}`.trim();
     case 'llm_done': {
       const count = num(p, 'tool_call_count');
-      if (count > 0) return `→ ${count} tool call${count === 1 ? '' : 's'}`;
+      // Suppress when tool calls are about to appear — they're shown as nested rows.
+      if (count > 0) return '';
       return str(p, 'stop_reason') || 'done';
     }
     case 'delay':
@@ -171,9 +182,10 @@ export function formatRelativeTime(recordedAt: string): string {
     if (Number.isNaN(t)) return '';
     if (feedStartMs === null) {
       feedStartMs = t;
-      return '+0s';
+      return 'now';
     }
     const delta = Math.max(0, Math.round((t - feedStartMs) / 1000));
+    if (delta === 0) return 'now';
     if (delta < 60) return `+${delta}s`;
     const m = Math.floor(delta / 60);
     const s = delta % 60;
@@ -196,6 +208,10 @@ export function appendActivityRow(msg: ActivityMessage): void {
   row.className = 'activity-feed__row';
   row.setAttribute('data-subtype', msg.subtype);
 
+  // Suppress empty summaries (e.g. llm_done when tool calls follow).
+  const summaryText = formatActivitySummary(msg.subtype, msg.payload);
+  if (summaryText === '') return;
+
   // Mark non-zero shell exits for CSS error highlighting
   if (msg.subtype === 'shell_done') {
     const code = typeof msg.payload['exit_code'] === 'number' ? msg.payload['exit_code'] : 0;
@@ -213,7 +229,7 @@ export function appendActivityRow(msg: ActivityMessage): void {
 
   const summary = document.createElement('span');
   summary.className = 'activity-feed__summary';
-  summary.textContent = formatActivitySummary(msg.subtype, msg.payload);
+  summary.textContent = summaryText;
 
   const ts = document.createElement('time');
   ts.className = 'activity-feed__ts';

--- a/agentception/static/js/format_utils.ts
+++ b/agentception/static/js/format_utils.ts
@@ -1,0 +1,214 @@
+/**
+ * format_utils.ts — shared formatting helpers for the activity feed.
+ *
+ * Used by both activity_feed.ts (tool_invoked rows) and tool_call_card.ts
+ * (structured tool-call cards). Keep this module free of DOM and icon imports.
+ */
+
+// ── Tool humanisation ──────────────────────────────────────────────────────────
+
+const TOOL_LABELS: Readonly<Record<string, string>> = {
+  read_file:              'Read file',
+  read_file_lines:        'Read file',
+  get_file_contents:      'Read file',
+  list_directory:         'List dir',
+  write_file:             'Write file',
+  create_file:            'Create file',
+  create_or_update_file:  'Write file',
+  replace_in_file:        'Edit file',
+  delete_file:            'Delete file',
+  search_codebase:        'Search',
+  search_text:            'Search',
+  grep_search:            'Grep',
+  find_files:             'Find files',
+  shell_exec:             'Shell',
+  execute_command:        'Run command',
+  run_command:            'Run command',
+  bash:                   'Shell',
+  create_pull_request:    'Open PR',
+  merge_pull_request:     'Merge PR',
+  create_branch:          'Create branch',
+  list_issues:            'List issues',
+  search_issues:          'Search issues',
+  issue_read:             'Read issue',
+  issue_write:            'Write issue',
+  add_issue_comment:      'Comment on issue',
+  search_pull_requests:   'Search PRs',
+  pull_request_read:      'Read PR',
+};
+
+/**
+ * Return a human-readable label for a tool name.
+ * Falls back to splitting underscores: "git_commit" → "Git commit".
+ */
+export function humanizeTool(name: string): string {
+  const label = TOOL_LABELS[name];
+  if (label !== undefined) return label;
+  // git_ prefix → "Git <rest>"
+  if (name.startsWith('git_')) return 'Git ' + name.slice(4).replace(/_/g, ' ');
+  // Otherwise: replace underscores with spaces, capitalise first word
+  const words = name.replace(/_/g, ' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+// ── Path shortening ────────────────────────────────────────────────────────────
+
+// Keys whose values are filesystem paths worth shortening.
+const PATH_KEYS = new Set(['path', 'file_path', 'filename', 'filepath']);
+
+/**
+ * Strip common runtime prefixes and return a compact path string.
+ *   ac://runs/{run_id}/agentception/foo.ts  →  agentception/foo.ts
+ *   /app/agentception/foo.ts                →  agentception/foo.ts
+ * Long paths show last two components:      →  …/js/foo.ts
+ */
+export function shortenPath(path: string): string {
+  let p = path
+    .replace(/^ac:\/\/runs\/[^/]+\//, '')   // strip ac://runs/{id}/
+    .replace(/^\/(?:app|workspace)\//, '')  // strip /app/ or /workspace/
+    .replace(/^\//, '');                    // strip any remaining leading /
+
+  const parts = p.split('/').filter(Boolean);
+  if (parts.length > 3 || p.length > 55) {
+    const tail = parts.slice(-2).join('/');
+    p = parts.length > 2 ? `…/${tail}` : tail;
+  }
+  return p;
+}
+
+// ── Arg parsing ────────────────────────────────────────────────────────────────
+
+// Noise keys — never worth surfacing in the compact display.
+const SKIP_KEYS = new Set([
+  'encoding', 'sudo', 'wait', 'timeout', 'recursive',
+  'follow_symbolic_links', 'ignore_case', 'case_sensitive',
+]);
+
+// These keys carry the "main" value of a tool call.
+const PRIMARY_KEYS = [
+  'path', 'command', 'query', 'pattern', 'branch',
+  'content', 'url', 'message', 'file_path',
+];
+
+/**
+ * Parse a raw arg string (JSON or Python dict str() notation) into an object.
+ * Returns null when the string is empty or cannot be parsed.
+ */
+export function parseArgsRaw(raw: string): Record<string, unknown> | null {
+  if (!raw || raw === '{}' || raw === '') return null;
+
+  // 1. Try JSON directly.
+  try {
+    const p = JSON.parse(raw);
+    if (p !== null && typeof p === 'object' && !Array.isArray(p)) {
+      return p as Record<string, unknown>;
+    }
+  } catch { /* fall through */ }
+
+  // 2. Convert Python dict notation → JSON and retry.
+  try {
+    const json = raw
+      .replace(/'/g, '"')
+      .replace(/\bTrue\b/g, 'true')
+      .replace(/\bFalse\b/g, 'false')
+      .replace(/\bNone\b/g, 'null');
+    const p = JSON.parse(json);
+    if (p !== null && typeof p === 'object' && !Array.isArray(p)) {
+      return p as Record<string, unknown>;
+    }
+  } catch { /* fall through */ }
+
+  return null;
+}
+
+/**
+ * Compact one-liner for a parsed args object.
+ * Finds the "primary" key (path, command, query…) and returns its value,
+ * cleaned up (path prefixes stripped, length capped).
+ * Falls back to the first non-noise key when no primary key is found.
+ */
+export function formatArgsCompact(args: Record<string, unknown>): string {
+  const entries = Object.entries(args).filter(([k]) => !SKIP_KEYS.has(k));
+  if (entries.length === 0) return '';
+
+  const primaryKey = PRIMARY_KEYS.find(k => args[k] !== undefined && args[k] !== null);
+
+  if (primaryKey !== undefined) {
+    const raw = String(args[primaryKey]);
+    const val = PATH_KEYS.has(primaryKey) ? shortenPath(raw) : raw;
+    return val.length > 80 ? val.slice(0, 77) + '…' : val;
+  }
+
+  // No recognised primary key — show first non-noise key=value.
+  const [k, v] = entries[0];
+  const raw = typeof v === 'string' ? v : JSON.stringify(v);
+  return `${k}: ${raw.length > 70 ? raw.slice(0, 67) + '…' : raw}`;
+}
+
+/**
+ * Full "key=value  ·  key=value" display for tool-call cards.
+ * All keys are shown (unlike compact which shows just the primary).
+ */
+export function formatArgsFull(args: Record<string, unknown>): string {
+  const entries = Object.entries(args);
+  if (entries.length === 0) return '';
+  return entries
+    .map(([k, v]) => {
+      const raw = typeof v === 'string' ? v : JSON.stringify(v);
+      const val = PATH_KEYS.has(k) ? shortenPath(raw.length > 70 ? raw.slice(0, 67) + '…' : raw) : (raw.length > 70 ? raw.slice(0, 67) + '…' : raw);
+      return `${k}=${val}`;
+    })
+    .join('  ·  ');
+}
+
+/**
+ * Convenience: parse raw arg string → full key=value display.
+ * Used by tool_call_card to render the args row.
+ */
+export function parseArgPreview(raw: string): string {
+  if (!raw || raw === '{}' || raw === '') return '';
+  const parsed = parseArgsRaw(raw);
+  if (parsed !== null) return formatArgsFull(parsed);
+  return raw.length >= 120 ? raw.slice(0, 117) + '…' : raw;
+}
+
+// ── Result formatting ──────────────────────────────────────────────────────────
+
+/**
+ * Format result_preview (JSON string from backend) into a human-readable line.
+ * Used by tool_call_card to render the result row.
+ */
+export function formatResultPreview(preview: string): string {
+  if (!preview) return '';
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(preview);
+  } catch {
+    const t = preview.trim();
+    return t.length > 240 ? t.slice(0, 237) + '…' : t;
+  }
+
+  if (typeof parsed === 'string') {
+    const t = parsed.trim();
+    return t.length > 240 ? t.slice(0, 237) + '…' : t;
+  }
+  if (Array.isArray(parsed)) {
+    return `[${parsed.length} item${parsed.length === 1 ? '' : 's'}]`;
+  }
+  if (parsed !== null && typeof parsed === 'object') {
+    const obj = parsed as Record<string, unknown>;
+    if ('ok' in obj && !obj['ok']) {
+      const msg = typeof obj['error'] === 'string' ? obj['error'] : 'unknown error';
+      return `error: ${msg}`;
+    }
+    return Object.entries(obj)
+      .slice(0, 4)
+      .map(([k, v]) => {
+        const raw = typeof v === 'string' ? v : JSON.stringify(v);
+        return `${k}: ${raw.length > 50 ? raw.slice(0, 47) + '…' : raw}`;
+      })
+      .join('  ·  ');
+  }
+  return String(parsed).slice(0, 240);
+}

--- a/agentception/static/js/tool_call_card.ts
+++ b/agentception/static/js/tool_call_card.ts
@@ -10,10 +10,14 @@
  *   with result text; falls back to a standalone card if none found.
  *
  * arg_preview comes from the backend as str(args)[:120] — Python dict notation.
- * We parse it into readable key=value pairs before display.
+ * Parsing and formatting is delegated to format_utils.
  */
 
 import * as icons from './icons';
+import { parseArgPreview, formatResultPreview, humanizeTool } from './format_utils';
+
+// Re-export so callers and tests can import from a single stable location.
+export { parseArgPreview, formatResultPreview } from './format_utils';
 
 interface ToolCallSseMessage {
   t: "tool_call";
@@ -50,99 +54,14 @@ function categoriseTool(toolName: string): ToolCategory {
 export function svgForTool(toolName: string): string {
   const category = categoriseTool(toolName);
   switch (category) {
-    case 'search':    return icons.search;
-    case 'file-read': return icons.fileDoc;
-    case 'file-write':return icons.pencil;
-    case 'shell':     return icons.terminal;
-    case 'git':       return icons.gitBranch;
-    case 'github':    return icons.gitHub;
-    default:          return icons.wrench;
+    case 'search':     return icons.search;
+    case 'file-read':  return icons.fileDoc;
+    case 'file-write': return icons.pencil;
+    case 'shell':      return icons.terminal;
+    case 'git':        return icons.gitBranch;
+    case 'github':     return icons.gitHub;
+    default:           return icons.wrench;
   }
-}
-
-// ── Arg formatting ─────────────────────────────────────────────────────────────
-
-/**
- * Parse the backend's args_preview (Python dict str() notation, truncated at
- * 120 chars) into a readable "key=value  ·  key=value" string.
- */
-export function parseArgPreview(raw: string): string {
-  if (!raw || raw === '{}' || raw === '') return '';
-
-  let parsed: Record<string, unknown> | null = null;
-
-  // 1. Try JSON directly.
-  try {
-    parsed = JSON.parse(raw) as Record<string, unknown>;
-  } catch {
-    // 2. Convert Python dict notation → JSON and retry.
-    try {
-      const json = raw
-        .replace(/'/g, '"')
-        .replace(/\bTrue\b/g, 'true')
-        .replace(/\bFalse\b/g, 'false')
-        .replace(/\bNone\b/g, 'null');
-      parsed = JSON.parse(json) as Record<string, unknown>;
-    } catch {
-      // 3. Return raw with a truncation marker if it was cut off.
-      return raw.length >= 120 ? raw.slice(0, 117) + '…' : raw;
-    }
-  }
-
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return raw;
-  }
-
-  const entries = Object.entries(parsed);
-  if (entries.length === 0) return '';
-
-  return entries
-    .map(([k, v]) => {
-      const raw = typeof v === 'string' ? v : JSON.stringify(v);
-      const val = raw.length > 70 ? raw.slice(0, 67) + '…' : raw;
-      return `${k}=${val}`;
-    })
-    .join('  ·  ');
-}
-
-// ── Result formatting ──────────────────────────────────────────────────────────
-
-/** Format result_preview (JSON string from backend) into a human-readable line. */
-export function formatResultPreview(preview: string): string {
-  if (!preview) return '';
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(preview);
-  } catch {
-    const t = preview.trim();
-    return t.length > 240 ? t.slice(0, 237) + '…' : t;
-  }
-
-  if (typeof parsed === 'string') {
-    const t = parsed.trim();
-    return t.length > 240 ? t.slice(0, 237) + '…' : t;
-  }
-  if (Array.isArray(parsed)) {
-    return `[${parsed.length} item${parsed.length === 1 ? '' : 's'}]`;
-  }
-  if (parsed !== null && typeof parsed === 'object') {
-    const obj = parsed as Record<string, unknown>;
-    // Surface errors immediately.
-    if ('ok' in obj && !obj['ok']) {
-      const msg = typeof obj['error'] === 'string' ? obj['error'] : 'unknown error';
-      return `error: ${msg}`;
-    }
-    // Show up to 4 key=value pairs.
-    return Object.entries(obj)
-      .slice(0, 4)
-      .map(([k, v]) => {
-        const raw = typeof v === 'string' ? v : JSON.stringify(v);
-        return `${k}: ${raw.length > 50 ? raw.slice(0, 47) + '…' : raw}`;
-      })
-      .join('  ·  ');
-  }
-  return String(parsed).slice(0, 240);
 }
 
 // ── DOM builders ───────────────────────────────────────────────────────────────
@@ -153,7 +72,7 @@ function buildToolCallCard(toolName: string, argsPreview: string): HTMLElement {
   card.dataset['tool'] = toolName;
   card.dataset['toolCategory'] = categoriseTool(toolName);
 
-  // Header: icon + tool name
+  // Header: icon + human-readable tool name
   const header = document.createElement('div');
   header.className = 'tool-call-card__header';
 
@@ -165,7 +84,7 @@ function buildToolCallCard(toolName: string, argsPreview: string): HTMLElement {
 
   const name = document.createElement('span');
   name.className = 'tool-call-card__name';
-  name.textContent = toolName;
+  name.textContent = humanizeTool(toolName);
 
   header.appendChild(icon);
   header.appendChild(name);

--- a/agentception/static/scss/pages/_activity-feed.scss
+++ b/agentception/static/scss/pages/_activity-feed.scss
@@ -31,6 +31,17 @@
   &[data-subtype="delay"]       { border-left-color: #f59e0b; opacity: 0.55; }
   &[data-subtype="error"]       { border-left-color: #ef4444; color: #fca5a5; }
 
+  // Nested rows — visually indented under the LLM iteration that spawned them.
+  // The left border stays at the container edge (tree connector effect).
+  &[data-subtype="tool_invoked"],
+  &[data-subtype="github_tool"],
+  &[data-subtype^="file_"],
+  &[data-subtype^="shell"],
+  &[data-subtype="git_push"],
+  &[data-subtype="delay"] {
+    padding-left: 1.4rem;
+  }
+
   // llm_iter: iteration milestone — slightly elevated, model name prominent
   &[data-subtype="llm_iter"] {
     color: rgba(167, 139, 250, 0.9);


### PR DESCRIPTION
## Summary

- **`format_utils.ts`** (new shared module): `humanizeTool`, `parseArgsRaw`, `formatArgsCompact`, `formatArgsFull`, `shortenPath`, `parseArgPreview`, `formatResultPreview` — single source of truth for all activity-feed formatting
- **No double-arrow**: `tool_invoked` rows drop the `→` text prefix (SVG icon already provides it)
- **Humanized tool names**: `read_file` → `Read file`, `run_command` → `Run command`, `create_pull_request` → `Open PR`, etc.
- **Compact args**: primary arg value displayed after `·` separator (path/command/query); `ac://runs/{id}/` and `/app/` prefixes stripped; deep paths abbreviated to last 2 components
- **Suppress redundant `llm_done`**: when `tool_call_count > 0`, the row is skipped — the tool invocation rows below it carry the same info
- **Visual nesting**: `tool_invoked`, `github_tool`, `file_*`, `shell_*`, `git_push`, `delay` rows get 1.4rem left-indent, forming a tree under the `llm_iter` parent
- **`+0s` → `now`**: first event and zero-delta events show `now` instead
- **Cleaner shell/file rows**: `shell_start` shows cmd only (no `$`); `shell_done` shows byte count or `ok`; file paths shortened
- **Tool cards show humanized names** too
- 209/209 tests passing; 31 new `format_utils` tests

## Test plan
- [ ] `npm test` — 209/209
- [ ] `npm run type-check` — zero errors
- [ ] `npm run build` — clean