### PR TITLE
fix: .gitattributes for built bundles + codify dev→main merge strategy

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -99,8 +99,10 @@ Only fall back to `gh` CLI when the MCP server does not cover the required opera
    - `docker compose exec agentception npm run build` if any `.js` or `.scss` files changed
    CI does **not** run on feature → dev PRs. Local verification is the gate.
 5. **Open a PR** against `dev` via `create_pull_request` MCP tool (never push directly to `dev`).
-6. **Merge the PR immediately** via `merge_pull_request` MCP tool (squash). Do not wait for CI — it does not run on dev PRs. Never leave a PR open.
-7. **Delete the remote branch** — pass `deleteBranch: true` to `merge_pull_request`, or run `git push origin --delete <branch>`.
+6. **Merge the PR immediately** via `merge_pull_request` MCP tool. Do not wait for CI — it does not run on dev PRs. Never leave a PR open.
+   - **Feature → dev PRs:** use `mergeMethod: "squash"`. Collapses WIP commits into one clean unit; the feature branch is deleted so the squash is never re-traversed.
+   - **Dev → main PRs:** use `mergeMethod: "merge"` (a true merge commit, never squash). Squashing dev into main severs the commit-graph relationship between the branches, which means every subsequent dev→main merge sees conflicts even when nothing actually conflicts. A merge commit preserves both parents so the next merge correctly identifies what has already landed. After the merge commit, immediately pull main into dev (`git checkout dev && git merge origin/main && git push`) to advance the merge base before the next feature cycle.
+7. **Delete the remote branch** — pass `deleteBranch: true` to `merge_pull_request`, or run `git push origin --delete <branch>`. (For dev→main, set `deleteBranch: false` — `dev` is never deleted.)
 8. **Delete the local branch** — `git checkout dev && git branch -D <branch>`.
 9. **Pull dev** — `git pull origin dev`.
 10. **Verify clean** — `git status` must show `nothing to commit, working tree clean`.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,26 @@
-agentception/static/scss/pages/_build.scss merge=union
-agentception/static/scss/pages/_inspector-layout.scss merge=union
-agentception/static/scss/pages/_thought-block.scss merge=union
-agentception/static/scss/pages/_file-edit-card.scss merge=union
-agentception/static/scss/pages/_assistant-bubble.scss merge=union
-agentception/static/scss/pages/_tool-call-card.scss merge=union
-agentception/static/scss/pages/_event-card.scss merge=union
-agentception/db/queries/types.py merge=union
-agentception/db/queries/board.py merge=union
-agentception/db/queries/runs.py merge=union
-agentception/db/queries/messages.py merge=union
-agentception/db/queries/events.py merge=union
-agentception/db/queries/metrics.py merge=union
+# ── Text normalisation ─────────────────────────────────────────────────────────
+# Ensure consistent line endings across platforms.
+* text=auto
+
+# ── Generated / compiled bundles ───────────────────────────────────────────────
+# These files are produced by `npm run build` and committed as build artifacts.
+# They must never be text-merged — the result of a three-way merge of minified
+# JS or compiled CSS is always invalid.  During a dev → main merge, always
+# take the incoming (dev) version wholesale.  The next build will regenerate
+# them correctly from source anyway.
+agentception/static/app.js  merge=ours
+agentception/static/app.css merge=ours
+
+# ── Lock files ─────────────────────────────────────────────────────────────────
+# package-lock.json is auto-generated; merge conflicts in it are always noise.
+# Prefer the incoming side and let `npm install` reconcile if needed.
+package-lock.json merge=ours
+
+# ── Diffs ──────────────────────────────────────────────────────────────────────
+# Improve diff output for common file types.
+*.py    diff=python
+*.ts    diff=javascript
+*.js    diff=javascript
+*.scss  diff=css
+*.html  diff=html
+*.md    diff=markdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,9 @@ Every task follows this complete lifecycle — no step is optional:
    docker compose exec agentception npm run build   # only if .js or .scss files changed
    ```
 7. **Open a pull request.** Always create a PR against `dev` — never push directly. Use the `create_pull_request` MCP tool (preferred) or `gh pr create`. Every change, no matter how small, goes through a PR.
-8. **Merge the PR immediately.** Use `merge_pull_request` MCP tool (squash merge). Do not wait for CI — it does not run on feature → dev PRs. Do not leave PRs open.
+8. **Merge the PR immediately.** Use `merge_pull_request` MCP tool. Do not wait for CI — it does not run on feature → dev PRs. Do not leave PRs open.
+   - **Feature → dev:** `mergeMethod: "squash"` — collapses WIP history into one clean commit.
+   - **Dev → main:** `mergeMethod: "merge"` — never squash. Squashing dev into main severs the commit-graph relationship between the branches: git can no longer determine what has already been merged, so every subsequent dev→main PR generates spurious conflicts. A true merge commit preserves both parents and advances the merge base correctly. After the merge, immediately run `git checkout dev && git merge origin/main && git push` to re-sync the merge base before the next feature cycle.
 9. **Delete the remote branch.** The `merge_pull_request` MCP tool does this automatically with `deleteBranch: true`; if using `gh`, run `git push origin --delete <branch>`.
 10. **Delete the local branch.** `git checkout dev && git branch -D <branch>`.
 11. **Pull dev.** `git pull origin dev` — confirm `git status` shows `nothing to commit, working tree clean` before starting the next task.


### PR DESCRIPTION
## Root cause of recurring merge conflicts

Feature→dev PRs use **squash** (correct). Dev→main PRs were *also* using squash (incorrect).

Squash severs the commit-graph link between `dev` and `main`. Git determines "what needs merging" by finding the common ancestor of two branches. After a squash, the common ancestor is still the commit *before* the squash — not the squash commit itself, because it has no parent in `dev`'s history. So every subsequent dev→main PR sees:

> "Since the last common ancestor: `dev` added commits A, B, C and `main` added squash S."

Git tries to merge them as if S is brand-new content, even though S *is* A+B+C. The result is spurious conflicts in every file both branches touched. The band-aid was repeatedly merging `main` back into `dev` (the "Merge main into dev" commits), which temporarily restored a usable merge base.

## Fix

**`.gitattributes`** — tells git to always accept the incoming (`dev`) side for auto-generated build artifacts during merges:
- `agentception/static/app.js` — 450 KB minified IIFE; text-merging it is always wrong
- `agentception/static/app.css` — compiled SCSS; same
- `package-lock.json` — auto-generated; prefer incoming and let `npm install` reconcile if needed

Also configures language-specific diff drivers for better `git diff` output on `.py`, `.ts`, `.scss`, `.html`.

**`.cursorrules` / `AGENTS.md`** — codifies the rule so agents and humans never repeat the mistake:
- Feature → dev: `mergeMethod: "squash"` ✔️
- Dev → main: `mergeMethod: "merge"` (true merge commit) ✔️ — never squash
- After each dev→main merge: immediately `git checkout dev && git merge origin/main && git push` to advance the merge base before the next feature cycle

## Test plan
- [ ] After merging this PR into `dev`, merge `dev` into `main` (PR #1102) using `mergeMethod: "merge"`
- [ ] Confirm no conflicts
- [ ] After that merge, pull `main` into `dev` and verify clean `git status`