### PR TITLE
feat: inspector + agent pages polish — persona card, activity feed, cog arch

### DIFF
--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -526,6 +526,39 @@ async def inspector_partial(request: Request, run_id: str) -> HTMLResponse:
     )
 
 
+@router.get("/ui/runs/{run_id}/persona-card", response_class=HTMLResponse)
+async def persona_card_partial(request: Request, run_id: str) -> HTMLResponse:
+    """Return an inline persona mini-card HTML partial for the inspector panel.
+
+    Fetches the cognitive_arch string for *run_id* from the DB, resolves it via
+    ``resolve_cognitive_arch``, and renders ``_persona_card.html``.  Returns an
+    empty 204 when the run has no cognitive_arch so the HTMX swap is a no-op.
+    """
+    from agentception.routes.roles import resolve_cognitive_arch
+
+    cognitive_arch_str: str | None = None
+    try:
+        async with get_session() as session:
+            result = await session.execute(
+                select(ACAgentRun.cognitive_arch).where(ACAgentRun.id == run_id)
+            )
+            raw = result.scalar_one_or_none()
+            cognitive_arch_str = str(raw) if raw is not None else None
+    except Exception:
+        cognitive_arch_str = None
+
+    if not cognitive_arch_str:
+        return HTMLResponse(content="", status_code=204)
+
+    persona = resolve_cognitive_arch(cognitive_arch_str)
+    arch_id = cognitive_arch_str.replace(":", "-")
+    return _TEMPLATES.TemplateResponse(
+        request,
+        "_persona_card.html",
+        {"persona": persona, "arch_id": arch_id},
+    )
+
+
 @router.get("/ship/runs/{run_id}/tree", response_class=Response, response_model=None)
 async def agent_run_tree(run_id: str) -> Response:
     """Return the full agent tree for the batch containing *run_id*.

--- a/agentception/static/js/app.ts
+++ b/agentception/static/js/app.ts
@@ -14,7 +14,7 @@
  *   nav.ts          ✅ — projectSwitcher
  *   toast.ts        ✅ — toastStore
  *   controls.ts     ✅ — controlsKill
- *   build.ts        ✅ — buildPage, renderMd
+ *   build.ts        ✅ — buildPage, renderMd, agentDetailFeed
  *   plan.ts         ✅ — planForm
  *   org_designer.ts ✅ — orgDesigner
  *   overview.js     🟡 — pipelineDashboard, agentCard, phaseSwitcher,
@@ -38,7 +38,7 @@
 import { projectSwitcher } from './nav.ts';
 import { toastStore } from './toast.ts';
 import { controlsKill } from './controls.ts';
-import { buildPage, renderMd } from './build.ts';
+import { buildPage, renderMd, agentDetailFeed } from './build.ts';
 import { planForm } from './plan.ts';
 import { orgDesigner } from './org_designer.ts';
 import { themeToggle } from './theme_toggle.ts';
@@ -68,6 +68,7 @@ Object.assign(window as unknown as Record<string, unknown>, {
   controlsKill,
   buildPage,
   renderMd,
+  agentDetailFeed,
   planForm,
   orgDesigner,
   themeToggle,

--- a/agentception/static/js/build.ts
+++ b/agentception/static/js/build.ts
@@ -12,7 +12,7 @@
  */
 
 import { marked } from 'marked';
-import { attachActivityFeedHandler } from './activity_feed';
+import { attachActivityFeedHandler, resetFeedSession } from './activity_feed';
 import { attachEventCardHandler } from './event_card';
 import { attachFileEditHandler } from './file_edit_card';
 import { attachThoughtHandler } from './thought_block';
@@ -356,6 +356,29 @@ export function buildPage() {
     },
 
     renderMd,
+  };
+}
+
+// ── Agent detail page feed component ─────────────────────────────────────────
+
+/**
+ * Alpine component for the standalone agent detail page (/agents/{run_id}).
+ *
+ * Opens the same SSE stream used by the inspector panel and attaches all the
+ * same activity-feed handlers.  Works for both live and completed runs — for
+ * completed runs the stream drains all stored events then closes.
+ */
+export function agentDetailFeed(runId: string): { init(): void } {
+  return {
+    init(): void {
+      resetFeedSession();
+      const src = new EventSource(`/ship/runs/${encodeURIComponent(runId)}/stream`);
+      attachFileEditHandler(src);
+      attachActivityFeedHandler(src);
+      attachThoughtHandler(src);
+      attachToolCallHandler(src);
+      attachEventCardHandler(src);
+    },
   };
 }
 

--- a/agentception/static/scss/pages/_agent-detail.scss
+++ b/agentception/static/scss/pages/_agent-detail.scss
@@ -404,29 +404,45 @@
 /* ── Cognitive architecture panel (on agent detail page) ─────── */
 
 .cog-panel {
-  padding: 1rem 1.25rem;
+  padding: 1.25rem 1.5rem;
 }
 
 .cog-panel__header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 1rem;
-  margin-bottom: 0.5rem;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.cog-panel__emoji {
+  font-size: 2rem;
+  line-height: 1;
+  flex-shrink: 0;
 }
 
 .cog-panel__title {
   font-weight: 700;
   color: var(--text-primary);
-  font-size: 1rem;
+  font-size: 1.2rem;
+  letter-spacing: -0.02em;
 }
 
 .cog-panel__sub {
+  display: inline-block;
+  margin-top: 0.2rem;
   font-size: 0.72rem;
-  color: var(--accent-muted);
-  background: rgba(124,106,247,.12);
-  border-radius: 4px;
-  padding: 0.1rem 0.4rem;
+  color: var(--accent-bright);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-xs);
+  padding: 0.1rem 0.5rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+
+  &:hover, &.cog-chip--active {
+    background: rgba(124,106,247,.15);
+    border-color: var(--accent);
+  }
 }
 
 .cog-panel__detail-link {
@@ -438,20 +454,62 @@
 .cog-panel__detail-link:hover { text-decoration: underline; }
 
 .cog-panel__desc {
-  font-size: 0.82rem;
+  font-size: 0.84rem;
   color: var(--text-secondary);
-  line-height: 1.55;
-  margin: 0 0 0.75rem;
+  line-height: 1.6;
+  margin: 0 0 1rem;
 
   // Markdown output styling
   p        { margin: 0 0 0.5em; &:last-child { margin-bottom: 0; } }
   strong   { font-weight: 600; color: var(--text-primary); }
   em       { font-style: italic; }
   code     { font-family: var(--font-mono); font-size: 0.78rem;
-              background: rgba(255,255,255,0.07); border-radius: 3px; padding: 0 0.3em; }
+              background: var(--bg-elevated); border: 1px solid var(--border-subtle);
+              border-radius: 3px; padding: 0 0.3em; }
   a        { color: var(--accent); text-decoration: underline; }
   ul, ol   { margin: 0.4em 0; padding-left: 1.4em; }
-  li       { margin: 0.1em 0; }
+  li       { margin: 0.15em 0; }
+}
+
+// Collapsible prompt prefix.
+.cog-panel__prompt-details {
+  margin-top: 1rem;
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 0.75rem;
+}
+
+.cog-panel__prompt-toggle {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+  padding: 0;
+  margin-bottom: 0;
+  transition: color 0.15s;
+
+  &::before {
+    content: '▶';
+    font-size: 0.6rem;
+    transition: transform 0.2s;
+  }
+
+  &:hover { color: var(--text-secondary); }
+
+  // Rotate the triangle when open
+  details[open] > & {
+    margin-bottom: 0.5rem;
+    &::before { transform: rotate(90deg); }
+  }
+
+  // Safari/Chrome put the marker differently — hide the default one
+  &::-webkit-details-marker { display: none; }
 }
 
 // Full-prompt rendered markdown block beneath the hero panel.
@@ -468,10 +526,12 @@
   strong   { font-weight: 600; color: var(--text-secondary); }
   em       { font-style: italic; }
   code     { font-family: var(--font-mono); font-size: 0.72rem;
-              background: rgba(255,255,255,0.07); border-radius: 3px; padding: 0 0.3em; }
-  pre      { background: rgba(255,255,255,0.05); border-radius: var(--radius-xs);
+              background: var(--bg-elevated); border: 1px solid var(--border-subtle);
+              border-radius: 3px; padding: 0 0.3em; }
+  pre      { background: var(--bg-elevated); border: 1px solid var(--border-subtle);
+              border-radius: var(--radius-xs);
               padding: 0.6em 0.8em; overflow-x: auto; margin: 0.5em 0;
-              code { background: none; padding: 0; } }
+              code { background: none; border: none; padding: 0; } }
   ul, ol   { margin: 0.4em 0; padding-left: 1.4em; }
   li       { margin: 0.15em 0; }
   a        { color: var(--accent); text-decoration: underline; }
@@ -480,7 +540,7 @@
 
 .cog-panel__body {
   display: flex;
-  gap: 1rem;
+  gap: 1.25rem;
   flex-wrap: wrap;
 }
 
@@ -490,28 +550,55 @@
   text-transform: uppercase;
   letter-spacing: 0.07em;
   color: var(--text-muted);
-  margin-bottom: 0.35rem;
+  margin-bottom: 0.4rem;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  // Subtle separator line
+  &::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--border-subtle);
+  }
 }
 
 .cog-atoms-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.3rem;
+  gap: 0.35rem;
 }
 
 .cog-atom-pill {
   display: flex;
   flex-direction: column;
   background: var(--bg-elevated);
-  border: 1px solid var(--border-subtle);
-  border-radius: 5px;
-  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: 0.3rem 0.6rem;
   font-size: 0.7rem;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.12s;
+
+  &:hover {
+    border-color: var(--accent);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+    transform: translateY(-1px);
+  }
+
+  &.cog-chip--active {
+    border-color: var(--accent);
+    background: rgba(124,106,247,.08);
+  }
 }
 
 .cog-atom-pill__key {
   color: var(--text-muted);
   font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .cog-atom-pill__val {
@@ -522,7 +609,7 @@
 .cog-skills-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem;
+  gap: 0.3rem;
 }
 
 /* ── Cognitive architecture standalone page (/cognitive-arch/*) ─ */
@@ -1206,3 +1293,39 @@
   }
 }
 
+
+// ── Agent detail activity feed ────────────────────────────────────────────────
+
+.agent-feed-section {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 400px;
+  max-height: 70vh;
+
+  .agent-section-title {
+    flex-shrink: 0;
+  }
+}
+
+.agent-feed__feed {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  background: var(--bg-void);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255,255,255,0.1) transparent;
+
+  &::-webkit-scrollbar       { width: 4px; }
+  &::-webkit-scrollbar-track { background: transparent; }
+  &::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.12); border-radius: 2px; }
+
+  [data-theme="light"] & {
+    scrollbar-color: rgba(0,0,0,0.15) transparent;
+    &::-webkit-scrollbar-thumb { background: rgba(0,0,0,0.15); }
+  }
+}

--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -652,51 +652,6 @@ body:has(.build-layout) nav.topnav {
   &--done     { -webkit-line-clamp: 2; margin-bottom: 0; }
 }
 
-// ── Card icon links (hover-revealed — transcript + cognitive arch) ────────────
-
-.build-issue__icon-links {
-  position: absolute;
-  top: 0.3rem;
-  right: 0.3rem;
-  display: flex;
-  gap: 0.2rem;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.15s var(--ease-out);
-  z-index: 1;
-}
-
-// Reveal on hover for any card that is not pointer-events:none (i.e. not --done)
-.build-issue:not(.build-issue--done):hover .build-issue__icon-links {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.build-issue__icon-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  border-radius: var(--radius-xs);
-  background: var(--bg-surface);
-  border: 1px solid var(--border-default);
-  color: var(--text-faint);
-  text-decoration: none;
-  transition:
-    color       0.15s var(--ease-out),
-    background  0.15s var(--ease-out),
-    border-color 0.15s var(--ease-out);
-
-  svg { flex-shrink: 0; display: block; }
-
-  &:hover {
-    color: var(--accent-bright);
-    background: var(--bg-overlay);
-    border-color: var(--accent);
-  }
-}
-
 // ── Inspector panel (right) — sticky as board scrolls ────────────────────────
 
 .build-inspector {
@@ -803,6 +758,28 @@ body:has(.build-layout) nav.topnav {
     transition: color 0.15s, background 0.15s;
     margin-top: 1px;
     &:hover { background: var(--bg-overlay); color: var(--text-primary); }
+  }
+
+  &__icon-link {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: var(--radius-xs);
+    background: var(--bg-overlay);
+    border: 1px solid var(--border-default);
+    color: var(--text-faint);
+    text-decoration: none;
+    margin-top: 1px;
+    transition: color 0.15s var(--ease-out), background 0.15s var(--ease-out), border-color 0.15s var(--ease-out);
+    svg { flex-shrink: 0; display: block; }
+    &:hover {
+      color: var(--accent-bright);
+      background: var(--bg-surface);
+      border-color: var(--accent);
+    }
   }
 
   &__run-meta {
@@ -2320,6 +2297,94 @@ $preset-accents: (
 
   &--on  { color: var(--warning); }
   &--off { color: var(--success); }
+}
+
+// ── Inspector persona mini-card ───────────────────────────────────────────────
+
+.build-inspector__persona {
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+}
+
+.build-inspector__persona-skeleton {
+  padding: 0.5rem 0.875rem;
+  font-size: 0.75rem;
+  color: var(--text-faint);
+}
+
+.persona-card {
+  padding: 0.5rem 0.875rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  &__emoji {
+    font-size: 1.25rem;
+    line-height: 1;
+    flex-shrink: 0;
+  }
+
+  &__meta {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+
+  &__name {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__archetype {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+
+  &__profile-link {
+    flex-shrink: 0;
+    font-size: 0.7rem;
+    color: var(--accent-bright);
+    text-decoration: none;
+    white-space: nowrap;
+    &:hover { text-decoration: underline; }
+  }
+
+  &__skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    padding-left: 1.75rem; // indent under emoji
+  }
+
+  &__skill-chip {
+    display: inline-block;
+    font-size: 0.65rem;
+    font-weight: 500;
+    color: var(--text-muted);
+    background: var(--bg-overlay);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-xs);
+    padding: 0.1rem 0.4rem;
+
+    &--more {
+      color: var(--text-faint);
+      background: transparent;
+    }
+  }
 }
 
 // ── Activity feed container — terminal-style scrollable log ──────────────────

--- a/agentception/templates/_build_board.html
+++ b/agentception/templates/_build_board.html
@@ -21,37 +21,6 @@
   {%- if not group_complete and lane != 'done' %}@click='$dispatch("inspect-issue", {{ issue | tojson }})'{% endif %}
 >
 
-  {# ── Icon links (agent + cog-arch) — shown in active/pr/reviewing lanes only #}
-  {% if active_run and lane in ('active', 'pr_open', 'reviewing') %}
-  <div class="build-issue__icon-links">
-    <a class="build-issue__icon-link"
-       href="/agents/{{ active_run.id }}"
-       title="View agent transcript"
-       @click.stop>
-      <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <path d="M10 2h4v4"/>
-        <path d="M14 2L9 7"/>
-        <path d="M7 3H3a1 1 0 00-1 1v9a1 1 0 001 1h9a1 1 0 001-1V9"/>
-      </svg>
-    </a>
-    {% if active_run.cognitive_arch %}
-    <a class="build-issue__icon-link"
-       href="/cognitive-arch/{{ active_run.cognitive_arch | replace(':', '-') }}"
-       title="View cognitive architecture: {{ active_run.cognitive_arch }}"
-       @click.stop>
-      <svg width="11" height="11" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <circle cx="5" cy="5" r="2"/>
-        <circle cx="11" cy="5" r="2"/>
-        <circle cx="8" cy="12" r="2"/>
-        <line x1="7" y1="5" x2="9" y2="5"/>
-        <line x1="5.8" y1="6.8" x2="7.2" y2="10.2"/>
-        <line x1="10.2" y1="6.8" x2="8.8" y2="10.2"/>
-      </svg>
-    </a>
-    {% endif %}
-  </div>
-  {% endif %}
-
   {# ── Header: issue number + role label pill + state dot #}
   <div class="build-issue__header">
     <a class="build-issue__number" href="{{ issue.url }}" target="_blank" rel="noopener" @click.stop>

--- a/agentception/templates/_persona_card.html
+++ b/agentception/templates/_persona_card.html
@@ -1,0 +1,36 @@
+{#
+  _persona_card.html — compact persona mini-card for the inspector panel.
+  Context:
+    persona  — dict from resolve_cognitive_arch()
+    arch_id  — URL-safe arch string (colons → hyphens)
+#}
+<div class="persona-card">
+  <div class="persona-card__header">
+    <span class="persona-card__emoji">{{ persona.archetype_emoji }}</span>
+    <div class="persona-card__meta">
+      <span class="persona-card__name">{{ persona.display_name }}</span>
+      {% if persona.archetype %}
+      <span class="persona-card__archetype">{{ persona.archetype | replace('_', ' ') | title }}</span>
+      {% endif %}
+    </div>
+    <a class="persona-card__profile-link"
+       href="/cognitive-arch/{{ arch_id }}"
+       target="_blank" rel="noopener"
+       title="Full cognitive architecture profile">
+      Full profile →
+    </a>
+  </div>
+
+  {% if persona.skill_domains %}
+  <div class="persona-card__skills">
+    {% for skill in persona.skill_domains[:4] %}
+    <span class="persona-card__skill-chip">{{ skill | replace('_', ' ') | title }}</span>
+    {% endfor %}
+    {% if persona.skill_domains | length > 4 %}
+    <span class="persona-card__skill-chip persona-card__skill-chip--more">
+      +{{ persona.skill_domains | length - 4 }} more
+    </span>
+    {% endif %}
+  </div>
+  {% endif %}
+</div>

--- a/agentception/templates/agent.html
+++ b/agentception/templates/agent.html
@@ -181,26 +181,12 @@
   <div></div>
   {% endif %}
 
-  {# ── Timeline (right) ─────────────────────────────────────────────────── #}
-  {% if events %}
-  <section class="card" aria-label="Timeline">
-    <h2 class="agent-section-title">Timeline</h2>
-    <ul class="build-timeline">
-      {% for ev in events %}
-      <li class="build-timeline__item build-timeline__item--{{ ev.event_type }}">
-        <span class="build-timeline__icon">{{ ev.icon }}</span>
-        <div class="build-timeline__body">
-          <span class="build-timeline__type">{{ ev.event_type | replace('_', ' ') }}</span>
-          <span class="build-timeline__detail">{{ ev.detail }}</span>
-          {%- if ev.recorded_at %}
-          <time class="build-timeline__time" title="{{ ev.recorded_at }}">
-            {{ ev.recorded_at[0:10] }} {{ ev.recorded_at[11:16] }} UTC
-          </time>
-          {%- endif %}
-        </div>
-      </li>
-      {% endfor %}
-    </ul>
+  {# ── Activity feed (right) ────────────────────────────────────────────── #}
+  {% if node and node.id %}
+  <section class="card agent-feed-section" aria-label="Activity"
+           x-data='agentDetailFeed({{ node.id | tojson }})'>
+    <h2 class="agent-section-title">Activity</h2>
+    <div id="activity-feed" class="agent-feed__feed" role="log" aria-live="polite" aria-label="Agent activity"></div>
   </section>
   {% else %}
   <div></div>

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -112,6 +112,28 @@
                    target="_blank" rel="noopener"
                    x-text="'PR #' + activeIssue.run.pr_number"></a>
               </template>
+              {# Transcript + cognitive-arch links — moved here from the Kanban card #}
+              <template x-if="activeIssue.run && activeIssue.run.id">
+                <a class="build-inspector__icon-link"
+                   :href="'/agents/' + activeIssue.run.id"
+                   title="View agent transcript"
+                   target="_blank" rel="noopener">
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M10 2h4v4"/><path d="M14 2L9 7"/><path d="M7 3H3a1 1 0 00-1 1v9a1 1 0 001 1h9a1 1 0 001-1V9"/>
+                  </svg>
+                </a>
+              </template>
+              <template x-if="activeIssue.run && activeIssue.run.cognitive_arch">
+                <a class="build-inspector__icon-link"
+                   :href="'/cognitive-arch/' + activeIssue.run.cognitive_arch.replaceAll(':', '-')"
+                   title="View cognitive architecture"
+                   target="_blank" rel="noopener">
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="5" cy="5" r="2"/><circle cx="11" cy="5" r="2"/><circle cx="8" cy="12" r="2"/>
+                    <line x1="7" y1="5" x2="9" y2="5"/><line x1="5.8" y1="6.8" x2="7.2" y2="10.2"/><line x1="10.2" y1="6.8" x2="8.8" y2="10.2"/>
+                  </svg>
+                </a>
+              </template>
               <button class="build-inspector__close" @click="clearInspect()">✕</button>
             </div>
           </div>
@@ -153,6 +175,17 @@
           <template x-if="activeIssue.run && activeIssue.run.agent_status === 'failed'">
             <div class="build-inspector__no-agent">
               <p>This run failed. Use <strong>Design org →</strong> to launch again and create a new run.</p>
+            </div>
+          </template>
+
+          {# Persona mini-card — lazy-loaded when a run with a cognitive_arch is selected #}
+          <template x-if="activeIssue.run && activeIssue.run.id && activeIssue.run.cognitive_arch">
+            <div class="build-inspector__persona"
+                 :hx-get="'/ui/runs/' + activeIssue.run.id + '/persona-card'"
+                 hx-trigger="load"
+                 hx-swap="innerHTML"
+                 x-init="$nextTick(() => htmx.process($el))">
+              <div class="build-inspector__persona-skeleton">Loading persona…</div>
             </div>
           </template>
 

--- a/agentception/templates/cognitive_arch.html
+++ b/agentception/templates/cognitive_arch.html
@@ -95,13 +95,12 @@
   </div>
 
   {% if persona.prompt_prefix %}
-  <div class="cog-panel__prompt mt-2" style="padding:0.75rem 1rem;background:var(--bg-elevated);border-top:1px solid var(--border-subtle);">
-    <div class="cog-panel__section-label" style="margin-bottom:0.4rem;">Prompt Prefix</div>
-    {# Render the full prompt prefix as markdown — it is authored in markdown. #}
+  <details class="cog-panel__prompt-details">
+    <summary class="cog-panel__prompt-toggle">Prompt Prefix</summary>
     <div class="cog-panel__prompt-body"
          x-data
          x-init="$el.innerHTML = renderMd($el.textContent)">{{ persona.prompt_prefix }}</div>
-  </div>
+  </details>
   {% endif %}
 </div>
 


### PR DESCRIPTION
## Summary

- **Move icon links from Kanban card to inspector toolbar**: The transcript and cognitive-arch icon links now live in the inspector panel header (next to the PR chip and close button), decluttering individual cards.
- **Inline persona mini-card in inspector**: A new HTMX-lazy-loaded `_persona_card.html` partial shows the agent's emoji, display name, archetype chip, and up to 4 skill domain chips between the run-meta bar and the activity feed. Backed by a new `GET /ui/runs/{run_id}/persona-card` endpoint.
- **Activity feed on agent detail page**: Replaced the raw JSON Timeline section with the same rich SSE-driven activity feed used in the inspector. Added `agentDetailFeed(runId)` Alpine component in `build.ts` and exported from `app.ts`.
- **Cognitive arch page polish**: Wrapped the Prompt Prefix in a collapsible `<details>` element (closed by default). Improved hero panel sizing, atom pill hover effects, section label separator lines, skill chip sizing, and light-mode friendly colours throughout `_agent-detail.scss`.

## Test plan

- [x] `mypy agentception/ tests/` — zero errors
- [x] `typing_audit.py --max-any 0` — passes
- [x] `npm test` — 280 tests green
- [x] `npm run build` — bundles built cleanly
- [x] `generate.py --check` — no drift