### PR TITLE
fix: block Launch and show inline error when scope=issue has no ticket

### DIFF
--- a/agentception/static/js/org_designer.ts
+++ b/agentception/static/js/org_designer.ts
@@ -1000,6 +1000,7 @@ interface OrgDesignerComponent {
   readonly filteredRoleGroups: RoleGroup[];
   readonly filteredFigures: FigureItem[];
   readonly availableEditTypes: Array<'coordinator' | 'worker'>;
+  readonly scopeError: string;
   readonly launchReady: boolean;
   readonly launchPreviewText: string;
   readonly activePresetName: string;
@@ -1131,8 +1132,24 @@ export function orgDesigner(): OrgDesignerComponent {
       return availableChildTypes(this.editParentRole);
     },
 
+    /** Non-empty string when the current org tree has a scope configuration
+     *  error that must be resolved before launching. */
+    get scopeError(): string {
+      if (!this._root) return '';
+      if (this._root.scope === 'issue' && this._root.scopeIssueNumber === null) {
+        return 'Select a ticket: open the node editor, choose Ticket scope, and pick a ticket.';
+      }
+      return '';
+    },
+
     get launchReady(): boolean {
-      return !!(this._root && this._root.role && !this.launching && !this.launchSuccess);
+      return !!(
+        this._root &&
+        this._root.role &&
+        !this.scopeError &&
+        !this.launching &&
+        !this.launchSuccess
+      );
     },
 
     get launchPreviewText(): string {

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -339,7 +339,10 @@
     </template>
 
     {# Error / success feedback #}
-    <template x-if="launchError">
+    <template x-if="scopeError">
+      <span class="od-header__launch-err" x-text="scopeError"></span>
+    </template>
+    <template x-if="!scopeError && launchError">
       <span class="od-header__launch-err" x-text="launchError"></span>
     </template>
     <template x-if="launchSuccess && launchResult">


### PR DESCRIPTION
## Summary

- A preset saved with `scope='issue'` but no ticket selected bypassed the launch button guard and hit the server, returning a raw `422` error string.
- New `scopeError` getter detects the missing-ticket condition before any network request is made: the Launch button is disabled and the message `"Select a ticket: open the node editor, choose Ticket scope, and pick a ticket."` appears immediately in the header error slot.
- The server-side 422 guard (PR #1143) remains as a safety net.

## Test plan

- [ ] Load a preset with scope=Ticket but no ticket selected → Launch button is greyed out, error shown
- [ ] Select a ticket → error clears, Launch button re-enables
- [ ] `tsc --noEmit` passes (zero errors)
- [ ] JS bundle rebuilt