### PR TITLE
fix(feed): correct search result injection ordering and label

### DIFF
--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -460,7 +460,7 @@ describe('appendActivityRow', () => {
       expect(vals.some(v => v === '10–50')).toBe(true);
     });
 
-    it('detail panel humanizes n_results to "results"', () => {
+    it('detail panel humanizes n_results to "limit"', () => {
       appendActivityRow({
         t: 'activity',
         subtype: 'tool_invoked',
@@ -473,8 +473,9 @@ describe('appendActivityRow', () => {
       const row = document.querySelector<HTMLElement>('.activity-feed__row');
       row?.click();
       const keys = Array.from(document.querySelectorAll('.af__detail-key')).map(el => el.textContent);
-      expect(keys).toContain('results');
+      expect(keys).toContain('limit');
       expect(keys).not.toContain('n_results');
+      expect(keys).not.toContain('results');
     });
 
     describe('file_read expandable rows', () => {

--- a/agentception/static/js/__tests__/format_utils.test.ts
+++ b/agentception/static/js/__tests__/format_utils.test.ts
@@ -120,8 +120,8 @@ describe('humanizeTool', () => {
 });
 
 describe('humanizeDetailKey', () => {
-  it('humanizes n_results → results', () => {
-    expect(humanizeDetailKey('n_results')).toBe('results');
+  it('humanizes n_results → limit (the request cap, not result count)', () => {
+    expect(humanizeDetailKey('n_results')).toBe('limit');
   });
 
   it('humanizes start_line → from line', () => {

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -533,16 +533,16 @@ export function appendActivityRow(msg: ActivityMessage): void {
   }
 
   // dir_listed: inject entries into the preceding list_directory detail panel.
+  // Search the full feed (not just current step) so timing edge-cases at step
+  // boundaries don't cause the injector to miss the target panel.
   if (msg.subtype === 'dir_listed') {
-    const target = getCurrentAppendTarget(feed);
-    injectDirListedIntoPanel(target, msg.payload);
+    injectDirListedIntoPanel(feed, msg.payload);
     return;
   }
 
   // search_results: inject matched file list into the preceding search detail panel.
   if (msg.subtype === 'search_results') {
-    const target = getCurrentAppendTarget(feed);
-    injectSearchResultsIntoPanel(target, msg.payload);
+    injectSearchResultsIntoPanel(feed, msg.payload);
     return;
   }
 

--- a/agentception/static/js/format_utils.ts
+++ b/agentception/static/js/format_utils.ts
@@ -158,7 +158,7 @@ export function humanizeTool(name: string): string {
  */
 const ARG_KEY_LABELS: Readonly<Record<string, string>> = {
   // Search
-  n_results:       'results',
+  n_results:       'limit',
   num_results:     'results',
   max_results:     'max results',
   query:           'query',

--- a/scripts/retrofit_activity_events.py
+++ b/scripts/retrofit_activity_events.py
@@ -400,6 +400,34 @@ async def _backfill_search_results(session: AsyncSession) -> int:
         ).fetchall()
     ]
 
+    # Also purge any search_results events that were inserted with wrong
+    # timestamps (same second as run_command / other events) so the
+    # re-insertion below uses the corrected anchor timestamps.
+    purge_runs: list[str] = [
+        r[0]
+        for r in (
+            await session.execute(
+                text("""
+                    SELECT DISTINCT agent_run_id
+                    FROM agent_events
+                    WHERE (payload::jsonb)->>'subtype' = 'search_results'
+                """)
+            )
+        ).fetchall()
+    ]
+    if purge_runs:
+        for pr in purge_runs:
+            await session.execute(
+                text("""
+                    DELETE FROM agent_events
+                    WHERE agent_run_id = :run_id
+                      AND (payload::jsonb)->>'subtype' = 'search_results'
+                """),
+                {"run_id": pr},
+            )
+        log.info("search_results — purged stale events for %d runs before re-insert", len(purge_runs))
+        needs_backfill = list(set(needs_backfill) | set(purge_runs))
+
     if not needs_backfill:
         log.info("search_results — nothing to backfill")
         return 0
@@ -455,7 +483,10 @@ async def _backfill_search_results(session: AsyncSession) -> int:
         inserted = 0
         for invocation, result in pairs:
             files = _parse_search_files(result["content"])
-            emit_at = result["recorded_at"]
+            # Anchor the emit time to the tool_invoked timestamp + 1 s to
+            # guarantee it sorts after the invocation in the SSE stream
+            # regardless of wall-clock precision at result time.
+            emit_at = invocation["recorded_at"] + datetime.timedelta(seconds=1)
 
             payload = json.dumps({
                 "subtype": "search_results",


### PR DESCRIPTION
## Summary

- **Injection scope**: search the full feed element when injecting `dir_listed` / `search_results`, not just the current step container. Step-boundary timing edge cases could cause the injector to search the wrong container and miss the target panel.
- **Label**: `n_results` now maps to `limit` instead of `results` — the param is the request cap, not matches found. Showing `results: 10` implied the search found 10 things.
- **Retrofit timestamps**: `search_results` events now anchor to `invocation.recorded_at + 1 s` (not the tool result timestamp), guaranteeing they sort strictly after their `tool_invoked` event. The script purges and re-inserts to fix previously stored events with wrong timestamps.

## Test plan

- [x] `tsc --noEmit` — zero errors
- [x] 274 Vitest tests passing (updated label assertions)
- [x] `npm run build` — bundles clean
- [x] Retrofit re-ran: 61 events purged and re-inserted with corrected timestamps