### PR TITLE
feat(feed): show search result files nested inside search rows

### DIFF
--- a/agentception/db/activity_events.py
+++ b/agentception/db/activity_events.py
@@ -60,6 +60,7 @@ ACTIVITY_SUBTYPES: frozenset[str] = frozenset(
         "git_push",
         "github_tool",
         "dir_listed",
+        "search_results",
         "delay",
         "error",
     }
@@ -175,6 +176,19 @@ class DirListedPayload(TypedDict):
     entries: str  # newline-delimited; split on "\n" to get individual names
 
 
+class SearchResultsPayload(TypedDict):
+    """Payload for ``search_results`` activity events.
+
+    Emitted after a successful ``search_codebase`` or ``search_text`` call.
+    ``files`` is a newline-delimited string of unique relative file paths that
+    contained at least one match.  ``result_count`` is the number of unique
+    files — a convenience field so the frontend need not split to count.
+    """
+
+    result_count: int
+    files: str  # newline-delimited; split on "\\n" to get individual paths
+
+
 class FileReplacedPayload(TypedDict):
     """Payload for ``file_replaced`` activity events.
 
@@ -264,6 +278,7 @@ SUBTYPE_TYPEDDICT_NAMES: dict[str, str] = {
     "git_push": "GitPushPayload",
     "github_tool": "GithubToolPayload",
     "dir_listed": "DirListedPayload",
+    "search_results": "SearchResultsPayload",
     "delay": "DelayPayload",
     "error": "ErrorPayload",
 }

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -2657,7 +2657,30 @@ async def _dispatch_local_tool(
             return {"ok": False, "error": f"search_text: directory '{directory}' is outside the allowed scope."}
         n_results_raw = args.get("n_results", 30)
         n_results = int(n_results_raw) if isinstance(n_results_raw, int) else 30
-        return await search_text(pattern_raw, directory, n_results=n_results)
+        result = await search_text(pattern_raw, directory, n_results=n_results)
+        if result.get("ok") and session is not None and run_id is not None:
+            raw_matches = result.get("matches")
+            # rg --heading output: non-digit lines are file paths; digit:content lines are matches.
+            files: list[str] = []
+            if isinstance(raw_matches, str):
+                seen: set[str] = set()
+                for line in raw_matches.splitlines():
+                    stripped = line.strip()
+                    if stripped and not stripped[0].isdigit() and ":" not in stripped[:6]:
+                        # Shorten to worktree-relative path when possible.
+                        try:
+                            rel = str(Path(stripped).relative_to(worktree_path))
+                        except ValueError:
+                            rel = stripped
+                        if rel not in seen:
+                            seen.add(rel)
+                            files.append(rel)
+            persist_activity_event(session, run_id, "search_results", {
+                "result_count": len(files),
+                "files": "\n".join(files),
+            })
+            await session.flush()
+        return result
 
     if name == "run_command":
         command_raw = args.get("command")
@@ -2712,6 +2735,24 @@ async def _dispatch_local_tool(
         collection_raw = args.get("collection")
         collection_arg: str | None = collection_raw if isinstance(collection_raw, str) else None
         matches = await search_codebase(query_raw, n_results, collection=collection_arg)
+        if session is not None and run_id is not None:
+            seen_files: set[str] = set()
+            unique_files: list[str] = []
+            for m in matches:
+                f = m.get("file", "")
+                file_str = f if isinstance(f, str) else str(f)
+                try:
+                    rel = str(Path(file_str).relative_to(worktree_path))
+                except ValueError:
+                    rel = file_str
+                if rel not in seen_files:
+                    seen_files.add(rel)
+                    unique_files.append(rel)
+            persist_activity_event(session, run_id, "search_results", {
+                "result_count": len(unique_files),
+                "files": "\n".join(unique_files),
+            })
+            await session.flush()
         return {
             "ok": True,
             "matches": [

--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -623,6 +623,79 @@ describe('appendActivityRow', () => {
       });
     });
 
+    describe('search_results nested inside search row', () => {
+      it('search_results does NOT create a standalone row', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'tool_invoked',
+          payload: {
+            tool_name: 'search_codebase',
+            arg_preview: "{'query': 'auth flow', 'n_results': 5}",
+          },
+          recorded_at: '',
+        });
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'search_results',
+          payload: { result_count: 2, files: 'src/auth.ts\nsrc/login.ts' },
+          recorded_at: '',
+        });
+        expect(document.querySelectorAll('.activity-feed__row').length).toBe(1);
+      });
+
+      it('search_results injects file list into the search detail panel', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'tool_invoked',
+          payload: {
+            tool_name: 'search_codebase',
+            arg_preview: "{'query': 'auth flow', 'n_results': 5}",
+          },
+          recorded_at: '',
+        });
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'search_results',
+          payload: { result_count: 2, files: 'src/auth.ts\nsrc/login.ts' },
+          recorded_at: '',
+        });
+        const row = document.querySelector<HTMLElement>('.activity-feed__row');
+        row?.click();
+        const detail = document.querySelector('[data-search-target]');
+        const pre = detail?.querySelector('.af__content-preview');
+        expect(pre?.textContent).toBe('src/auth.ts\nsrc/login.ts');
+      });
+
+      it('search_results with no matches shows "(no matches)"', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'tool_invoked',
+          payload: { tool_name: 'search_text', arg_preview: "{'pattern': 'foo'}" },
+          recorded_at: '',
+        });
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'search_results',
+          payload: { result_count: 0, files: '' },
+          recorded_at: '',
+        });
+        const row = document.querySelector<HTMLElement>('.activity-feed__row');
+        row?.click();
+        const detail = document.querySelector('[data-search-target]');
+        expect(detail?.textContent).toContain('no matches');
+      });
+
+      it('search_results with no preceding search is silently dropped', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'search_results',
+          payload: { result_count: 1, files: 'src/foo.ts' },
+          recorded_at: '',
+        });
+        expect(document.querySelector('.activity-feed__row')).toBeNull();
+      });
+    });
+
     describe('tool_invoked diff display', () => {
       it('renders find/replace diff blocks for old_string and new_string', () => {
         appendActivityRow({

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -457,6 +457,48 @@ function injectDirListedIntoPanel(
 }
 
 /**
+ * Append search result file paths into an existing tool-detail panel.
+ *
+ * search_results is not a standalone row — it is a child of the search
+ * tool_invoked row that preceded it.  Finds the most recently rendered
+ * search detail panel (data-search-target) within the container and injects
+ * a 'files' key row followed by a pre listing the matched file paths.
+ */
+function injectSearchResultsIntoPanel(
+  container: HTMLElement,
+  payload: Record<string, unknown>,
+): void {
+  const panels = container.querySelectorAll<HTMLElement>('[data-search-target]');
+  const panel = panels.length > 0 ? panels[panels.length - 1] : null;
+  if (panel === null) return;
+
+  const rawFiles = payload['files'];
+  const files: string[] = typeof rawFiles === 'string' && rawFiles.length > 0
+    ? rawFiles.split('\n').filter(f => f.length > 0)
+    : [];
+
+  const filesLine = document.createElement('div');
+  filesLine.className = 'af__detail-line';
+  const k = document.createElement('span');
+  k.className = 'af__detail-key';
+  k.textContent = 'files';
+  filesLine.appendChild(k);
+  panel.appendChild(filesLine);
+
+  if (files.length > 0) {
+    const pre = document.createElement('pre');
+    pre.className = 'af__content-preview';
+    pre.textContent = files.join('\n');
+    panel.appendChild(pre);
+  } else {
+    const note = document.createElement('span');
+    note.className = 'af__detail-val';
+    note.textContent = '(no matches)';
+    filesLine.appendChild(note);
+  }
+}
+
+/**
  * Insert a sticky model-info row at the top of the feed on the first llm_iter event.
  * Subsequent llm_iter events are ignored — the model is constant for a run.
  */
@@ -494,6 +536,13 @@ export function appendActivityRow(msg: ActivityMessage): void {
   if (msg.subtype === 'dir_listed') {
     const target = getCurrentAppendTarget(feed);
     injectDirListedIntoPanel(target, msg.payload);
+    return;
+  }
+
+  // search_results: inject matched file list into the preceding search detail panel.
+  if (msg.subtype === 'search_results') {
+    const target = getCurrentAppendTarget(feed);
+    injectSearchResultsIntoPanel(target, msg.payload);
     return;
   }
 
@@ -575,6 +624,11 @@ export function appendActivityRow(msg: ActivityMessage): void {
     // Tag list_directory panels so dir_listed can inject entries into them.
     if (str(msg.payload, 'tool_name') === 'list_directory') {
       detailPanel.setAttribute('data-list-dir-target', '');
+    }
+    // Tag search panels so search_results can inject file matches into them.
+    const toolN = str(msg.payload, 'tool_name');
+    if (toolN === 'search_codebase' || toolN === 'search_text') {
+      detailPanel.setAttribute('data-search-target', '');
     }
 
     const toggle = (): void => {


### PR DESCRIPTION
## Summary

- `search_results` events now carry the list of matched file paths and are injected into the preceding `search_codebase` / `search_text` detail panel — same pattern as `dir_listed` / `list_directory`.
- Clicking the Search row expands to show query, results count, and a scrollable file list.
- **Backend**: `search_codebase` deduplicates file paths from match objects; `search_text` parses rg `--heading` output to extract file path lines. Both emit a `search_results` activity event.
- **Frontend**: Panels tagged `data-search-target`; `injectSearchResultsIntoPanel` appends the file list below existing args.

## Test plan

- [x] `mypy` — zero errors
- [x] `tsc --noEmit` — zero errors  
- [x] 274 Vitest unit tests passing (4 new: no-standalone-row, file injection, no-matches, orphan drop)
- [x] `npm run build` — bundles clean
- [x] `generate.py --check` — no drift