### PR TITLE
fix: extract shared role-file loader with family fallback; fix mcp/prompts path

### DIFF
--- a/agentception/mcp/prompts.py
+++ b/agentception/mcp/prompts.py
@@ -42,6 +42,7 @@ import yaml
 
 from agentception.types import JsonValue
 from agentception.db.queries import RunContextRow, get_run_context
+from agentception.services.role_loader import load_role_file
 from agentception.mcp.types import (
     ACPromptArgument,
     ACPromptContent,
@@ -558,18 +559,15 @@ def _render_task_briefing(ctx: RunContextRow, role_content: str) -> str:
 
 
 def _load_role_content(role: str) -> str:
-    """Return the Markdown content of the role file for *role*, or empty string."""
+    """Return the Markdown content of the role file for *role*, or empty string.
+
+    Delegates to :func:`~agentception.services.role_loader.load_role_file` so
+    that the family-fallback logic (``python-developer`` → ``developer``) is
+    consistent with the agent-loop path.
+    """
     if not role:
         return ""
-    path = _AGENTCEPTION_DIR / "roles" / f"{role}.md"
-    try:
-        return path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        logger.warning("⚠️  task/briefing: role file not found for %r", role)
-        return ""
-    except OSError as exc:
-        logger.warning("⚠️  task/briefing: could not read role file for %r: %s", role, exc)
-        return ""
+    return load_role_file(role, _AGENTCEPTION_DIR / "roles")
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -62,6 +62,7 @@ from agentception.services.llm import (
     completion_with_tools,
 )
 from agentception.services.code_indexer import SearchMatch, search_codebase
+from agentception.services.role_loader import load_role_file
 from agentception.types import JsonSchemaObj, JsonValue
 from agentception.services.github_mcp_client import GitHubMCPClient
 from agentception.tools.definitions import (
@@ -1245,84 +1246,17 @@ async def _load_task_from_db(run_id: str) -> AgentTaskSpec | None:
         return None
 
 
-def _role_base_fallback(role: str) -> str | None:
-    """Return the base role slug to try when *role*'s file is missing.
-
-    Language- and domain-prefixed roles (e.g. ``python-developer``,
-    ``react-developer``, ``data-engineer``) share execution contracts with
-    their base family.  When the specific file is absent, loading the base
-    file is far better than returning an empty system prompt.
-
-    Returns ``None`` when no meaningful fallback exists (e.g. the role has no
-    ``-`` separator, or the suffix is not a known base family).
-    """
-    _BASE_FAMILIES = frozenset({
-        "developer", "coordinator", "engineer", "analyst",
-        "architect", "researcher", "writer", "programmer",
-    })
-    if "-" not in role:
-        return None
-    suffix = role.rsplit("-", 1)[-1]
-    return suffix if suffix in _BASE_FAMILIES else None
-
-
 def _load_role_prompt(role: str | None, variant: str | None = None) -> str:
     """Return the Markdown content of the role file for *role*.
 
-    When *variant* is provided and non-empty, the function first looks for a
-    variant-specific file ``{role}-{variant}.md`` and returns its content if
-    found.  If the variant file does not exist, it falls back to the base
-    ``{role}.md`` file — the same behaviour as when *variant* is ``None``.
-
-    When the exact role file is missing, the function tries the role-family
-    base (e.g. ``python-developer`` → ``developer``) before giving up.  Falls
-    back to an empty string only when no role file can be found at all.
+    Delegates to :func:`~agentception.services.role_loader.load_role_file` so
+    that the variant and role-family fallback logic lives in one place.
     """
     if not role:
         logger.warning("⚠️ _load_role_prompt — no role specified")
         return ""
-
     roles_dir = settings.repo_dir / ".agentception" / "roles"
-
-    # Try the variant file first when a variant is requested.
-    if variant:
-        candidate = roles_dir / f"{role}-{variant}.md"
-        if candidate.exists():
-            logger.info("Loading role file: %s (variant=%s)", candidate, variant)
-            try:
-                return candidate.read_text(encoding="utf-8")
-            except OSError as exc:
-                logger.warning(
-                    "⚠️ _load_role_prompt — OS error reading %s: %s", candidate, exc
-                )
-                # Fall through to the base file.
-
-    # Try the exact role file.
-    role_path = roles_dir / f"{role}.md"
-    logger.info("Loading role file: %s (variant=%s)", role_path, variant)
-    try:
-        return role_path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        pass
-    except OSError as exc:
-        logger.warning("⚠️ _load_role_prompt — OS error reading %s: %s", role_path, exc)
-        return ""
-
-    # Exact file missing — try the role-family base (python-developer → developer).
-    base = _role_base_fallback(role)
-    if base:
-        base_path = roles_dir / f"{base}.md"
-        try:
-            content = base_path.read_text(encoding="utf-8")
-            logger.info(
-                "✅ _load_role_prompt — using family fallback %s → %s", role, base
-            )
-            return content
-        except OSError:
-            pass
-
-    logger.warning("⚠️ _load_role_prompt — role file not found: %s", role_path)
-    return ""
+    return load_role_file(role, roles_dir, variant=variant)
 
 
 # ---------------------------------------------------------------------------

--- a/agentception/services/role_loader.py
+++ b/agentception/services/role_loader.py
@@ -1,0 +1,91 @@
+"""Shared role-file loading utilities.
+
+Both the agent loop (``services/agent_loop.py``) and the MCP prompts layer
+(``mcp/prompts.py``) need to resolve a role slug to Markdown content.  This
+module owns that logic in a single place so the fallback behaviour is
+consistent across all call paths.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Role-family suffixes that serve as meaningful fallbacks for specialised
+#: roles.  ``python-developer`` → ``developer``, ``data-engineer`` → ``engineer``, etc.
+_BASE_FAMILIES: frozenset[str] = frozenset({
+    "developer", "coordinator", "engineer", "analyst",
+    "architect", "researcher", "writer", "programmer",
+})
+
+
+def role_family_fallback(role: str) -> str | None:
+    """Return the base role slug to try when *role*'s file is missing.
+
+    Language- and domain-prefixed roles (e.g. ``python-developer``,
+    ``react-developer``, ``data-engineer``) share execution contracts with
+    their base family.  When the specific file is absent, loading the base
+    file is far better than returning an empty system prompt.
+
+    Returns ``None`` when no meaningful fallback exists (e.g. the role has no
+    ``-`` separator, or the suffix is not a known base family).
+    """
+    if "-" not in role:
+        return None
+    suffix = role.rsplit("-", 1)[-1]
+    return suffix if suffix in _BASE_FAMILIES else None
+
+
+def load_role_file(role: str, roles_dir: Path, variant: str | None = None) -> str:
+    """Return the Markdown content of the role file for *role*.
+
+    Resolution order:
+
+    1. ``{roles_dir}/{role}-{variant}.md`` (only when *variant* is non-empty)
+    2. ``{roles_dir}/{role}.md``
+    3. ``{roles_dir}/{base}.md`` where *base* is the role-family fallback
+       (e.g. ``python-developer`` → ``developer``)
+
+    Returns an empty string when no file can be found at all.
+    """
+    if not role:
+        logger.warning("⚠️  load_role_file — no role specified")
+        return ""
+
+    # 1. Variant file.
+    if variant:
+        candidate = roles_dir / f"{role}-{variant}.md"
+        if candidate.exists():
+            logger.info("load_role_file: loading %s (variant=%s)", candidate, variant)
+            try:
+                return candidate.read_text(encoding="utf-8")
+            except OSError as exc:
+                logger.warning("⚠️  load_role_file — OS error reading %s: %s", candidate, exc)
+
+    # 2. Exact role file.
+    role_path = roles_dir / f"{role}.md"
+    try:
+        content = role_path.read_text(encoding="utf-8")
+        logger.info("load_role_file: loaded %s", role_path)
+        return content
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("⚠️  load_role_file — OS error reading %s: %s", role_path, exc)
+        return ""
+
+    # 3. Role-family fallback (e.g. python-developer → developer).
+    base = role_family_fallback(role)
+    if base:
+        base_path = roles_dir / f"{base}.md"
+        try:
+            content = base_path.read_text(encoding="utf-8")
+            logger.info("✅ load_role_file — using family fallback %s → %s", role, base)
+            return content
+        except OSError:
+            pass
+
+    logger.warning("⚠️  load_role_file — role file not found: %s", role_path)
+    return ""


### PR DESCRIPTION
## Summary

- **`mcp/prompts.py` was missing the role-family fallback** — the `task/briefing` MCP prompt path called `_load_role_content` which had no fallback logic, so every specialised role without its own `.md` file (e.g. `python-developer`) logged a warning and returned an empty role prompt to the agent.
- **Extracted shared `services/role_loader.py`** — new module owns `load_role_file(role, roles_dir, variant)` and `role_family_fallback(role)`. Both `agent_loop._load_role_prompt` and `mcp/prompts._load_role_content` now delegate to it. Local copies of `_role_base_fallback` and `_load_role_prompt` in `agent_loop.py` are deleted.

## Test plan
- [x] `mypy agentception/services/role_loader.py agentception/mcp/prompts.py agentception/services/agent_loop.py` — zero errors
- [x] `pytest test_label_context_and_dispatch.py test_build_commands_rebase.py` — 32/32 pass