### PR TITLE
fix: role fallback, 422 on missing issue number, edit-panel validation

### DIFF
--- a/agentception/routes/api/dispatch.py
+++ b/agentception/routes/api/dispatch.py
@@ -1269,6 +1269,12 @@ async def dispatch_label_agent(req: LabelDispatchRequest) -> LabelDispatchRespon
     role, tier = _role_and_tier_for_scope(req.scope, req.role)
     org_domain = _org_domain_for_role(role)
 
+    if req.scope == "issue" and req.scope_issue_number is None:
+        raise HTTPException(
+            status_code=422,
+            detail="scope_issue_number is required when scope='issue'.",
+        )
+
     if req.scope == "phase" and req.scope_label:
         scope_value = req.scope_label
         scope_type: ScopeType = "label"

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -1245,6 +1245,27 @@ async def _load_task_from_db(run_id: str) -> AgentTaskSpec | None:
         return None
 
 
+def _role_base_fallback(role: str) -> str | None:
+    """Return the base role slug to try when *role*'s file is missing.
+
+    Language- and domain-prefixed roles (e.g. ``python-developer``,
+    ``react-developer``, ``data-engineer``) share execution contracts with
+    their base family.  When the specific file is absent, loading the base
+    file is far better than returning an empty system prompt.
+
+    Returns ``None`` when no meaningful fallback exists (e.g. the role has no
+    ``-`` separator, or the suffix is not a known base family).
+    """
+    _BASE_FAMILIES = frozenset({
+        "developer", "coordinator", "engineer", "analyst",
+        "architect", "researcher", "writer", "programmer",
+    })
+    if "-" not in role:
+        return None
+    suffix = role.rsplit("-", 1)[-1]
+    return suffix if suffix in _BASE_FAMILIES else None
+
+
 def _load_role_prompt(role: str | None, variant: str | None = None) -> str:
     """Return the Markdown content of the role file for *role*.
 
@@ -1253,8 +1274,9 @@ def _load_role_prompt(role: str | None, variant: str | None = None) -> str:
     found.  If the variant file does not exist, it falls back to the base
     ``{role}.md`` file — the same behaviour as when *variant* is ``None``.
 
-    Falls back to an empty string when the role is unknown or the file is
-    missing, so the agent still has the system prompt's runtime note.
+    When the exact role file is missing, the function tries the role-family
+    base (e.g. ``python-developer`` → ``developer``) before giving up.  Falls
+    back to an empty string only when no role file can be found at all.
     """
     if not role:
         logger.warning("⚠️ _load_role_prompt — no role specified")
@@ -1275,17 +1297,32 @@ def _load_role_prompt(role: str | None, variant: str | None = None) -> str:
                 )
                 # Fall through to the base file.
 
-    # Base (default) role file.
+    # Try the exact role file.
     role_path = roles_dir / f"{role}.md"
     logger.info("Loading role file: %s (variant=%s)", role_path, variant)
     try:
         return role_path.read_text(encoding="utf-8")
     except FileNotFoundError:
-        logger.warning("⚠️ _load_role_prompt — role file not found: %s", role_path)
-        return ""
+        pass
     except OSError as exc:
         logger.warning("⚠️ _load_role_prompt — OS error reading %s: %s", role_path, exc)
         return ""
