### PR TITLE
feat: asset cache-busting + retrofit missing shell_done events

### DIFF
--- a/agentception/routes/ui/_shared.py
+++ b/agentception/routes/ui/_shared.py
@@ -9,6 +9,7 @@ This module is the single source of truth for:
 from __future__ import annotations
 
 import datetime
+import hashlib
 import logging
 import os
 from pathlib import Path
@@ -217,3 +218,23 @@ _TEMPLATES.env.globals["gh_repo"] = _settings.gh_repo
 _TEMPLATES.env.globals["gh_base_url"] = f"https://github.com/{_settings.gh_repo}"
 # Bare repo name (without org prefix) used to build RESTful URL paths.
 _TEMPLATES.env.globals["repo_name"] = _settings.gh_repo.split("/")[-1]
+
+# ---------------------------------------------------------------------------
+# Asset cache-busting: ?v=<first-8-chars-of-md5> appended to CSS/JS URLs.
+# Re-computed at process startup so every `docker compose restart` picks up
+# the latest bundle without the browser serving a stale cached version.
+# ---------------------------------------------------------------------------
+def _asset_fingerprint(filename: str) -> str:
+    """Return the first 8 hex chars of the MD5 of *filename* under static/.
+
+    Falls back to "dev" if the file is missing (e.g. in CI before first build).
+    """
+    static_dir = _HERE.parent.parent / "static"
+    path = static_dir / filename
+    try:
+        digest = hashlib.md5(path.read_bytes(), usedforsecurity=False).hexdigest()  # noqa: S324
+        return digest[:8]
+    except OSError:
+        return "dev"
+
+_TEMPLATES.env.globals["static_ver"] = _asset_fingerprint("app.js")

--- a/agentception/templates/base.html
+++ b/agentception/templates/base.html
@@ -14,7 +14,7 @@
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='8' fill='%238b5cf6'/><text x='50%25' y='56%25' dominant-baseline='middle' text-anchor='middle' font-size='18' font-family='monospace' fill='white'>⚡</text></svg>" />
 
   <!-- Design system (includes Inter @import) -->
-  <link rel="stylesheet" href="/static/app.css" />
+  <link rel="stylesheet" href="/static/app.css?v={{ static_ver }}" />
 
   <!-- HTMX 2.x — server-driven hypermedia -->
   <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.min.js" defer></script>
@@ -22,8 +22,10 @@
   <!-- Alpine.js component library — must load before Alpine initialises.
        type="module" is required because app.js uses ES import statements.
        Module scripts are deferred by default and execute in document order,
-       so this runs before the Alpine CDN tag below. -->
-  <script src="/static/app.js" type="module"></script>
+       so this runs before the Alpine CDN tag below.
+       ?v= fingerprint ensures the browser fetches the latest bundle after
+       every npm run build without requiring a manual cache clear. -->
+  <script src="/static/app.js?v={{ static_ver }}" type="module"></script>
 
   <!-- Alpine.js 3.x — lightweight reactivity (loads after app.js) -->
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.3/dist/cdn.min.js" defer></script>

--- a/scripts/retrofit_activity_events.py
+++ b/scripts/retrofit_activity_events.py
@@ -24,6 +24,11 @@ Applies back-fills in a single transaction:
    predate the ``stdout_preview`` field are patched with a lorem-ipsum
    placeholder so the shell-output injection UX can be validated.
 
+5b. **shell_done (missing)** — ``run_command`` invocations that have NO
+    corresponding ``shell_done`` event at all (emitted by older code that
+    skipped the event) get a placeholder ``shell_done`` inserted so the
+    injection target panel receives content.
+
 6. **github_result** — Historical ``github_tool`` calls that predate the
    ``github_result`` event type get a lorem-ipsum placeholder injected so
    the GitHub result preview UX can be validated.
@@ -697,6 +702,108 @@ async def _backfill_shell_output(session: AsyncSession) -> int:
 
 
 # ---------------------------------------------------------------------------
