### PR TITLE
fix: set HF_HOME during Dockerfile model pre-download to match runtime path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,11 +114,17 @@ RUN pip install --no-cache-dir -e /app
 # so downloading at runtime inside the container will fail (403 CONNECT tunnel).
 # Baking the model here means it is always present after a clean build and
 # survives volume recreation without any manual recovery steps.
-RUN python3 -c "\
+#
+# HF_HOME must be set to the agentception user's cache directory so the model
+# lands in the same path the runtime app reads from.  Without this, the build
+# runs as root and writes to /root/.cache/huggingface — a cache miss every
+# startup — causing fastembed to re-download the model at runtime.
+RUN HF_HOME=/home/agentception/.cache/huggingface python3 -c "\
 from fastembed import TextEmbedding; \
 m = TextEmbedding(model_name='jinaai/jina-embeddings-v2-base-code'); \
 list(m.embed(['warm-up'])); \
-print('Embedding model pre-downloaded.')"
+print('Embedding model pre-downloaded.')" \
+    && chown -R agentception:agentception /home/agentception/.cache
 
 # Entrypoint: performs privileged startup (resolv.conf, asset compilation,
 # DB migrations, ownership fixes) then drops to the agentception user via


### PR DESCRIPTION
## Summary

The ONNX embedding model pre-download `RUN` step ran as `root`, so fastembed cached the model under `/root/.cache/huggingface`. At runtime `HF_HOME` is set to `/home/agentception/.cache/huggingface`, so fastembed saw a cache miss on every container startup and re-downloaded the ~600 MB model — triggering HuggingFace unauthenticated rate-limit warnings on every boot.

**Fix:** prefix the `RUN` command with `HF_HOME=/home/agentception/.cache/huggingface` so the model is written to the same path the app reads from, then `chown` the cache directory to the `agentception` user so it remains readable at runtime.

## Test plan
- Rebuild the image: `docker compose build agentception && docker compose up -d agentception`
- Confirm no `huggingface_hub` rate-limit warning on startup
- Confirm `search_codebase` calls succeed without model re-download delay

## HF_TOKEN
A `HF_TOKEN=` placeholder has been added to `.env` (gitignored). Get a read-only token at https://huggingface.co/settings/tokens and paste it there to suppress the unauthenticated-request warning entirely.