### PR TITLE
fix: bake jina embedding model into image at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,17 @@ COPY pyproject.toml /app/pyproject.toml
 # Install the package itself so `agentception.*` imports resolve.
 RUN pip install --no-cache-dir -e /app
 
+# Pre-download the ONNX embedding model into the image layer.
+# Docker build has unrestricted network access; the runtime proxy does not,
+# so downloading at runtime inside the container will fail (403 CONNECT tunnel).
+# Baking the model here means it is always present after a clean build and
+# survives volume recreation without any manual recovery steps.
+RUN python3 -c "\
+from fastembed import TextEmbedding; \
+m = TextEmbedding(model_name='jinaai/jina-embeddings-v2-base-code'); \
+list(m.embed(['warm-up'])); \
+print('Embedding model pre-downloaded.')"
+
 # Entrypoint: performs privileged startup (resolv.conf, asset compilation,
 # DB migrations, ownership fixes) then drops to the agentception user via
 # gosu before exec'ing the server command.


### PR DESCRIPTION
## Summary

- Docker's runtime proxy blocks outbound HTTPS to `huggingface.co` (403 on CONNECT tunnel), so fastembed's lazy model download always fails inside the running container.
- Moving the download to a `RUN` step in the Dockerfile means the model is baked into the image layer at build time, where Docker has unrestricted network access.
- After this change the model is always present after a clean build — no named volume dependency, no manual recovery steps needed.

## Test plan

- [ ] `docker compose build agentception` completes and prints `Embedding model pre-downloaded.`
- [ ] No `[ONNXRuntimeError] : 3 : NO_SUCHFILE` errors in container logs after the rebuild