### PR TITLE
feat: output preview for read_file_lines, read_symbol, read_window, find_call_sites

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -2582,6 +2582,20 @@ async def _dispatch_local_tool(
         result = read_file_lines(resolved, start_raw, end_raw)
         if result.get("ok"):
             _auto_track_file_read(resolved, worktree_path)
+            if session is not None and run_id is not None:
+                raw_content = result.get("content")
+                if isinstance(raw_content, str) and raw_content:
+                    preview = "\n".join(raw_content.splitlines()[:20])[:1500]
+                    path_str = (
+                        str(resolved.relative_to(worktree_path))
+                        if resolved.is_relative_to(worktree_path)
+                        else str(resolved)
+                    )
+                    persist_activity_event(session, run_id, "file_read", {
+                        "path": path_str,
+                        "content_preview": preview,
+                    })
+                    await session.flush()
         return result
 
     if name == "replace_in_file":
@@ -2797,6 +2811,20 @@ async def _dispatch_local_tool(
         result = read_symbol(resolved, symbol_raw)
         if result.get("ok"):
             _auto_track_file_read(resolved, worktree_path)
+            if session is not None and run_id is not None:
+                raw_content = result.get("content")
+                if isinstance(raw_content, str) and raw_content:
+                    preview = "\n".join(raw_content.splitlines()[:20])[:1500]
+                    path_str = (
+                        str(resolved.relative_to(worktree_path))
+                        if resolved.is_relative_to(worktree_path)
+                        else str(resolved)
+                    )
+                    persist_activity_event(session, run_id, "file_read", {
+                        "path": path_str,
+                        "content_preview": preview,
+                    })
+                    await session.flush()
         return result
 
     if name == "read_window":
@@ -2817,6 +2845,20 @@ async def _dispatch_local_tool(
         result = read_window(resolved_rw, center_raw, before=before, after=after)
         if result.get("ok"):
             _auto_track_file_read(resolved_rw, worktree_path)
+            if session is not None and run_id is not None:
+                raw_content = result.get("content")
+                if isinstance(raw_content, str) and raw_content:
+                    preview = "\n".join(raw_content.splitlines()[:20])[:1500]
+                    path_str = (
+                        str(resolved_rw.relative_to(worktree_path))
+                        if resolved_rw.is_relative_to(worktree_path)
+                        else str(resolved_rw)
+                    )
+                    persist_activity_event(session, run_id, "file_read", {
+                        "path": path_str,
+                        "content_preview": preview,
+                    })
+                    await session.flush()
         return result
 
     if name == "find_call_sites":
@@ -2825,7 +2867,30 @@ async def _dispatch_local_tool(
             return {"ok": False, "error": "find_call_sites: 'symbol_name' must be a string"}
         n_raw = args.get("n_results", 30)
         n_results_fc = int(n_raw) if isinstance(n_raw, int) else 30
-        return await find_call_sites(symbol_raw, worktree_path, n_results=n_results_fc)
+        fc_result = await find_call_sites(symbol_raw, worktree_path, n_results=n_results_fc)
+        if fc_result.get("ok") and session is not None and run_id is not None:
+            raw_matches = fc_result.get("matches")
+            fc_files: list[str] = []
+            if isinstance(raw_matches, str) and raw_matches != "(no call sites found)":
+                fc_seen: set[str] = set()
+                for line in raw_matches.splitlines():
+                    stripped = line.strip()
+                    # rg --heading: file paths are non-empty, don't start with a
+                    # digit, and don't have a colon in the first 6 chars.
+                    if stripped and not stripped[0].isdigit() and ":" not in stripped[:6]:
+                        try:
+                            rel = str(Path(stripped).relative_to(worktree_path))
+                        except ValueError:
+                            rel = stripped
+                        if rel not in fc_seen:
+                            fc_seen.add(rel)
+                            fc_files.append(rel)
+            persist_activity_event(session, run_id, "search_results", {
+                "result_count": len(fc_files),
+                "files": "\n".join(fc_files),
+            })
+            await session.flush()
+        return fc_result
 
     if name == "update_working_memory":
         update = WorkingMemory()

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -702,11 +702,20 @@ export function appendActivityRow(msg: ActivityMessage): void {
       detailPanel.setAttribute('data-list-dir-target', '');
     }
     // Tag search panels so search_results can inject file matches into them.
-    if (toolN === 'search_codebase' || toolN === 'search_text') {
+    if (
+      toolN === 'search_codebase' ||
+      toolN === 'search_text' ||
+      toolN === 'find_call_sites'
+    ) {
       detailPanel.setAttribute('data-search-target', '');
     }
-    // Tag read_file / read_file_lines panels so file_read can inject content previews.
-    if (toolN === 'read_file' || toolN === 'read_file_lines') {
+    // Tag all file-read tools so file_read can inject content previews.
+    if (
+      toolN === 'read_file' ||
+      toolN === 'read_file_lines' ||
+      toolN === 'read_symbol' ||
+      toolN === 'read_window'
+    ) {
       detailPanel.setAttribute('data-file-read-target', '');
     }
     // Tag run_command panels so shell_done can inject stdout preview into them.

--- a/agentception/static/js/format_utils.ts
+++ b/agentception/static/js/format_utils.ts
@@ -109,6 +109,8 @@ export function parseModelInfo(model: string): ModelInfo {
 const TOOL_LABELS: Readonly<Record<string, string>> = {
   read_file:              'Read file',
   read_file_lines:        'Read file',
+  read_symbol:            'Read symbol',
+  read_window:            'Read window',
   get_file_contents:      'Read file',
   list_directory:         'List dir',
   write_file:             'Write file',
@@ -116,6 +118,7 @@ const TOOL_LABELS: Readonly<Record<string, string>> = {
   create_or_update_file:  'Write file',
   replace_in_file:        'Edit file',
   delete_file:            'Delete file',
+  find_call_sites:        'Find usages',
   search_codebase:        'Search',
   search_text:            'Search',
   grep_search:            'Grep',


### PR DESCRIPTION
## Summary
- Closes the last 4 tool preview gaps — every local tool now surfaces output in the inspector for future runs
- `read_file_lines`, `read_symbol`, `read_window` → emit `file_read` event with `content_preview` (first 20 lines / 1 500 chars); panel already tagged `data-file-read-target`, injection just works
- `find_call_sites` → emits `search_results` event with unique file paths parsed from ripgrep heading output; panel tagged `data-search-target`
- Frontend: extend tagging to `read_symbol`, `read_window` (file-read target) and `find_call_sites` (search target)
- Humanised TOOL_LABELS: `read_symbol` → "Read symbol", `read_window` → "Read window", `find_call_sites` → "Find usages"

## Test plan
- [ ] 280 unit tests pass
- [ ] tsc --noEmit clean
- [ ] mypy clean
- [ ] Next agent run: expanding a read_symbol/read_window row shows the code content; find_call_sites shows matched file list
