### PR TITLE
fix: stash dirty working tree before rebase in build_complete_run

### DIFF
--- a/agentception/mcp/build_commands.py
+++ b/agentception/mcp/build_commands.py
@@ -91,6 +91,24 @@ async def _rebase_and_push_worktree(
     )
     await proc.communicate()
 
+    # Stash any uncommitted changes before rebasing.  Automated steps
+    # (generate.py, indexers) can leave modified files in the worktree even
+    # after the agent commits; git rebase refuses to start when the working
+    # tree is dirty and the rebase commit touches the same files.
+    stash_proc = await asyncio.create_subprocess_exec(
+        "git", "stash", "--include-untracked",
+        cwd=wt_path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stash_stdout, _ = await stash_proc.communicate()
+    stashed = b"No local changes" not in stash_stdout
+    if stashed:
+        logger.info(
+            "ℹ️  _rebase_and_push_worktree: stashed dirty working tree before rebase for run_id=%r",
+            agent_run_id,
+        )
+
     proc = await asyncio.create_subprocess_exec(
         "git", "rebase", base,
         cwd=wt_path,
@@ -107,6 +125,14 @@ async def _rebase_and_push_worktree(
             stderr=asyncio.subprocess.PIPE,
         )
         await abort_proc.communicate()
+        if stashed:
+            pop_proc = await asyncio.create_subprocess_exec(
+                "git", "stash", "pop",
+                cwd=wt_path,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await pop_proc.communicate()
         logger.error(
             "❌ _rebase_and_push_worktree: rebase onto %s failed for run_id=%r — %s",
             base,
@@ -121,6 +147,21 @@ async def _rebase_and_push_worktree(
                 "Resolve the conflicts manually and call build_complete_run again."
             ),
         }
+
+    if stashed:
+        pop_proc = await asyncio.create_subprocess_exec(
+            "git", "stash", "pop",
+            cwd=wt_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        pop_stdout, pop_stderr = await pop_proc.communicate()
+        if pop_proc.returncode != 0:
+            logger.warning(
+                "⚠️  _rebase_and_push_worktree: stash pop after rebase failed for run_id=%r — %s",
+                agent_run_id,
+                pop_stderr.decode(errors="replace").strip(),
+            )
 
     branch_proc = await asyncio.create_subprocess_exec(
         "git", "rev-parse", "--abbrev-ref", "HEAD",

--- a/agentception/tests/test_build_commands_rebase.py
+++ b/agentception/tests/test_build_commands_rebase.py
@@ -73,13 +73,14 @@ async def test_rebase_succeeds_force_pushes_and_dispatches_reviewer() -> None:
     wt_path = "/worktrees/issue-10"
     branch_name = "agent/issue-10"
 
-    # Subprocess sequence: fetch, rebase, rev-parse, push
+    # Subprocess sequence: fetch, stash (no-op), rebase, rev-parse, push
     fetch_proc = _make_proc(0)
+    stash_proc = _make_proc(0, stdout=b"No local changes to save; HEAD unchanged")
     rebase_proc = _make_proc(0)
     rev_parse_proc = _make_proc(0, stdout=f"{branch_name}\n".encode())
     push_proc = _make_proc(0)
 
-    subprocess_calls = iter([fetch_proc, rebase_proc, rev_parse_proc, push_proc])
+    subprocess_calls = iter([fetch_proc, stash_proc, rebase_proc, rev_parse_proc, push_proc])
 
     async def fake_create_subprocess_exec(*args: str | int | bool | float | None, **kwargs: str | int | bool | float | None) -> AsyncMock:
         return next(subprocess_calls)
@@ -160,10 +161,11 @@ async def test_rebase_conflict_returns_error_and_aborts() -> None:
     wt_path = "/worktrees/issue-20"
 
     fetch_proc = _make_proc(0)
+    stash_proc = _make_proc(0, stdout=b"No local changes to save; HEAD unchanged")
     rebase_proc = _make_proc(1, stderr=b"CONFLICT (content): Merge conflict in foo.py")
     abort_proc = _make_proc(0)
 
-    subprocess_calls = iter([fetch_proc, rebase_proc, abort_proc])
+    subprocess_calls = iter([fetch_proc, stash_proc, rebase_proc, abort_proc])
 
     async def fake_create_subprocess_exec(*args: str | int | bool | float | None, **kwargs: str | int | bool | float | None) -> AsyncMock:
         return next(subprocess_calls)
@@ -404,10 +406,11 @@ async def test_label_dispatch_branch_forwarded_to_reviewer() -> None:
     label_branch = "agent/documentation-improvement-a1b2"
 
     fetch_proc = _make_proc(0)
+    stash_proc = _make_proc(0, stdout=b"No local changes to save; HEAD unchanged")
     rebase_proc = _make_proc(0)
     rev_parse_proc = _make_proc(0, stdout=f"{label_branch}\n".encode())
     push_proc = _make_proc(0)
-    subprocess_calls = iter([fetch_proc, rebase_proc, rev_parse_proc, push_proc])
+    subprocess_calls = iter([fetch_proc, stash_proc, rebase_proc, rev_parse_proc, push_proc])
 
     async def fake_create_subprocess_exec(*args: str | int | bool | float | None, **kwargs: str | int | bool | float | None) -> AsyncMock:
         return next(subprocess_calls)


### PR DESCRIPTION
## Summary

`_rebase_and_push_worktree` called `git rebase` without first checking for uncommitted changes. Automated steps (generate.py, code indexer) can leave modified files in the worktree after the agent commits, causing git rebase to abort with `"local changes would be overwritten by merge"`.

**Fix:** run `git stash --include-untracked` before the rebase and `git stash pop` after (on both success and conflict paths). If the stash is a no-op (no local changes), the `stashed` flag stays false and no pop is attempted.

## Also fixed in .env (local, not committed)
- `LOCAL_LLM_COMPLETION_TOKEN_CEILING` raised from `8192` → `16384` — the model's chain-of-thought was exhausting the output token budget, causing empty LLM responses and spurious `stop_reason=tool_calls with 0 tool calls` warnings
- `LOCAL_LLM_MAX_SYSTEM_CHARS` already raised from `12000` → `20000` in previous session

## Test plan
- [x] `pytest agentception/tests/test_build_commands_rebase.py` — 5/5 pass
- [x] `mypy agentception/mcp/build_commands.py` — zero errors