### PR TITLE
fix: colon separator in tool summary rows

### DIFF
--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -243,7 +243,7 @@ function buildToolSummary(summaryText: string): HTMLElement {
 
     const sep = document.createElement('span');
     sep.className = 'af__tool-sep';
-    sep.textContent = '  ·  ';
+    sep.textContent = ': ';
 
     const val = document.createElement('span');
     val.className = 'af__tool-value';


### PR DESCRIPTION
Changes ` · ` to `: ` in the tool invocation rows so they read `Read file: context` instead of `Read file · context`.