### PR TITLE
fix: add agentception-qdrant to NO_PROXY — short name 'qdrant' didn't match container hostname

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,13 +118,14 @@ services:
       # Standard-case and uppercase variants are both set for maximum tool
       # coverage (curl, git, npm, Python httpx/requests all check one or both).
       # NO_PROXY excludes internal Docker services that must not go through the
-      # proxy: postgres, qdrant, and the local LLM server on the host.
+      # proxy: postgres, qdrant (both short name and full container name),
+      # and the local LLM server on the host.
       HTTP_PROXY: "http://proxy:8888"
       HTTPS_PROXY: "http://proxy:8888"
-      NO_PROXY: "localhost,127.0.0.1,postgres,qdrant,host.docker.internal,::1"
+      NO_PROXY: "localhost,127.0.0.1,postgres,qdrant,agentception-qdrant,host.docker.internal,::1"
       http_proxy: "http://proxy:8888"
       https_proxy: "http://proxy:8888"
-      no_proxy: "localhost,127.0.0.1,postgres,qdrant,host.docker.internal,::1"
+      no_proxy: "localhost,127.0.0.1,postgres,qdrant,agentception-qdrant,host.docker.internal,::1"
     volumes:
       # gh CLI auth (read-only). Container HOME is /home/agentception.
       - ${HOME}/.config/gh:/home/agentception/.config/gh:ro


### PR DESCRIPTION
## Summary

- The default `qdrant_url` in `config.py` is `http://agentception-qdrant:6333` (full container name), but `NO_PROXY` / `no_proxy` in `docker-compose.yml` only listed `qdrant` (short name).
- `httpx` (used by `qdrant-client`) does exact hostname matching against `NO_PROXY` — `agentception-qdrant` did not match `qdrant`, so every Qdrant search request was routed through `tinyproxy`, which blocked it with `403 Filtered`.
- Added `agentception-qdrant` to both `NO_PROXY` and `no_proxy` entries. Both the short alias and the full container name are now listed.

## Test plan
- Rebuild and restart: `docker compose up -d --build agentception`
- Confirm `search_codebase` calls no longer log `403 Filtered`