### PR TITLE
feat: step groups, two-line iter, tool label/value, M:SS time

### DIFF
--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -5,9 +5,11 @@ import {
   attachActivityFeedHandler,
   getSubtypeIcon,
   resetFeedStartTime,
+  resetFeedSession,
   formatRelativeTime,
   type ActivityMessage,
 } from '../activity_feed';
+import { resetStepContext } from '../step_context';
 
 function makeSource(): EventSource {
   return new EventTarget() as unknown as EventSource;
@@ -103,10 +105,17 @@ describe('formatActivitySummary', () => {
     expect(formatActivitySummary('unknown_subtype', {})).toBe('unknown_subtype');
   });
 
-  it('formats llm_iter — model and turn at front', () => {
+  it('formats llm_iter with network: model · Iteration N', () => {
+    // claude-3-5 → 2-part version → Anthropic: 3.5
     expect(
       formatActivitySummary('llm_iter', { model: 'claude-3-5', turns: 2 })
-    ).toBe('claude-3-5  ·  turn 2');
+    ).toBe('Anthropic: 3.5  ·  Iteration 2');
+  });
+
+  it('formats llm_iter for local model', () => {
+    expect(
+      formatActivitySummary('llm_iter', { model: 'local', turns: 1 })
+    ).toBe('Local: local  ·  Iteration 1');
   });
 
   it('formats llm_usage as human-readable token counts', () => {
@@ -220,22 +229,22 @@ describe('formatRelativeTime', () => {
     expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('now');
   });
 
-  it('returns +Ns for subsequent events', () => {
-    resetFeedStartTime();
-    formatRelativeTime('2026-03-15T12:00:00Z'); // seed start time
-    expect(formatRelativeTime('2026-03-15T12:00:29Z')).toBe('+29s');
-  });
-
-  it('returns +Mm for minute offsets', () => {
+  it('returns M:SS for subsequent events (0:29 for 29 seconds)', () => {
     resetFeedStartTime();
     formatRelativeTime('2026-03-15T12:00:00Z');
-    expect(formatRelativeTime('2026-03-15T12:02:00Z')).toBe('+2m');
+    expect(formatRelativeTime('2026-03-15T12:00:29Z')).toBe('0:29');
   });
 
-  it('returns +MmNs for mixed offsets', () => {
+  it('returns M:SS with zero-padded seconds (2:00 for 2 minutes)', () => {
     resetFeedStartTime();
     formatRelativeTime('2026-03-15T12:00:00Z');
-    expect(formatRelativeTime('2026-03-15T12:01:05Z')).toBe('+1m5s');
+    expect(formatRelativeTime('2026-03-15T12:02:00Z')).toBe('2:00');
+  });
+
+  it('returns M:SS with zero-padded seconds (1:05 for 1m5s)', () => {
+    resetFeedStartTime();
+    formatRelativeTime('2026-03-15T12:00:00Z');
+    expect(formatRelativeTime('2026-03-15T12:01:05Z')).toBe('1:05');
   });
 
   it('returns empty string for invalid timestamp', () => {
@@ -248,6 +257,7 @@ describe('appendActivityRow', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="activity-feed"></div>';
     resetFeedStartTime();
+    resetStepContext();
   });
 
   it('appends a row with data-subtype, summary, and relative time', () => {
@@ -300,6 +310,31 @@ describe('appendActivityRow', () => {
     expect(row?.hasAttribute('data-exit-nonzero')).toBe(false);
   });
 
+  it('renders llm_iter as two-line summary (af__iter-model + af__iter-num)', () => {
+    appendActivityRow({
+      t: 'activity',
+      subtype: 'llm_iter',
+      payload: { model: 'local', turns: 1 },
+      recorded_at: '',
+    });
+    const row = document.querySelector('.activity-feed__row');
+    expect(row?.getAttribute('data-subtype')).toBe('llm_iter');
+    expect(row?.querySelector('.af__iter-model')?.textContent).toBe('Local: local');
+    expect(row?.querySelector('.af__iter-num')?.textContent).toBe('Iteration 1');
+  });
+
+  it('renders tool_invoked with split label / value spans', () => {
+    appendActivityRow({
+      t: 'activity',
+      subtype: 'tool_invoked',
+      payload: { tool_name: 'read_file', arg_preview: "{'path': 'src/foo.py'}" },
+      recorded_at: '',
+    });
+    const row = document.querySelector('.activity-feed__row');
+    expect(row?.querySelector('.af__tool-label')?.textContent).toBe('Read file');
+    expect(row?.querySelector('.af__tool-value')?.textContent).toContain('foo.py');
+  });
+
   it('does NOT append a row for llm_done when tool calls follow', () => {
     appendActivityRow({
       t: 'activity',
@@ -322,10 +357,19 @@ describe('appendActivityRow', () => {
   });
 });
 
+describe('resetFeedSession', () => {
+  it('resets feed start time and step context', () => {
+    resetFeedSession();
+    // After reset, the next event returns "now"
+    expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('now');
+  });
+});
+
 describe('attachActivityFeedHandler', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="activity-feed"></div>';
     resetFeedStartTime();
+    resetStepContext();
   });
 
   it('appends a row when msg.t === "activity"', () => {

--- a/agentception/static/js/__tests__/event_card.test.ts
+++ b/agentception/static/js/__tests__/event_card.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { attachEventCardHandler } from '../event_card';
+import { resetStepContext } from '../step_context';
 
 function makeSource(): EventSource {
   return new EventTarget() as unknown as EventSource;
@@ -12,13 +13,16 @@ function dispatch(src: EventTarget, data: object): void {
 describe('attachEventCardHandler', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="activity-feed"></div>';
+    resetStepContext();
   });
 
-  it('renders step_start card with correct text', () => {
+  it('renders step_start card inside a .step-group wrapper', () => {
     const src = makeSource();
     attachEventCardHandler(src);
     dispatch(src, { t: 'event', event_type: 'step_start', payload: { step: 'Step 2' }, recorded_at: '' });
-    const card = document.querySelector('.event-card');
+    const group = document.querySelector('.step-group');
+    expect(group).not.toBeNull();
+    const card = group?.querySelector('.event-card');
     expect(card).not.toBeNull();
     expect(card?.getAttribute('data-event-type')).toBe('step_start');
     expect(card?.querySelector('.event-card__text')?.textContent).toBe('Step 2');
@@ -30,6 +34,26 @@ describe('attachEventCardHandler', () => {
     dispatch(src, { t: 'event', event_type: 'step_start', payload: { step: 'Step 1' }, recorded_at: '' });
     const icon = document.querySelector('.event-card__icon');
     expect(icon?.innerHTML).toContain('<svg');
+  });
+
+  it('collapses the previous step group when a new step_start arrives', () => {
+    const src = makeSource();
+    attachEventCardHandler(src);
+    dispatch(src, { t: 'event', event_type: 'step_start', payload: { step: 'Step 1' }, recorded_at: '' });
+    dispatch(src, { t: 'event', event_type: 'step_start', payload: { step: 'Step 2' }, recorded_at: '' });
+    const groups = document.querySelectorAll('.step-group');
+    expect(groups.length).toBe(2);
+    expect(groups[0]?.classList.contains('step-group--collapsed')).toBe(true);
+    expect(groups[1]?.classList.contains('step-group--current')).toBe(true);
+  });
+
+  it('step_start card is clickable (has role=button)', () => {
+    const src = makeSource();
+    attachEventCardHandler(src);
+    dispatch(src, { t: 'event', event_type: 'step_start', payload: { step: 'Step 1' }, recorded_at: '' });
+    const card = document.querySelector('.event-card[data-event-type="step_start"]');
+    expect(card?.getAttribute('role')).toBe('button');
+    expect(card?.getAttribute('aria-expanded')).toBe('true');
   });
 
   it('renders done card with summary text', () => {

--- a/agentception/static/js/__tests__/format_utils.test.ts
+++ b/agentception/static/js/__tests__/format_utils.test.ts
@@ -7,7 +7,48 @@ import {
   formatArgsFull,
   parseArgPreview,
   formatResultPreview,
+  parseModelInfo,
 } from '../format_utils';
+
+describe('parseModelInfo', () => {
+  it('parses claude-sonnet-4-6 → Anthropic / sonnet 4.6', () => {
+    const result = parseModelInfo('claude-sonnet-4-6');
+    expect(result.network).toBe('Anthropic');
+    expect(result.modelShort).toBe('sonnet 4.6');
+  });
+
+  it('parses claude-opus-4-6 → Anthropic / opus 4.6', () => {
+    const result = parseModelInfo('claude-opus-4-6');
+    expect(result.network).toBe('Anthropic');
+    expect(result.modelShort).toBe('opus 4.6');
+  });
+
+  it('parses two-part claude version (claude-3-5 → Anthropic / 3.5)', () => {
+    const result = parseModelInfo('claude-3-5');
+    expect(result.network).toBe('Anthropic');
+    expect(result.modelShort).toBe('3.5');
+  });
+
+  it('parses local → Local / local', () => {
+    const result = parseModelInfo('local');
+    expect(result.network).toBe('Local');
+    expect(result.modelShort).toBe('local');
+  });
+
+  it('parses gpt-4o → OpenAI', () => {
+    expect(parseModelInfo('gpt-4o').network).toBe('OpenAI');
+  });
+
+  it('parses gemini-pro → Google', () => {
+    expect(parseModelInfo('gemini-pro').network).toBe('Google');
+  });
+
+  it('falls back to Remote for unknown models', () => {
+    const result = parseModelInfo('unknown-model-xyz');
+    expect(result.network).toBe('Remote');
+    expect(result.modelShort).toBe('unknown-model-xyz');
+  });
+});
 
 describe('humanizeTool', () => {
   it('maps known tool names to human labels', () => {

--- a/agentception/static/js/__tests__/step_context.test.ts
+++ b/agentception/static/js/__tests__/step_context.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getCurrentAppendTarget, openStepGroup, resetStepContext } from '../step_context';
+
+function makeFeed(): HTMLElement {
+  const el = document.createElement('div');
+  el.id = 'activity-feed';
+  document.body.appendChild(el);
+  return el;
+}
+
+function makeHeader(): HTMLElement {
+  const el = document.createElement('div');
+  el.className = 'event-card';
+  el.dataset['eventType'] = 'step_start';
+  return el;
+}
+
+describe('step_context', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    resetStepContext();
+  });
+
+  it('getCurrentAppendTarget returns feed when no step is open', () => {
+    const feed = makeFeed();
+    expect(getCurrentAppendTarget(feed)).toBe(feed);
+  });
+
+  it('getCurrentAppendTarget returns step body after openStepGroup', () => {
+    const feed = makeFeed();
+    openStepGroup(feed, makeHeader());
+    const target = getCurrentAppendTarget(feed);
+    expect(target).not.toBe(feed);
+    expect(target.classList.contains('step-group__body')).toBe(true);
+  });
+
+  it('openStepGroup appends a .step-group to feed', () => {
+    const feed = makeFeed();
+    openStepGroup(feed, makeHeader());
+    expect(feed.querySelector('.step-group')).not.toBeNull();
+  });
+
+  it('openStepGroup marks the new group --current', () => {
+    const feed = makeFeed();
+    openStepGroup(feed, makeHeader());
+    expect(feed.querySelector('.step-group--current')).not.toBeNull();
+  });
+
+  it('openStepGroup collapses the previous group on the second call', () => {
+    const feed = makeFeed();
+    openStepGroup(feed, makeHeader());
+    openStepGroup(feed, makeHeader());
+    const groups = feed.querySelectorAll('.step-group');
+    expect(groups.length).toBe(2);
+    expect(groups[0]?.classList.contains('step-group--collapsed')).toBe(true);
+    expect(groups[1]?.classList.contains('step-group--current')).toBe(true);
+  });
+
+  it('resetStepContext makes getCurrentAppendTarget return feed again', () => {
+    const feed = makeFeed();
+    openStepGroup(feed, makeHeader());
+    resetStepContext();
+    expect(getCurrentAppendTarget(feed)).toBe(feed);
+  });
+
+  it('the header element is placed inside the step-group', () => {
+    const feed = makeFeed();
+    const header = makeHeader();
+    openStepGroup(feed, header);
+    const group = feed.querySelector('.step-group');
+    expect(group?.contains(header)).toBe(true);
+  });
+});

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -7,10 +7,20 @@
  *
  * Smart scroll: new rows scroll the feed only when the user is already near
  * the bottom — reading old content is never interrupted.
+ *
+ * Step grouping: rows are appended into the current step group body (managed
+ * by step_context.ts) so they collapse when the next step starts.
  */
 
 import * as icons from './icons';
-import { humanizeTool, parseArgsRaw, formatArgsCompact, shortenPath } from './format_utils';
+import {
+  humanizeTool,
+  parseArgsRaw,
+  formatArgsCompact,
+  shortenPath,
+  parseModelInfo,
+} from './format_utils';
+import { getCurrentAppendTarget, resetStepContext } from './step_context';
 
 /** SSE activity message shape from the inspector stream. */
 export interface ActivityMessage {
@@ -60,13 +70,15 @@ export function shouldAutoScroll(feed: HTMLElement): boolean {
 /**
  * Human-readable one-line summary from subtype and payload.
  * Uses textContent-safe strings only (no innerHTML with payload).
+ * llm_iter returns a single-line fallback; the DOM builder in
+ * appendActivityRow produces the richer two-line layout.
  */
 export function formatActivitySummary(subtype: string, payload: Record<string, unknown>): string {
   const p = payload ?? {};
   switch (subtype) {
     case 'tool_invoked':
     case 'github_tool': {
-      // Icon already provides the arrow — no need for `→` text prefix.
+      // Icon already provides the arrow — no '→' text prefix needed.
       const toolName = str(p, 'tool_name');
       const argPreview = str(p, 'arg_preview');
       const label = humanizeTool(toolName);
@@ -100,9 +112,10 @@ export function formatActivitySummary(subtype: string, payload: Record<string, u
     case 'git_push':
       return str(p, 'branch') || 'push';
     case 'llm_iter': {
-      const model = str(p, 'model') || 'unknown';
+      // Single-line fallback (DOM builder renders two-line layout).
+      const { network, modelShort } = parseModelInfo(str(p, 'model'));
       const turns = num(p, 'turns');
-      return `${model}  ·  turn ${turns}`;
+      return `${network}: ${modelShort}  ·  Iteration ${turns}`;
     }
     case 'llm_usage': {
       const inp = num(p, 'input_tokens');
@@ -117,7 +130,7 @@ export function formatActivitySummary(subtype: string, payload: Record<string, u
       return `(${fmtNum(num(p, 'chars'))} ch)  ${str(p, 'text_preview')}`.trim();
     case 'llm_done': {
       const count = num(p, 'tool_call_count');
-      // Suppress when tool calls are about to appear — they're shown as nested rows.
+      // Suppress when tool calls follow — they are shown as nested rows below.
       if (count > 0) return '';
       return str(p, 'stop_reason') || 'done';
     }
@@ -175,7 +188,19 @@ export function resetFeedStartTime(): void {
   feedStartMs = null;
 }
 
-/** Format recorded_at as a relative offset from the first feed event: +0s, +1m5s, … */
+/**
+ * Reset all feed session state (timestamp + step groups).
+ * Call this whenever the feed is cleared or a new run begins.
+ */
+export function resetFeedSession(): void {
+  feedStartMs = null;
+  resetStepContext();
+}
+
+/**
+ * Format recorded_at as a timer offset from the first feed event.
+ * Uses M:SS notation: "now", "0:29", "1:05", "10:30".
+ */
 export function formatRelativeTime(recordedAt: string): string {
   try {
     const t = new Date(recordedAt).getTime();
@@ -186,17 +211,77 @@ export function formatRelativeTime(recordedAt: string): string {
     }
     const delta = Math.max(0, Math.round((t - feedStartMs) / 1000));
     if (delta === 0) return 'now';
-    if (delta < 60) return `+${delta}s`;
     const m = Math.floor(delta / 60);
     const s = delta % 60;
-    return s > 0 ? `+${m}m${s}s` : `+${m}m`;
+    const ss = s.toString().padStart(2, '0');
+    return `${m}:${ss}`;
   } catch {
     return '';
   }
 }
 
+// ── Row builders ───────────────────────────────────────────────────────────────
+
 /**
- * Create a single activity row and append it to #activity-feed.
+ * Build the summary element for a tool_invoked / github_tool row.
+ * The tool label uses a sans-serif span so it reads as a category,
+ * while the arg value spans in mono so it reads as data.
+ */
+function buildToolSummary(summaryText: string): HTMLElement {
+  const summary = document.createElement('span');
+  summary.className = 'activity-feed__summary';
+
+  const dotIdx = summaryText.indexOf('  ·  ');
+  if (dotIdx !== -1) {
+    const label = document.createElement('span');
+    label.className = 'af__tool-label';
+    label.textContent = summaryText.slice(0, dotIdx);
+
+    const sep = document.createElement('span');
+    sep.className = 'af__tool-sep';
+    sep.textContent = '  ·  ';
+
+    const val = document.createElement('span');
+    val.className = 'af__tool-value';
+    val.textContent = summaryText.slice(dotIdx + 5);
+
+    summary.appendChild(label);
+    summary.appendChild(sep);
+    summary.appendChild(val);
+  } else {
+    summary.textContent = summaryText;
+  }
+  return summary;
+}
+
+/**
+ * Build the two-line summary element for llm_iter rows:
+ *   Line 1 (prominent): "{network}: {modelShort}"  e.g. "Anthropic: sonnet 4.6"
+ *   Line 2 (muted):     "Iteration N"
+ */
+function buildIterSummary(payload: Record<string, unknown>): HTMLElement {
+  const { network, modelShort } = parseModelInfo(str(payload, 'model'));
+  const turns = num(payload, 'turns');
+
+  const summary = document.createElement('span');
+  summary.className = 'activity-feed__summary';
+
+  const line1 = document.createElement('span');
+  line1.className = 'af__iter-model';
+  line1.textContent = `${network}: ${modelShort}`;
+
+  const line2 = document.createElement('span');
+  line2.className = 'af__iter-num';
+  line2.textContent = `Iteration ${turns}`;
+
+  summary.appendChild(line1);
+  summary.appendChild(line2);
+  return summary;
+}
+
+/**
+ * Create a single activity row and append it to the current step body
+ * (or #activity-feed root if no step is open yet).
  * One SSE message → one DOM append. No innerHTML with payload data.
  * Icon column uses innerHTML with hardcoded SVG strings from icons.ts.
  */
@@ -204,20 +289,22 @@ export function appendActivityRow(msg: ActivityMessage): void {
   const feed = document.getElementById('activity-feed');
   if (!feed) return;
 
+  // Resolve the summary text first so we can bail on empty rows.
+  // llm_iter is handled separately (two-line DOM layout, no plain text needed).
+  let summaryText = '';
+  if (msg.subtype !== 'llm_iter') {
+    summaryText = formatActivitySummary(msg.subtype, msg.payload);
+    if (summaryText === '') return; // e.g. llm_done when tool calls follow
+  }
+
   const row = document.createElement('div');
   row.className = 'activity-feed__row';
   row.setAttribute('data-subtype', msg.subtype);
 
-  // Suppress empty summaries (e.g. llm_done when tool calls follow).
-  const summaryText = formatActivitySummary(msg.subtype, msg.payload);
-  if (summaryText === '') return;
-
-  // Mark non-zero shell exits for CSS error highlighting
+  // Mark non-zero shell exits for CSS error highlighting.
   if (msg.subtype === 'shell_done') {
     const code = typeof msg.payload['exit_code'] === 'number' ? msg.payload['exit_code'] : 0;
-    if (code !== 0) {
-      row.dataset['exitNonzero'] = 'true';
-    }
+    if (code !== 0) row.dataset['exitNonzero'] = 'true';
   }
 
   // Icon: hardcoded SVG via innerHTML (safe — getSubtypeIcon returns only static strings)
@@ -227,20 +314,32 @@ export function appendActivityRow(msg: ActivityMessage): void {
   // eslint-disable-next-line no-unsanitized/property
   icon.innerHTML = getSubtypeIcon(msg.subtype);
 
-  const summary = document.createElement('span');
-  summary.className = 'activity-feed__summary';
-  summary.textContent = summaryText;
-
+  // Timestamp
   const ts = document.createElement('time');
   ts.className = 'activity-feed__ts';
   ts.textContent = formatRelativeTime(msg.recorded_at);
   ts.setAttribute('datetime', msg.recorded_at);
   ts.setAttribute('title', msg.recorded_at);
 
+  // Summary — subtype-specific layout
+  let summaryEl: HTMLElement;
+  if (msg.subtype === 'llm_iter') {
+    summaryEl = buildIterSummary(msg.payload);
+  } else if (msg.subtype === 'tool_invoked' || msg.subtype === 'github_tool') {
+    summaryEl = buildToolSummary(summaryText);
+  } else {
+    summaryEl = document.createElement('span');
+    summaryEl.className = 'activity-feed__summary';
+    summaryEl.textContent = summaryText;
+  }
+
   row.appendChild(icon);
-  row.appendChild(summary);
+  row.appendChild(summaryEl);
   row.appendChild(ts);
-  feed.appendChild(row);
+
+  // Route into the current step body, or the feed root if no step is open.
+  const target = getCurrentAppendTarget(feed);
+  target.appendChild(row);
 
   if (shouldAutoScroll(feed)) {
     feed.scrollTop = feed.scrollHeight;

--- a/agentception/static/js/event_card.ts
+++ b/agentception/static/js/event_card.ts
@@ -2,7 +2,8 @@
  * EventCard — renders structured MCP lifecycle events in the activity feed.
  *
  * Handled event_types:
- *   step_start  ▶  agent begins a named step
+ *   step_start  ▶  agent begins a named step (wraps subsequent rows in a
+ *                  collapsible .step-group; click the header to expand/collapse)
  *   blocker     ⚠  agent is stalled on external dependency
  *   decision    ⚡  agent made an architectural choice
  *   done        ✓  agent declared work complete
@@ -11,6 +12,7 @@
  */
 
 import * as icons from './icons';
+import { openStepGroup } from './step_context';
 
 interface EventSseMessage {
   t: 'event';
@@ -45,7 +47,50 @@ function eventText(msg: EventSseMessage): string {
   }
 }
 
-/** Append a div.event-card to #activity-feed for each renderable SSE event. */
+/** Build and append a single event card. Exported for testing. */
+export function appendEventCard(feed: HTMLElement, m: EventSseMessage): void {
+  const card = document.createElement('div');
+  card.className = 'event-card';
+  card.dataset['eventType'] = m.event_type;
+
+  // Icon: hardcoded SVG via innerHTML (safe — EVENT_ICONS contains only static strings)
+  const icon = document.createElement('span');
+  icon.className = 'event-card__icon';
+  icon.setAttribute('aria-hidden', 'true');
+  // eslint-disable-next-line no-unsanitized/property
+  icon.innerHTML = EVENT_ICONS[m.event_type] ?? icons.dot;
+
+  const text = document.createElement('span');
+  text.className = 'event-card__text';
+  text.textContent = eventText(m);
+
+  card.appendChild(icon);
+  card.appendChild(text);
+
+  if (m.event_type === 'step_start') {
+    // step_start becomes the collapsible group header.
+    // The group auto-collapses the previous step and opens a fresh body.
+    card.classList.add('step-group__header');
+    card.setAttribute('role', 'button');
+    card.setAttribute('aria-expanded', 'true');
+    card.addEventListener('click', () => {
+      const group = card.closest<HTMLElement>('.step-group');
+      if (group === null) return;
+      const collapsed = group.classList.toggle('step-group--collapsed');
+      card.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    });
+    openStepGroup(feed, card);
+  } else {
+    feed.appendChild(card);
+  }
+
+  // Smart scroll: only scroll if user is near the bottom
+  if (feed.scrollHeight - feed.scrollTop - feed.clientHeight < 80) {
+    feed.scrollTop = feed.scrollHeight;
+  }
+}
+
+/** Register a handler on source that appends event cards to #activity-feed. */
 export function attachEventCardHandler(source: EventSource): void {
   source.addEventListener('message', (evt: MessageEvent<string>) => {
     let msg: AnySseMessage;
@@ -61,28 +106,6 @@ export function attachEventCardHandler(source: EventSource): void {
     const feed = document.getElementById('activity-feed');
     if (!feed) return;
 
-    const card = document.createElement('div');
-    card.className = 'event-card';
-    card.dataset['eventType'] = m.event_type;
-
-    // Icon: hardcoded SVG via innerHTML (safe — EVENT_ICONS contains only static strings)
-    const icon = document.createElement('span');
-    icon.className = 'event-card__icon';
-    icon.setAttribute('aria-hidden', 'true');
-    // eslint-disable-next-line no-unsanitized/property
-    icon.innerHTML = EVENT_ICONS[m.event_type] ?? icons.dot;
-
-    const text = document.createElement('span');
-    text.className = 'event-card__text';
-    text.textContent = eventText(m);
-
-    card.appendChild(icon);
-    card.appendChild(text);
-    feed.appendChild(card);
-
-    // Smart scroll: only scroll if user is near the bottom
-    if (feed.scrollHeight - feed.scrollTop - feed.clientHeight < 80) {
-      feed.scrollTop = feed.scrollHeight;
-    }
+    appendEventCard(feed, m);
   });
 }

--- a/agentception/static/js/format_utils.ts
+++ b/agentception/static/js/format_utils.ts
@@ -5,6 +5,55 @@
  * (structured tool-call cards). Keep this module free of DOM and icon imports.
  */
 
+// ── Model info ────────────────────────────────────────────────────────────────
+
+export interface ModelInfo {
+  /** Human-readable network/provider name: "Anthropic", "Local", "OpenAI", … */
+  network: string;
+  /** Short model label: "sonnet 4.6", "opus 4.6", "local", … */
+  modelShort: string;
+}
+
+/**
+ * Derive a network label and short model name from a raw model identifier.
+ *
+ * Examples:
+ *   "claude-sonnet-4-6"  → { network: "Anthropic", modelShort: "sonnet 4.6" }
+ *   "claude-opus-4-6"    → { network: "Anthropic", modelShort: "opus 4.6" }
+ *   "local"              → { network: "Local",      modelShort: "local" }
+ *   "gpt-4o"             → { network: "OpenAI",     modelShort: "gpt-4o" }
+ */
+export function parseModelInfo(model: string): ModelInfo {
+  const m = (model ?? '').trim();
+  const ml = m.toLowerCase();
+
+  if (ml.startsWith('claude-')) {
+    const afterClaude = m.slice('claude-'.length); // e.g. "sonnet-4-6"
+    const parts = afterClaude.split('-').filter(Boolean);
+    if (parts.length >= 3) {
+      // family + major.minor  e.g. ["sonnet", "4", "6"] → "sonnet 4.6"
+      const family = parts.slice(0, -2).join('-');
+      const ver = `${parts[parts.length - 2]}.${parts[parts.length - 1]}`;
+      return { network: 'Anthropic', modelShort: `${family} ${ver}`.trim() };
+    }
+    if (parts.length === 2) {
+      return { network: 'Anthropic', modelShort: `${parts[0]}.${parts[1]}` };
+    }
+    return { network: 'Anthropic', modelShort: afterClaude };
+  }
+  if (ml.startsWith('gpt-') || ml.startsWith('o1') || ml.startsWith('o3')) {
+    return { network: 'OpenAI', modelShort: m };
+  }
+  if (ml.startsWith('gemini')) {
+    return { network: 'Google', modelShort: m };
+  }
+  if (ml === 'local') {
+    return { network: 'Local', modelShort: 'local' };
+  }
+  // Unknown model — show as-is with a generic network label
+  return { network: 'Remote', modelShort: m };
+}
+
 // ── Tool humanisation ──────────────────────────────────────────────────────────
 
 const TOOL_LABELS: Readonly<Record<string, string>> = {

--- a/agentception/static/js/step_context.ts
+++ b/agentception/static/js/step_context.ts
@@ -1,0 +1,53 @@
+/**
+ * step_context.ts — shared singleton for step-group management in #activity-feed.
+ *
+ * event_card.ts calls openStepGroup() when a step_start event arrives.
+ * activity_feed.ts calls getCurrentAppendTarget() to route new rows into
+ * the current step's body element (rather than the feed root).
+ *
+ * Call resetStepContext() whenever the feed is cleared or a new run starts.
+ */
+
+/** The <div class="step-group__body"> of the currently open step, or null. */
+let _currentStepBody: HTMLElement | null = null;
+
+/**
+ * Return the element that new activity rows should be appended to.
+ * Falls back to feed when no step group has been opened yet.
+ */
+export function getCurrentAppendTarget(feed: HTMLElement): HTMLElement {
+  return _currentStepBody ?? feed;
+}
+
+/**
+ * Close the previous step group (collapses it) and open a new one.
+ * The supplied headerEl (the event-card div) is moved inside the group wrapper.
+ */
+export function openStepGroup(feed: HTMLElement, headerEl: HTMLElement): void {
+  // Collapse and deactivate the previous group, if any.
+  const prev = feed.querySelector<HTMLElement>('.step-group--current');
+  if (prev !== null) {
+    prev.classList.remove('step-group--current');
+    prev.classList.add('step-group--collapsed');
+  }
+
+  // Build the new group wrapper.
+  const group = document.createElement('div');
+  group.className = 'step-group step-group--current';
+
+  // The event-card header lives at the top of the group.
+  group.appendChild(headerEl);
+
+  // Body receives subsequent activity rows.
+  const body = document.createElement('div');
+  body.className = 'step-group__body';
+  group.appendChild(body);
+
+  feed.appendChild(group);
+  _currentStepBody = body;
+}
+
+/** Reset state — call when the feed is cleared or a new run begins. */
+export function resetStepContext(): void {
+  _currentStepBody = null;
+}

--- a/agentception/static/scss/pages/_activity-feed.scss
+++ b/agentception/static/scss/pages/_activity-feed.scss
@@ -42,17 +42,52 @@
     padding-left: 1.4rem;
   }
 
-  // llm_iter: iteration milestone — slightly elevated, model name prominent
+  // llm_iter: iteration milestone — two-line layout (model on line 1, iteration on line 2)
   &[data-subtype="llm_iter"] {
-    color: rgba(167, 139, 250, 0.9);
-    padding-top: 0.2rem;
-    padding-bottom: 0.15rem;
+    align-items: flex-start; // align icon to top of the two-line block
+    padding-top: 0.25rem;
+    padding-bottom: 0.2rem;
     border-left-width: 3px;
-    font-weight: 500;
+
+    .activity-feed__summary {
+      display: flex;
+      flex-direction: column;
+      gap: 0.1rem;
+    }
   }
 
   &[data-subtype="llm_usage"] {
     color: rgba(167, 139, 250, 0.5);
+  }
+
+  // Two-line llm_iter typography
+  .af__iter-model {
+    color: rgba(167, 139, 250, 0.9);
+    font-weight: 500;
+    font-size: 0.695rem;
+  }
+
+  .af__iter-num {
+    font-family: var(--font-sans, sans-serif);
+    font-size: 0.595rem;
+    font-weight: 400;
+    color: rgba(167, 139, 250, 0.45);
+    letter-spacing: 0.01em;
+  }
+
+  // Tool invoked: sans-serif label, mono value — visually separates category from data
+  .af__tool-label {
+    font-family: var(--font-sans, sans-serif);
+    color: rgba(255, 255, 255, 0.38);
+  }
+
+  .af__tool-sep {
+    color: rgba(255, 255, 255, 0.2);
+  }
+
+  .af__tool-value {
+    font-family: var(--font-mono);
+    color: rgba(255, 255, 255, 0.82);
   }
 
   // File writes are highlighted
@@ -120,8 +155,24 @@
 
   &[data-subtype^="shell"] { border-left-color: #9ca3af; }
 
-  &[data-subtype="llm_iter"] {
-    color: rgba(109, 40, 217, 0.9);
+  .af__iter-model {
+    color: rgba(109, 40, 217, 0.85);
+  }
+
+  .af__iter-num {
+    color: rgba(109, 40, 217, 0.45);
+  }
+
+  .af__tool-label {
+    color: rgba(0, 0, 0, 0.38);
+  }
+
+  .af__tool-sep {
+    color: rgba(0, 0, 0, 0.2);
+  }
+
+  .af__tool-value {
+    color: rgba(0, 0, 0, 0.8);
   }
 
   &[data-subtype="llm_usage"] {

--- a/agentception/static/scss/pages/_event-card.scss
+++ b/agentception/static/scss/pages/_event-card.scss
@@ -1,3 +1,37 @@
+// ── Step group — collapsible section wrapper ───────────────────────────────────
+//
+// event_card.ts wraps a step_start header + all subsequent activity rows inside
+// a .step-group div. When the next step arrives the previous group is collapsed.
+// Clicking the step header toggles .step-group--collapsed on the group.
+
+.step-group {
+  // No extra visual chrome — the header and body render as if they were at root.
+
+  &__body {
+    // Rows are hidden when the group is collapsed.
+  }
+
+  // Collapsed state: hide the body.
+  &--collapsed {
+    .step-group__body {
+      display: none;
+    }
+
+    // Rotate the chevron to show "expand" affordance.
+    .event-card[data-event-type='step_start'] .event-card__icon svg {
+      transform: rotate(0deg);
+    }
+  }
+
+  // Expanded/current state: chevron rotated 90° so the triangle points down.
+  &--current,
+  &:not(.step-group--collapsed) {
+    .event-card[data-event-type='step_start'] .event-card__icon svg {
+      transform: rotate(90deg);
+    }
+  }
+}
+
 // ── Event card ────────────────────────────────────────────────────────────────
 // Structured MCP lifecycle events: step_start, blocker, decision, done,
 // message (free-form agent note), error (structured MCP error).
@@ -17,7 +51,7 @@
   border-left: 2px solid transparent;
   line-height: 1.9;
 
-  // Step start: full-width section divider
+  // Step start: full-width section divider + click-to-collapse affordance
   &[data-event-type='step_start'] {
     margin-top: 0.5rem;
     padding-top: 0.4rem;
@@ -29,17 +63,27 @@
     font-weight: 700;
     letter-spacing: 0.1em;
     text-transform: uppercase;
+    cursor: pointer;
+    user-select: none;
 
-    // First step_start has no top separator
-    &:first-child {
+    &:hover {
+      color: rgba(255, 255, 255, 0.6);
+    }
+
+    // First step_start inside a group — no extra top separator needed
+    // since the group itself provides the separator.
+    .step-group:first-child & {
       margin-top: 0;
       border-top: none;
     }
 
     .event-card__icon {
       color: rgba(255, 255, 255, 0.3);
-      // Slightly smaller play triangle
-      svg { width: 9px; height: 9px; }
+      svg {
+        width: 9px;
+        height: 9px;
+        transition: transform 0.15s ease;
+      }
     }
   }
 
@@ -103,6 +147,10 @@
   &[data-event-type='step_start'] {
     border-top-color: rgba(0, 0, 0, 0.08);
     color: rgba(0, 0, 0, 0.4);
+
+    &:hover {
+      color: rgba(0, 0, 0, 0.65);
+    }
 
     .event-card__icon {
       color: rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
## Summary

- **Collapsible step groups**: `step_start` events now create a `.step-group` wrapper. When the next step arrives, the previous group auto-collapses. Click the step header to expand/collapse; chevron rotates 90° when expanded.
- **Two-line `llm_iter`**: Line 1 shows `{Network}: {model}` (e.g. `Anthropic: sonnet 4.6`); line 2 shows `Iteration N` (renamed from "turn"). `parseModelInfo()` derives network from model identifier.
- **Tool label / arg value split**: `tool_invoked` rows split into a sans-serif muted label (`Read file`) and a bright mono value (`src/foo.py`). Visual contrast makes it immediately clear what is the tool type vs what is the actual data.
- **M:SS time format**: `now`, `0:29`, `1:05`, `2:00` — timer-style, zero-padded seconds.
- `step_context.ts` (new): shared singleton; `getCurrentAppendTarget()` routes rows to the current step body; `resetFeedSession()` resets everything on run start.
- 229/229 tests; new `step_context.test.ts` (7 tests) and expanded `format_utils.test.ts`.

## Test plan
- [ ] `npm test` — 229/229
- [ ] `npm run type-check` — zero errors
- [ ] `npm run build` — clean