### PR TITLE
fix: pre-populate role/figure in editor and suppress scopeError while editing

### DIFF
--- a/agentception/static/js/org_designer.ts
+++ b/agentception/static/js/org_designer.ts
@@ -1136,6 +1136,12 @@ export function orgDesigner(): OrgDesignerComponent {
      *  error that must be resolved before launching. */
     get scopeError(): string {
       if (!this._root) return '';
+      // If the edit panel is open for the root node and a ticket is already selected
+      // in the panel (even before Apply), the user is actively fixing the config — suppress.
+      const editingRoot = this.selectedNodeId === this._root.id;
+      if (editingRoot && this.editScope === 'issue' && this.editScopeIssueNumber !== null) {
+        return '';
+      }
       if (this._root.scope === 'issue' && this._root.scopeIssueNumber === null) {
         return 'Select a ticket: open the node editor, choose Ticket scope, and pick a ticket.';
       }

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -536,7 +536,7 @@
                 <template x-for="group in filteredRoleGroups" :key="group.label">
                   <optgroup :label="group.label">
                     <template x-for="r in group.roles" :key="r.slug">
-                      <option :value="r.slug" x-text="r.label"></option>
+                      <option :value="r.slug" :selected="r.slug === editRole" x-text="r.label"></option>
                     </template>
                   </optgroup>
                 </template>
@@ -549,7 +549,7 @@
               <select class="od-editor__select" x-model="editFigure">
                 <option value="">— role default —</option>
                 <template x-for="fig in filteredFigures" :key="fig.id">
-                  <option :value="fig.id" x-text="fig.name"></option>
+                  <option :value="fig.id" :selected="fig.id === editFigure" x-text="fig.name"></option>
                 </template>
               </select>
             </div>


### PR DESCRIPTION
## Summary

- **`scopeError` shown despite ticket being selected in panel** — The getter read `this._root.scopeIssueNumber` (saved/committed state), so the "Select a ticket" warning persisted while the edit panel was open with a ticket already chosen but not yet Applied. Now suppresses the error whenever the edit panel is open for the root node and `editScopeIssueNumber !== null`.
- **Role and figure dropdowns not pre-populating on re-open** — Alpine.js `x-model` on a `<select>` with `<option>` elements rendered dynamically via `x-for` can evaluate before the matching option exists in the DOM. Added explicit `:selected="r.slug === editRole"` and `:selected="fig.id === editFigure"` bindings so the correct option is always marked regardless of evaluation order.

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] `npm test` — 291/291 pass
- [x] `npm run build:js` — clean bundle