### PR TITLE
fix: stable org designer toolbar — Toggle and Close never shift position

### DIFF
--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -319,17 +319,8 @@
       </span>
     </template>
 
-    {# Live / Design mode toggle — only shown when there are known batches #}
-    <template x-if="activeBatches.length > 0">
-      <div class="od-header__mode-toggle">
-        <button class="od-header__mode-btn"
-                :class="liveMode ? 'od-header__mode-btn--active' : ''"
-                @click="enterLiveMode()">● Live</button>
-        <button class="od-header__mode-btn"
-                :class="!liveMode ? 'od-header__mode-btn--active' : ''"
-                @click="enterDesignMode()">Design</button>
-      </div>
-    </template>
+    {# Presets + Launch appear here so they expand LEFTWARD into the flex:1
+       title gap — keeping Toggle and Close pinned at the right edge always. #}
 
     {# Back to presets (canvas / design mode only) #}
     <template x-if="!presetsOpen && !liveMode">
@@ -349,6 +340,20 @@
       </button>
     </template>
 
+    {# Live / Design mode toggle — only shown when there are known batches.
+       Always the second-to-last item so it never shifts position. #}
+    <template x-if="activeBatches.length > 0">
+      <div class="od-header__mode-toggle">
+        <button class="od-header__mode-btn"
+                :class="liveMode ? 'od-header__mode-btn--active' : ''"
+                @click="enterLiveMode()">● Live</button>
+        <button class="od-header__mode-btn"
+                :class="!liveMode ? 'od-header__mode-btn--active' : ''"
+                @click="enterDesignMode()">Design</button>
+      </div>
+    </template>
+
+    {# Close is always the last item — never moves. #}
     <button class="od-header__btn od-header__btn--close" @click="close()">✕ Close</button>
   </div>
 


### PR DESCRIPTION
## Problem

Clicking Live ↔ Design caused the Presets and Launch buttons to appear/disappear **after** the mode toggle, pushing the Close button rightward. Every mode switch made the entire right side of the toolbar jump.

## Fix

Reorder the DOM so Presets and Launch appear **before** the mode toggle. Since `od-header__title` has `flex: 1`, it fills all remaining space and the controls cluster is packed against the right edge. With Toggle and Close always as the last two items in that cluster, they sit at the same pixel position regardless of whether Presets/Launch are rendered.

- Live mode: `[initiative] [save-as] ... [Toggle] [Close]`
- Design mode: `[initiative] [save-as] ... [Presets] [Launch] [Toggle] [Close]`

Presets and Launch expand leftward into the title's flex space — Toggle and Close never move.