### PR TITLE
fix: replace dead think=false with reasoning_effort=none for Ollama

### DIFF
--- a/agentception/services/llm.py
+++ b/agentception/services/llm.py
@@ -1000,21 +1000,28 @@ def _normalize_openai_message_content(message: dict[str, JsonValue]) -> str:
       reasoning + text), concatenate only non-reasoning text parts so the
       returned string is the final answer.
 
-    Emits a warning when content is empty but a ``reasoning`` field is present
-    (Ollama/Qwen3 non-streaming format), which indicates the token budget was
-    exhausted during chain-of-thought before the model could write its answer.
-    Raise ``LOCAL_LLM_COMPLETION_TOKEN_CEILING`` to fix.
+    Emits a warning when content is empty but a ``reasoning`` / ``thinking``
+    field is present (Ollama/Qwen3 non-streaming format), which indicates the
+    token budget was exhausted during chain-of-thought before the model could
+    write its answer.  This should no longer happen with ``reasoning_effort``
+    set correctly, but the guard remains as a safety net.
     """
     raw: JsonValue = message.get("content")
     if raw is None or raw == "":
-        # Ollama ≤0.17 uses "reasoning"; Ollama 0.18+ uses "reasoning_content".
-        # Check both so the warning fires regardless of server version.
-        reasoning: JsonValue = message.get("reasoning_content") or message.get("reasoning")
+        # Ollama 0.18+ uses "reasoning_content" in /v1 responses;
+        # older versions used "reasoning".  Check both.
+        reasoning: JsonValue = (
+            message.get("reasoning_content")
+            or message.get("thinking")
+            or message.get("reasoning")
+        )
         if isinstance(reasoning, str) and reasoning:
             logger.warning(
                 "⚠️ Local LLM returned empty content with non-empty reasoning — "
-                "token budget exhausted during chain-of-thought. "
-                "Raise LOCAL_LLM_COMPLETION_TOKEN_CEILING (currently %d).",
+                "token budget exhausted. "
+                "Verify reasoning_effort=none is accepted by the server "
+                "(Ollama 0.18+ required). "
+                "Current LOCAL_LLM_COMPLETION_TOKEN_CEILING=%d.",
                 settings.local_llm_completion_token_ceiling,
             )
         return ""
@@ -1089,14 +1096,15 @@ async def call_local_with_tools(
         "temperature": temperature,
         "max_tokens": _local_cap_max_tokens(max_tokens),
         # Disable chain-of-thought for individual tool-call iterations.
-        # Each agent turn is a small decision ("read this file", "search for
-        # that pattern") that does not benefit from 30k+ tokens of internal
-        # reasoning.  With think=True the model exhausts the entire 32k token
-        # budget on reasoning and has zero tokens left to write the tool call,
-        # producing empty content and stop_reason=tool_calls with 0 calls.
-        # The iterative tool-calling loop IS the reasoning mechanism — the
-        # model builds understanding turn-by-turn, not in one giant CoT block.
-        "think": False,
+        # reasoning_effort="none" is the correct parameter on Ollama's
+        # OpenAI-compatible /v1/chat/completions endpoint — think=true/false
+        # is silently ignored there.  With default thinking ON, Qwen3.5-35B
+        # burns 4000–5000 completion tokens per turn on internal reasoning
+        # before emitting a tool call (175 s at 29k context); with
+        # reasoning_effort="none" the same turn costs ~31–173 tokens and
+        # completes in 2–16 s.  The iterative tool loop IS the reasoning
+        # mechanism; per-turn CoT adds zero quality and exhausts the budget.
+        "reasoning_effort": "none",
     }
     if tools:
         payload["tools"] = _tools_to_openai(tools)
@@ -1254,7 +1262,7 @@ def _local_completion_payload(
     max_tokens: int = 128,
     stream: bool = False,
     model_override: str = "",
-    think: bool = False,
+    reasoning_effort: str = "none",
 ) -> dict[str, JsonValue]:
     """Build request body for local single-turn completion (no tools).
 
@@ -1263,11 +1271,13 @@ def _local_completion_payload(
     changing the global ``LOCAL_LLM_MODEL`` setting.  When empty, falls back
     to ``settings.local_llm_model``.
 
-    ``think`` controls Qwen3-family chain-of-thought via the Ollama 0.18+
-    ``"think"`` field.  Pass ``think=False`` for calls that need only a short
-    structured response (e.g. recon planning JSON) to avoid burning the token
-    budget on unnecessary reasoning.  Pass ``think=True`` (default for the
-    agent tool loop) when reasoning improves output quality.
+    ``reasoning_effort`` controls Qwen3-family chain-of-thought on Ollama's
+    OpenAI-compatible endpoint.  Valid values: ``"none"`` (off), ``"low"``,
+    ``"medium"``, ``"high"`` (on).  Note: ``think=true/false`` is silently
+    ignored by /v1/chat/completions — ``reasoning_effort`` is the correct
+    parameter.  Defaults to ``"none"`` for structured short-response calls
+    (recon JSON, summaries); pass ``"medium"`` or ``"high"`` for planning
+    streams where chain-of-thought improves output quality.
     """
     capped = _local_cap_max_tokens(max_tokens)
     payload: dict[str, JsonValue] = {
@@ -1279,7 +1289,7 @@ def _local_completion_payload(
         "max_tokens": capped,
         "stream": stream,
         "frequency_penalty": 0.3,
-        "think": think,
+        "reasoning_effort": reasoning_effort,
     }
     model = model_override or settings.local_llm_model
     if model:
@@ -1432,7 +1442,7 @@ async def _local_completion_stream(
             max_tokens=max_tokens,
             stream=True,
             model_override=plan_model,
-            think=True,
+            reasoning_effort="medium",
         )
         # read=120s is the inter-chunk idle timeout: if the server stops sending any
         # SSE data for 120 seconds we abort.  During normal streaming, Ollama emits


### PR DESCRIPTION
## Summary

- `think=true/false` is **silently ignored** by Ollama's `/v1/chat/completions` endpoint — all three values produce identical output
- `reasoning_effort="none"` is the correct Ollama parameter and actually works: eliminates all thinking tokens, 4–28x fewer completion tokens, 16x faster per turn
- At agent scale (29k context), default thinking consumed **4,850 tokens / 175 s** per turn; `reasoning_effort="none"` costs **173 tokens / 10.6 s**

## Changes

- `call_local_llm_with_tools`: `"think": False` → `"reasoning_effort": "none"`
- `_local_completion_payload`: removed dead `think: bool` parameter, replaced with `reasoning_effort: str = "none"`; streaming planner uses `"medium"`  
- `_normalize_openai_message_content`: updated exhaustion warning to point at the correct fix

## Test plan

- [x] `mypy agentception/ tests/` — 305 files, zero errors
- [x] `pytest agentception/tests/test_llm.py -v` — 14/14 passed
- [x] Manual `curl` tests proved: `think=false` = no-op; `reasoning_effort="none"` = 2 tokens vs 145 tokens