+# 5b. shell_done missing-event back-fill
+# ---------------------------------------------------------------------------
+
+async def _backfill_missing_shell_done(session: AsyncSession) -> int:
+    """Insert placeholder shell_done events for run_command calls with no shell_done.
+
+    Some historical runs have ``run_command`` tool_invoked events but no
+    corresponding ``shell_done`` event (the event was never emitted by an older
+    version of the code).  A placeholder with lorem-ipsum stdout_preview is
+    inserted at ``invocation.recorded_at + 1 second`` so the shell-output
+    injection UX can be validated.
+
+    Matching algorithm: for each run, sort ``run_command`` invocations and
+    ``shell_done`` events by time and match them greedily (each invocation is
+    paired with the earliest ``shell_done`` that follows it).  Unmatched
+    invocations get a placeholder.
+
+    Returns the number of placeholder events inserted.
+    """
+    invocations_rows = (
+        await session.execute(
+            text("""
+                SELECT id, agent_run_id, recorded_at
+                FROM agent_events
+                WHERE event_type = 'activity'
+                  AND (payload::jsonb)->>'subtype' = 'tool_invoked'
+                  AND (payload::jsonb)->>'tool_name' = 'run_command'
+                ORDER BY agent_run_id, recorded_at
+            """)
+        )
+    ).fetchall()
+
+    if not invocations_rows:
+        log.info("missing_shell_done — no run_command invocations found")
+        return 0
+
+    shell_done_rows = (
+        await session.execute(
+            text("""
+                SELECT agent_run_id, recorded_at
+                FROM agent_events
+                WHERE event_type = 'activity'
+                  AND (payload::jsonb)->>'subtype' = 'shell_done'
+                ORDER BY agent_run_id, recorded_at
+            """)
+        )
+    ).fetchall()
+
+    # Group shell_done timestamps by run_id (mutable list, consumed as we match).
+    from collections import defaultdict
+    shell_done_by_run: dict[str, list[datetime.datetime]] = defaultdict(list)
+    for row in shell_done_rows:
+        shell_done_by_run[row[0]].append(row[1])
+
+    inserted = 0
+    for inv_id, run_id, inv_ts in invocations_rows:
+        dones = shell_done_by_run[run_id]
+        # Find first shell_done that comes AFTER this invocation.
+        matched = False
+        for i, done_ts in enumerate(dones):
+            if done_ts > inv_ts:
+                dones.pop(i)
+                matched = True
+                break
+        if matched:
+            continue
+
+        # No matching shell_done — insert a placeholder.
+        emit_at = inv_ts + datetime.timedelta(seconds=1)
+        placeholder = {
+            "subtype": "shell_done",
+            "exit_code": 0,
+            "stdout_bytes": len(_LOREM_IPSUM),
+            "stderr_bytes": 0,
+            "stdout_preview": _LOREM_IPSUM,
+            "stderr_preview": "",
+        }
+        if not DRY_RUN:
+            await session.execute(
+                text("""
+                    INSERT INTO agent_events
+                        (agent_run_id, event_type, payload, recorded_at)
+                    VALUES (:run_id, 'activity', :payload, :ts)
+                """),
+                {
+                    "run_id": run_id,
+                    "payload": json.dumps(placeholder),
+                    "ts": emit_at,
+                },
+            )
+        log.info(
+            "missing_shell_done — %s run=%s inv_id=%d at=%s%s",
+            "[DRY]" if DRY_RUN else "[INSERT]",
+            run_id, inv_id, emit_at,
+            " (dry-run, not written)" if DRY_RUN else "",
+        )
+        inserted += 1
+
+    return inserted
+
+
+# ---------------------------------------------------------------------------
 # 6. github_result back-fill
 # ---------------------------------------------------------------------------
 
@@ -795,27 +902,30 @@ async def main() -> None:
     async with get_session() as session:
         log.info("=== Activity-event retrofit  (dry_run=%s) ===", DRY_RUN)
 
-        dir_listed_count    = await _backfill_dir_listed(session)
-        search_results_count = await _backfill_search_results(session)
-        llm_reply_count     = await _extend_llm_reply_previews(session)
-        file_read_count     = await _backfill_file_read(session)
-        shell_output_count  = await _backfill_shell_output(session)
-        github_result_count = await _backfill_github_result(session)
+        dir_listed_count         = await _backfill_dir_listed(session)
+        search_results_count     = await _backfill_search_results(session)
+        llm_reply_count          = await _extend_llm_reply_previews(session)
+        file_read_count          = await _backfill_file_read(session)
+        shell_output_count       = await _backfill_shell_output(session)
+        missing_shell_done_count = await _backfill_missing_shell_done(session)
+        github_result_count      = await _backfill_github_result(session)
 
         if not DRY_RUN:
             await session.commit()
             log.info(
                 "=== Done — dir_listed: %d  search_results: %d  llm_reply: %d  "
-                "file_read: %d  shell_output: %d  github_result: %d ===",
+                "file_read: %d  shell_output: %d  missing_shell_done: %d  github_result: %d ===",
                 dir_listed_count, search_results_count, llm_reply_count,
-                file_read_count, shell_output_count, github_result_count,
+                file_read_count, shell_output_count, missing_shell_done_count, github_result_count,
             )
         else:
             log.info(
                 "=== Dry-run — would insert/update: %d dir_listed  %d search_results  "
-                "%d file_read  %d shell_output  %d github_result  update: %d llm_reply ===",
+                "%d file_read  %d shell_output  %d missing_shell_done  "
+                "%d github_result  update: %d llm_reply ===",
                 dir_listed_count, search_results_count,
-                file_read_count, shell_output_count, github_result_count, llm_reply_count,
+                file_read_count, shell_output_count, missing_shell_done_count,
+                github_result_count, llm_reply_count,
             )
 
 


### PR DESCRIPTION
## Summary
- Adds MD5 fingerprint of `app.js` as `?v=` query string on all CSS/JS URLs so browsers always fetch the latest bundle after every `npm run build` — no more stale JS cache causing missing previews
- Adds `_backfill_missing_shell_done` to the retrofit script: inserts lorem-ipsum `shell_done` placeholder events for `run_command` invocations that had no `shell_done` event at all (3 matched)

## Test plan
- [ ] Server restart computes new fingerprint; browser loads latest `app.js` without hard refresh
- [ ] Historical run inspector shows shell output previews in expanded run_command rows
