### PR TITLE
fix: disable chain-of-thought in agent tool loop

### DIFF
--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -1088,14 +1088,15 @@ async def call_local_with_tools(
         "messages": request_messages,
         "temperature": temperature,
         "max_tokens": _local_cap_max_tokens(max_tokens),
-        # Explicitly enable thinking for the agent tool loop.  Ollama 0.18+
-        # honours this field for Qwen3-family models — without it the server
-        # defaults to thinking=on but the field is absent from the response,
-        # which makes it impossible to separate reasoning tokens from content
-        # tokens when diagnosing token-budget exhaustion.  Setting it
-        # explicitly also future-proofs the call: if a future Ollama version
-        # defaults to think=off, agent quality degrades silently without this.
-        "think": True,
+        # Disable chain-of-thought for individual tool-call iterations.
+        # Each agent turn is a small decision ("read this file", "search for
+        # that pattern") that does not benefit from 30k+ tokens of internal
+        # reasoning.  With think=True the model exhausts the entire 32k token
+        # budget on reasoning and has zero tokens left to write the tool call,
+        # producing empty content and stop_reason=tool_calls with 0 calls.
+        # The iterative tool-calling loop IS the reasoning mechanism — the
+        # model builds understanding turn-by-turn, not in one giant CoT block.
+        "think": False,
     }
     if tools:
         payload["tools"] = _tools_to_openai(tools)


### PR DESCRIPTION
## Summary

- Changes `"think": True` → `"think": False` in `call_local_llm_with_tools`
- The model was consuming all 32,768 token ceiling on reasoning *per iteration*, leaving zero tokens for the actual tool call
- Result: empty content, `stop_reason=tool_calls` with 0 tool calls, \"token budget exhausted\" warning

## Why think=False is correct for tool-call iterations

The agent loop is already an iterative reasoning architecture. Each turn is a small, concrete decision: which file to read, what to search for, what code to write. These don't need 30k tokens of internal monologue — they need a fast, direct answer.

The CoT value is in the *accumulation* of tool call results across turns, not in per-turn reasoning. With think=False, the model acts immediately on each turn and builds understanding through the tool results it receives.

## What think=True was added for

It was added (PR #1160) to make token-budget exhaustion detectable — `reasoning_content` only appears in the response when think=True. That detection now works via the `_normalize_openai_message_content` check for both `reasoning_content` and `reasoning` keys, so we can safely flip to think=False without losing observability.