### PR TITLE
fix: raise recon planning max_tokens 500→2000 for Qwen3 thinking mode

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -1865,7 +1865,11 @@ async def _run_recon_phase(
             raw_plan = await completion(
                 task_text,
                 system_prompt=system_prompt + _RECON_SYSTEM_ADDENDUM,
-                max_tokens=500,
+                # 2000 tokens gives Qwen3-family models enough headroom for
+                # extended chain-of-thought before emitting the JSON object.
+                # 500 was exhausted entirely by thinking, leaving no budget
+                # for the actual output and causing parse failures.
+                max_tokens=2000,
                 temperature=0.0,
             )
         except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary

- The recon LLM planning call hardcoded `max_tokens=500`
- Qwen3-family models run extended chain-of-thought (thinking) before emitting output; 500 tokens is consumed entirely by reasoning, leaving zero budget for the actual JSON response
- `_parse_recon_json` then fails → `⚠️ recon phase: could not parse plan from LLM response` every run
- Raised to `2000` — gives ~1800 tokens for thinking and ~200 for the JSON object (more than enough for the small exploration plan)

## Test plan
- [ ] `mypy agentception/services/agent_loop.py` — clean ✅
- [ ] Dispatch an agent; confirm no `could not parse plan` warning in logs
- [ ] Confirm recon phase logs `✅ recon: files=N searches=M`