### PR TITLE
feat: dir_listed activity event — show list_directory results in inspector

### DIFF
--- a/agentception/db/activity_events.py
+++ b/agentception/db/activity_events.py
@@ -59,6 +59,7 @@ ACTIVITY_SUBTYPES: frozenset[str] = frozenset(
         "file_written",
         "git_push",
         "github_tool",
+        "dir_listed",
         "delay",
         "error",
     }
@@ -160,6 +161,20 @@ class FileReadPayload(TypedDict):
     content_preview: NotRequired[str]
 
 
+class DirListedPayload(TypedDict):
+    """Payload for ``dir_listed`` activity events.
+
+    Emitted after a successful ``list_directory`` tool call.
+    ``entries`` is a newline-delimited string of file/directory names;
+    directories carry a trailing ``/``.  ``entry_count`` is a convenience
+    field for the summary row so the frontend need not split to count.
+    """
+
+    path: str
+    entry_count: int
+    entries: str  # newline-delimited; split on "\n" to get individual names
+
+
 class FileReplacedPayload(TypedDict):
     """Payload for ``file_replaced`` activity events.
 
@@ -248,6 +263,7 @@ SUBTYPE_TYPEDDICT_NAMES: dict[str, str] = {
     "file_written": "FileWrittenPayload",
     "git_push": "GitPushPayload",
     "github_tool": "GithubToolPayload",
+    "dir_listed": "DirListedPayload",
     "delay": "DelayPayload",
     "error": "ErrorPayload",
 }

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -2626,7 +2626,26 @@ async def _dispatch_local_tool(
         if not _is_safe_read_path(list_path, worktree_path):
             logger.warning("⚠️ path_sandbox: list_directory blocked — %s", list_path)
             return {"ok": False, "error": f"list_directory: path '{list_path}' is outside the allowed scope."}
-        return list_directory(list_path)
+        result = list_directory(list_path)
+        if result.get("ok") and session is not None and run_id is not None:
+            raw_entries = result.get("entries")
+            str_entries: list[str] = (
+                [e for e in raw_entries if isinstance(e, str)]
+                if isinstance(raw_entries, list)
+                else []
+            )
+            path_str = (
+                str(list_path.relative_to(worktree_path))
+                if list_path.is_relative_to(worktree_path)
+                else str(list_path)
+            )
+            persist_activity_event(session, run_id, "dir_listed", {
+                "path": path_str,
+                "entry_count": len(str_entries),
+                "entries": "\n".join(str_entries),
+            })
+            await session.flush()
+        return result
 
     if name == "search_text":
         pattern_raw = args.get("pattern")

--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -533,6 +533,47 @@ describe('appendActivityRow', () => {
       });
     });
 
+    describe('dir_listed expandable rows', () => {
+      it('dir_listed row has data-expandable', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'dir_listed',
+          payload: { path: '.', entry_count: 3, entries: 'src/\ntests/\nREADME.md' },
+          recorded_at: '',
+        });
+        const row = document.querySelector<HTMLElement>('.activity-feed__row');
+        expect(row?.dataset['expandable']).toBe('true');
+      });
+
+      it('clicking dir_listed row reveals entry list', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'dir_listed',
+          payload: { path: '.', entry_count: 3, entries: 'src/\ntests/\nREADME.md' },
+          recorded_at: '',
+        });
+        const row = document.querySelector<HTMLElement>('.activity-feed__row');
+        const detail = document.querySelector('.af__tool-detail');
+        expect(detail?.hasAttribute('hidden')).toBe(true);
+        row?.click();
+        expect(detail?.hasAttribute('hidden')).toBe(false);
+        const pre = detail?.querySelector('.af__content-preview');
+        expect(pre?.textContent).toBe('src/\ntests/\nREADME.md');
+      });
+
+      it('dir_listed summary shows entry count', () => {
+        expect(
+          formatActivitySummary('dir_listed', { entry_count: 5, path: '.', entries: '' })
+        ).toBe('5 entries');
+      });
+
+      it('dir_listed summary uses singular for 1 entry', () => {
+        expect(
+          formatActivitySummary('dir_listed', { entry_count: 1, path: '.', entries: 'README.md' })
+        ).toBe('1 entry');
+      });
+    });
+
     it('non-tool rows (shell_done) do not get data-expandable', () => {
       appendActivityRow({
         t: 'activity',

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -24,7 +24,7 @@ import {
 } from './format_utils';
 
 /** Subtypes that support click-to-expand detail panel. */
-const EXPANDABLE_SUBTYPES = new Set(['tool_invoked', 'github_tool', 'file_read']);
+const EXPANDABLE_SUBTYPES = new Set(['tool_invoked', 'github_tool', 'file_read', 'dir_listed']);
 import { getCurrentAppendTarget, getCurrentStepHeader, resetStepContext } from './step_context';
 
 /** SSE activity message shape from the inspector stream. */
@@ -114,6 +114,10 @@ export function formatActivitySummary(subtype: string, payload: Record<string, u
       return shortenPath(str(p, 'path'));
     case 'file_written':
       return `${shortenPath(str(p, 'path'))}  ·  ${fmtBytes(num(p, 'byte_count'))}`;
+    case 'dir_listed': {
+      const count = num(p, 'entry_count');
+      return `${count} ${count === 1 ? 'entry' : 'entries'}`;
+    }
     case 'git_push':
       return str(p, 'branch') || 'push';
     case 'llm_iter':
@@ -168,6 +172,8 @@ export function getSubtypeIcon(subtype: string): string {
     case 'shell_start':
     case 'shell_done':
       return icons.terminal;
+    case 'dir_listed':
+      return icons.folder;
     case 'git_push':
       return icons.gitPush;
     case 'delay':
@@ -354,6 +360,36 @@ function buildFileReadDetail(payload: Record<string, unknown>): HTMLElement {
 }
 
 /**
+ * Build the expandable detail panel for a dir_listed row.
+ * Renders the entries list as a compact preformatted block, one entry per line.
+ * Directories show a trailing /, files are plain names.
+ */
+function buildDirListedDetail(payload: Record<string, unknown>): HTMLElement {
+  const panel = document.createElement('div');
+  panel.className = 'af__tool-detail af__tool-detail--dir-listed';
+  panel.setAttribute('hidden', '');
+
+  const rawEntries = payload['entries'];
+  const entries: string[] = typeof rawEntries === 'string' && rawEntries.length > 0
+    ? rawEntries.split('\n').filter(e => e.length > 0)
+    : [];
+
+  if (entries.length > 0) {
+    const pre = document.createElement('pre');
+    pre.className = 'af__content-preview';
+    pre.textContent = entries.join('\n');
+    panel.appendChild(pre);
+  } else {
+    const note = document.createElement('span');
+    note.className = 'af__detail-val';
+    note.textContent = '(empty directory)';
+    panel.appendChild(note);
+  }
+
+  return panel;
+}
+
+/**
  * Insert a sticky model-info row at the top of the feed on the first llm_iter event.
  * Subsequent llm_iter events are ignored — the model is constant for a run.
  */
@@ -460,7 +496,9 @@ export function appendActivityRow(msg: ActivityMessage): void {
 
     detailPanel = msg.subtype === 'file_read'
       ? buildFileReadDetail(msg.payload)
-      : buildToolDetail(msg.payload);
+      : msg.subtype === 'dir_listed'
+        ? buildDirListedDetail(msg.payload)
+        : buildToolDetail(msg.payload);
 
     const toggle = (): void => {
       const isOpen = row.getAttribute('aria-expanded') === 'true';

--- a/agentception/static/js/icons.ts
+++ b/agentception/static/js/icons.ts
@@ -159,6 +159,12 @@ export const checkmark = s('<polyline points="2,7 5.5,10.5 12,4"/>');
 /** Chevron right — expand affordance for tool call rows */
 export const chevronRight = s('<polyline points="5,2 10,7 5,12"/>');
 
+/** Folder — directory listing result */
+export const folder = s(
+  '<path d="M1 3h5l2 2h5a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H1' +
+  'a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z"/>',
+);
+
 /** Speech bubble — message */
 export const speech = s(
   '<path d="M1 2h12a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H9l-2 2-2-2H1' +


### PR DESCRIPTION
## Summary

**Backend**
- `DirListedPayload` TypedDict: `path`, `entry_count`, `entries` (newline-delimited string)
- `dir_listed` added to `ACTIVITY_SUBTYPES`
- `agent_loop._dispatch_local_tool`: emits `dir_listed` after every successful `list_directory` call, with proper `isinstance` narrowing for `JsonValue` typing

**Frontend**
- New `folder` SVG icon in `icons.ts`
- `dir_listed` row: expandable, folder icon, summary shows `"N entries"`
- Click reveals the full directory listing as a scrollable pre block (reuses `.af__content-preview` SCSS from `file_read`)
- Entries show with trailing `/` for directories, plain names for files

## Test plan

- [x] 267 Vitest tests pass
- [x] Zero mypy errors
- [x] Zero TypeScript type errors
- [x] JS + CSS bundles build cleanly