### PR TITLE
fix: persona card profile link — same tab, stable hover colour in light mode

### DIFF
--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -2357,10 +2357,10 @@ $preset-accents: (
   &__profile-link {
     flex-shrink: 0;
     font-size: 0.7rem;
-    color: var(--accent-bright);
+    color: var(--accent);
     text-decoration: none;
     white-space: nowrap;
-    &:hover { text-decoration: underline; }
+    &:hover { color: var(--accent); text-decoration: underline; }
   }
 
   &__skills {

--- a/agentception/templates/_persona_card.html
+++ b/agentception/templates/_persona_card.html
@@ -15,7 +15,6 @@
     </div>
     <a class="persona-card__profile-link"
        href="/cognitive-arch/{{ arch_id }}"
-       target="_blank" rel="noopener"
        title="Full cognitive architecture profile">
       Full profile →
     </a>


### PR DESCRIPTION
- Remove `target="_blank"` so "Full profile →" navigates in the same tab
- Change link colour from `var(--accent-bright)` (can resolve to white in dark theme) to `var(--accent)` and pin hover colour explicitly so it stays visible in both light and dark mode