### PR TITLE
fix: remove icon links from toolbar; persona card arrow links to transcript

### DIFF
--- a/agentception/routes/ui/build_ui.py
+++ b/agentception/routes/ui/build_ui.py
@@ -555,7 +555,7 @@ async def persona_card_partial(request: Request, run_id: str) -> HTMLResponse:
     return _TEMPLATES.TemplateResponse(
         request,
         "_persona_card.html",
-        {"persona": persona, "arch_id": arch_id},
+        {"persona": persona, "arch_id": arch_id, "run_id": run_id},
     )
 
 

--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -833,27 +833,6 @@ body:has(.build-layout) nav.topnav {
     &:hover { background: var(--bg-overlay); color: var(--text-primary); }
   }
 
-  &__icon-link {
-    flex-shrink: 0;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 24px;
-    height: 24px;
-    border-radius: var(--radius-xs);
-    background: var(--bg-overlay);
-    border: 1px solid var(--border-default);
-    color: var(--text-faint);
-    text-decoration: none;
-    transition: color 0.15s var(--ease-out), background 0.15s var(--ease-out), border-color 0.15s var(--ease-out);
-    svg { flex-shrink: 0; display: block; }
-    &:hover {
-      color: var(--accent-bright);
-      background: var(--bg-surface);
-      border-color: var(--accent);
-    }
-  }
-
   &__pr-link {
     font-size: 0.6rem;
     font-family: var(--font-mono);

--- a/agentception/templates/_persona_card.html
+++ b/agentception/templates/_persona_card.html
@@ -29,8 +29,8 @@
     {% endif %}
   </div>
   <a class="persona-card__profile-link"
-     href="/cognitive-arch/{{ arch_id }}"
-     title="Full cognitive architecture profile">
+     href="/agents/{{ run_id }}"
+     title="View agent transcript">
     →
   </a>
 </div>

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -112,27 +112,6 @@
                        target="_blank" rel="noopener"
                        x-text="'PR #' + activeIssue.run.pr_number"></a>
                   </template>
-                  <template x-if="activeIssue.run && activeIssue.run.id">
-                    <a class="build-inspector__icon-link"
-                       :href="'/agents/' + activeIssue.run.id"
-                       title="View agent transcript"
-                       target="_blank" rel="noopener">
-                      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                        <path d="M10 2h4v4"/><path d="M14 2L9 7"/><path d="M7 3H3a1 1 0 00-1 1v9a1 1 0 001 1h9a1 1 0 001-1V9"/>
-                      </svg>
-                    </a>
-                  </template>
-                  <template x-if="activeIssue.run && activeIssue.run.cognitive_arch">
-                    <a class="build-inspector__icon-link"
-                       :href="'/cognitive-arch/' + activeIssue.run.cognitive_arch.replaceAll(':', '-')"
-                       title="View cognitive architecture"
-                       target="_blank" rel="noopener">
-                      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                        <circle cx="5" cy="5" r="2"/><circle cx="11" cy="5" r="2"/><circle cx="8" cy="12" r="2"/>
-                        <line x1="7" y1="5" x2="9" y2="5"/><line x1="5.8" y1="6.8" x2="7.2" y2="10.2"/><line x1="10.2" y1="6.8" x2="8.8" y2="10.2"/>
-                      </svg>
-                    </a>
-                  </template>
                   <button class="build-inspector__close" @click="clearInspect()">✕</button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- Remove the transcript and cognitive-architecture icon links from the inspector toolbar — they duplicated access that the persona card already provides and added visual clutter.
- The persona card `→` arrow now links to `/agents/{run_id}` (agent transcript page) instead of the cognitive architecture page, making it the single entry point for digging deeper into a run.
- Pass `run_id` to the `_persona_card.html` template context so the link renders server-side.
- Delete the now-dead `__icon-link` SCSS block.