### PR TITLE
fix: persistent fastembed volume — end the repeated ONNX downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,48 +102,12 @@ RUN npm ci --include=dev
 COPY agentception/requirements.txt /app/agentception/requirements.txt
 RUN pip install --no-cache-dir -r /app/agentception/requirements.txt
 
-# Pre-download all ONNX models used by code_indexer into the image layer.
-#
-# IMPORTANT — this step must stay BEFORE "COPY agentception/".  Docker layer
-# caching works top-down: any layer that changes invalidates all layers below
-# it.  If the download were placed after the COPY, every single code change
-# would bust the cache here and force a full 600 MB re-download.  Placing it
-# here means it is only re-run when requirements.txt changes (i.e. a fastembed
-# version bump) — which is exactly the right trigger.
-#
-# HF_TOKEN is passed as a build arg so HuggingFace Hub uses authenticated
-# requests, which have higher rate limits and avoid the unauthenticated-
-# request warning.  The token is declared as an ARG so it is NOT baked into
-# the image layer (Docker ARGs are not persisted in the final image env).
-#
-# HF_HOME is set to the agentception user's cache directory so the models
-# land in the same path the runtime app reads from.  Without this the build
-# runs as root and writes to /root/.cache — a cache miss every startup.
-#
-# Models baked here:
-#   - jinaai/jina-embeddings-v2-base-code  (embedding — TextEmbedding)
-#   - BAAI/bge-reranker-base               (reranker  — TextCrossEncoder)
-ARG HF_TOKEN=""
-# HOME must be set to the agentception user's home so that fastembed writes
-# its cache to /home/agentception/.cache/fastembed/ — fastembed derives its
-# cache root from Path.home(), not from HF_HOME.  Without this the build
-# (running as root) writes to /root/.cache/fastembed/, which is invisible to
-# the runtime agentception user and causes NO_SUCHFILE errors at startup.
-# HF_HOME controls the HuggingFace Hub SDK cache (model card metadata, etc.)
-# and must also point into the agentception user's directory.
-RUN HOME=/home/agentception \
-    HF_HOME=/home/agentception/.cache/huggingface \
-    HF_TOKEN=${HF_TOKEN} \
-    python3 -c "\
-from fastembed import TextEmbedding; \
-from fastembed.rerank.cross_encoder import TextCrossEncoder; \
-emb = TextEmbedding(model_name='jinaai/jina-embeddings-v2-base-code'); \
-list(emb.embed(['warm-up'])); \
-print('Embedding model pre-downloaded.'); \
-rnk = TextCrossEncoder(model_name='BAAI/bge-reranker-base'); \
-list(rnk.rerank('query', ['doc'])); \
-print('Reranker model pre-downloaded.')" \
-    && chown -R agentception:agentception /home/agentception/.cache
+# FastEmbed ONNX models are NOT downloaded at build time.
+# They are stored in the agentception-fastembed-cache named Docker volume and
+# verified / downloaded at container startup by entrypoint.sh.  This means:
+#   - docker compose build is fast (no 600 MB download per build)
+#   - models persist across every rebuild and restart
+#   - entrypoint.sh is self-healing: if the volume is empty it downloads once
 
 # Copy the full package.
 COPY agentception/ /app/agentception/

--- a/agentception/tests/test_agent_loop.py
+++ b/agentception/tests/test_agent_loop.py
@@ -479,27 +479,27 @@ class TestRoleBaseFallback:
     """Unit tests for _role_base_fallback."""
 
     def test_python_developer_returns_developer(self) -> None:
-        from agentception.services.agent_loop import _role_base_fallback
+        from agentception.services.role_loader import role_family_fallback as _role_base_fallback
 
         assert _role_base_fallback("python-developer") == "developer"
 
     def test_typescript_developer_returns_developer(self) -> None:
-        from agentception.services.agent_loop import _role_base_fallback
+        from agentception.services.role_loader import role_family_fallback as _role_base_fallback
 
         assert _role_base_fallback("typescript-developer") == "developer"
 
     def test_data_engineer_returns_engineer(self) -> None:
-        from agentception.services.agent_loop import _role_base_fallback
+        from agentception.services.role_loader import role_family_fallback as _role_base_fallback
 
         assert _role_base_fallback("data-engineer") == "engineer"
 
     def test_no_hyphen_returns_none(self) -> None:
-        from agentception.services.agent_loop import _role_base_fallback
+        from agentception.services.role_loader import role_family_fallback as _role_base_fallback
 
         assert _role_base_fallback("developer") is None
 
     def test_unknown_suffix_returns_none(self) -> None:
-        from agentception.services.agent_loop import _role_base_fallback
+        from agentception.services.role_loader import role_family_fallback as _role_base_fallback
 
         assert _role_base_fallback("python-specialist") is None
 
