### PR TITLE
fix: remove dead events fetching code from agent detail route

### DIFF
--- a/agentception/routes/ui/agents.py
+++ b/agentception/routes/ui/agents.py
@@ -12,7 +12,6 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from agentception.db.queries import (
-    AgentEventRow,
     AgentMessageRow,
     AgentRunDetail,
     AgentRunRow,
@@ -534,14 +533,15 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
     1. In-memory state — live status, branch, issue number from the poller.
     2. Postgres ``ac_agent_runs`` — historical run metadata and status.
     3. Postgres ``ac_agent_messages`` — transcript messages (stored by the agent loop).
-    4. Postgres ``ac_agent_events`` — structured MCP events for the timeline.
-    5. GitHub API — issue body, PR checks, PR reviews (fetched in parallel).
+    4. GitHub API — issue body, PR checks, PR reviews (fetched in parallel).
+
+    The activity feed is rendered client-side via the SSE stream
+    (``/ship/runs/{run_id}/stream``) rather than pre-fetched here.
 
     Returns HTTP 404 only when the agent is absent from both in-memory state
     and the Postgres history.
     """
     from agentception.db.queries import (
-        get_agent_events_tail,
         get_agent_run_detail,
         get_sibling_runs,
     )
@@ -651,7 +651,6 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
         except Exception:
             return None
 
-    events: list[AgentEventRow]
     issue_detail: IssueDetailRow | None
     pr_checks: list[dict[str, JsonValue]]
     pr_reviews: list[dict[str, JsonValue]]
@@ -667,20 +666,18 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
             return None
 
     (
-        events,
         issue_detail,
         pr_checks,
         pr_reviews,
         siblings,
     ) = await asyncio.gather(
-        get_agent_events_tail(agent_id),
         _safe_get_issue_from_db(issue_number) if issue_number else _noop_none(),
         _safe_get_pr_checks(pr_number) if pr_number else _noop_list_dict(),
         _safe_get_pr_reviews(pr_number) if pr_number else _noop_list_dict(),
         _safe_get_siblings(batch_id) if batch_id else _noop_list_sibling(),
     )
 
-    # Fetch parent run separately (to avoid the 5-coroutine overload limit in mypy)
+    # Fetch parent run separately (to avoid the 4-coroutine overload limit in mypy)
     # and extract the grandparent run id for the org chart.
     grandparent_run_id: str | None = None
     if parent_run_id:
@@ -688,45 +685,6 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
         if parent_run and isinstance(parent_run, dict):
             gp = parent_run.get("parent_run_id")
             grandparent_run_id = str(gp) if gp else None
-
-    # Pre-process events: parse payload JSON so the template has plain dicts.
-    import json as _json
-
-    def _event_detail_text(ev: AgentEventRow) -> str:
-        """Extract the human-readable summary string from an event payload."""
-        try:
-            p: dict[str, JsonValue] = _json.loads(ev["payload"])
-        except Exception:
-            return ev["payload"]
-        etype = ev["event_type"]
-        if etype == "step_start":
-            return str(p.get("step", ""))
-        if etype == "blocker":
-            return str(p.get("description", ""))
-        if etype == "decision":
-            decision = str(p.get("decision", ""))
-            rationale = str(p.get("rationale", ""))
-            return f"{decision} — {rationale}" if rationale else decision
-        if etype == "done":
-            return str(p.get("summary", "") or p.get("pr_url", ""))
-        return ev["payload"]
-
-    _event_icon: dict[str, str] = {
-        "step_start": "▶",
-        "blocker": "🚧",
-        "decision": "💡",
-        "done": "✅",
-    }
-
-    processed_events = [
-        {
-            "event_type": ev["event_type"],
-            "icon": _event_icon.get(ev["event_type"], "•"),
-            "detail": _event_detail_text(ev),
-            "recorded_at": ev["recorded_at"],
-        }
-        for ev in events
-    ]
 
     # ── Duration / date strings ─────────────────────────────────────────────
     # Only use completed_at for duration — last_activity_at is updated by the
@@ -756,8 +714,6 @@ async def agent_detail(request: Request, agent_id: str) -> Response:
             "messages": messages,
             "db_run": db_run,
             "persona": persona,
-            # Enrichment
-            "events": processed_events,
             "issue_detail": issue_detail,
             "pr_checks": pr_checks,
             "pr_reviews": pr_reviews,


### PR DESCRIPTION
## Summary

The `Timeline` section in `agent.html` was replaced by the SSE-driven activity feed in PR #1126. This removes all the now-dead code that was still running but discarded:

- `AgentEventRow` import
- `get_agent_events_tail` lazy import and call
- `events` type annotation and gather slot
- `_event_detail_text()` helper function
- `_event_icon` dict
- `processed_events` list comprehension
- `"events": processed_events` template context key

Mypy: zero errors.

## Test plan

- [x] `mypy agentception/routes/ui/agents.py` — zero errors