### PR TITLE
fix: correct fastembed import path for TextCrossEncoder in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,7 +124,8 @@ RUN pip install --no-cache-dir -e /app
 #   - jinaai/jina-embeddings-v2-base-code  (embedding — TextEmbedding)
 #   - BAAI/bge-reranker-base               (reranker  — TextCrossEncoder)
 RUN HF_HOME=/home/agentception/.cache/huggingface python3 -c "\
-from fastembed import TextEmbedding, TextCrossEncoder; \
+from fastembed import TextEmbedding; \
+from fastembed.rerank.cross_encoder import TextCrossEncoder; \
 emb = TextEmbedding(model_name='jinaai/jina-embeddings-v2-base-code'); \
 list(emb.embed(['warm-up'])); \
 print('Embedding model pre-downloaded.'); \


### PR DESCRIPTION
## Summary

- `fastembed` 0.7.4 does not re-export `TextCrossEncoder` at the package top-level (`from fastembed import TextCrossEncoder` → `ImportError`)
- The class lives at `fastembed.rerank.cross_encoder.TextCrossEncoder` — matching what `code_indexer.py` already uses
- The wrong import caused the model pre-download `RUN` step to fail in under 1 second (before downloading anything), breaking every image rebuild

## Note

This is a build-time fix only. The running container is unaffected — the model is already cached there from earlier builds.