### PR TITLE
fix: branch name truncates to card width (not hardcoded length)

### DIFF
--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -596,11 +596,16 @@ body:has(.build-layout) nav.topnav {
 }
 
 // PR chip row (PR Open / Reviewing lanes).
+// width: 100% is required so that .build-issue__branch's max-width: 100%
+// resolves against the card width rather than its own content width.
+// Without it the parent flex container shrinks to content and truncation
+// never triggers regardless of how long the branch name is.
 .build-issue__pr-row {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
   align-items: flex-start;
+  width: 100%;
 }
 
 .build-issue__pr-chip {


### PR DESCRIPTION
## Problem

`agent/documentation-improvement-c3ee` was overflowing the card boundary instead of truncating with an ellipsis.

`.build-issue__branch` already had all the right CSS:
```scss
white-space: nowrap;
overflow: hidden;
text-overflow: ellipsis;
max-width: 100%;
```

...but truncation never fired. The root cause:

`.build-issue__pr-row` is a `flex-direction: column` container inside `.build-issue__footer`, which has `align-items: flex-start`. That alignment mode sizes flex children to their **content width** rather than stretching them. So `max-width: 100%` on `.build-issue__branch` resolved against the branch name's own intrinsic width — a circular reference that made the constraint a no-op.

## Fix

Add `width: 100%` to `.build-issue__pr-row`. The row now fills the card width, giving `max-width: 100%` on the branch span a real anchor to resolve against. The ellipsis then fires at the card boundary, regardless of how long the branch name is.