### PR TITLE
fix: activity feed — remove color borders, drop iteration count, fix local model name

### DIFF
--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -1099,7 +1099,9 @@ async def call_local_with_tools(
             session,
             run_id,
             "llm_iter",
-            {"iteration": iteration, "model": model, "turns": len(messages)},
+            # Use the resolved model name so the UI shows e.g. "qwen2.5:7b"
+            # rather than the generic "local" default parameter value.
+            {"iteration": iteration, "model": agent_model or model, "turns": len(messages)},
         )
         await session.flush()
 

--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -105,17 +105,22 @@ describe('formatActivitySummary', () => {
     expect(formatActivitySummary('unknown_subtype', {})).toBe('unknown_subtype');
   });
 
-  it('formats llm_iter with network: model · Iteration N', () => {
-    // claude-3-5 → 2-part version → Anthropic: 3.5
+  it('formats llm_iter as network: modelShort (no iteration count)', () => {
     expect(
       formatActivitySummary('llm_iter', { model: 'claude-3-5', turns: 2 })
-    ).toBe('Anthropic: 3.5  ·  Iteration 2');
+    ).toBe('Anthropic: 3.5');
   });
 
-  it('formats llm_iter for local model', () => {
+  it('formats llm_iter for local placeholder model as just "Local"', () => {
     expect(
       formatActivitySummary('llm_iter', { model: 'local', turns: 1 })
-    ).toBe('Local: local  ·  Iteration 1');
+    ).toBe('Local');
+  });
+
+  it('formats llm_iter for Ollama Qwen model', () => {
+    expect(
+      formatActivitySummary('llm_iter', { model: 'qwen2.5:7b', turns: 1 })
+    ).toBe('Local: Qwen 2.5');
   });
 
   it('formats llm_usage as human-readable token counts', () => {
@@ -310,7 +315,20 @@ describe('appendActivityRow', () => {
     expect(row?.hasAttribute('data-exit-nonzero')).toBe(false);
   });
 
-  it('renders llm_iter as two-line summary (af__iter-model + af__iter-num)', () => {
+  it('renders llm_iter as single-line summary with af__iter-model span', () => {
+    appendActivityRow({
+      t: 'activity',
+      subtype: 'llm_iter',
+      payload: { model: 'qwen2.5:7b', turns: 1 },
+      recorded_at: '',
+    });
+    const row = document.querySelector('.activity-feed__row');
+    expect(row?.getAttribute('data-subtype')).toBe('llm_iter');
+    expect(row?.querySelector('.af__iter-model')?.textContent).toBe('Local: Qwen 2.5');
+    expect(row?.querySelector('.af__iter-num')).toBeNull();
+  });
+
+  it('renders llm_iter for unknown local model as just "Local"', () => {
     appendActivityRow({
       t: 'activity',
       subtype: 'llm_iter',
@@ -318,9 +336,7 @@ describe('appendActivityRow', () => {
       recorded_at: '',
     });
     const row = document.querySelector('.activity-feed__row');
-    expect(row?.getAttribute('data-subtype')).toBe('llm_iter');
-    expect(row?.querySelector('.af__iter-model')?.textContent).toBe('Local: local');
-    expect(row?.querySelector('.af__iter-num')?.textContent).toBe('Iteration 1');
+    expect(row?.querySelector('.af__iter-model')?.textContent).toBe('Local');
   });
 
   it('renders tool_invoked with split label / value spans', () => {

--- a/agentception/static/js/__tests__/format_utils.test.ts
+++ b/agentception/static/js/__tests__/format_utils.test.ts
@@ -8,6 +8,7 @@ import {
   parseArgPreview,
   formatResultPreview,
   parseModelInfo,
+  modelLabel,
 } from '../format_utils';
 
 describe('parseModelInfo', () => {
@@ -29,10 +30,40 @@ describe('parseModelInfo', () => {
     expect(result.modelShort).toBe('3.5');
   });
 
-  it('parses local → Local / local', () => {
+  it('parses local → Local with empty modelShort (avoids "Local: local")', () => {
     const result = parseModelInfo('local');
     expect(result.network).toBe('Local');
-    expect(result.modelShort).toBe('local');
+    expect(result.modelShort).toBe('');
+  });
+
+  it('parses qwen2.5:7b → Local / Qwen 2.5', () => {
+    const result = parseModelInfo('qwen2.5:7b');
+    expect(result.network).toBe('Local');
+    expect(result.modelShort).toBe('Qwen 2.5');
+  });
+
+  it('parses qwen3:14b → Local / Qwen 3', () => {
+    const result = parseModelInfo('qwen3:14b');
+    expect(result.network).toBe('Local');
+    expect(result.modelShort).toBe('Qwen 3');
+  });
+
+  it('parses qwen2.5-coder:7b → Local / Qwen 2.5', () => {
+    const result = parseModelInfo('qwen2.5-coder:7b');
+    expect(result.network).toBe('Local');
+    expect(result.modelShort).toBe('Qwen 2.5');
+  });
+
+  it('parses llama3.1:8b → Local / Llama 3.1', () => {
+    const result = parseModelInfo('llama3.1:8b');
+    expect(result.network).toBe('Local');
+    expect(result.modelShort).toBe('Llama 3.1');
+  });
+
+  it('parses mistral:7b → Local / Mistral', () => {
+    const result = parseModelInfo('mistral:7b');
+    expect(result.network).toBe('Local');
+    expect(result.modelShort).toBe('Mistral');
   });
 
   it('parses gpt-4o → OpenAI', () => {
@@ -47,6 +78,20 @@ describe('parseModelInfo', () => {
     const result = parseModelInfo('unknown-model-xyz');
     expect(result.network).toBe('Remote');
     expect(result.modelShort).toBe('unknown-model-xyz');
+  });
+});
+
+describe('modelLabel', () => {
+  it('formats network + modelShort when both present', () => {
+    expect(modelLabel({ network: 'Anthropic', modelShort: 'sonnet 4.6' })).toBe('Anthropic: sonnet 4.6');
+  });
+
+  it('shows just network when modelShort is empty (avoids "Local: local")', () => {
+    expect(modelLabel({ network: 'Local', modelShort: '' })).toBe('Local');
+  });
+
+  it('formats local Qwen model', () => {
+    expect(modelLabel(parseModelInfo('qwen2.5:7b'))).toBe('Local: Qwen 2.5');
   });
 });
 

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -19,6 +19,7 @@ import {
   formatArgsCompact,
   shortenPath,
   parseModelInfo,
+  modelLabel,
 } from './format_utils';
 import { getCurrentAppendTarget, resetStepContext } from './step_context';
 
@@ -111,12 +112,8 @@ export function formatActivitySummary(subtype: string, payload: Record<string, u
       return `${shortenPath(str(p, 'path'))}  ·  ${fmtBytes(num(p, 'byte_count'))}`;
     case 'git_push':
       return str(p, 'branch') || 'push';
-    case 'llm_iter': {
-      // Single-line fallback (DOM builder renders two-line layout).
-      const { network, modelShort } = parseModelInfo(str(p, 'model'));
-      const turns = num(p, 'turns');
-      return `${network}: ${modelShort}  ·  Iteration ${turns}`;
-    }
+    case 'llm_iter':
+      return modelLabel(parseModelInfo(str(p, 'model')));
     case 'llm_usage': {
       const inp = num(p, 'input_tokens');
       const cw  = num(p, 'cache_write');
@@ -255,27 +252,18 @@ function buildToolSummary(summaryText: string): HTMLElement {
 }
 
 /**
- * Build the two-line summary element for llm_iter rows:
- *   Line 1 (prominent): "{network}: {modelShort}"  e.g. "Anthropic: sonnet 4.6"
- *   Line 2 (muted):     "Iteration N"
+ * Build the summary element for llm_iter rows.
+ * Shows "{network}: {modelShort}" or just "{network}" when the model is unknown.
  */
 function buildIterSummary(payload: Record<string, unknown>): HTMLElement {
-  const { network, modelShort } = parseModelInfo(str(payload, 'model'));
-  const turns = num(payload, 'turns');
-
   const summary = document.createElement('span');
   summary.className = 'activity-feed__summary';
 
-  const line1 = document.createElement('span');
-  line1.className = 'af__iter-model';
-  line1.textContent = `${network}: ${modelShort}`;
+  const label = document.createElement('span');
+  label.className = 'af__iter-model';
+  label.textContent = modelLabel(parseModelInfo(str(payload, 'model')));
 
-  const line2 = document.createElement('span');
-  line2.className = 'af__iter-num';
-  line2.textContent = `Iteration ${turns}`;
-
-  summary.appendChild(line1);
-  summary.appendChild(line2);
+  summary.appendChild(label);
   return summary;
 }
 

--- a/agentception/static/js/format_utils.ts
+++ b/agentception/static/js/format_utils.ts
@@ -10,18 +10,35 @@
 export interface ModelInfo {
   /** Human-readable network/provider name: "Anthropic", "Local", "OpenAI", … */
   network: string;
-  /** Short model label: "sonnet 4.6", "opus 4.6", "local", … */
+  /**
+   * Short model label: "sonnet 4.6", "Qwen 2.5", …
+   * Empty string when the model is unknown local — display as just `network`.
+   */
   modelShort: string;
 }
 
 /**
+ * Format a ModelInfo into a display label.
+ * Shows "{network}: {modelShort}" when modelShort is known, otherwise "{network}".
+ */
+export function modelLabel(info: ModelInfo): string {
+  return info.modelShort ? `${info.network}: ${info.modelShort}` : info.network;
+}
+
+/**
  * Derive a network label and short model name from a raw model identifier.
+ * Handles Anthropic (claude-*), OpenAI (gpt-*, o1, o3), Google (gemini-*),
+ * and common local/Ollama model families (qwen*, llama*, mistral*, phi*, deepseek*).
  *
  * Examples:
- *   "claude-sonnet-4-6"  → { network: "Anthropic", modelShort: "sonnet 4.6" }
- *   "claude-opus-4-6"    → { network: "Anthropic", modelShort: "opus 4.6" }
- *   "local"              → { network: "Local",      modelShort: "local" }
- *   "gpt-4o"             → { network: "OpenAI",     modelShort: "gpt-4o" }
+ *   "claude-sonnet-4-6"   → { network: "Anthropic", modelShort: "sonnet 4.6" }
+ *   "claude-opus-4-6"     → { network: "Anthropic", modelShort: "opus 4.6" }
+ *   "qwen2.5-coder:7b"    → { network: "Local",     modelShort: "Qwen 2.5" }
+ *   "qwen3:14b"           → { network: "Local",     modelShort: "Qwen 3" }
+ *   "llama3.1:8b"         → { network: "Local",     modelShort: "Llama 3.1" }
+ *   "mistral:7b"          → { network: "Local",     modelShort: "Mistral" }
+ *   "local"               → { network: "Local",     modelShort: "" }
+ *   "gpt-4o"              → { network: "OpenAI",    modelShort: "gpt-4o" }
  */
 export function parseModelInfo(model: string): ModelInfo {
   const m = (model ?? '').trim();
@@ -47,8 +64,41 @@ export function parseModelInfo(model: string): ModelInfo {
   if (ml.startsWith('gemini')) {
     return { network: 'Google', modelShort: m };
   }
+
+  // Local/Ollama model families.
+  // Strip Ollama size tags (:7b, :14b, :latest) before matching family names.
+  const ollamaBase = ml.replace(/:.*$/, '');
+
+  if (ollamaBase.startsWith('qwen')) {
+    const match = ollamaBase.match(/qwen(\d+(?:\.\d+)?)/);
+    const ver = match?.[1] ?? '';
+    return { network: 'Local', modelShort: ver ? `Qwen ${ver}` : 'Qwen' };
+  }
+  if (ollamaBase.startsWith('llama')) {
+    const match = ollamaBase.match(/llama(\d+(?:\.\d+)?)/);
+    const ver = match?.[1] ?? '';
+    return { network: 'Local', modelShort: ver ? `Llama ${ver}` : 'Llama' };
+  }
+  if (ollamaBase.startsWith('mistral')) {
+    return { network: 'Local', modelShort: 'Mistral' };
+  }
+  if (ollamaBase.startsWith('phi')) {
+    const match = ollamaBase.match(/phi(\d+(?:\.\d+)?)/);
+    const ver = match?.[1] ?? '';
+    return { network: 'Local', modelShort: ver ? `Phi ${ver}` : 'Phi' };
+  }
+  if (ollamaBase.startsWith('deepseek')) {
+    return { network: 'Local', modelShort: 'DeepSeek' };
+  }
+  if (ollamaBase.startsWith('gemma')) {
+    const match = ollamaBase.match(/gemma(\d+(?:\.\d+)?)/);
+    const ver = match?.[1] ?? '';
+    return { network: 'Local', modelShort: ver ? `Gemma ${ver}` : 'Gemma' };
+  }
+
   if (ml === 'local') {
-    return { network: 'Local', modelShort: 'local' };
+    // Generic local placeholder — show just "Local" with no redundant suffix.
+    return { network: 'Local', modelShort: '' };
   }
   // Unknown model — show as-is with a generic network label
   return { network: 'Remote', modelShort: m };

--- a/agentception/static/scss/pages/_activity-feed.scss
+++ b/agentception/static/scss/pages/_activity-feed.scss
@@ -21,15 +21,8 @@
     background: rgba(255, 255, 255, 0.03);
   }
 
-  // Color-coded left border by event category
-  &[data-subtype^="llm"]   { border-left-color: #7c3aed; }
-  &[data-subtype^="file"]  { border-left-color: #10b981; }
-  &[data-subtype="tool_invoked"],
-  &[data-subtype="github_tool"] { border-left-color: #f59e0b; }
-  &[data-subtype^="shell"] { border-left-color: #4b5563; }
-  &[data-subtype="git_push"]    { border-left-color: #38bdf8; }
-  &[data-subtype="delay"]       { border-left-color: #f59e0b; opacity: 0.55; }
-  &[data-subtype="error"]       { border-left-color: #ef4444; color: #fca5a5; }
+  &[data-subtype="delay"]  { opacity: 0.55; }
+  &[data-subtype="error"]  { border-left-color: #ef4444; color: #fca5a5; }
 
   // Nested rows — visually indented under the LLM iteration that spawned them.
   // The left border stays at the container edge (tree connector effect).
@@ -42,37 +35,20 @@
     padding-left: 1.4rem;
   }
 
-  // llm_iter: iteration milestone — two-line layout (model on line 1, iteration on line 2)
+  // llm_iter: LLM iteration milestone row — slightly elevated typography
   &[data-subtype="llm_iter"] {
-    align-items: flex-start; // align icon to top of the two-line block
-    padding-top: 0.25rem;
-    padding-bottom: 0.2rem;
-    border-left-width: 3px;
-
-    .activity-feed__summary {
-      display: flex;
-      flex-direction: column;
-      gap: 0.1rem;
-    }
+    padding-top: 0.2rem;
+    padding-bottom: 0.15rem;
   }
 
   &[data-subtype="llm_usage"] {
     color: rgba(167, 139, 250, 0.5);
   }
 
-  // Two-line llm_iter typography
   .af__iter-model {
     color: rgba(167, 139, 250, 0.9);
     font-weight: 500;
     font-size: 0.695rem;
-  }
-
-  .af__iter-num {
-    font-family: var(--font-sans, sans-serif);
-    font-size: 0.595rem;
-    font-weight: 400;
-    color: rgba(167, 139, 250, 0.45);
-    letter-spacing: 0.01em;
   }
 
   // Tool invoked: sans-serif label, mono value — visually separates category from data
@@ -118,11 +94,6 @@
     }
   }
 
-  // llm_iter icon slightly brighter to match the elevated row
-  &[data-subtype="llm_iter"] .activity-feed__icon {
-    opacity: 0.85;
-  }
-
   .activity-feed__summary {
     min-width: 0;
     overflow: hidden;
@@ -157,10 +128,6 @@
 
   .af__iter-model {
     color: rgba(109, 40, 217, 0.85);
-  }
-
-  .af__iter-num {
-    color: rgba(109, 40, 217, 0.45);
   }
 
   .af__tool-label {


### PR DESCRIPTION
## Summary

Three fixes to the `llm_iter` row in the activity feed:

### 1. Remove colour-coded left borders
The per-category `border-left-color` rules added visual noise without meaning. Only error/non-zero-exit rows keep a coloured border (those carry real signal).

### 2. Drop "Iteration N" second line
The step count already establishes context; the iteration number inside a step is redundant noise. `buildIterSummary` now renders a single `.af__iter-model` span. Matching SCSS removes the `flex-direction: column` layout and the now-unused `.af__iter-num` selector.

### 3. Fix "Local: local" → "Local: Qwen 2.5" (or just "Local")

Two root causes:

**Backend (`llm.py`):** `local_llm_tool_call` was emitting `llm_iter` with `"model": model` — the default parameter value `"local"` — instead of `"model": agent_model or model`, the resolved setting (e.g. `"qwen2.5:7b"`).

**Frontend (`format_utils.ts`):** `parseModelInfo` had no handling for Ollama model strings. Added recognition for Qwen, Llama, Mistral, Phi, DeepSeek, and Gemma families, stripping Ollama size tags (`:7b`, `:14b`) for display:
- `"qwen2.5:7b"` → `Local: Qwen 2.5`
- `"qwen3:14b"` → `Local: Qwen 3`
- `"llama3.1:8b"` → `Local: Llama 3.1`
- `"local"` (unknown fallback) → `Local` (no redundant `: local` suffix)

Added `modelLabel(info)` helper that emits `"Network: model"` or just `"Network"` when modelShort is empty.

## Tests
239/239 passing, 0 mypy errors, 0 tsc errors.