@@ -509,54 +509,36 @@ class TestLoadRolePromptFamilyFallback:
 
     def test_python_developer_falls_back_to_developer(self, tmp_path: Path) -> None:
         """python-developer.md missing → load developer.md instead of empty string."""
-        import unittest.mock as mock
+        from agentception.services.role_loader import load_role_file
 
         roles_dir = tmp_path / ".agentception" / "roles"
         roles_dir.mkdir(parents=True)
         (roles_dir / "developer.md").write_text("# Developer role content", encoding="utf-8")
         # python-developer.md intentionally absent
 
-        from agentception.services.agent_loop import _load_role_prompt
-
-        with mock.patch(
-            "agentception.services.agent_loop.settings.repo_dir", tmp_path
-        ):
-            result = _load_role_prompt("python-developer")
-
+        result = load_role_file("python-developer", roles_dir)
         assert result == "# Developer role content"
 
     def test_exact_role_preferred_over_family_fallback(self, tmp_path: Path) -> None:
         """When python-developer.md exists, it wins over developer.md."""
-        import unittest.mock as mock
+        from agentception.services.role_loader import load_role_file
 
         roles_dir = tmp_path / ".agentception" / "roles"
         roles_dir.mkdir(parents=True)
         (roles_dir / "developer.md").write_text("# Developer role content", encoding="utf-8")
         (roles_dir / "python-developer.md").write_text("# Python developer role content", encoding="utf-8")
 
-        from agentception.services.agent_loop import _load_role_prompt
-
-        with mock.patch(
-            "agentception.services.agent_loop.settings.repo_dir", tmp_path
-        ):
-            result = _load_role_prompt("python-developer")
-
+        result = load_role_file("python-developer", roles_dir)
         assert result == "# Python developer role content"
 
     def test_unknown_role_no_fallback_returns_empty(self, tmp_path: Path) -> None:
         """Completely unknown roles still return empty string gracefully."""
-        import unittest.mock as mock
+        from agentception.services.role_loader import load_role_file
 
         roles_dir = tmp_path / ".agentception" / "roles"
         roles_dir.mkdir(parents=True)
 
-        from agentception.services.agent_loop import _load_role_prompt
-
-        with mock.patch(
-            "agentception.services.agent_loop.settings.repo_dir", tmp_path
-        ):
-            result = _load_role_prompt("nonexistent-specialist")
-
+        result = load_role_file("nonexistent-specialist", roles_dir)
         assert result == ""
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,11 +28,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        # Pass HF_TOKEN at build time so the model pre-download step uses
-        # authenticated HuggingFace requests (higher rate limits, no warning).
-        # Set HF_TOKEN in .env — it is read here and in the runtime env below.
-        HF_TOKEN: ${HF_TOKEN:-}
     container_name: agentception-app
     restart: unless-stopped
     # Security hardening: prevent privilege escalation inside the container.
@@ -112,6 +107,10 @@ services:
       # HF_HOME under agentception's home so downloads and token file are writable.
       # entrypoint.sh chowns the mounted model_cache volume here before dropping privs.
       HF_HOME: /home/agentception/.cache/huggingface
+      # fastembed reads FASTEMBED_CACHE_PATH to locate its model cache.
+      # Without this it falls back to tempfile.gettempdir() = /tmp/fastembed_cache,
+      # which is wiped on every container restart, causing repeated re-downloads.
+      FASTEMBED_CACHE_PATH: /home/agentception/.cache/fastembed
       # Optional: set HF_TOKEN in .env to avoid HuggingFace rate-limit warnings
       # on model downloads and enable authenticated access to private models.
       HF_TOKEN: ${HF_TOKEN:-}
@@ -168,13 +167,14 @@ services:
       - ${HOME}/.agentception/worktrees/agentception:/worktrees
       # Persist HuggingFace hub files (tokens, metadata) across container restarts.
       - model_cache:/home/agentception/.cache/huggingface
-      # NOTE: fastembed ONNX models are NOT stored in a named volume.
-      # They are baked into the image layer at build time (see Dockerfile RUN step
-      # before COPY agentception/).  A named volume would shadow the image layer —
-      # if the volume was ever created before the models were correctly baked, it
-      # permanently masks them, causing NO_SUCHFILE errors at runtime.  Using the
-      # image layer directly is simpler and more reliable: models are always present
-      # after a clean build and never go stale.
+      # Persist FastEmbed ONNX models across container restarts and rebuilds.
+      # fastembed defaults to /tmp/fastembed_cache (tempfile.gettempdir()) which is
+      # wiped on every restart.  The volume ensures models are downloaded exactly
+      # once.  FASTEMBED_CACHE_PATH overrides fastembed's default so both the app
+      # and the entrypoint startup-check write to and read from the same location.
+      # entrypoint.sh verifies model completeness at startup and re-downloads only
+      # if the ONNX file is missing (self-healing for fresh volume or corruption).
+      - fastembed_cache:/home/agentception/.cache/fastembed
     # Use Cloudflare DNS instead of Docker's embedded resolver.
     # Docker's embedded DNS caches whichever node it gets first, and GitHub
     # occasionally has dead nodes in rotation (e.g. 140.82.116.6) that refuse
