### PR TITLE
fix: clear activity feed DOM when switching between inspector cards

### DIFF
--- a/agentception/static/js/__tests__/activity_feed.test.ts
+++ b/agentception/static/js/__tests__/activity_feed.test.ts
@@ -6,6 +6,7 @@ import {
   getSubtypeIcon,
   resetFeedStartTime,
   resetFeedSession,
+  clearFeed,
   formatRelativeTime,
   type ActivityMessage,
 } from '../activity_feed';
@@ -886,6 +887,33 @@ describe('resetFeedSession', () => {
     const header = document.getElementById('af-model-header');
     expect(header).not.toBeNull();
     expect(header?.textContent).toBe('Anthropic: 3.5');
+  });
+});
+
+describe('clearFeed', () => {
+  beforeEach(() => {
+    resetFeedSession();
+  });
+
+  it('removes all child nodes from #activity-feed', () => {
+    document.body.innerHTML = '<div id="activity-feed"><div class="row">old</div></div>';
+    clearFeed();
+    expect(document.getElementById('activity-feed')?.children.length).toBe(0);
+  });
+
+  it('resets feed session state so the next event starts at 0:00', () => {
+    document.body.innerHTML = '<div id="activity-feed"></div>';
+    // Seed a first timestamp so feedStartMs is non-null
+    formatRelativeTime('2026-03-15T12:00:00Z');
+    // clearFeed should reset that state
+    clearFeed();
+    expect(formatRelativeTime('2026-03-15T12:05:00Z')).toBe('0:00');
+  });
+
+  it('is a no-op when #activity-feed does not exist', () => {
+    document.body.innerHTML = '';
+    // Should not throw
+    expect(() => clearFeed()).not.toThrow();
   });
 });
 

--- a/agentception/static/js/activity_feed.ts
+++ b/agentception/static/js/activity_feed.ts
@@ -211,6 +211,18 @@ export function resetFeedSession(): void {
 }
 
 /**
+ * Clear the #activity-feed DOM element and reset all feed session state.
+ *
+ * Call this whenever the inspector switches to a different run so the previous
+ * run's rows don't bleed into the newly selected one.
+ */
+export function clearFeed(): void {
+  const feedEl = document.getElementById('activity-feed');
+  if (feedEl) feedEl.innerHTML = '';
+  resetFeedSession();
+}
+
+/**
  * Format recorded_at as a timer offset from the first feed event.
  * Uses M:SS notation: "now", "0:29", "1:05", "10:30".
  */

--- a/agentception/static/js/build.ts
+++ b/agentception/static/js/build.ts
@@ -12,7 +12,7 @@
  */
 
 import { marked } from 'marked';
-import { attachActivityFeedHandler, resetFeedSession } from './activity_feed';
+import { attachActivityFeedHandler, clearFeed, resetFeedSession } from './activity_feed';
 import { attachEventCardHandler } from './event_card';
 import { attachFileEditHandler } from './file_edit_card';
 import { attachThoughtHandler } from './thought_block';
@@ -227,6 +227,7 @@ export function buildPage() {
       if (this.activeIssue?.number === issue.number) return;
       this._closeStream();
       this._stopDurationTimer();
+      clearFeed();
       this.activeIssue = issue;
       this.thoughts = [];
       this.startAgentLoading = false;
@@ -243,6 +244,7 @@ export function buildPage() {
       this._closeStream();
       this._stopTreePoll();
       this._stopDurationTimer();
+      clearFeed();
       this.activeIssue = null;
       this.runDuration = '';
       this.thoughts = [];


### PR DESCRIPTION
## Summary

- Switching issue cards called `_closeStream()` but never cleared the `#activity-feed` DOM, so rows from the previously selected run remained visible when a different card was clicked.
- Add `clearFeed()` to `activity_feed.ts` — clears `#activity-feed` innerHTML and calls `resetFeedSession()` — then call it in `onInspect()` (before opening the new stream) and `clearInspect()` (when the panel is closed).
- Add 3 regression tests: DOM is wiped, session state is reset, and it is a no-op when the element doesn't exist.