### PR TITLE
feat: output preview for every tool call (shell + GitHub MCP)

### DIFF
--- a/agentception/db/activity_events.py
+++ b/agentception/db/activity_events.py
@@ -59,6 +59,7 @@ ACTIVITY_SUBTYPES: frozenset[str] = frozenset(
         "file_written",
         "git_push",
         "github_tool",
+        "github_result",
         "dir_listed",
         "search_results",
         "delay",
@@ -136,15 +137,19 @@ class ShellStartPayload(dict[str, str | int | float | bool | None]):
     cwd: str
 
 
-class ShellDonePayload(dict[str, str | int | float | bool | None]):
+class ShellDonePayload(TypedDict):
     """Payload for ``shell_done`` activity events.
 
     Emitted after a shell command exits (success or failure).
+    ``stdout_preview`` carries the first 30 lines / 2 000 chars of stdout
+    for display in the inspector detail panel.
     """
 
     exit_code: int
     stdout_bytes: int
     stderr_bytes: int
+    stdout_preview: NotRequired[str]
+    stderr_preview: NotRequired[str]
 
 
 class FileReadPayload(TypedDict):
@@ -227,15 +232,27 @@ class GitPushPayload(dict[str, str | int | float | bool | None]):
     branch: str
 
 
-class GithubToolPayload(dict[str, str | int | float | bool | None]):
+class GithubToolPayload(TypedDict):
     """Payload for ``github_tool`` activity events.
 
     Emitted when the agent calls a GitHub MCP tool (e.g. ``create_pull_request``).
-    ``arg_preview`` is truncated to ≤120 chars before storage.
+    ``arg_preview`` is truncated to ≤500 chars before storage.
     """
 
     tool_name: str
-    arg_preview: str  # ≤120 chars
+    arg_preview: str
+
+
+class GithubResultPayload(TypedDict):
+    """Payload for ``github_result`` activity events.
+
+    Emitted immediately after a ``github_tool`` event with the first 30 lines /
+    2 000 chars of the MCP tool result text.  Injected into the preceding
+    github_tool detail panel in the inspector.
+    """
+
+    tool_name: str
+    result_preview: str
 
 
 class DelayPayload(dict[str, str | int | float | bool | None]):
@@ -277,6 +294,7 @@ SUBTYPE_TYPEDDICT_NAMES: dict[str, str] = {
     "file_written": "FileWrittenPayload",
     "git_push": "GitPushPayload",
     "github_tool": "GithubToolPayload",
+    "github_result": "GithubResultPayload",
     "dir_listed": "DirListedPayload",
     "search_results": "SearchResultsPayload",
     "delay": "DelayPayload",

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -2453,6 +2453,13 @@ async def _dispatch_single_tool(
                         "github_tool",
                         {"tool_name": name, "arg_preview": str(args)[:500]},
                     )
+                    result_preview = "\n".join(text.splitlines()[:30])[:2000]
+                    persist_activity_event(
+                        session,
+                        run_id,
+                        "github_result",
+                        {"tool_name": name, "result_preview": result_preview},
+                    )
                     await session.flush()
                 except Exception as exc:
                     logger.warning("⚠️ persist github_tool failed: %s", exc)

--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -696,6 +696,100 @@ describe('appendActivityRow', () => {
       });
     });
 