@@ -253,6 +253,8 @@ volumes:
     name: agentception-qdrant-data
   model_cache:
     name: agentception-model-cache
+  fastembed_cache:
+    name: agentception-fastembed-cache
   node_modules:
     name: agentception-node-modules
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -69,6 +69,40 @@ chown agentception:agentception /worktrees
 echo "[entrypoint] fixing ownership of HuggingFace cache …"
 chown -R agentception:agentception /home/agentception/.cache/huggingface
 
+# /home/agentception/.cache/fastembed — named volume (agentception-fastembed-cache).
+#   FastEmbed ONNX models.  Fix ownership so the agentception user can write here,
+#   then verify both ONNX files are present.  If either is missing (fresh volume
+#   or corruption), download now — this is the self-healing mechanism that means
+#   models are downloaded exactly once and never lost across restarts or rebuilds.
+echo "[entrypoint] fixing ownership of fastembed cache …"
+mkdir -p /home/agentception/.cache/fastembed
+chown -R agentception:agentception /home/agentception/.cache/fastembed
+
+JINA_ONNX=$(find /home/agentception/.cache/fastembed/models--jinaai--jina-embeddings-v2-base-code -name 'model.onnx' 2>/dev/null | head -1)
+BGE_ONNX=$(find /home/agentception/.cache/fastembed/models--BAAI--bge-reranker-base -name 'model.onnx' 2>/dev/null | head -1)
+
+if [ -z "$JINA_ONNX" ] || [ -z "$BGE_ONNX" ]; then
+  echo "[entrypoint] FastEmbed ONNX models missing — downloading (one-time setup) …"
+  FASTEMBED_CACHE_PATH=/home/agentception/.cache/fastembed \
+  HOME=/home/agentception \
+  HF_HOME=/home/agentception/.cache/huggingface \
+  HF_TOKEN="${HF_TOKEN:-}" \
+  python3 -c "
+from fastembed import TextEmbedding
+from fastembed.rerank.cross_encoder import TextCrossEncoder
+emb = TextEmbedding(model_name='jinaai/jina-embeddings-v2-base-code', cache_dir='/home/agentception/.cache/fastembed')
+list(emb.embed(['warm-up']))
+print('[entrypoint] Jina embedding model: ready')
+rnk = TextCrossEncoder(model_name='BAAI/bge-reranker-base', cache_dir='/home/agentception/.cache/fastembed')
+list(rnk.rerank('query', ['doc']))
+print('[entrypoint] BGE reranker model: ready')
+"
+  chown -R agentception:agentception /home/agentception/.cache/fastembed
+  echo "[entrypoint] FastEmbed models ready."
+else
+  echo "[entrypoint] FastEmbed models present — skipping download."
+fi
+
 # ── 6. Drop to non-root user ─────────────────────────────────────────────────
 # gosu is a purpose-built setuid helper (analogous to sudo -u but without the
 # shell overhead).  It sets UID/GID and execs "$@" — typically uvicorn — as


### PR DESCRIPTION
## Root cause (why it kept happening)

fastembed's default cache path is `tempfile.gettempdir()` = `/tmp/fastembed_cache`, not `~/.cache/fastembed`. Docker wipes `/tmp` on every container restart.

The Dockerfile pre-download step set `HOME=/home/agentception` — but **fastembed never reads `HOME`**. It reads `FASTEMBED_CACHE_PATH`. So every build-time download landed in `/tmp/fastembed_cache/` (inside the build container's `/tmp`), while the app explicitly passes `cache_dir=/home/agentception/.cache/fastembed`. The two paths never matched. The models were never where the app looked for them.

## What changes

| | Before | After |
|---|---|---|
| **Model storage** | `/tmp/fastembed_cache` — wiped on restart | `agentception-fastembed-cache` volume at `/home/agentception/.cache/fastembed` — persists forever |
| **Build time** | 10+ min (600MB download per build) | Fast — no model download in Dockerfile |
| **Fresh install** | Re-download every restart | `entrypoint.sh` downloads once, self-heals if volume corrupted |
| **Env var** | Not set — fastembed fell back to `/tmp` | `FASTEMBED_CACHE_PATH=/home/agentception/.cache/fastembed` explicitly set |

## Migration

The `agentception-fastembed-cache` volume must be pre-populated on existing installs. See setup docs update. For this session the volume was already populated manually before this PR.

## Also fixed

Pre-existing mypy errors: `_role_base_fallback` and `_load_role_prompt` tests in `test_agent_loop.py` were still importing from `agent_loop` after those functions moved to `role_loader` in PR #1148.