### PR TITLE
feat(feed): nest dir_listed entries inside list_directory row

### DIFF
--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -533,19 +533,32 @@ describe('appendActivityRow', () => {
       });
     });
 
-    describe('dir_listed expandable rows', () => {
-      it('dir_listed row has data-expandable', () => {
+    describe('dir_listed nested inside list_directory row', () => {
+      it('dir_listed does NOT create a standalone row', () => {
+        // Emit a list_directory tool_invoked first, then a dir_listed result.
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'tool_invoked',
+          payload: { tool_name: 'list_directory', arg_preview: "{'path': '.'}" },
+          recorded_at: '',
+        });
         appendActivityRow({
           t: 'activity',
           subtype: 'dir_listed',
           payload: { path: '.', entry_count: 3, entries: 'src/\ntests/\nREADME.md' },
           recorded_at: '',
         });
-        const row = document.querySelector<HTMLElement>('.activity-feed__row');
-        expect(row?.dataset['expandable']).toBe('true');
+        // Only one row — the tool_invoked one.
+        expect(document.querySelectorAll('.activity-feed__row').length).toBe(1);
       });
 
-      it('clicking dir_listed row reveals entry list', () => {
+      it('dir_listed injects entries into the list_directory detail panel', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'tool_invoked',
+          payload: { tool_name: 'list_directory', arg_preview: "{'path': '.'}" },
+          recorded_at: '',
+        });
         appendActivityRow({
           t: 'activity',
           subtype: 'dir_listed',
@@ -553,24 +566,20 @@ describe('appendActivityRow', () => {
           recorded_at: '',
         });
         const row = document.querySelector<HTMLElement>('.activity-feed__row');
-        const detail = document.querySelector('.af__tool-detail');
-        expect(detail?.hasAttribute('hidden')).toBe(true);
         row?.click();
-        expect(detail?.hasAttribute('hidden')).toBe(false);
+        const detail = document.querySelector('[data-list-dir-target]');
         const pre = detail?.querySelector('.af__content-preview');
         expect(pre?.textContent).toBe('src/\ntests/\nREADME.md');
       });
 
-      it('dir_listed summary shows entry count', () => {
-        expect(
-          formatActivitySummary('dir_listed', { entry_count: 5, path: '.', entries: '' })
-        ).toBe('5 entries');
-      });
-
-      it('dir_listed summary uses singular for 1 entry', () => {
-        expect(
-          formatActivitySummary('dir_listed', { entry_count: 1, path: '.', entries: 'README.md' })
-        ).toBe('1 entry');
+      it('dir_listed with no preceding list_directory is silently dropped', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'dir_listed',
+          payload: { path: '.', entry_count: 1, entries: 'README.md' },
+          recorded_at: '',
+        });
+        expect(document.querySelector('.activity-feed__row')).toBeNull();
       });
     });
 

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -25,7 +25,7 @@ import {
 
 /** Subtypes that support click-to-expand detail panel. */
 const EXPANDABLE_SUBTYPES = new Set([
-  'tool_invoked', 'github_tool', 'file_read', 'dir_listed', 'llm_reply',
+  'tool_invoked', 'github_tool', 'file_read', 'llm_reply',
 ]);
 import { getCurrentAppendTarget, getCurrentStepHeader, resetStepContext } from './step_context';
 
@@ -414,19 +414,34 @@ function buildFileReadDetail(payload: Record<string, unknown>): HTMLElement {
 }
 
 /**
- * Build the expandable detail panel for a dir_listed row.
- * Renders the entries list as a compact preformatted block, one entry per line.
- * Directories show a trailing /, files are plain names.
+ * Append directory-listing entries into an existing tool-detail panel.
+ *
+ * dir_listed is not a standalone row — it is a child of the list_directory
+ * tool_invoked row that preceded it.  This function finds the most recently
+ * rendered list_directory detail panel (identified by data-list-dir-target)
+ * within the given container and injects the entries beneath the existing
+ * arg key-value lines.
  */
-function buildDirListedDetail(payload: Record<string, unknown>): HTMLElement {
-  const panel = document.createElement('div');
-  panel.className = 'af__tool-detail af__tool-detail--dir-listed';
-  panel.setAttribute('hidden', '');
+function injectDirListedIntoPanel(
+  container: HTMLElement,
+  payload: Record<string, unknown>,
+): void {
+  const panels = container.querySelectorAll<HTMLElement>('[data-list-dir-target]');
+  const panel = panels.length > 0 ? panels[panels.length - 1] : null;
+  if (panel === null) return;
 
   const rawEntries = payload['entries'];
   const entries: string[] = typeof rawEntries === 'string' && rawEntries.length > 0
     ? rawEntries.split('\n').filter(e => e.length > 0)
     : [];
+
+  const entriesLine = document.createElement('div');
+  entriesLine.className = 'af__detail-line';
+  const k = document.createElement('span');
+  k.className = 'af__detail-key';
+  k.textContent = 'entries';
+  entriesLine.appendChild(k);
+  panel.appendChild(entriesLine);
 
   if (entries.length > 0) {
     const pre = document.createElement('pre');
@@ -437,10 +452,8 @@ function buildDirListedDetail(payload: Record<string, unknown>): HTMLElement {
     const note = document.createElement('span');
     note.className = 'af__detail-val';
     note.textContent = '(empty directory)';
-    panel.appendChild(note);
+    entriesLine.appendChild(note);
   }
-
-  return panel;
 }
 
 /**
@@ -474,6 +487,13 @@ export function appendActivityRow(msg: ActivityMessage): void {
   // llm_iter: show model once in a sticky header at the top of the feed, then skip.
   if (msg.subtype === 'llm_iter') {
     ensureModelHeader(feed, msg.payload);
+    return;
+  }
+
+  // dir_listed: inject entries into the preceding list_directory detail panel.
+  if (msg.subtype === 'dir_listed') {
+    const target = getCurrentAppendTarget(feed);
+    injectDirListedIntoPanel(target, msg.payload);
     return;
   }
 
@@ -548,10 +568,14 @@ export function appendActivityRow(msg: ActivityMessage): void {
     chevron.innerHTML = icons.chevronRight;
     row.appendChild(chevron);
 
-    detailPanel = msg.subtype === 'file_read'   ? buildFileReadDetail(msg.payload)
-      : msg.subtype === 'dir_listed'             ? buildDirListedDetail(msg.payload)
-      : msg.subtype === 'llm_reply'              ? buildLlmReplyDetail(msg.payload)
+    detailPanel = msg.subtype === 'file_read' ? buildFileReadDetail(msg.payload)
+      : msg.subtype === 'llm_reply'          ? buildLlmReplyDetail(msg.payload)
       : buildToolDetail(msg.payload);
+
+    // Tag list_directory panels so dir_listed can inject entries into them.
+    if (str(msg.payload, 'tool_name') === 'list_directory') {
+      detailPanel.setAttribute('data-list-dir-target', '');
+    }
 
     const toggle = (): void => {
       const isOpen = row.getAttribute('aria-expanded') === 'true';


### PR DESCRIPTION
## Summary

- `dir_listed` is a *result*, not a peer event — it now injects directory entries directly into the detail panel of the preceding `list_directory` `tool_invoked` row instead of rendering a separate folder-icon row.
- Clicking "List dir: ." expands to show both the path arg and the full entries list in one panel.
- Uses `data-list-dir-target` attribute to tag list_directory detail panels; the injector finds the nearest one in the current step container.

## Test plan

- [x] `tsc --noEmit` — zero errors
- [x] 270 Vitest unit tests passing (replaced 4 old standalone-row tests with 3 nesting-behaviour tests)
- [x] `npm run build` — bundles clean