+    describe('shell_done injects stdout into run_command panel', () => {
+      it('shell_done still creates its own row', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'tool_invoked',
+          payload: { tool_name: 'run_command', arg_preview: "{'command': 'echo hi'}" },
+          recorded_at: '',
+        });
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'shell_done',
+          payload: { exit_code: 0, stdout_bytes: 3, stderr_bytes: 0, stdout_preview: 'hi', stderr_preview: '' },
+          recorded_at: '',
+        });
+        expect(document.querySelectorAll('.activity-feed__row').length).toBe(2);
+      });
+
+      it('shell_done injects stdout_preview into the run_command detail panel', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'tool_invoked',
+          payload: { tool_name: 'run_command', arg_preview: "{'command': 'echo hi'}" },
+          recorded_at: '',
+        });
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'shell_done',
+          payload: { exit_code: 0, stdout_bytes: 3, stderr_bytes: 0, stdout_preview: 'hi', stderr_preview: '' },
+          recorded_at: '',
+        });
+        const detail = document.querySelector<HTMLElement>('[data-shell-output-target]');
+        expect(detail).not.toBeNull();
+        const pre = detail?.querySelector('.af__content-preview');
+        expect(pre?.textContent).toBe('hi');
+      });
+
+      it('shell_done with no preceding run_command still creates its own row', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'shell_done',
+          payload: { exit_code: 0, stdout_bytes: 0, stderr_bytes: 0 },
+          recorded_at: '',
+        });
+        expect(document.querySelectorAll('.activity-feed__row').length).toBe(1);
+      });
+    });
+
+    describe('github_result nested inside github_tool row', () => {
+      it('github_result does NOT create a standalone row', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'github_tool',
+          payload: { tool_name: 'issue_read', arg_preview: "{'owner': 'foo', 'repo': 'bar', 'issue_number': 1}" },
+          recorded_at: '',
+        });
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'github_result',
+          payload: { tool_name: 'issue_read', result_preview: '# Issue 1\nSome content.' },
+          recorded_at: '',
+        });
+        expect(document.querySelectorAll('.activity-feed__row').length).toBe(1);
+      });
+
+      it('github_result injects result_preview into the github_tool detail panel', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'github_tool',
+          payload: { tool_name: 'issue_read', arg_preview: "{'owner': 'foo', 'repo': 'bar', 'issue_number': 1}" },
+          recorded_at: '',
+        });
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'github_result',
+          payload: { tool_name: 'issue_read', result_preview: '# Issue 1\nSome content.' },
+          recorded_at: '',
+        });
+        const detail = document.querySelector<HTMLElement>('[data-github-result-target]');
+        expect(detail).not.toBeNull();
+        const pre = detail?.querySelector('.af__content-preview');
+        expect(pre?.textContent).toBe('# Issue 1\nSome content.');
+      });
+
+      it('github_result with no preceding github_tool is silently dropped', () => {
+        appendActivityRow({
+          t: 'activity',
+          subtype: 'github_result',
+          payload: { tool_name: 'issue_read', result_preview: 'hello' },
+          recorded_at: '',
+        });
+        expect(document.querySelector('.activity-feed__row')).toBeNull();
+      });
+    });
+
     describe('tool_invoked diff display', () => {
       it('renders find/replace diff blocks for old_string and new_string', () => {
         appendActivityRow({

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -496,6 +496,70 @@ function injectSearchResultsIntoPanel(
 }
 
 /**
+ * Append shell stdout/stderr preview into the most recent run_command tool panel.
+ *
+ * shell_done continues to render its own summary row (exit code + byte count)
+ * AND additionally injects stdout into the preceding run_command tool_invoked
+ * detail panel (tagged data-shell-output-target) so the output is visible on
+ * expand without leaving the tool row.
+ */
+function injectShellOutputIntoPanel(
+  container: HTMLElement,
+  payload: Record<string, unknown>,
+): void {
+  const panels = container.querySelectorAll<HTMLElement>('[data-shell-output-target]');
+  const panel = panels.length > 0 ? panels[panels.length - 1] : null;
+  if (panel === null) return;
+
+  const stdout = str(payload, 'stdout_preview');
+  const stderr = str(payload, 'stderr_preview');
+  if (!stdout && !stderr) return;
+
+  if (stdout) {
+    const pre = document.createElement('pre');
+    pre.className = 'af__content-preview';
+    pre.textContent = stdout;
+    panel.appendChild(pre);
+  }
+  if (stderr) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'af__diff-block af__diff-block--old';
+    const lbl = document.createElement('span');
+    lbl.className = 'af__diff-label';
+    lbl.textContent = 'stderr';
+    const pre = document.createElement('pre');
+    pre.className = 'af__content-preview';
+    pre.textContent = stderr;
+    wrapper.appendChild(lbl);
+    wrapper.appendChild(pre);
+    panel.appendChild(wrapper);
+  }
+}
+
+/**
+ * Append GitHub MCP tool result preview into the most recent github_tool panel.
+ *
+ * github_result is not a standalone row — it is injected as a child of the
+ * github_tool invocation row that preceded it.
+ */
+function injectGithubResultIntoPanel(
+  container: HTMLElement,
+  payload: Record<string, unknown>,
+): void {
+  const panels = container.querySelectorAll<HTMLElement>('[data-github-result-target]');
+  const panel = panels.length > 0 ? panels[panels.length - 1] : null;
+  if (panel === null) return;
+
+  const preview = str(payload, 'result_preview');
+  if (!preview) return;
+
+  const pre = document.createElement('pre');
+  pre.className = 'af__content-preview';
+  pre.textContent = preview;
+  panel.appendChild(pre);
+}
+
+/**
  * Insert a sticky model-info row at the top of the feed on the first llm_iter event.
  * Subsequent llm_iter events are ignored — the model is constant for a run.
  */
@@ -535,6 +599,12 @@ export function appendActivityRow(msg: ActivityMessage): void {
     return;
   }
 
+  // github_result: inject MCP result text into the preceding github_tool panel.
+  if (msg.subtype === 'github_result') {
+    injectGithubResultIntoPanel(feed, msg.payload);
+    return;
+  }
+
   // dir_listed: inject entries into the preceding list_directory detail panel.
   // Search the full feed (not just current step) so timing edge-cases at step
   // boundaries don't cause the injector to miss the target panel.
@@ -570,9 +640,11 @@ export function appendActivityRow(msg: ActivityMessage): void {
   row.setAttribute('data-subtype', msg.subtype);
 
   // Mark non-zero shell exits for CSS error highlighting.
+  // Also inject stdout/stderr preview into the preceding run_command detail panel.
   if (msg.subtype === 'shell_done') {
     const code = typeof msg.payload['exit_code'] === 'number' ? msg.payload['exit_code'] : 0;
     if (code !== 0) row.dataset['exitNonzero'] = 'true';
+    injectShellOutputIntoPanel(feed, msg.payload);
   }
 
   // Icon: hardcoded SVG via innerHTML (safe — getSubtypeIcon returns only static strings)
@@ -636,6 +708,14 @@ export function appendActivityRow(msg: ActivityMessage): void {
     // Tag read_file / read_file_lines panels so file_read can inject content previews.
     if (toolN === 'read_file' || toolN === 'read_file_lines') {
       detailPanel.setAttribute('data-file-read-target', '');
+    }
+    // Tag run_command panels so shell_done can inject stdout preview into them.
+    if (toolN === 'run_command') {
+      detailPanel.setAttribute('data-shell-output-target', '');
+    }
+    // Tag github_tool panels so github_result can inject result preview into them.
+    if (msg.subtype === 'github_tool') {
+      detailPanel.setAttribute('data-github-result-target', '');
     }
 
     const toggle = (): void => {

--- a/agentception/tools/shell_tools.py
+++ b/agentception/tools/shell_tools.py
@@ -312,6 +312,8 @@ async def run_command(
     # activity event — see docs/reference/activity-events.md
     if run_id and session is not None:
         try:
+            stdout_preview = "\n".join(stdout.splitlines()[:30])[:2000]
+            stderr_preview = "\n".join(stderr.splitlines()[:10])[:500] if stderr.strip() else ""
             activity_events.persist_activity_event(
                 session,
                 run_id,
@@ -320,6 +322,8 @@ async def run_command(
                     "exit_code": exit_code,
                     "stdout_bytes": len(raw_out),
                     "stderr_bytes": len(raw_err),
+                    "stdout_preview": stdout_preview,
+                    "stderr_preview": stderr_preview,
                 },
             )
             await session.flush()

--- a/scripts/retrofit_activity_events.py
+++ b/scripts/retrofit_activity_events.py
@@ -17,8 +17,16 @@ Applies back-fills in a single transaction:
 
 4. **file_read content_preview** — Runs that called ``read_file`` before the
    ``file_read`` activity-event type gained a ``content_preview`` field get
-   synthetic ``file_read`` events reconstructed from the raw tool results
-   stored in ``agent_messages``.
+   lorem-ipsum placeholder ``file_read`` events so the preview UX can be
+   validated against existing runs.
+
+5. **shell_done stdout_preview** — Historical ``shell_done`` events that
+   predate the ``stdout_preview`` field are patched with a lorem-ipsum
+   placeholder so the shell-output injection UX can be validated.
+
+6. **github_result** — Historical ``github_tool`` calls that predate the
+   ``github_result`` event type get a lorem-ipsum placeholder injected so
+   the GitHub result preview UX can be validated.
 
 Run (idempotent — safe to re-run):
 
@@ -629,6 +637,156 @@ async def _backfill_file_read(session: AsyncSession) -> int:
 
 
 # ---------------------------------------------------------------------------
+# 5. shell_done stdout_preview back-fill
+# ---------------------------------------------------------------------------
+
+async def _backfill_shell_output(session: AsyncSession) -> int:
+    """Patch historical shell_done events to include a lorem-ipsum stdout_preview.
+
+    shell_done events written before stdout_preview was added carry no output.
+    This inserts a placeholder so the shell-output injection UX can be
+    validated against existing runs.  Idempotent — events that already have
+    stdout_preview are skipped.
+
+    Returns the number of events updated.
+    """
+    rows: list[tuple[int, str]] = [
+        (r[0], r[1])
+        for r in (
+            await session.execute(
+                text("""
+                    SELECT id, agent_run_id
+                    FROM agent_events
+                    WHERE event_type = 'activity'
+                      AND (payload::jsonb)->>'subtype' = 'shell_done'
+                      AND (payload::jsonb)->>'stdout_preview' IS NULL
+                    ORDER BY id
+                """)
+            )
+        ).fetchall()
+    ]
+
+    if not rows:
+        log.info("shell_output — nothing to backfill")
+        return 0
+
+    log.info("shell_output — %d shell_done events need stdout_preview", len(rows))
+    updated = 0
+    for event_id, run_id in rows:
+        if not DRY_RUN:
+            await session.execute(
+                text("""
+                    UPDATE agent_events
+                    SET payload = payload::jsonb || :patch
+                    WHERE id = :event_id
+                """),
+                {
+                    "event_id": event_id,
+                    "patch": json.dumps({"stdout_preview": _LOREM_IPSUM}),
+                },
+            )
+        log.info(
+            "shell_output — %s id=%d run=%s%s",
+            "[DRY]" if DRY_RUN else "[UPDATE]",
+            event_id, run_id,
+            " (dry-run, not written)" if DRY_RUN else "",
+        )
+        updated += 1
+
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# 6. github_result back-fill
+# ---------------------------------------------------------------------------
+
+async def _backfill_github_result(session: AsyncSession) -> int:
+    """Insert placeholder github_result events for historical github_tool calls.
+
+    github_tool events written before the github_result event type was
+    introduced have no result preview.  A lorem-ipsum placeholder is written
+    so the result-injection UX can be validated against existing runs.
+    Idempotent — runs that already have github_result events are skipped.
+
+    Returns the number of placeholder events inserted.
+    """
+    needs_backfill: list[str] = [
+        r[0]
+        for r in (
+            await session.execute(
+                text("""
+                    SELECT DISTINCT agent_run_id
+                    FROM agent_events
+                    WHERE event_type = 'activity'
+                      AND (payload::jsonb)->>'subtype' = 'github_tool'
+                      AND agent_run_id NOT IN (
+                          SELECT DISTINCT agent_run_id
+                          FROM agent_events
+                          WHERE (payload::jsonb)->>'subtype' = 'github_result'
+                      )
+                    ORDER BY 1
+                """)
+            )
+        ).fetchall()
+    ]
+
+    if not needs_backfill:
+        log.info("github_result — nothing to backfill")
+        return 0
+
+    log.info("github_result — runs needing backfill: %s", needs_backfill)
+    total_inserted = 0
+
+    for run_id in needs_backfill:
+        invocations: list[_ToolInvoked] = [
+            {"event_id": r[0], "run_id": run_id, "recorded_at": r[1]}
+            for r in (
+                await session.execute(
+                    text("""
+                        SELECT id, recorded_at
+                        FROM agent_events
+                        WHERE agent_run_id = :run_id
+                          AND event_type = 'activity'
+                          AND (payload::jsonb)->>'subtype' = 'github_tool'
+                        ORDER BY recorded_at
+                    """),
+                    {"run_id": run_id},
+                )
+            ).fetchall()
+        ]
+
+        inserted = 0
+        for invocation in invocations:
+            emit_at = invocation["recorded_at"] + datetime.timedelta(seconds=1)
+            payload = json.dumps({
+                "subtype": "github_result",
+                "tool_name": "",
+                "result_preview": _LOREM_IPSUM,
+            })
+            if not DRY_RUN:
+                await session.execute(
+                    text("""
+                        INSERT INTO agent_events
+                            (agent_run_id, issue_number, event_type, payload, recorded_at)
+                        VALUES
+                            (:run_id, NULL, 'activity', :payload, :recorded_at)
+                    """),
+                    {"run_id": run_id, "payload": payload, "recorded_at": emit_at},
+                )
+            log.info(
+                "github_result — %s run=%s placeholder inserted%s",
+                "[DRY]" if DRY_RUN else "[INSERT]",
+                run_id,
+                " (dry-run, not written)" if DRY_RUN else "",
+            )
+            inserted += 1
+
+        total_inserted += inserted
+
+    return total_inserted
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -641,17 +799,23 @@ async def main() -> None:
         search_results_count = await _backfill_search_results(session)
         llm_reply_count     = await _extend_llm_reply_previews(session)
         file_read_count     = await _backfill_file_read(session)
+        shell_output_count  = await _backfill_shell_output(session)
+        github_result_count = await _backfill_github_result(session)
 
         if not DRY_RUN:
             await session.commit()
             log.info(
-                "=== Done — dir_listed: %d  search_results: %d  llm_reply: %d  file_read: %d ===",
-                dir_listed_count, search_results_count, llm_reply_count, file_read_count,
+                "=== Done — dir_listed: %d  search_results: %d  llm_reply: %d  "
+                "file_read: %d  shell_output: %d  github_result: %d ===",
+                dir_listed_count, search_results_count, llm_reply_count,
+                file_read_count, shell_output_count, github_result_count,
             )
         else:
             log.info(
-                "=== Dry-run — would insert: %d dir_listed  %d search_results  %d file_read  update: %d llm_reply ===",
-                dir_listed_count, search_results_count, file_read_count, llm_reply_count,
+                "=== Dry-run — would insert/update: %d dir_listed  %d search_results  "
+                "%d file_read  %d shell_output  %d github_result  update: %d llm_reply ===",
+                dir_listed_count, search_results_count,
+                file_read_count, shell_output_count, github_result_count, llm_reply_count,
             )
 
 


### PR DESCRIPTION
## Summary
- **Shell commands** (`run_command`): `shell_done` now carries `stdout_preview` (30 lines / 2 KB) + `stderr_preview`; injected into the `run_command` tool row detail panel on expand
- **GitHub MCP calls**: new `github_result` event type emitted after every `github_tool` call, carrying `result_preview` (30 lines / 2 KB of the MCP response); injected into the `github_tool` panel
- Retrofit inserts lorem-ipsum placeholders for both on historical runs (9 shell_done patched, 1 github_result inserted)

## Test plan
- [x] 280 unit tests passing
- [x] `mypy` clean (304 files)
- [x] `tsc --noEmit` clean
- [x] JS bundle rebuilt