### PR TITLE
feat: redesign inspector header into three information-rich zones

### DIFF
--- a/agentception/static/js/__tests__/build.test.ts
+++ b/agentception/static/js/__tests__/build.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { formatRunDuration } from '../build';
+
+describe('formatRunDuration', () => {
+  const BASE = '2025-01-01T12:00:00.000Z';
+
+  it('returns empty string for null spawnedAt', () => {
+    expect(formatRunDuration(null, null, 'done')).toBe('');
+  });
+
+  it('returns empty string for unparseable spawnedAt', () => {
+    expect(formatRunDuration('not-a-date', null, 'done')).toBe('');
+  });
+
+  it('formats completed run in seconds only', () => {
+    const lastActivity = '2025-01-01T12:00:45.000Z'; // 45s after start
+    expect(formatRunDuration(BASE, lastActivity, 'done')).toBe('ran 45s');
+  });
+
+  it('formats completed run in minutes and seconds', () => {
+    const lastActivity = '2025-01-01T12:08:23.000Z'; // 8m 23s after start
+    expect(formatRunDuration(BASE, lastActivity, 'done')).toBe('ran 8m 23s');
+  });
+
+  it('uses "running" prefix for implementing status', () => {
+    // Pin "now" to 30s after spawn
+    const fakeNow = new Date('2025-01-01T12:00:30.000Z').getTime();
+    const spy = vi.spyOn(Date, 'now').mockReturnValue(fakeNow);
+    try {
+      expect(formatRunDuration(BASE, null, 'implementing')).toBe('running 30s');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('uses "running" prefix for reviewing status', () => {
+    const fakeNow = new Date('2025-01-01T12:02:05.000Z').getTime();
+    const spy = vi.spyOn(Date, 'now').mockReturnValue(fakeNow);
+    try {
+      expect(formatRunDuration(BASE, null, 'reviewing')).toBe('running 2m 5s');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('uses lastActivityAt for non-active statuses', () => {
+    const lastActivity = '2025-01-01T12:05:00.000Z'; // 5m after start
+    expect(formatRunDuration(BASE, lastActivity, 'stale')).toBe('ran 5m 0s');
+  });
+
+  it('clamps negative deltas to 0s', () => {
+    // lastActivity before spawned (shouldn't happen but must not crash)
+    const lastActivity = '2025-01-01T11:59:00.000Z';
+    expect(formatRunDuration(BASE, lastActivity, 'done')).toBe('ran 0s');
+  });
+});

--- a/agentception/static/js/build.ts
+++ b/agentception/static/js/build.ts
@@ -26,6 +26,39 @@ interface AgentRun {
   agent_status?: string;
   tier: string | null;
   role: string | null;
+  steps_completed: number;
+  spawned_at: string;
+  last_activity_at: string | null;
+  current_step: string | null;
+  branch: string | null;
+  cognitive_arch: string | null;
+}
+
+/**
+ * Format a human-readable run duration from ISO timestamps.
+ *
+ * Returns "ran Xm Ys" for completed runs, "running Xm Ys" for active ones.
+ * Falls back to an empty string when `spawnedAt` is missing or unparseable.
+ */
+export function formatRunDuration(
+  spawnedAt: string | null,
+  lastActivityAt: string | null,
+  agentStatus: string,
+): string {
+  if (!spawnedAt) return '';
+  const startMs = Date.parse(spawnedAt);
+  if (isNaN(startMs)) return '';
+  const isActive = agentStatus === 'implementing' || agentStatus === 'reviewing';
+  const endMs = isActive
+    ? Date.now()
+    : lastActivityAt
+      ? (Date.parse(lastActivityAt) || Date.now())
+      : Date.now();
+  const totalSecs = Math.max(0, Math.floor((endMs - startMs) / 1000));
+  const mins = Math.floor(totalSecs / 60);
+  const secs = totalSecs % 60;
+  const prefix = isActive ? 'running ' : 'ran ';
+  return mins > 0 ? `${prefix}${mins}m ${secs}s` : `${prefix}${secs}s`;
 }
 
 export interface ActiveIssue {
@@ -122,6 +155,10 @@ export function buildPage() {
     streamOpen: false,
     _evtSource: null as EventSource | null,
 
+    // ── run duration display ─────────────────────────────────────────────
+    runDuration: '',
+    _durationTimer: null as ReturnType<typeof setInterval> | null,
+
     // ── agent hierarchy tree ─────────────────────────────────────────────
     agentTreeNodes: [] as AgentTreeNode[],
     agentTreeBatchId: null as string | null,
@@ -162,6 +199,15 @@ export function buildPage() {
       return this.agentTreeNodes.length > 0;
     },
 
+    /** Issue labels with initiative slug and phase labels stripped, capped at 3. */
+    get filteredLabels(): string[] {
+      if (!this.activeIssue) return [];
+      const initiative = window._buildInitiative ?? '';
+      return this.activeIssue.labels
+        .filter((l) => !l.startsWith('phase-') && l !== initiative)
+        .slice(0, 3);
+    },
+
     // repo is injected by an inline <script> in the template.
     get repo(): string {
       return window._buildRepo ?? '';
@@ -180,6 +226,7 @@ export function buildPage() {
     onInspect(issue: ActiveIssue): void {
       if (this.activeIssue?.number === issue.number) return;
       this._closeStream();
+      this._stopDurationTimer();
       this.activeIssue = issue;
       this.thoughts = [];
       this.startAgentLoading = false;
@@ -188,13 +235,16 @@ export function buildPage() {
       if (issue.run) {
         this._openStream(issue.run.id);
         this._startTreePoll(`/ship/runs/${encodeURIComponent(issue.run.id)}/tree`);
+        this._startDurationTimer(issue.run);
       }
     },
 
     clearInspect(): void {
       this._closeStream();
       this._stopTreePoll();
+      this._stopDurationTimer();
       this.activeIssue = null;
+      this.runDuration = '';
       this.thoughts = [];
       this.chatMessage = '';
       this.chatError = null;
@@ -274,6 +324,28 @@ export function buildPage() {
         // Non-fatal — board will sync on next poll.
       } finally {
         this.agentStopping = false;
+      }
+    },
+
+    _startDurationTimer(run: AgentRun): void {
+      this._stopDurationTimer();
+      const isActive = run.agent_status === 'implementing' || run.agent_status === 'reviewing';
+      this.runDuration = formatRunDuration(run.spawned_at, run.last_activity_at, run.agent_status ?? '');
+      if (isActive) {
+        this._durationTimer = setInterval(() => {
+          this.runDuration = formatRunDuration(
+            run.spawned_at,
+            run.last_activity_at,
+            run.agent_status ?? '',
+          );
+        }, 1000);
+      }
+    },
+
+    _stopDurationTimer(): void {
+      if (this._durationTimer !== null) {
+        clearInterval(this._durationTimer);
+        this._durationTimer = null;
       }
     },
 

--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -709,106 +709,93 @@ body:has(.build-layout) nav.topnav {
     overflow: hidden;
   }
 
+  // ── Zone A: Issue Identity ────────────────────────────────────────────────
+
   &__toolbar {
     display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 0.5rem;
-    padding: 0.625rem 0.875rem;
+    flex-direction: column;
+    padding: 0.625rem 0.875rem 0.5rem;
     background: var(--bg-surface);
     border-bottom: 1px solid var(--border-subtle);
     flex-shrink: 0;
     position: sticky;
     top: 0;
     z-index: 10;
+    gap: 0.25rem;
   }
 
   &__toolbar-left {
     display: flex;
     flex-direction: column;
-    gap: 0.2rem;
+    gap: 0.25rem;
     min-width: 0;
+    width: 100%;
+  }
+
+  &__toolbar-top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    min-width: 0;
+  }
+
+  &__toolbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    flex-shrink: 0;
   }
 
   &__num {
     font-size: 0.7rem;
     font-family: var(--font-mono);
-    font-weight: 500;
+    font-weight: 600;
     color: var(--accent-bright);
     text-decoration: none;
+    flex-shrink: 0;
     &:hover { color: var(--text-primary); text-decoration: none; }
   }
 
   &__title {
-    font-size: 0.8125rem;
+    font-size: 0.875rem;
     color: var(--text-primary);
-    font-weight: 500;
+    font-weight: 600;
     line-height: 1.4;
+    letter-spacing: -0.01em;
   }
 
-  &__close {
-    flex-shrink: 0;
-    background: none;
-    border: none;
-    color: var(--text-faint);
-    cursor: pointer;
-    padding: 3px 6px;
-    border-radius: var(--radius-xs);
-    font-size: 0.8125rem;
-    transition: color 0.15s, background 0.15s;
-    margin-top: 1px;
-    &:hover { background: var(--bg-overlay); color: var(--text-primary); }
-  }
-
-  &__icon-link {
-    flex-shrink: 0;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 24px;
-    height: 24px;
-    border-radius: var(--radius-xs);
-    background: var(--bg-overlay);
-    border: 1px solid var(--border-default);
-    color: var(--text-faint);
-    text-decoration: none;
-    margin-top: 1px;
-    transition: color 0.15s var(--ease-out), background 0.15s var(--ease-out), border-color 0.15s var(--ease-out);
-    svg { flex-shrink: 0; display: block; }
-    &:hover {
-      color: var(--accent-bright);
-      background: var(--bg-surface);
-      border-color: var(--accent);
-    }
-  }
-
-  &__run-meta {
+  &__labels-row {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
     gap: 0.3rem;
-    padding: 0.5rem 0.875rem;
-    border-bottom: 1px solid var(--border-subtle);
-    flex-shrink: 0;
+    min-height: 1.25rem;
   }
 
-  &__run-role {
-    font-size: 0.6rem;
+  &__label-chip {
+    font-size: 0.575rem;
     font-family: var(--font-mono);
     color: var(--text-muted);
     background: var(--bg-elevated);
     border: 1px solid var(--border-default);
     border-radius: var(--radius-xs);
-    padding: 1px 6px;
+    padding: 1px 5px;
+    white-space: nowrap;
+    max-width: 180px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   &__run-status {
-    font-size: 0.6rem;
+    font-size: 0.575rem;
     font-weight: 700;
     border-radius: var(--radius-xs);
-    padding: 1px 7px;
+    padding: 1px 6px;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.07em;
+    margin-left: auto;
+    flex-shrink: 0;
 
     &--implementing,
     &--pending_launch {
@@ -833,12 +820,38 @@ body:has(.build-layout) nav.topnav {
     }
   }
 
-  &__run-since {
-    font-size: 0.6rem;
+  &__close {
+    flex-shrink: 0;
+    background: none;
+    border: none;
     color: var(--text-faint);
-    font-family: var(--font-mono);
-    font-variant-numeric: tabular-nums;
-    margin-left: auto;
+    cursor: pointer;
+    padding: 3px 6px;
+    border-radius: var(--radius-xs);
+    font-size: 0.8125rem;
+    transition: color 0.15s, background 0.15s;
+    &:hover { background: var(--bg-overlay); color: var(--text-primary); }
+  }
+
+  &__icon-link {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: var(--radius-xs);
+    background: var(--bg-overlay);
+    border: 1px solid var(--border-default);
+    color: var(--text-faint);
+    text-decoration: none;
+    transition: color 0.15s var(--ease-out), background 0.15s var(--ease-out), border-color 0.15s var(--ease-out);
+    svg { flex-shrink: 0; display: block; }
+    &:hover {
+      color: var(--accent-bright);
+      background: var(--bg-surface);
+      border-color: var(--accent);
+    }
   }
 
   &__pr-link {
@@ -850,7 +863,145 @@ body:has(.build-layout) nav.topnav {
     border: 1px solid rgba(139, 92, 246, 0.22);
     border-radius: var(--radius-xs);
     padding: 1px 6px;
+    white-space: nowrap;
     &:hover { color: var(--text-primary); text-decoration: none; }
+  }
+
+  // ── Zone B: Execution State ────────────────────────────────────────────────
+
+  &__exec {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: 0.4rem 0.875rem 0.45rem;
+    border-bottom: 1px solid var(--border-subtle);
+    background: var(--bg-elevated);
+    flex-shrink: 0;
+  }
+
+  &__exec-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+
+  &__run-role {
+    font-size: 0.6rem;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-xs);
+    padding: 1px 6px;
+    white-space: nowrap;
+  }
+
+  &__tier-badge {
+    font-size: 0.575rem;
+    font-weight: 700;
+    font-family: var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    border-radius: var(--radius-xs);
+    padding: 1px 5px;
+    white-space: nowrap;
+
+    &--engineer, &--worker {
+      background: var(--bg-overlay);
+      color: var(--text-faint);
+      border: 1px solid var(--border-default);
+    }
+    &--vp {
+      background: var(--info-dim);
+      color: var(--info);
+      border: 1px solid var(--info-border);
+    }
+    &--cto, &--coordinator {
+      background: rgba(251, 191, 36, 0.12);
+      color: #d97706;
+      border: 1px solid rgba(251, 191, 36, 0.3);
+
+      @media (prefers-color-scheme: dark) {
+        color: #fbbf24;
+      }
+    }
+    &--unknown {
+      background: var(--bg-overlay);
+      color: var(--text-faint);
+      border: 1px solid var(--border-subtle);
+    }
+  }
+
+  &__exec-sep {
+    font-size: 0.6rem;
+    color: var(--text-faint);
+    user-select: none;
+    margin: 0 0.05rem;
+  }
+
+  &__exec-steps {
+    font-size: 0.6rem;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  &__exec-duration {
+    font-size: 0.6rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  &__exec-branch {
+    font-size: 0.575rem;
+    font-family: var(--font-mono);
+    color: var(--text-faint);
+    background: var(--bg-surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-xs);
+    padding: 1px 5px;
+    margin-left: auto;
+    // Show the trailing part (unique suffix) when truncated
+    max-width: 200px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    direction: rtl;
+    text-align: left;
+  }
+
+  &__exec-step {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding-top: 0.1rem;
+  }
+
+  &__exec-pulse {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--success);
+    flex-shrink: 0;
+    animation: exec-pulse 1.8s ease-in-out infinite;
+  }
+
+  @keyframes exec-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50%       { opacity: 0.4; transform: scale(0.75); }
+  }
+
+  &__exec-step-text {
+    font-size: 0.6rem;
+    color: var(--text-muted);
+    font-style: italic;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 280px;
   }
 
   &__no-agent {
@@ -2313,30 +2464,38 @@ $preset-accents: (
   color: var(--text-faint);
 }
 
-.persona-card {
-  padding: 0.5rem 0.875rem 0.6rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+// ── Zone C: Agent Attribution persona card ────────────────────────────────────
 
-  &__header {
+.persona-card {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.875rem 0.55rem;
+
+  &__left {
+    flex-shrink: 0;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
   }
 
   &__emoji {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
     line-height: 1;
-    flex-shrink: 0;
   }
 
-  &__meta {
+  &__body {
     flex: 1;
     min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.1rem;
+    gap: 0.25rem;
+  }
+
+  &__top {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    flex-wrap: wrap;
   }
 
   &__name {
@@ -2346,43 +2505,59 @@ $preset-accents: (
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    letter-spacing: -0.01em;
   }
 
   &__archetype {
-    font-size: 0.7rem;
-    color: var(--text-muted);
+    font-size: 0.625rem;
+    color: var(--text-faint);
     font-family: var(--font-mono);
-  }
-
-  &__profile-link {
-    flex-shrink: 0;
-    font-size: 0.7rem;
-    color: var(--accent);
-    text-decoration: none;
     white-space: nowrap;
-    &:hover { color: var(--accent); text-decoration: underline; }
   }
 
   &__skills {
     display: flex;
     flex-wrap: wrap;
     gap: 0.25rem;
-    padding-left: 1.75rem; // indent under emoji
   }
 
   &__skill-chip {
     display: inline-block;
-    font-size: 0.65rem;
+    font-size: 0.575rem;
     font-weight: 500;
     color: var(--text-muted);
-    background: var(--bg-overlay);
+    background: var(--bg-elevated);
     border: 1px solid var(--border-default);
     border-radius: var(--radius-xs);
-    padding: 0.1rem 0.4rem;
+    padding: 1px 5px;
 
     &--more {
       color: var(--text-faint);
       background: transparent;
+      border-color: transparent;
+    }
+  }
+
+  &__profile-link {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: var(--radius-xs);
+    background: var(--bg-overlay);
+    border: 1px solid var(--border-default);
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: color 0.15s var(--ease-out), background 0.15s var(--ease-out), border-color 0.15s var(--ease-out);
+
+    &:hover {
+      color: var(--accent-bright);
+      background: var(--bg-surface);
+      border-color: var(--accent);
+      text-decoration: none;
     }
   }
 }

--- a/agentception/templates/_persona_card.html
+++ b/agentception/templates/_persona_card.html
@@ -1,35 +1,36 @@
 {#
-  _persona_card.html — compact persona mini-card for the inspector panel.
+  _persona_card.html — compact persona attribution strip for the inspector panel.
   Context:
     persona  — dict from resolve_cognitive_arch()
     arch_id  — URL-safe arch string (colons → hyphens)
 #}
 <div class="persona-card">
-  <div class="persona-card__header">
+  <div class="persona-card__left">
     <span class="persona-card__emoji">{{ persona.archetype_emoji }}</span>
-    <div class="persona-card__meta">
+  </div>
+  <div class="persona-card__body">
+    <div class="persona-card__top">
       <span class="persona-card__name">{{ persona.display_name }}</span>
       {% if persona.archetype %}
       <span class="persona-card__archetype">{{ persona.archetype | replace('_', ' ') | title }}</span>
       {% endif %}
     </div>
-    <a class="persona-card__profile-link"
-       href="/cognitive-arch/{{ arch_id }}"
-       title="Full cognitive architecture profile">
-      Full profile →
-    </a>
-  </div>
-
-  {% if persona.skill_domains %}
-  <div class="persona-card__skills">
-    {% for skill in persona.skill_domains[:4] %}
-    <span class="persona-card__skill-chip">{{ skill | replace('_', ' ') | title }}</span>
-    {% endfor %}
-    {% if persona.skill_domains | length > 4 %}
-    <span class="persona-card__skill-chip persona-card__skill-chip--more">
-      +{{ persona.skill_domains | length - 4 }} more
-    </span>
+    {% if persona.skill_domains %}
+    <div class="persona-card__skills">
+      {% for skill in persona.skill_domains[:4] %}
+      <span class="persona-card__skill-chip">{{ skill | replace('_', ' ') | title }}</span>
+      {% endfor %}
+      {% if persona.skill_domains | length > 4 %}
+      <span class="persona-card__skill-chip persona-card__skill-chip--more">
+        +{{ persona.skill_domains | length - 4 }}
+      </span>
+      {% endif %}
+    </div>
     {% endif %}
   </div>
-  {% endif %}
+  <a class="persona-card__profile-link"
+     href="/cognitive-arch/{{ arch_id }}"
+     title="Full cognitive architecture profile">
+    →
+  </a>
 </div>

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -99,53 +99,87 @@
       <template x-if="activeIssue">
         <div class="build-inspector__content">
 
+          {# ── ZONE A: Issue Identity ──────────────────────────────────────── #}
           <div class="build-inspector__toolbar">
             <div class="build-inspector__toolbar-left">
-              <a class="build-inspector__num" :href="activeIssue.url" target="_blank" rel="noopener"
-                 x-text="'#' + activeIssue.number"></a>
+              <div class="build-inspector__toolbar-top">
+                <a class="build-inspector__num" :href="activeIssue.url" target="_blank" rel="noopener"
+                   x-text="'#' + activeIssue.number"></a>
+                <div class="build-inspector__toolbar-actions">
+                  <template x-if="activeIssue.run && activeIssue.run.pr_number">
+                    <a class="build-inspector__pr-link"
+                       :href="'https://github.com/' + repo + '/pull/' + activeIssue.run.pr_number"
+                       target="_blank" rel="noopener"
+                       x-text="'PR #' + activeIssue.run.pr_number"></a>
+                  </template>
+                  <template x-if="activeIssue.run && activeIssue.run.id">
+                    <a class="build-inspector__icon-link"
+                       :href="'/agents/' + activeIssue.run.id"
+                       title="View agent transcript"
+                       target="_blank" rel="noopener">
+                      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <path d="M10 2h4v4"/><path d="M14 2L9 7"/><path d="M7 3H3a1 1 0 00-1 1v9a1 1 0 001 1h9a1 1 0 001-1V9"/>
+                      </svg>
+                    </a>
+                  </template>
+                  <template x-if="activeIssue.run && activeIssue.run.cognitive_arch">
+                    <a class="build-inspector__icon-link"
+                       :href="'/cognitive-arch/' + activeIssue.run.cognitive_arch.replaceAll(':', '-')"
+                       title="View cognitive architecture"
+                       target="_blank" rel="noopener">
+                      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <circle cx="5" cy="5" r="2"/><circle cx="11" cy="5" r="2"/><circle cx="8" cy="12" r="2"/>
+                        <line x1="7" y1="5" x2="9" y2="5"/><line x1="5.8" y1="6.8" x2="7.2" y2="10.2"/><line x1="10.2" y1="6.8" x2="8.8" y2="10.2"/>
+                      </svg>
+                    </a>
+                  </template>
+                  <button class="build-inspector__close" @click="clearInspect()">✕</button>
+                </div>
+              </div>
               <span class="build-inspector__title" x-text="activeIssue.title"></span>
-            </div>
-            <div style="display:flex;align-items:center;gap:0.4rem;flex-shrink:0;">
-              <template x-if="activeIssue.run && activeIssue.run.pr_number">
-                <a class="build-inspector__pr-link"
-                   :href="'https://github.com/' + repo + '/pull/' + activeIssue.run.pr_number"
-                   target="_blank" rel="noopener"
-                   x-text="'PR #' + activeIssue.run.pr_number"></a>
+              {# Labels + status badge row — always shown when a run exists #}
+              <template x-if="activeIssue.run">
+                <div class="build-inspector__labels-row">
+                  <template x-for="label in filteredLabels" :key="label">
+                    <span class="build-inspector__label-chip" x-text="label"></span>
+                  </template>
+                  <span class="build-inspector__run-status"
+                        :class="'build-inspector__run-status--' + (activeIssue.run.agent_status || 'unknown')"
+                        x-text="activeIssue.run.agent_status || 'unknown'"></span>
+                </div>
               </template>
-              {# Transcript + cognitive-arch links — moved here from the Kanban card #}
-              <template x-if="activeIssue.run && activeIssue.run.id">
-                <a class="build-inspector__icon-link"
-                   :href="'/agents/' + activeIssue.run.id"
-                   title="View agent transcript"
-                   target="_blank" rel="noopener">
-                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <path d="M10 2h4v4"/><path d="M14 2L9 7"/><path d="M7 3H3a1 1 0 00-1 1v9a1 1 0 001 1h9a1 1 0 001-1V9"/>
-                  </svg>
-                </a>
-              </template>
-              <template x-if="activeIssue.run && activeIssue.run.cognitive_arch">
-                <a class="build-inspector__icon-link"
-                   :href="'/cognitive-arch/' + activeIssue.run.cognitive_arch.replaceAll(':', '-')"
-                   title="View cognitive architecture"
-                   target="_blank" rel="noopener">
-                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <circle cx="5" cy="5" r="2"/><circle cx="11" cy="5" r="2"/><circle cx="8" cy="12" r="2"/>
-                    <line x1="7" y1="5" x2="9" y2="5"/><line x1="5.8" y1="6.8" x2="7.2" y2="10.2"/><line x1="10.2" y1="6.8" x2="8.8" y2="10.2"/>
-                  </svg>
-                </a>
-              </template>
-              <button class="build-inspector__close" @click="clearInspect()">✕</button>
             </div>
           </div>
 
-          {# run-meta bar: role chip + agent_status chip #}
+          {# ── ZONE B: Execution State ─────────────────────────────────────── #}
           <template x-if="activeIssue.run">
-            <div class="build-inspector__run-meta">
-              <span class="build-inspector__run-role" x-text="activeIssue.run.role || 'agent'"></span>
-              <span class="build-inspector__run-status"
-                    :class="'build-inspector__run-status--' + (activeIssue.run.agent_status || 'unknown')"
-                    x-text="activeIssue.run.agent_status || 'unknown'"></span>
-              <span class="build-inspector__run-since" x-text="activeIssue.run.id ? '#' + activeIssue.run.id : ''"></span>
+            <div class="build-inspector__exec">
+              <div class="build-inspector__exec-row">
+                <span class="build-inspector__run-role" x-text="activeIssue.run.role || 'agent'"></span>
+                <template x-if="activeIssue.run.tier">
+                  <span class="build-inspector__tier-badge"
+                        :class="'build-inspector__tier-badge--' + activeIssue.run.tier"
+                        x-text="activeIssue.run.tier"></span>
+                </template>
+                <template x-if="activeIssue.run.steps_completed > 0">
+                  <span class="build-inspector__exec-sep">·</span>
+                  <span class="build-inspector__exec-steps"
+                        x-text="activeIssue.run.steps_completed + ' steps'"></span>
+                </template>
+                <template x-if="runDuration">
+                  <span class="build-inspector__exec-sep">·</span>
+                  <span class="build-inspector__exec-duration" x-text="runDuration"></span>
+                </template>
+                <template x-if="activeIssue.run.branch">
+                  <span class="build-inspector__exec-branch" x-text="activeIssue.run.branch"></span>
+                </template>
+              </div>
+              <template x-if="activeIssue.run.current_step && (activeIssue.run.agent_status === 'implementing' || activeIssue.run.agent_status === 'reviewing')">
+                <div class="build-inspector__exec-step">
+                  <span class="build-inspector__exec-pulse" aria-hidden="true"></span>
+                  <span class="build-inspector__exec-step-text" x-text="activeIssue.run.current_step"></span>
+                </div>
+              </template>
             </div>
           </template>
 


### PR DESCRIPTION
## Summary

- **Zone A (Issue Identity)**: restructured toolbar with issue number + action cluster at top, prominent title, and a labels + status badge row. Labels are filtered (strips `phase-*` and initiative slugs, max 3) and displayed as chips alongside the colour-coded status badge pushed right.
- **Zone B (Execution State)**: replaced thin run-meta bar with an exec strip showing role chip, tier badge (engineer/vp/cto with distinct colours), step count, human-readable run duration (`ran 8m 23s`), and branch name. A pulsing green dot + "Currently: …" row appears for active runs.
- **Zone C (Agent Attribution)**: persona card redesigned as a compact horizontal strip — oversized emoji / name + archetype / skill chips / arrow icon link.

## Data pipeline

Extended `AgentRun` TS interface with `steps_completed`, `spawned_at`, `last_activity_at`, `current_step`, `branch`, `cognitive_arch` (all already carried by `RunForIssueRow` in the backend — zero backend changes needed). Added `formatRunDuration()` helper with live `setInterval` clock for active runs. Added `filteredLabels` getter using `window._buildInitiative`.

Removed dead `__run-meta` and `__run-since` SCSS. Added 8 unit tests for `formatRunDuration`.

## Verification

- `mypy agentception/ tests/` — 0 errors
- `typing_audit.py --max-any 0` — 0 violations
- `npx tsc --noEmit` — 0 errors
- `npm test` — 288 tests pass (8 new)
- `npm run build` — both bundles built cleanly
- `generate.py --check` — no drift