### PR TITLE
feat: expandable tool call rows in activity feed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ RUN ARCH=$(dpkg --print-architecture) \
 # Install Node.js dependencies — Linux-native binaries baked into the image.
 # A named volume (node_modules) in docker-compose preserves this layer at runtime
 # so the ./:/app bind mount cannot shadow it with macOS host binaries.
-COPY package.json package-lock.json tsconfig.json /app/
+COPY package.json package-lock.json tsconfig.json vitest.config.ts /app/
 RUN npm ci --include=dev
 
 # Install Python dependencies.

--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -351,6 +351,77 @@ describe('appendActivityRow', () => {
     expect(row?.querySelector('.af__tool-value')?.textContent).toContain('foo.py');
   });
 
+  describe('expandable tool rows', () => {
+    it('tool_invoked row has data-expandable and aria-expanded=false', () => {
+      appendActivityRow({
+        t: 'activity',
+        subtype: 'tool_invoked',
+        payload: { tool_name: 'read_file', arg_preview: '{"path": "foo.py"}' },
+        recorded_at: '',
+      });
+      const row = document.querySelector<HTMLElement>('.activity-feed__row');
+      expect(row?.dataset['expandable']).toBe('true');
+      expect(row?.getAttribute('aria-expanded')).toBe('false');
+      expect(row?.querySelector('.af__chevron')).not.toBeNull();
+    });
+
+    it('clicking a tool_invoked row reveals its detail panel', () => {
+      appendActivityRow({
+        t: 'activity',
+        subtype: 'tool_invoked',
+        payload: { tool_name: 'read_file', arg_preview: '{"path": "foo.py"}' },
+        recorded_at: '',
+      });
+      const row = document.querySelector<HTMLElement>('.activity-feed__row');
+      const detail = document.querySelector('.af__tool-detail');
+      expect(detail?.hasAttribute('hidden')).toBe(true);
+      row?.click();
+      expect(detail?.hasAttribute('hidden')).toBe(false);
+      expect(row?.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('clicking again collapses the detail panel', () => {
+      appendActivityRow({
+        t: 'activity',
+        subtype: 'tool_invoked',
+        payload: { tool_name: 'read_file', arg_preview: '{"path": "foo.py"}' },
+        recorded_at: '',
+      });
+      const row = document.querySelector<HTMLElement>('.activity-feed__row');
+      const detail = document.querySelector('.af__tool-detail');
+      row?.click();
+      row?.click();
+      expect(detail?.hasAttribute('hidden')).toBe(true);
+      expect(row?.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('detail panel shows parsed arg key-value pairs', () => {
+      appendActivityRow({
+        t: 'activity',
+        subtype: 'tool_invoked',
+        payload: { tool_name: 'read_file', arg_preview: '{"path": "src/main.py", "encoding": "utf-8"}' },
+        recorded_at: '',
+      });
+      const row = document.querySelector<HTMLElement>('.activity-feed__row');
+      row?.click();
+      const keys = Array.from(document.querySelectorAll('.af__detail-key')).map(el => el.textContent);
+      const vals = Array.from(document.querySelectorAll('.af__detail-val')).map(el => el.textContent);
+      expect(keys).toContain('path');
+      expect(vals.some(v => v?.includes('main.py'))).toBe(true);
+    });
+
+    it('non-tool rows (llm_usage) do not get data-expandable', () => {
+      appendActivityRow({
+        t: 'activity',
+        subtype: 'llm_usage',
+        payload: { input_tokens: 100, cache_write: 0, cache_read: 0 },
+        recorded_at: '',
+      });
+      const row = document.querySelector<HTMLElement>('.activity-feed__row');
+      expect(row?.dataset['expandable']).toBeUndefined();
+    });
+  });
+
   it('does NOT append a row for llm_done when tool calls follow', () => {
     appendActivityRow({
       t: 'activity',

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -21,6 +21,9 @@ import {
   parseModelInfo,
   modelLabel,
 } from './format_utils';
+
+/** Subtypes that support click-to-expand args detail. */
+const EXPANDABLE_SUBTYPES = new Set(['tool_invoked', 'github_tool']);
 import { getCurrentAppendTarget, resetStepContext } from './step_context';
 
 /** SSE activity message shape from the inspector stream. */
@@ -252,6 +255,52 @@ function buildToolSummary(summaryText: string): HTMLElement {
 }
 
 /**
+ * Build the collapsible args detail panel for a tool_invoked / github_tool row.
+ * Hidden by default; shown when the parent row is expanded.
+ * All content set via textContent — no innerHTML with payload data.
+ */
+function buildToolDetail(payload: Record<string, unknown>): HTMLElement {
+  const panel = document.createElement('div');
+  panel.className = 'af__tool-detail';
+  panel.setAttribute('hidden', '');
+
+  const argPreview = str(payload, 'arg_preview');
+  const parsed = parseArgsRaw(argPreview);
+
+  if (parsed !== null && Object.keys(parsed).length > 0) {
+    for (const [key, val] of Object.entries(parsed)) {
+      const line = document.createElement('div');
+      line.className = 'af__detail-line';
+
+      const k = document.createElement('span');
+      k.className = 'af__detail-key';
+      k.textContent = key;
+
+      const v = document.createElement('span');
+      v.className = 'af__detail-val';
+      v.textContent = typeof val === 'string'
+        ? val
+        : JSON.stringify(val, null, 2);
+
+      line.appendChild(k);
+      line.appendChild(v);
+      panel.appendChild(line);
+    }
+  } else if (argPreview && argPreview !== '{}') {
+    // Couldn't parse — show raw preview
+    const line = document.createElement('div');
+    line.className = 'af__detail-line';
+    const v = document.createElement('span');
+    v.className = 'af__detail-val';
+    v.textContent = argPreview;
+    line.appendChild(v);
+    panel.appendChild(line);
+  }
+
+  return panel;
+}
+
+/**
  * Build the summary element for llm_iter rows.
  * Shows "{network}: {modelShort}" or just "{network}" when the model is unknown.
  */
@@ -325,9 +374,46 @@ export function appendActivityRow(msg: ActivityMessage): void {
   row.appendChild(summaryEl);
   row.appendChild(ts);
 
+  // Expandable tool rows: chevron + detail panel
+  const isExpandable = EXPANDABLE_SUBTYPES.has(msg.subtype);
+  let detailPanel: HTMLElement | null = null;
+
+  if (isExpandable) {
+    row.dataset['expandable'] = 'true';
+    row.setAttribute('role', 'button');
+    row.setAttribute('aria-expanded', 'false');
+    row.setAttribute('tabindex', '0');
+
+    const chevron = document.createElement('span');
+    chevron.className = 'af__chevron';
+    chevron.setAttribute('aria-hidden', 'true');
+    // eslint-disable-next-line no-unsanitized/property
+    chevron.innerHTML = icons.chevronRight;
+    row.appendChild(chevron);
+
+    detailPanel = buildToolDetail(msg.payload);
+
+    const toggle = (): void => {
+      const isOpen = row.getAttribute('aria-expanded') === 'true';
+      row.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+      if (isOpen) {
+        detailPanel?.setAttribute('hidden', '');
+      } else {
+        detailPanel?.removeAttribute('hidden');
+      }
+    };
+    row.addEventListener('click', toggle);
+    row.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); }
+    });
+  }
+
   // Route into the current step body, or the feed root if no step is open.
   const target = getCurrentAppendTarget(feed);
   target.appendChild(row);
+  if (detailPanel !== null) {
+    target.appendChild(detailPanel);
+  }
 
   if (shouldAutoScroll(feed)) {
     feed.scrollTop = feed.scrollHeight;

--- a/agentception/static/js/icons.ts
+++ b/agentception/static/js/icons.ts
@@ -156,6 +156,9 @@ export const decision = s(
 /** Checkmark — done */
 export const checkmark = s('<polyline points="2,7 5.5,10.5 12,4"/>');
 
+/** Chevron right — expand affordance for tool call rows */
+export const chevronRight = s('<polyline points="5,2 10,7 5,12"/>');
+
 /** Speech bubble — message */
 export const speech = s(
   '<path d="M1 2h12a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H9l-2 2-2-2H1' +

--- a/agentception/static/scss/pages/_activity-feed.scss
+++ b/agentception/static/scss/pages/_activity-feed.scss
@@ -51,6 +51,17 @@
     font-size: 0.695rem;
   }
 
+  // Expandable tool rows: 4-column grid (chevron at end), pointer cursor
+  &[data-expandable] {
+    grid-template-columns: 1.25rem 1fr auto 0.875rem;
+    cursor: pointer;
+    user-select: none;
+
+    &[aria-expanded="true"] {
+      .af__chevron svg { transform: rotate(90deg); }
+    }
+  }
+
   // Tool invoked: sans-serif label, mono value — visually separates category from data
   .af__tool-label {
     font-family: var(--font-sans, sans-serif);
@@ -64,6 +75,26 @@
   .af__tool-value {
     font-family: var(--font-mono);
     color: rgba(255, 255, 255, 0.82);
+  }
+
+  // Chevron expand indicator
+  .af__chevron {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(255, 255, 255, 0.12);
+    transition: color 0.1s;
+    flex-shrink: 0;
+
+    svg {
+      width: 9px;
+      height: 9px;
+      transition: transform 0.15s ease;
+    }
+  }
+
+  &[data-expandable]:hover .af__chevron {
+    color: rgba(255, 255, 255, 0.4);
   }
 
   // File writes are highlighted
@@ -115,7 +146,68 @@
   }
 }
 
+// ── Tool call detail panel ─────────────────────────────────────────────────────
+// Sibling to .activity-feed__row[data-expandable]; toggled via `hidden` attr.
+// Left-padded to align with the summary column (nested row indent + icon + gap).
+
+.af__tool-detail {
+  padding: 0.3rem 0.75rem 0.4rem calc(1.4rem + 1.25rem + 0.4rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  border-left: 2px solid transparent;
+  background: rgba(255, 255, 255, 0.02);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+
+  &[hidden] { display: none; }
+}
+
+.af__detail-line {
+  display: flex;
+  gap: 0.6rem;
+  min-width: 0;
+  font-size: 0.625rem;
+  line-height: 1.6;
+}
+
+.af__detail-key {
+  font-family: var(--font-sans, sans-serif);
+  color: rgba(255, 255, 255, 0.3);
+  flex-shrink: 0;
+  min-width: 3.5rem;
+}
+
+.af__detail-val {
+  font-family: var(--font-mono);
+  color: rgba(255, 255, 255, 0.72);
+  min-width: 0;
+  overflow-wrap: break-word;
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+
 // ── Light mode overrides ───────────────────────────────────────────────────────
+
+[data-theme="light"] .af__tool-detail {
+  background: rgba(0, 0, 0, 0.02);
+  border-bottom-color: rgba(0, 0, 0, 0.05);
+}
+
+[data-theme="light"] .af__detail-key {
+  color: rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="light"] .af__detail-val {
+  color: rgba(0, 0, 0, 0.75);
+}
+
+[data-theme="light"] .activity-feed__row[data-expandable] .af__chevron {
+  color: rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="light"] .activity-feed__row[data-expandable]:hover .af__chevron {
+  color: rgba(0, 0, 0, 0.4);
+}
 
 [data-theme="light"] .activity-feed__row {
   color: rgba(0, 0, 0, 0.55);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     // jsdom gives us localStorage, ReadableStream, TextEncoder, etc.
     environment: 'jsdom',
     include: ['agentception/static/js/**/*.test.ts'],
+    exclude: ['agentception/tests/**', 'node_modules/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
## Summary

- **Tool rows expand on click** — `tool_invoked` and `github_tool` rows now show a subtle chevron and are clickable. Clicking toggles an inline args detail panel directly below the row.
- **Args displayed as key · value pairs** — each argument from `arg_preview` is parsed and rendered as `af__detail-key` / `af__detail-val` spans. Falls back to raw text if parsing fails.
- **Keyboard accessible** — `role=button`, `tabindex=0`, `aria-expanded`, Enter/Space toggles.
- **Fully themed** — light and dark mode styles.
- **5 new unit tests** covering expand, collapse, key-value rendering, and non-expandable row guard.

## Also fixed: Vitest config never reached Docker container

`vitest.config.ts` was never copied into the image (`Dockerfile` only copied `package.json`, `tsconfig.json`). Without the config, Vitest used its default include patterns (`**/*.spec.ts`) and picked up the Playwright E2E spec (`agentception/tests/e2e/plan.spec.ts`), which poisoned the jsdom environment for all other test files — causing intermittent 80+ test failures. Fixed by adding `vitest.config.ts` to the `Dockerfile COPY` step and adding an explicit `exclude: ['agentception/tests/**']` to the config.