### PR TITLE
fix: log exact JSONDecodeError and expand recon raw dump to 2000 chars

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -1603,10 +1603,20 @@ def _parse_recon_json(raw: str) -> _ReconPlan | None:
         return None
     try:
         data: JsonValue = json.loads(text[start:end])
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "⚠️ recon parse: JSONDecodeError at pos %d — %s — extracted=%r",
+            exc.pos,
+            exc.msg,
+            text[start:end][:300],
+        )
         return None
 
     if not isinstance(data, dict):
+        logger.warning(
+            "⚠️ recon parse: parsed value is not a dict (%s)",
+            type(data).__name__,
+        )
         return None
 
     files_raw = data.get("files", [])
@@ -1877,7 +1887,7 @@ async def _run_recon_phase(
         if parsed is None:
             logger.warning(
                 "⚠️ recon phase: could not parse plan from LLM response — raw=%r",
-                raw_plan[:500] if raw_plan else "<empty>",
+                raw_plan[:2000] if raw_plan else "<empty>",
             )
             return
         plan = parsed


### PR DESCRIPTION
## Summary

- `_parse_recon_json` was swallowing `JSONDecodeError` silently — the only signal was the outer \"could not parse plan\" warning with 500 chars of the raw response, which was too short to see whether the JSON even closed
- Now logs the exact decode error position + message + 300 chars of the extracted substring that failed
- Also logs when the parsed value is unexpectedly not a dict
- Expands outer warning raw dump from 500 → 2000 chars so the full LLM response is visible when parsing fails

## Why

The raw in the logs was ending mid-sentence in the `plan` field (truncated at 500 chars), making it impossible to tell whether the JSON was complete or the model stopped mid-output. With 2000 chars and explicit JSONDecodeError logging, the next failure will show exactly which code path triggered and what the malformed content looks like.

## Test plan
- All 6 recon parser tests pass (no behaviour change, only logging additions)