### PR TITLE
fix: add 'reviewer' to role family fallbacks so pr-reviewer maps to reviewer.md

### DIFF
--- a/agentception/services/role_loader.py
+++ b/agentception/services/role_loader.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 _BASE_FAMILIES: frozenset[str] = frozenset({
     "developer", "coordinator", "engineer", "analyst",
     "architect", "researcher", "writer", "programmer",
+    "reviewer",
 })
 
 


### PR DESCRIPTION
## Summary

`pr-reviewer` is the role slug used when spawning a reviewer agent. `reviewer.md` already exists in `.agentception/roles/`, but `role_family_fallback` only knew about the suffix families `developer`, `coordinator`, `engineer`, etc. — not `reviewer`. Adding `reviewer` to `_BASE_FAMILIES` means `pr-reviewer` → `reviewer.md` is resolved automatically, eliminating the `load_role_file — role file not found` warning.

## Test plan
- [x] `mypy agentception/services/role_loader.py` — zero errors
- Restart container and confirm no `role file not found` warning for `pr-reviewer`