### PR TITLE
feat: model info in feed header; token count on step header; remove tool indent

### DIFF
--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -9,7 +9,7 @@ import {
   formatRelativeTime,
   type ActivityMessage,
 } from '../activity_feed';
-import { resetStepContext } from '../step_context';
+import { openStepGroup, resetStepContext } from '../step_context';
 
 function makeSource(): EventSource {
   return new EventTarget() as unknown as EventSource;
@@ -261,8 +261,8 @@ describe('formatRelativeTime', () => {
 describe('appendActivityRow', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="activity-feed"></div>';
-    resetFeedStartTime();
-    resetStepContext();
+    // resetFeedSession resets start time, step context, AND model header flag
+    resetFeedSession();
   });
 
   it('appends a row with data-subtype, summary, and relative time', () => {
@@ -315,28 +315,56 @@ describe('appendActivityRow', () => {
     expect(row?.hasAttribute('data-exit-nonzero')).toBe(false);
   });
 
-  it('renders llm_iter as single-line summary with af__iter-model span', () => {
+  it('llm_iter inserts #af-model-header at top of feed (not a row)', () => {
     appendActivityRow({
       t: 'activity',
       subtype: 'llm_iter',
       payload: { model: 'qwen2.5:7b', turns: 1 },
       recorded_at: '',
     });
-    const row = document.querySelector('.activity-feed__row');
-    expect(row?.getAttribute('data-subtype')).toBe('llm_iter');
-    expect(row?.querySelector('.af__iter-model')?.textContent).toBe('Local: Qwen 2.5');
-    expect(row?.querySelector('.af__iter-num')).toBeNull();
+    // No activity row should be created
+    expect(document.querySelector('.activity-feed__row')).toBeNull();
+    // But the model header should appear
+    const header = document.getElementById('af-model-header');
+    expect(header).not.toBeNull();
+    expect(header?.textContent).toBe('Local: Qwen 2.5');
   });
 
-  it('renders llm_iter for unknown local model as just "Local"', () => {
+  it('llm_iter only inserts model header once for repeated events', () => {
     appendActivityRow({
       t: 'activity',
       subtype: 'llm_iter',
-      payload: { model: 'local', turns: 1 },
+      payload: { model: 'qwen2.5:7b', turns: 1 },
       recorded_at: '',
     });
-    const row = document.querySelector('.activity-feed__row');
-    expect(row?.querySelector('.af__iter-model')?.textContent).toBe('Local');
+    appendActivityRow({
+      t: 'activity',
+      subtype: 'llm_iter',
+      payload: { model: 'claude-3-5', turns: 2 },
+      recorded_at: '',
+    });
+    expect(document.querySelectorAll('#af-model-header').length).toBe(1);
+    expect(document.getElementById('af-model-header')?.textContent).toBe('Local: Qwen 2.5');
+  });
+
+  it('llm_usage updates step header token count (not a row)', () => {
+    // Simulate a step_start so there is a step header with .event-card__tokens
+    const feed = document.getElementById('activity-feed')!;
+    const stepHeader = document.createElement('div');
+    stepHeader.className = 'event-card step-group__header';
+    const tokSpan = document.createElement('span');
+    tokSpan.className = 'event-card__tokens';
+    stepHeader.appendChild(tokSpan);
+    openStepGroup(feed, stepHeader);
+
+    appendActivityRow({
+      t: 'activity',
+      subtype: 'llm_usage',
+      payload: { input_tokens: 17524, cache_write: 0, cache_read: 0 },
+      recorded_at: '',
+    });
+    expect(document.querySelector('.activity-feed__row')).toBeNull();
+    expect(tokSpan.textContent).toBe('17,524 tok');
   });
 
   it('renders tool_invoked with split label / value spans', () => {
@@ -410,11 +438,11 @@ describe('appendActivityRow', () => {
       expect(vals.some(v => v?.includes('main.py'))).toBe(true);
     });
 
-    it('non-tool rows (llm_usage) do not get data-expandable', () => {
+    it('non-tool rows (shell_done) do not get data-expandable', () => {
       appendActivityRow({
         t: 'activity',
-        subtype: 'llm_usage',
-        payload: { input_tokens: 100, cache_write: 0, cache_read: 0 },
+        subtype: 'shell_done',
+        payload: { exit_code: 0, stdout_bytes: 10, stderr_bytes: 0 },
         recorded_at: '',
       });
       const row = document.querySelector<HTMLElement>('.activity-feed__row');
@@ -445,18 +473,47 @@ describe('appendActivityRow', () => {
 });
 
 describe('resetFeedSession', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="activity-feed"></div>';
+  });
+
   it('resets feed start time and step context', () => {
     resetFeedSession();
     // After reset, the next event returns "now"
     expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('now');
+  });
+
+  it('resets the model header flag so it re-appears after a new run', () => {
+    // First run: model header appears
+    appendActivityRow({
+      t: 'activity',
+      subtype: 'llm_iter',
+      payload: { model: 'qwen2.5:7b', turns: 1 },
+      recorded_at: '',
+    });
+    expect(document.getElementById('af-model-header')).not.toBeNull();
+
+    // Reset simulates a new run starting
+    resetFeedSession();
+    document.body.innerHTML = '<div id="activity-feed"></div>';
+
+    // Second run: model header should appear again
+    appendActivityRow({
+      t: 'activity',
+      subtype: 'llm_iter',
+      payload: { model: 'claude-3-5', turns: 1 },
+      recorded_at: '',
+    });
+    const header = document.getElementById('af-model-header');
+    expect(header).not.toBeNull();
+    expect(header?.textContent).toBe('Anthropic: 3.5');
   });
 });
 
 describe('attachActivityFeedHandler', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="activity-feed"></div>';
-    resetFeedStartTime();
-    resetStepContext();
+    resetFeedSession();
   });
 
   it('appends a row when msg.t === "activity"', () => {

--- a/agentception/static/js/__tests__/step_context.test.ts
+++ b/agentception/static/js/__tests__/step_context.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { getCurrentAppendTarget, openStepGroup, resetStepContext } from '../step_context';
+import { getCurrentAppendTarget, getCurrentStepHeader, openStepGroup, resetStepContext } from '../step_context';
 
 function makeFeed(): HTMLElement {
   const el = document.createElement('div');
@@ -69,5 +69,32 @@ describe('step_context', () => {
     openStepGroup(feed, header);
     const group = feed.querySelector('.step-group');
     expect(group?.contains(header)).toBe(true);
+  });
+
+  it('getCurrentStepHeader returns null before any step is opened', () => {
+    expect(getCurrentStepHeader()).toBeNull();
+  });
+
+  it('getCurrentStepHeader returns the header element after openStepGroup', () => {
+    const feed = makeFeed();
+    const header = makeHeader();
+    openStepGroup(feed, header);
+    expect(getCurrentStepHeader()).toBe(header);
+  });
+
+  it('getCurrentStepHeader updates to the latest header on second openStepGroup', () => {
+    const feed = makeFeed();
+    const header1 = makeHeader();
+    const header2 = makeHeader();
+    openStepGroup(feed, header1);
+    openStepGroup(feed, header2);
+    expect(getCurrentStepHeader()).toBe(header2);
+  });
+
+  it('resetStepContext clears getCurrentStepHeader', () => {
+    const feed = makeFeed();
+    openStepGroup(feed, makeHeader());
+    resetStepContext();
+    expect(getCurrentStepHeader()).toBeNull();
   });
 });

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -24,7 +24,7 @@ import {
 
 /** Subtypes that support click-to-expand args detail. */
 const EXPANDABLE_SUBTYPES = new Set(['tool_invoked', 'github_tool']);
-import { getCurrentAppendTarget, resetStepContext } from './step_context';
+import { getCurrentAppendTarget, getCurrentStepHeader, resetStepContext } from './step_context';
 
 /** SSE activity message shape from the inspector stream. */
 export interface ActivityMessage {
@@ -183,17 +183,21 @@ export function getSubtypeIcon(subtype: string): string {
 /** ISO timestamp (ms) of the first event appended in this feed session. */
 let feedStartMs: number | null = null;
 
+/** True once the model header has been inserted into the feed. */
+let _modelHeaderShown = false;
+
 /** Reset the feed start time — call when the feed is cleared or a new run begins. */
 export function resetFeedStartTime(): void {
   feedStartMs = null;
 }
 
 /**
- * Reset all feed session state (timestamp + step groups).
+ * Reset all feed session state (timestamp + step groups + model header flag).
  * Call this whenever the feed is cleared or a new run begins.
  */
 export function resetFeedSession(): void {
   feedStartMs = null;
+  _modelHeaderShown = false;
   resetStepContext();
 }
 
@@ -301,19 +305,21 @@ function buildToolDetail(payload: Record<string, unknown>): HTMLElement {
 }
 
 /**
- * Build the summary element for llm_iter rows.
- * Shows "{network}: {modelShort}" or just "{network}" when the model is unknown.
+ * Insert a sticky model-info row at the top of the feed on the first llm_iter event.
+ * Subsequent llm_iter events are ignored — the model is constant for a run.
  */
-function buildIterSummary(payload: Record<string, unknown>): HTMLElement {
-  const summary = document.createElement('span');
-  summary.className = 'activity-feed__summary';
+function ensureModelHeader(feed: HTMLElement, payload: Record<string, unknown>): void {
+  if (_modelHeaderShown) return;
+  _modelHeaderShown = true;
 
-  const label = document.createElement('span');
-  label.className = 'af__iter-model';
-  label.textContent = modelLabel(parseModelInfo(str(payload, 'model')));
+  const label = modelLabel(parseModelInfo(str(payload, 'model')));
+  if (!label) return;
 
-  summary.appendChild(label);
-  return summary;
+  const header = document.createElement('div');
+  header.className = 'af__model-header';
+  header.id = 'af-model-header';
+  header.textContent = label;
+  feed.insertBefore(header, feed.firstChild);
 }
 
 /**
@@ -326,13 +332,27 @@ export function appendActivityRow(msg: ActivityMessage): void {
   const feed = document.getElementById('activity-feed');
   if (!feed) return;
 
-  // Resolve the summary text first so we can bail on empty rows.
-  // llm_iter is handled separately (two-line DOM layout, no plain text needed).
-  let summaryText = '';
-  if (msg.subtype !== 'llm_iter') {
-    summaryText = formatActivitySummary(msg.subtype, msg.payload);
-    if (summaryText === '') return; // e.g. llm_done when tool calls follow
+  // llm_iter: show model once in a sticky header at the top of the feed, then skip.
+  if (msg.subtype === 'llm_iter') {
+    ensureModelHeader(feed, msg.payload);
+    return;
   }
+
+  // llm_usage: inject token count into the current step header, then skip row.
+  if (msg.subtype === 'llm_usage') {
+    const stepHeader = getCurrentStepHeader();
+    if (stepHeader !== null) {
+      const tokEl = stepHeader.querySelector<HTMLElement>('.event-card__tokens');
+      if (tokEl !== null) {
+        tokEl.textContent = `${fmtNum(num(msg.payload, 'input_tokens'))} tok`;
+      }
+    }
+    return;
+  }
+
+  // Resolve summary text; bail on empty (e.g. llm_done when tool calls follow).
+  const summaryText = formatActivitySummary(msg.subtype, msg.payload);
+  if (summaryText === '') return;
 
   const row = document.createElement('div');
   row.className = 'activity-feed__row';
@@ -360,9 +380,7 @@ export function appendActivityRow(msg: ActivityMessage): void {
 
   // Summary — subtype-specific layout
   let summaryEl: HTMLElement;
-  if (msg.subtype === 'llm_iter') {
-    summaryEl = buildIterSummary(msg.payload);
-  } else if (msg.subtype === 'tool_invoked' || msg.subtype === 'github_tool') {
+  if (msg.subtype === 'tool_invoked' || msg.subtype === 'github_tool') {
     summaryEl = buildToolSummary(summaryText);
   } else {
     summaryEl = document.createElement('span');

--- a/agentception/static/js/event_card.ts
+++ b/agentception/static/js/event_card.ts
@@ -73,6 +73,12 @@ export function appendEventCard(feed: HTMLElement, m: EventSseMessage): void {
     card.classList.add('step-group__header');
     card.setAttribute('role', 'button');
     card.setAttribute('aria-expanded', 'true');
+
+    // Token count placeholder — filled by activity_feed.ts when llm_usage fires.
+    const tokens = document.createElement('span');
+    tokens.className = 'event-card__tokens';
+    card.appendChild(tokens);
+
     card.addEventListener('click', () => {
       const group = card.closest<HTMLElement>('.step-group');
       if (group === null) return;

--- a/agentception/static/js/step_context.ts
+++ b/agentception/static/js/step_context.ts
@@ -11,12 +11,24 @@
 /** The <div class="step-group__body"> of the currently open step, or null. */
 let _currentStepBody: HTMLElement | null = null;
 
+/** The step-group header card of the currently open step, or null. */
+let _currentStepHeader: HTMLElement | null = null;
+
 /**
  * Return the element that new activity rows should be appended to.
  * Falls back to feed when no step group has been opened yet.
  */
 export function getCurrentAppendTarget(feed: HTMLElement): HTMLElement {
   return _currentStepBody ?? feed;
+}
+
+/**
+ * Return the header card (event-card[data-event-type=step_start]) of the
+ * currently open step group, or null if no step has been opened yet.
+ * Used by activity_feed.ts to inject the token count into the step header.
+ */
+export function getCurrentStepHeader(): HTMLElement | null {
+  return _currentStepHeader;
 }
 
 /**
@@ -30,6 +42,8 @@ export function openStepGroup(feed: HTMLElement, headerEl: HTMLElement): void {
     prev.classList.remove('step-group--current');
     prev.classList.add('step-group--collapsed');
   }
+
+  _currentStepHeader = headerEl;
 
   // Build the new group wrapper.
   const group = document.createElement('div');
@@ -50,4 +64,5 @@ export function openStepGroup(feed: HTMLElement, headerEl: HTMLElement): void {
 /** Reset state — call when the feed is cleared or a new run begins. */
 export function resetStepContext(): void {
   _currentStepBody = null;
+  _currentStepHeader = null;
 }

--- a/agentception/static/scss/pages/_activity-feed.scss
+++ b/agentception/static/scss/pages/_activity-feed.scss
@@ -24,33 +24,6 @@
   &[data-subtype="delay"]  { opacity: 0.55; }
   &[data-subtype="error"]  { border-left-color: #ef4444; color: #fca5a5; }
 
-  // Nested rows — visually indented under the LLM iteration that spawned them.
-  // The left border stays at the container edge (tree connector effect).
-  &[data-subtype="tool_invoked"],
-  &[data-subtype="github_tool"],
-  &[data-subtype^="file_"],
-  &[data-subtype^="shell"],
-  &[data-subtype="git_push"],
-  &[data-subtype="delay"] {
-    padding-left: 1.4rem;
-  }
-
-  // llm_iter: LLM iteration milestone row — slightly elevated typography
-  &[data-subtype="llm_iter"] {
-    padding-top: 0.2rem;
-    padding-bottom: 0.15rem;
-  }
-
-  &[data-subtype="llm_usage"] {
-    color: rgba(167, 139, 250, 0.5);
-  }
-
-  .af__iter-model {
-    color: rgba(167, 139, 250, 0.9);
-    font-weight: 500;
-    font-size: 0.695rem;
-  }
-
   // Expandable tool rows: 4-column grid (chevron at end), pointer cursor
   &[data-expandable] {
     grid-template-columns: 1.25rem 1fr auto 0.875rem;
@@ -151,7 +124,9 @@
 // Left-padded to align with the summary column (nested row indent + icon + gap).
 
 .af__tool-detail {
-  padding: 0.3rem 0.75rem 0.4rem calc(1.4rem + 1.25rem + 0.4rem);
+  // Left-padding aligns detail text with the summary column:
+  // 0.5rem (row padding-left) + 1.25rem (icon width) + 0.4rem (gap)
+  padding: 0.3rem 0.75rem 0.4rem calc(0.5rem + 1.25rem + 0.4rem);
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
@@ -186,7 +161,25 @@
   white-space: pre-wrap;
 }
 
+// ── Model header ───────────────────────────────────────────────────────────────
+// Shown once at the top of the feed. Displays the model label (e.g. "Local: Qwen 3.5")
+// for the current run so it need not repeat in every step.
+
+.af__model-header {
+  padding: 0.35rem 0.75rem 0.3rem;
+  font-size: 0.6rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+  color: rgba(167, 139, 250, 0.45);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
 // ── Light mode overrides ───────────────────────────────────────────────────────
+
+[data-theme="light"] .af__model-header {
+  color: rgba(109, 40, 217, 0.4);
+  border-bottom-color: rgba(0, 0, 0, 0.05);
+}
 
 [data-theme="light"] .af__tool-detail {
   background: rgba(0, 0, 0, 0.02);
@@ -218,10 +211,6 @@
 
   &[data-subtype^="shell"] { border-left-color: #9ca3af; }
 
-  .af__iter-model {
-    color: rgba(109, 40, 217, 0.85);
-  }
-
   .af__tool-label {
     color: rgba(0, 0, 0, 0.38);
   }
@@ -232,10 +221,6 @@
 
   .af__tool-value {
     color: rgba(0, 0, 0, 0.8);
-  }
-
-  &[data-subtype="llm_usage"] {
-    color: rgba(109, 40, 217, 0.6);
   }
 
   &[data-subtype="file_replaced"],

--- a/agentception/static/scss/pages/_event-card.scss
+++ b/agentception/static/scss/pages/_event-card.scss
@@ -136,6 +136,20 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
+  // Token count — injected by activity_feed.ts when llm_usage fires.
+  // Sits at the far right of the step header line.
+  &__tokens {
+    font-size: 0.58rem;
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    color: rgba(167, 139, 250, 0.35);
+    white-space: nowrap;
+    letter-spacing: 0.02em;
+
+    // Hidden until a value is injected
+    &:empty { display: none; }
+  }
 }
 
 // ── Light mode overrides ───────────────────────────────────────────────────────
@@ -143,6 +157,10 @@
 
 [data-theme="light"] .event-card {
   color: rgba(0, 0, 0, 0.55);
+
+  &__tokens {
+    color: rgba(109, 40, 217, 0.3);
+  }
 
   &[data-event-type='step_start'] {
     border-top-color: rgba(0, 0, 0, 0.08);


### PR DESCRIPTION
## Summary

- **Model deduplication**: `llm_iter` rows are suppressed. A single `.af__model-header` strip (e.g. `Local: Qwen 3.5`) is inserted once at the top of the activity feed so it doesn't repeat on every step.
- **Token count on step header**: `llm_usage` events no longer create rows. Instead, the token count is injected right-aligned into the `STEP N` header line via a new `.event-card__tokens` placeholder.
- **No more tool indent**: `tool_invoked`, `github_tool`, `file_*`, `shell_*`, `git_push`, `delay` rows are no longer indented since `llm_iter` is no longer a visual parent — they sit flush with the rest of the feed.

## Test plan

- [x] 250 Vitest unit tests pass (`npm test`)
- [x] Zero TypeScript type errors (`npx tsc --noEmit`)
- [x] JS + CSS bundles rebuild cleanly (`npm run build`)
- [x] No template drift (`generate.py --check`)