### PR TITLE
fix: remove redundant scope error banner while editor is open; fix ticket dropdown null display

### DIFF
--- a/agentception/static/js/org_designer.ts
+++ b/agentception/static/js/org_designer.ts
@@ -1000,6 +1000,7 @@ interface OrgDesignerComponent {
   readonly filteredRoleGroups: RoleGroup[];
   readonly filteredFigures: FigureItem[];
   readonly availableEditTypes: Array<'coordinator' | 'worker'>;
+  readonly _rootIsValid: boolean;
   readonly scopeError: string;
   readonly launchReady: boolean;
   readonly launchPreviewText: string;
@@ -1134,14 +1135,21 @@ export function orgDesigner(): OrgDesignerComponent {
 
     /** Non-empty string when the current org tree has a scope configuration
      *  error that must be resolved before launching. */
+    /** True only when the root node's configuration is complete and launch-eligible. */
+    get _rootIsValid(): boolean {
+      if (!this._root || !this._root.role) return false;
+      if (this._root.scope === 'issue' && this._root.scopeIssueNumber === null) return false;
+      return true;
+    },
+
+    /**
+     * Header warning text. Only shown when the editor is NOT open for the root
+     * node — once the user opens the editor they can see the incomplete field
+     * directly; the banner is redundant and confusing while the panel is visible.
+     */
     get scopeError(): string {
       if (!this._root) return '';
-      // If the edit panel is open for the root node and a ticket is already selected
-      // in the panel (even before Apply), the user is actively fixing the config — suppress.
-      const editingRoot = this.selectedNodeId === this._root.id;
-      if (editingRoot && this.editScope === 'issue' && this.editScopeIssueNumber !== null) {
-        return '';
-      }
+      if (this.selectedNodeId === this._root.id) return '';
       if (this._root.scope === 'issue' && this._root.scopeIssueNumber === null) {
         return 'Select a ticket: open the node editor, choose Ticket scope, and pick a ticket.';
       }
@@ -1149,13 +1157,7 @@ export function orgDesigner(): OrgDesignerComponent {
     },
 
     get launchReady(): boolean {
-      return !!(
-        this._root &&
-        this._root.role &&
-        !this.scopeError &&
-        !this.launching &&
-        !this.launchSuccess
-      );
+      return this._rootIsValid && !this.launching && !this.launchSuccess;
     },
 
     get launchPreviewText(): string {

--- a/agentception/templates/build.html
+++ b/agentception/templates/build.html
@@ -608,9 +608,10 @@
                     <label class="od-editor__label">Ticket</label>
                     <select class="od-scope-select"
                             x-model.number="editScopeIssueNumber">
-                      <option value="" disabled>— select a ticket —</option>
+                      <option value="" :selected="editScopeIssueNumber === null" disabled>— select a ticket —</option>
                       <template x-for="iss in issues" :key="iss.number">
                         <option :value="iss.number"
+                                :selected="iss.number === editScopeIssueNumber"
                                 :disabled="iss.blocked"
                                 :class="{'od-scope-select__opt--blocked': iss.blocked}"
                                 x-text="'#' + iss.number + ' — ' + (iss.title.length > 52 ? iss.title.slice(0, 52) + '…' : iss.title) + (iss.blocked ? ' (blocked)' : '')"></option>


### PR DESCRIPTION
## Summary

- **Error banner hidden while editor is open** — `scopeError` now returns `''` whenever the root node editor panel is open. The banner is redundant (the user is already looking at the editor) and confusing (it says "open the editor" when the editor is already open). A new `_rootIsValid` getter carries the actual validity check independently.
- **`launchReady` decoupled from `scopeError`** — The Launch button now checks `_rootIsValid` directly, so it stays disabled when `scopeIssueNumber` is null even when the error banner is suppressed.
- **Ticket dropdown placeholder now renders correctly when null** — Previously, when `editScopeIssueNumber` was `null`, the browser defaulted to visually selecting the first issue option (standard `<select>` behaviour when no option matches). This made the preset appear fully configured when it wasn't. Added `:selected="editScopeIssueNumber === null"` to the placeholder and `:selected="iss.number === editScopeIssueNumber"` to each option to force correct rendering.

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] `npm test` — 291/291 pass
- [x] `npm run build:js` — clean bundle