### PR TITLE
fix: remove fastembed_cache named volume — use image layer directly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,12 +168,13 @@ services:
       - ${HOME}/.agentception/worktrees/agentception:/worktrees
       # Persist HuggingFace hub files (tokens, metadata) across container restarts.
       - model_cache:/home/agentception/.cache/huggingface
-      # Persist FastEmbed ONNX models across container restarts.
-      # Without this volume the three ONNX models (jina-v2 ~640 MB, BM25, bge-reranker ~280 MB)
-      # are re-downloaded from HuggingFace on every restart, adding ~60 s to the
-      # first dispatch after each restart.  With the volume they are loaded from
-      # disk on first use (~5–10 s) and stay warm for the lifetime of the volume.
-      - fastembed_cache:/home/agentception/.cache/fastembed
+      # NOTE: fastembed ONNX models are NOT stored in a named volume.
+      # They are baked into the image layer at build time (see Dockerfile RUN step
+      # before COPY agentception/).  A named volume would shadow the image layer —
+      # if the volume was ever created before the models were correctly baked, it
+      # permanently masks them, causing NO_SUCHFILE errors at runtime.  Using the
+      # image layer directly is simpler and more reliable: models are always present
+      # after a clean build and never go stale.
     # Use Cloudflare DNS instead of Docker's embedded resolver.
     # Docker's embedded DNS caches whichever node it gets first, and GitHub
     # occasionally has dead nodes in rotation (e.g. 140.82.116.6) that refuse
@@ -252,8 +253,6 @@ volumes:
     name: agentception-qdrant-data
   model_cache:
     name: agentception-model-cache
-  fastembed_cache:
-    name: agentception-fastembed-cache
   node_modules:
     name: agentception-node-modules
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -69,13 +69,6 @@ chown agentception:agentception /worktrees
 echo "[entrypoint] fixing ownership of HuggingFace cache …"
 chown -R agentception:agentception /home/agentception/.cache/huggingface
 
-# /home/agentception/.cache/fastembed — named volume (agentception-fastembed-cache).
-#   FastEmbed downloads ONNX models here on first dispatch; the agentception user
-#   must be able to write here.
-echo "[entrypoint] fixing ownership of FastEmbed cache …"
-mkdir -p /home/agentception/.cache/fastembed
-chown -R agentception:agentception /home/agentception/.cache/fastembed
-
 # ── 6. Drop to non-root user ─────────────────────────────────────────────────
 # gosu is a purpose-built setuid helper (analogous to sudo -u but without the
 # shell overhead).  It sets UID/GID and execs "$@" — typically uvicorn — as


### PR DESCRIPTION
## Summary

Named Docker volumes shadow image layer content. The `agentception-fastembed-cache` volume was created when models were downloading to the wrong path (before the `HOME=/home/agentception` fix). Docker **never re-initialises a non-empty volume from image content**, so the stale empty volume permanently masked the correctly-baked models, causing `NO_SUCHFILE` errors on every agent run.

## Fix

Remove the named volume entirely. The fastembed ONNX models are baked into the image layer at build time (Dockerfile `RUN` step placed *before* `COPY agentception/`). The image layer is the correct, stable source — no volume required, no stale-shadowing problem class possible.

## Verified

```
Testing embedding model...
  Embedding: OK (7.9s)
Testing reranker model...
  Reranker:  OK (19.7s)
Both models load from image layer — no download needed.
```

Run live inside the container against the rebuilt image. Zero ONNX errors.