### PR TITLE
feat: file content preview in file_read activity events

### DIFF
--- a/agentception/db/activity_events.py
+++ b/agentception/db/activity_events.py
@@ -29,7 +29,7 @@ import datetime
 import json
 import logging
 from collections.abc import Mapping
-from typing import TypedDict, Union
+from typing import NotRequired, TypedDict, Union
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
@@ -149,12 +149,15 @@ class FileReadPayload(TypedDict):
     """Payload for ``file_read`` activity events.
 
     Emitted when the agent reads a file or a line range from a file.
+    ``content_preview`` is a short excerpt (max 10 lines / 400 chars) of the
+    content that was actually read, shown in the inspector detail panel.
     """
 
     path: str
     start_line: int
     end_line: int
     total_lines: int
+    content_preview: NotRequired[str]
 
 
 class FileReplacedPayload(TypedDict):

--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -477,6 +477,62 @@ describe('appendActivityRow', () => {
       expect(keys).not.toContain('n_results');
     });
 
+    describe('file_read expandable rows', () => {
+      it('file_read row has data-expandable', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'file_read',
+          payload: {
+            path: 'src/main.py',
+            start_line: 1,
+            end_line: 10,
+            total_lines: 100,
+            content_preview: 'def main():\n    pass\n',
+          },
+          recorded_at: '',
+        });
+        const row = document.querySelector<HTMLElement>('.activity-feed__row');
+        expect(row?.dataset['expandable']).toBe('true');
+        expect(row?.getAttribute('aria-expanded')).toBe('false');
+      });
+
+      it('clicking file_read row reveals content preview', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'file_read',
+          payload: {
+            path: 'src/main.py',
+            start_line: 1,
+            end_line: 3,
+            total_lines: 50,
+            content_preview: 'def main():\n    pass\n',
+          },
+          recorded_at: '',
+        });
+        const row = document.querySelector<HTMLElement>('.activity-feed__row');
+        const detail = document.querySelector('.af__tool-detail');
+        expect(detail?.hasAttribute('hidden')).toBe(true);
+        row?.click();
+        expect(detail?.hasAttribute('hidden')).toBe(false);
+        const pre = detail?.querySelector('.af__content-preview');
+        expect(pre?.textContent).toBe('def main():\n    pass\n');
+      });
+
+      it('file_read without content_preview shows fallback note', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'file_read',
+          payload: { path: 'src/main.py', start_line: 1, end_line: 10, total_lines: 50 },
+          recorded_at: '',
+        });
+        const row = document.querySelector<HTMLElement>('.activity-feed__row');
+        row?.click();
+        const detail = document.querySelector('.af__tool-detail');
+        expect(detail?.querySelector('.af__content-preview')).toBeNull();
+        expect(detail?.querySelector('.af__detail-val')?.textContent).toContain('no preview');
+      });
+    });
+
     it('non-tool rows (shell_done) do not get data-expandable', () => {
       appendActivityRow({
         t: 'activity',

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -23,8 +23,8 @@ import {
   modelLabel,
 } from './format_utils';
 
-/** Subtypes that support click-to-expand args detail. */
-const EXPANDABLE_SUBTYPES = new Set(['tool_invoked', 'github_tool']);
+/** Subtypes that support click-to-expand detail panel. */
+const EXPANDABLE_SUBTYPES = new Set(['tool_invoked', 'github_tool', 'file_read']);
 import { getCurrentAppendTarget, getCurrentStepHeader, resetStepContext } from './step_context';
 
 /** SSE activity message shape from the inspector stream. */
@@ -327,6 +327,33 @@ function buildToolDetail(payload: Record<string, unknown>): HTMLElement {
 }
 
 /**
+ * Build the expandable detail panel for a file_read row.
+ * Shows the content_preview as a preformatted code excerpt when present.
+ * Falls back to a plain "no preview" note for older events that predate
+ * the content_preview field.
+ */
+function buildFileReadDetail(payload: Record<string, unknown>): HTMLElement {
+  const panel = document.createElement('div');
+  panel.className = 'af__tool-detail af__tool-detail--file-read';
+  panel.setAttribute('hidden', '');
+
+  const preview = str(payload, 'content_preview');
+  if (preview) {
+    const pre = document.createElement('pre');
+    pre.className = 'af__content-preview';
+    pre.textContent = preview;
+    panel.appendChild(pre);
+  } else {
+    const note = document.createElement('span');
+    note.className = 'af__detail-val';
+    note.textContent = '(no preview — re-run the agent to capture content)';
+    panel.appendChild(note);
+  }
+
+  return panel;
+}
+
+/**
  * Insert a sticky model-info row at the top of the feed on the first llm_iter event.
  * Subsequent llm_iter events are ignored — the model is constant for a run.
  */
@@ -414,7 +441,7 @@ export function appendActivityRow(msg: ActivityMessage): void {
   row.appendChild(summaryEl);
   row.appendChild(ts);
 
-  // Expandable tool rows: chevron + detail panel
+  // Expandable rows: chevron + subtype-specific detail panel
   const isExpandable = EXPANDABLE_SUBTYPES.has(msg.subtype);
   let detailPanel: HTMLElement | null = null;
 
@@ -431,7 +458,9 @@ export function appendActivityRow(msg: ActivityMessage): void {
     chevron.innerHTML = icons.chevronRight;
     row.appendChild(chevron);
 
-    detailPanel = buildToolDetail(msg.payload);
+    detailPanel = msg.subtype === 'file_read'
+      ? buildFileReadDetail(msg.payload)
+      : buildToolDetail(msg.payload);
 
     const toggle = (): void => {
       const isOpen = row.getAttribute('aria-expanded') === 'true';

--- a/agentception/static/scss/pages/_activity-feed.scss
+++ b/agentception/static/scss/pages/_activity-feed.scss
@@ -175,6 +175,35 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.04);
 }
 
+// ── File-read content preview ──────────────────────────────────────────────────
+// Shown inside .af__tool-detail--file-read when content_preview is present.
+// Rendered as a compact code block, not a key-value list.
+
+.af__content-preview {
+  margin: 0;
+  padding: 0.35rem 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  white-space: pre;
+  overflow-x: auto;
+  max-height: 10rem;
+  overflow-y: auto;
+  // Prevent the pre from stretching the panel wider than the feed column
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+[data-theme="light"] .af__content-preview {
+  color: rgba(0, 0, 0, 0.65);
+  background: rgba(0, 0, 0, 0.03);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+
 // ── Light mode overrides ───────────────────────────────────────────────────────
 
 [data-theme="light"] .af__model-header {

--- a/agentception/tools/file_tools.py
+++ b/agentception/tools/file_tools.py
@@ -311,11 +311,20 @@ def read_file_lines(
     )
     # activity event — see docs/reference/activity-events.md
     if run_id is not None and session is not None:
+        # Build a short content excerpt for the inspector detail panel.
+        # Cap at 10 lines and 400 chars so the payload stays lightweight.
+        _PREVIEW_MAX_LINES = 10
+        _PREVIEW_MAX_CHARS = 400
+        preview_lines = lines[clamped_start - 1 : clamped_start - 1 + _PREVIEW_MAX_LINES]
+        raw_preview = "".join(preview_lines)
+        if len(raw_preview) > _PREVIEW_MAX_CHARS:
+            raw_preview = raw_preview[:_PREVIEW_MAX_CHARS] + "…"
         _emit_activity(session, run_id, "file_read", {
             "path": _shorten_path(p, run_id),
             "start_line": clamped_start,
             "end_line": clamped_end,
             "total_lines": total,
+            "content_preview": raw_preview,
         })
     return {
         "ok": True,


### PR DESCRIPTION
## Summary

**Backend**
- `FileReadPayload` gains `content_preview: NotRequired[str]`
- `read_file_lines` now emits the first 10 lines / 400 chars of the content it just read as `content_preview` in the `file_read` event payload

**Frontend**
- `file_read` rows are now expandable — click the chevron to reveal a scrollable `<pre>` code block showing the content preview
- Falls back to a `(no preview — re-run the agent to capture content)` note for historical events that predate this field
- New `.af__content-preview` SCSS: compact code block, max-height 10rem, independently scrollable

## Test plan

- [x] 263 Vitest tests pass
- [x] Zero mypy errors (`agentception/db/activity_events.py`, `agentception/tools/file_tools.py`)
- [x] Zero TypeScript type errors
- [x] JS + CSS bundles rebuild cleanly