+
+    # Exact file missing — try the role-family base (python-developer → developer).
+    base = _role_base_fallback(role)
+    if base:
+        base_path = roles_dir / f"{base}.md"
+        try:
+            content = base_path.read_text(encoding="utf-8")
+            logger.info(
+                "✅ _load_role_prompt — using family fallback %s → %s", role, base
+            )
+            return content
+        except OSError:
+            pass
+
+    logger.warning("⚠️ _load_role_prompt — role file not found: %s", role_path)
+    return ""
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/static/js/org_designer.ts
+++ b/agentception/static/js/org_designer.ts
@@ -966,6 +966,7 @@ interface OrgDesignerComponent {
   editScope: 'full_initiative' | 'phase' | 'issue';
   editScopeLabel: string;
   editScopeIssueNumber: number | null;
+  editError: string | null;
   phases: PhaseItem[];
   issues: IssueItem[];
 
@@ -1071,6 +1072,7 @@ export function orgDesigner(): OrgDesignerComponent {
     editScope:            'full_initiative',
     editScopeLabel:       '',
     editScopeIssueNumber: null,
+    editError:            null,
     phases:               [],
     issues:               [],
 
@@ -1442,9 +1444,16 @@ export function orgDesigner(): OrgDesignerComponent {
     },
 
     applyEdit(): void {
+      this.editError = null;
       if (!this._root) return;
       const node = findNode(this._root, this.selectedNodeId ?? '');
       if (!node) return;
+
+      if (this.editScope === 'issue' && this.editScopeIssueNumber === null) {
+        this.editError = 'Select a ticket before applying.';
+        return;
+      }
+
       node.role             = this.editRole;
       node.figure           = this.editFigure;
       node.scope            = this.editScope;

--- a/agentception/static/scss/pages/_inspector-layout.scss
+++ b/agentception/static/scss/pages/_inspector-layout.scss
@@ -2198,6 +2198,14 @@ $preset-accents: (
   font-style: italic;
 }
 
+.od-editor__error {
+  font-size: 0.72rem;
+  color: var(--error, #e05252);
+  margin: 0;
+  padding: 0.375rem 1.125rem;
+  font-style: italic;
+}
+
 .od-editor__actions {
   display: flex;
   gap: 0.625rem;

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -624,6 +624,10 @@
 
           </div>
 
+          <template x-if="editError">
+            <p class="od-editor__error" x-text="editError"></p>
+          </template>
+
           <div class="od-editor__actions">
             <button class="od-editor__btn od-editor__btn--apply"
                     :disabled="!editRole"

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -475,6 +475,91 @@ class TestBuildSystemPrompt:
         assert "Docker container" in result
 
 
+class TestRoleBaseFallback:
+    """Unit tests for _role_base_fallback."""
+
+    def test_python_developer_returns_developer(self) -> None:
+        from agentception.services.agent_loop import _role_base_fallback
+
+        assert _role_base_fallback("python-developer") == "developer"
+
+    def test_typescript_developer_returns_developer(self) -> None:
+        from agentception.services.agent_loop import _role_base_fallback
+
+        assert _role_base_fallback("typescript-developer") == "developer"
+
+    def test_data_engineer_returns_engineer(self) -> None:
+        from agentception.services.agent_loop import _role_base_fallback
+
+        assert _role_base_fallback("data-engineer") == "engineer"
+
+    def test_no_hyphen_returns_none(self) -> None:
+        from agentception.services.agent_loop import _role_base_fallback
+
+        assert _role_base_fallback("developer") is None
+
+    def test_unknown_suffix_returns_none(self) -> None:
+        from agentception.services.agent_loop import _role_base_fallback
+
+        assert _role_base_fallback("python-specialist") is None
+
+
+class TestLoadRolePromptFamilyFallback:
+    """Regression tests: missing language-specific role falls back to base family."""
+
+    def test_python_developer_falls_back_to_developer(self, tmp_path: Path) -> None:
+        """python-developer.md missing → load developer.md instead of empty string."""
+        import unittest.mock as mock
+
+        roles_dir = tmp_path / ".agentception" / "roles"
+        roles_dir.mkdir(parents=True)
+        (roles_dir / "developer.md").write_text("# Developer role content", encoding="utf-8")
+        # python-developer.md intentionally absent
+
+        from agentception.services.agent_loop import _load_role_prompt
+
+        with mock.patch(
+            "agentception.services.agent_loop.settings.repo_dir", tmp_path
+        ):
+            result = _load_role_prompt("python-developer")
+
+        assert result == "# Developer role content"
+
+    def test_exact_role_preferred_over_family_fallback(self, tmp_path: Path) -> None:
+        """When python-developer.md exists, it wins over developer.md."""
+        import unittest.mock as mock
+
+        roles_dir = tmp_path / ".agentception" / "roles"
+        roles_dir.mkdir(parents=True)
+        (roles_dir / "developer.md").write_text("# Developer role content", encoding="utf-8")
+        (roles_dir / "python-developer.md").write_text("# Python developer role content", encoding="utf-8")
+
+        from agentception.services.agent_loop import _load_role_prompt
+
+        with mock.patch(
+            "agentception.services.agent_loop.settings.repo_dir", tmp_path
+        ):
+            result = _load_role_prompt("python-developer")
+
+        assert result == "# Python developer role content"
+
+    def test_unknown_role_no_fallback_returns_empty(self, tmp_path: Path) -> None:
+        """Completely unknown roles still return empty string gracefully."""
+        import unittest.mock as mock
+
+        roles_dir = tmp_path / ".agentception" / "roles"
+        roles_dir.mkdir(parents=True)
+
+        from agentception.services.agent_loop import _load_role_prompt
+
+        with mock.patch(
+            "agentception.services.agent_loop.settings.repo_dir", tmp_path
+        ):
+            result = _load_role_prompt("nonexistent-specialist")
+
+        assert result == ""
+
+
 class TestBuildToolDefinitions:
     def test_contains_local_tools(self) -> None:
         from agentception.services.agent_loop import _build_tool_definitions

--- a/agentception/tests/test_label_context_and_dispatch.py
+++ b/agentception/tests/test_label_context_and_dispatch.py
@@ -417,6 +417,19 @@ def test_dispatch_label_issue_scope_persists_issue_number_to_db(
     assert kwargs["tier"] == "worker"
 
 
+def test_dispatch_label_issue_scope_missing_issue_number_returns_422(
+    client: TestClient,
+) -> None:
+    """scope=issue without scope_issue_number must return HTTP 422, not silently fall through."""
+    res = client.post(
+        "/api/dispatch/label",
+        json=_dispatch_label_body(scope="issue"),  # scope_issue_number omitted
+    )
+    assert res.status_code == 422
+    detail = res.json()["detail"]
+    assert "scope_issue_number" in detail
+
+
 # ---------------------------------------------------------------------------
 # cascade_enabled field — smoke-test mode
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_load_role_prompt` now falls back to the role-family base when the specific file is missing (e.g. `python-developer` → `developer`), so agents dispatched with language-specific roles receive a proper system prompt instead of an empty one.
- `POST /api/dispatch/label` with `scope=issue` but no `scope_issue_number` now returns HTTP 422 immediately instead of silently falling through to label scope with `issue=0`.
- `applyEdit()` in the org designer now validates that a ticket is selected before saving `scope=issue`, and shows an inline error if the user tries to apply without one.

## Test plan

- [x] `TestRoleBaseFallback` (5 new unit tests for `_role_base_fallback`)
- [x] `TestLoadRolePromptFamilyFallback` (3 new regression tests for the fallback chain)
- [x] `test_dispatch_label_issue_scope_missing_issue_number_returns_422` (regression test for the 422 fix)
- [x] All 27 tests in `test_label_context_and_dispatch.py` pass
- [x] All 20 tests in `test_agentception_spawn_child.py` and `test_build_commands_rebase.py` pass
- [x] `mypy agentception/ tests/` — 0 errors (304 source files)
- [x] `typing_audit --max-any 0` — 0 violations
- [x] `npm run build` — JS and CSS bundles rebuilt