### PR TITLE
fix: style assistant-bubble for light mode (white gap between steps)

### DIFF
--- a/agentception/static/scss/pages/_assistant-bubble.scss
+++ b/agentception/static/scss/pages/_assistant-bubble.scss
@@ -16,3 +16,9 @@
   max-width: 100%;
   overflow-x: hidden;
 }
+
+[data-theme="light"] .assistant-bubble {
+  background: rgba(0, 0, 0, 0.03);
+  border-left-color: rgba(0, 0, 0, 0.15);
+  color: rgba(0, 0, 0, 0.7);
+}


### PR DESCRIPTION
## Summary

- Adds a `[data-theme="light"]` override to `.assistant-bubble` so it renders as a near-transparent tinted strip instead of solid white (`#ffffff`) in light mode
- Root cause: `--bg-elevated` resolves to `#ffffff` in light mode, making every assistant-bubble injected between step rows appear as an obvious white gap
- In dark mode the bubble was `#111b2e` and blended invisibly with the dark feed — the bug was only visible after switching to light mode

## Test plan

- [ ] Load Mission Control in light mode, click a card with steps — steps should be uniformly spaced with no white strips between them
- [ ] Switch to another card (no agent) and back — spacing should remain consistent
- [ ] Verify in dark mode — assistant-bubble still renders with the dark elevated background