### PR TITLE
fix: sans-serif colon separator; 0:00 timestamp instead of 'now'

### DIFF
--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -224,14 +224,14 @@ describe('formatRelativeTime', () => {
     resetFeedStartTime();
   });
 
-  it('returns "now" for the first event', () => {
-    expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('now');
+  it('returns "0:00" for the first event', () => {
+    expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('0:00');
   });
 
-  it('returns "now" for a second event at the same timestamp', () => {
+  it('returns "0:00" for a second event at the same timestamp', () => {
     resetFeedStartTime();
     formatRelativeTime('2026-03-15T12:00:00Z');
-    expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('now');
+    expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('0:00');
   });
 
   it('returns M:SS for subsequent events (0:29 for 29 seconds)', () => {
@@ -479,8 +479,8 @@ describe('resetFeedSession', () => {
 
   it('resets feed start time and step context', () => {
     resetFeedSession();
-    // After reset, the next event returns "now"
-    expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('now');
+    // After reset, the next event returns "0:00"
+    expect(formatRelativeTime('2026-03-15T12:00:00Z')).toBe('0:00');
   });
 
   it('resets the model header flag so it re-appears after a new run', () => {

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -211,10 +211,10 @@ export function formatRelativeTime(recordedAt: string): string {
     if (Number.isNaN(t)) return '';
     if (feedStartMs === null) {
       feedStartMs = t;
-      return 'now';
+      return '0:00';
     }
     const delta = Math.max(0, Math.round((t - feedStartMs) / 1000));
-    if (delta === 0) return 'now';
+    if (delta === 0) return '0:00';
     const m = Math.floor(delta / 60);
     const s = delta % 60;
     const ss = s.toString().padStart(2, '0');

--- a/agentception/static/scss/pages/_activity-feed.scss
+++ b/agentception/static/scss/pages/_activity-feed.scss
@@ -42,6 +42,7 @@
   }
 
   .af__tool-sep {
+    font-family: var(--font-sans, sans-serif);
     color: rgba(255, 255, 255, 0.2);
   }
 
@@ -216,6 +217,7 @@
   }
 
   .af__tool-sep {
+    font-family: var(--font-sans, sans-serif);
     color: rgba(0, 0, 0, 0.2);
   }
 


### PR DESCRIPTION
- `.af__tool-sep` (the `: ` between tool name and value) is now explicitly sans-serif so it reads as punctuation rather than code
- `formatRelativeTime` now returns `0:00` for the first/zero-delta event instead of `now`, keeping all timestamps in consistent M:SS format