### PR TITLE
fix: forward pr_branch from teardown_info to auto_dispatch_reviewer for label-dispatched runs

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -494,8 +494,14 @@ async def build_complete_run(
         # the conventional path worktrees_dir/run_id so we still attempt release —
         # otherwise the reviewer dispatch fails with "branch already used by worktree".
         worktree_released = True
+        # Capture the actual branch name so the reviewer can fetch the right
+        # remote ref.  Org-chart-dispatched runs use agent/{slug}-{hex} branches
+        # (not feat/issue-{N}), so we must read it from the DB rather than
+        # falling back to the convention.
+        impl_pr_branch: str | None = None
         if agent_run_id:
             teardown_info = await get_agent_run_teardown(agent_run_id)
+            impl_pr_branch = teardown_info.get("branch") if teardown_info else None
             wt_path = (
                 (teardown_info.get("worktree_path") if teardown_info else None)
                 or str(Path(settings.worktrees_dir) / agent_run_id)
@@ -533,7 +539,11 @@ async def build_complete_run(
 
         if worktree_released:
             asyncio.create_task(
-                auto_dispatch_reviewer(issue_number=issue_number, pr_url=pr_url),
+                auto_dispatch_reviewer(
+                    issue_number=issue_number,
+                    pr_url=pr_url,
+                    pr_branch=impl_pr_branch,
+                ),
                 name=f"auto-reviewer-{issue_number}",
             )
 

--- a/agentception/tests/test_build_commands_rebase.py
+++ b/agentception/tests/test_build_commands_rebase.py
@@ -18,6 +18,11 @@ Coverage:
 - test_no_worktree_path_skips_rebase_and_dispatches_reviewer
     When get_agent_run_teardown returns no worktree_path the rebase block
     is skipped entirely and the reviewer is still dispatched.
+- test_label_dispatch_branch_forwarded_to_reviewer
+    Regression: org-chart (label) dispatches use agent/{slug}-{hex} branches.
+    The branch read from teardown_info must be forwarded as pr_branch to
+    auto_dispatch_reviewer so it fetches the correct remote ref instead of
+    defaulting to the nonexistent feat/issue-{N} name.
 
 Run targeted:
     pytest agentception/tests/test_build_commands_rebase.py -v
@@ -378,4 +383,101 @@ async def test_rebase_succeeds_with_empty_worktree_path_dict() -> None:
     task_names = [c.kwargs.get("name", "") for c in mock_create_task.call_args_list]
     assert "auto-reviewer-40" in task_names, (
         f"Expected auto-reviewer-40 task; got: {task_names}"
+    )
+
+
+@pytest.mark.anyio
+async def test_label_dispatch_branch_forwarded_to_reviewer() -> None:
+    """Regression: org-chart label runs use non-standard branches — must be forwarded.
+
+    Agents dispatched via POST /api/dispatch/label (e.g. from the org chart
+    Ticket-scope picker) receive a branch name like ``agent/{slug}-{hex}``,
+    NOT the ``feat/issue-{N}`` convention.  When the implementer calls
+    build_complete_run, the branch read from get_agent_run_teardown must be
+    passed as ``pr_branch`` to auto_dispatch_reviewer so it fetches the
+    correct remote ref — without this, the reviewer dispatch silently fails
+    with a 422 "branch not found" error and no reviewer is ever spawned.
+    """
+    from agentception.mcp.build_commands import build_complete_run
+
+    agent_run_id = "label-documentation-improvement-a1b2c3"
+    wt_path = "/worktrees/label-documentation-improvement-a1b2c3"
+    # This is the non-standard branch created by /api/dispatch/label.
+    non_standard_branch = "agent/documentation-improvement-a1b2"
+
+    fetch_proc = _make_proc(0)
+    rebase_proc = _make_proc(0)
+    rev_parse_proc = _make_proc(0, stdout=f"{non_standard_branch}\n".encode())
+    push_proc = _make_proc(0)
+    subprocess_calls = iter([fetch_proc, rebase_proc, rev_parse_proc, push_proc])
+
+    async def fake_create_subprocess_exec(*args: str | int | bool | float | None, **kwargs: str | int | bool | float | None) -> AsyncMock:
+        return next(subprocess_calls)
+
+    with (
+        patch(
+            "agentception.mcp.build_commands.persist_agent_event",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "agentception.mcp.build_commands.complete_agent_run",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_role",
+            new_callable=AsyncMock,
+            return_value="developer",
+        ),
+        patch(
+            "agentception.mcp.build_commands.get_agent_run_teardown",
+            new_callable=AsyncMock,
+            return_value={
+                "worktree_path": wt_path,
+                "branch": non_standard_branch,
+            },
+        ),
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ),
+        patch(
+            "agentception.mcp.build_commands.release_worktree",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agentception.mcp.build_commands.auto_dispatch_reviewer",
+            new_callable=AsyncMock,
+        ) as mock_reviewer,
+        patch(
+            "agentception.mcp.build_commands.asyncio.create_task",
+            side_effect=make_create_task_side_effect(),
+        ) as mock_create_task,
+    ):
+        result = await build_complete_run(
+            issue_number=1072,
+            pr_url="https://github.com/cgcardona/agentception/pull/1075",
+            agent_run_id=agent_run_id,
+        )
+
+    assert result == {"ok": True, "event": "done", "status": "completed"}
+
+    # The auto-reviewer task must have been scheduled.
+    task_names = [c.kwargs.get("name", "") for c in mock_create_task.call_args_list]
+    assert "auto-reviewer-1072" in task_names, (
+        f"Expected auto-reviewer-1072 task; got: {task_names}"
+    )
+
+    # The non-standard branch must have been forwarded as pr_branch.
+    # auto_dispatch_reviewer is called to produce the coroutine that create_task
+    # receives — inspect the call even though the coroutine is closed by the
+    # create_task mock without being awaited.
+    mock_reviewer.assert_called_once()
+    forwarded_branch = mock_reviewer.call_args.kwargs.get("pr_branch")
+    assert forwarded_branch == non_standard_branch, (
+        f"Expected pr_branch={non_standard_branch!r} forwarded to auto_dispatch_reviewer; "
+        f"got pr_branch={forwarded_branch!r}. "
+        "Without this, org-chart-dispatched runs never spawn a reviewer because "
+        "auto_dispatch_reviewer defaults to feat/issue-N which does not exist."
     )


### PR DESCRIPTION
## Summary

- Org-chart (label) dispatches create branches named `agent/{slug}-{hex}`, not the `feat/issue-{N}` convention assumed by `auto_dispatch_reviewer`'s default fallback
- Because `build_complete_run`'s implementer path never passed `pr_branch` to `auto_dispatch_reviewer`, the reviewer dispatch silently failed with a 422 "remote branch not found" — no reviewer was ever spawned
- Fix: extract `impl_pr_branch` from `teardown_info` (already fetched) and forward it as `pr_branch` to `auto_dispatch_reviewer`, mirroring what the reviewer path already does for `auto_redispatch_after_rejection`
- Adds regression test `test_label_dispatch_branch_forwarded_to_reviewer`

## Root Cause

The reviewer path (`auto_redispatch_after_rejection`) already reads the branch from `teardown_info` and passes it correctly. The implementer path never received the same treatment, so any run dispatched via the org chart's Ticket scope would silently drop its reviewer.

## Test plan

- [x] `mypy agentception/mcp/build_commands.py agentception/tests/test_build_commands_rebase.py` — zero errors
- [x] All 40 build_commands tests pass (`test_build_commands.py`, `test_build_commands_rebase.py`, `test_mcp_build_commands_pr3.py`)
- [x] `generate.py --check` — no drift