### PR TITLE
fix: strengthen recon prompt to explicitly forbid tool calls and prose

### DIFF
--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -1515,24 +1515,36 @@ def _build_tool_definitions(
 _RECON_SYSTEM_ADDENDUM = """
 ---
 
-## RECON MODE — output a JSON exploration plan ONLY
+## RECON MODE — one-shot planning turn
 
-Before any implementation, emit exactly ONE JSON object:
+THIS IS NOT A TOOL-USE TURN.  There is no tool loop, no function dispatcher,
+and no way to call read_file, search_codebase, or any other tool here.
+Calling tools in this turn is impossible and will not work.
+
+Your ONLY job is to output a single JSON object that names the files and
+searches the main agent loop should execute BEFORE it starts work.
+
+FORBIDDEN — do not produce any of these:
+- Tool calls, function calls, or any invocation syntax (read_file(...), etc.)
+- bash, python, or any code fences other than the single ```json block below
+- Prose paragraphs, reasoning text, or markdown headers
+- Any text before or after the JSON object
+
+REQUIRED — respond with exactly this structure and nothing else:
 
 ```json
 {
-  "files": ["<relative paths of files most likely to need editing or serve as patterns — max 8>"],
-  "searches": ["<natural language queries for search_codebase — focus on patterns/helpers to copy — max 5>"],
+  "files": ["<relative path — e.g. agentception/services/foo.py>"],
+  "searches": ["<natural-language semantic search query>"],
   "plan": "<one sentence: your implementation approach>"
 }
 ```
 
-Rules:
-- Output ONLY the JSON object, nothing else.
-- Do not implement anything yet.
-- Maximum 8 files and 5 searches.
-- Prefer files you know you will edit over files you are merely curious about.
-- Note: files explicitly mentioned in the issue body are pre-loaded automatically — do not repeat them unless you need additional context beyond what is already injected.
+Constraints:
+- Maximum 8 entries in `files`, 5 entries in `searches`.
+- Both arrays may be empty if no pre-loading is needed.
+- Files mentioned verbatim in the issue are pre-loaded automatically — omit them.
+- Prefer files you will edit or copy patterns from over files you are merely curious about.
 """
 
 # Matches relative file paths that appear verbatim in issue text.


### PR DESCRIPTION
## Summary

- The model was outputting \`read_file(path=\"ac://runs/...\")\` in a bash fence during the recon phase instead of the required JSON plan
- The original rule \"Output ONLY the JSON object, nothing else\" was too weak to override tool-use patterns baked into the main system prompt
- New addendum opens with \"THIS IS NOT A TOOL-USE TURN\" (all-caps), lists every forbidden output form explicitly, and explains that tool calls cannot work here because there is no dispatcher

## Root cause

The main agent system prompt teaches the model about tools. The recon call appends a brief addendum, but the model's tool-use priors won beat a single vague "nothing else" rule. The model saw a task, inferred it needed to read a file, and reached for the tool-call pattern it knows best.

## What changed

\`_RECON_SYSTEM_ADDENDUM\` now:
1. Opens with an unambiguous declaration that this is not a tool-use turn
2. Explicitly lists what is FORBIDDEN (tool calls, bash fences, prose)
3. Explicitly lists what is REQUIRED (exactly one json fence, nothing else)
4. Explains *why* tool calls won't work (no dispatcher present)