### PR TITLE
fix: allow recon phase to succeed with empty files/searches lists

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -1625,9 +1625,6 @@ def _parse_recon_json(raw: str) -> _ReconPlan | None:
     )
     plan_str = str(plan_raw) if isinstance(plan_raw, str) else ""
 
-    if not files and not searches:
-        return None
-
     return _ReconPlan(files=files, searches=searches, plan=plan_str)
 
 

--- a/agentception/tests/test_file_tools_symbol.py
+++ b/agentception/tests/test_file_tools_symbol.py
@@ -207,7 +207,29 @@ def test_parse_recon_json_returns_none_for_garbage() -> None:
     from agentception.services.agent_loop import _parse_recon_json
 
     assert _parse_recon_json("not json at all") is None
-    assert _parse_recon_json('{"files": [], "searches": []}') is None  # both empty
+
+
+def test_parse_recon_json_empty_lists_valid() -> None:
+    """A plan with empty files/searches but a non-empty plan string is valid.
+
+    Reviewer agents intentionally return empty lists when they don't need to
+    pre-load files — the plan field carries the intent and the recon phase
+    becomes a no-op, allowing the agent to proceed with existing context.
+    """
+    from agentception.services.agent_loop import _parse_recon_json
+
+    plan = _parse_recon_json('{"files": [], "searches": [], "plan": "Fetch issue first."}')
+    assert plan is not None
+    assert plan.files == []
+    assert plan.searches == []
+    assert plan.plan == "Fetch issue first."
+
+    # A response with no plan key and both lists empty still returns a plan
+    # (no-op recon) — the guard was removed because empty is a valid outcome.
+    plan2 = _parse_recon_json('{"files": [], "searches": []}')
+    assert plan2 is not None
+    assert plan2.files == []
+    assert plan2.searches == []
 
 
 def test_parse_recon_json_json_in_prose() -> None:


### PR DESCRIPTION
## Summary

- Removes the `if not files and not searches: return None` guard in `_parse_recon_json`
- Reviewer agents correctly return `{"files":[], "searches":[], "plan":"..."}` — they don't need to pre-load source files before reviewing a PR
- The old guard treated this valid response as a parse failure, emitting a spurious `⚠️ recon phase: could not parse plan` warning and aborting the recon phase
- With the guard removed, empty-lists plans are accepted and the recon phase becomes a no-op; the agent proceeds with existing context

## Root cause

The model returned exactly:
```
I need to fetch the issue details first since the pre-loaded context appears incomplete.

\`\`\`json
{"files": [], "searches": [], "plan": "Fetch GitHub issue #1072..."}
\`\`\`
```
The JSON parsed fine, but `not [] and not []` → `True` → `return None`.

## Test plan
- `test_parse_recon_json_empty_lists_valid` — new regression test covering both empty-with-plan and empty-without-plan
- All 6 recon parser tests pass