### PR TITLE
fix: sync .env.example with current config defaults and document all vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,105 +1,135 @@
-# ── Database ────────────────────────────────────────────────────────────────
-# Password for the Postgres database.
+# =============================================================================
+# AgentCeption — Environment Configuration Example
+# =============================================================================
+# Copy this file to .env and fill in the values.
+#   cp .env.example .env
+#
+# .env is gitignored and never committed.  See docs/guides/setup.md for the
+# full setup walkthrough.
+
+# ── Database ─────────────────────────────────────────────────────────────────
+# Password for the Postgres container.
 # REQUIRED — there is no default. Generate with: openssl rand -hex 16
-# Used by docker-compose.yml to set POSTGRES_PASSWORD and build DATABASE_URL.
 DB_PASSWORD=
 
-# ── GitHub ──────────────────────────────────────────────────────────────────
+# ── GitHub ───────────────────────────────────────────────────────────────────
 # Personal access token with repo + issues scope.
 # Create at: https://github.com/settings/tokens
 # Optional when using gh CLI auth via ~/.config/gh volume mount (see docker-compose.yml).
 GITHUB_TOKEN=
 
-# ── HuggingFace ──────────────────────────────────────────────────────────────
-# Optional: HuggingFace Hub token.  Without it, model downloads are rate-limited
-# to ~1 request/s (unauthenticated).  Get one at https://huggingface.co/settings/tokens
-# The models used (jina-embeddings-v2-base-code, bm25, bge-reranker) are public;
-# the token is only needed to avoid the rate-limit warning and speed up downloads.
-HF_TOKEN=
-
 # The GitHub repo this AgentCeption instance manages (owner/repo).
 # REQUIRED — replace with your own repo.
-GH_REPO=cgcardona/your-repo
+GH_REPO=owner/your-repo
 
-# ── LLM (Anthropic) ─────────────────────────────────────────────────────────
+# ── LLM — Anthropic (cloud) ──────────────────────────────────────────────────
 # API key from https://console.anthropic.com → API Keys
-# Required for Phase 1A planning (brain dump → PlanSpec YAML) and all agent runs.
+# Required when LLM_PROVIDER=anthropic (default).
 ANTHROPIC_API_KEY=
 
-# ── LLM (Local / Ollama) ────────────────────────────────────────────────────
-# Optional: use Ollama (local) as LLM backend instead of Anthropic.
-# See docs/guides/local-llm.md for full Ollama setup (macOS, Linux, Windows).
+# ── LLM — Local / Ollama ─────────────────────────────────────────────────────
+# Use a local Ollama server instead of Anthropic for all LLM calls.
+# See docs/guides/local-llm.md for the full setup walkthrough.
+#
+# Two ways to enable — use one, not both:
+#   LLM_PROVIDER=local          (preferred)
+#   USE_LOCAL_LLM=true          (legacy; overrides LLM_PROVIDER)
+#
 # LLM_PROVIDER=local
-# LOCAL_LLM_BASE_URL=http://host.docker.internal:11434
-# LOCAL_LLM_MODEL=qwen3:30b-a3b
-#
-# Token budget for the local model.  Qwen3-family uses extended chain-of-
-# thought (thinking mode); the reasoning tokens count against max_tokens so
-# the ceiling must be large enough for thinking + actual output.
-# LOCAL_LLM_COMPLETION_TOKEN_CEILING=16384
-#
-# System-prompt character cap.  Qwen3 35B compiled prompts are ~14-16k chars;
-# set this above that value or the prompt will be silently truncated.
-# LOCAL_LLM_MAX_SYSTEM_CHARS=20000
-#
-# Context character cap for the user message (task briefing + injected files).
-# LOCAL_LLM_MAX_CONTEXT_CHARS=60000
-#
-# Recon planning call budget — must be large enough for CoT + JSON output.
-# 2000 is the minimum for Qwen3-family; raise if you see parse failures.
-# (This is set in code, not via env; documented here for reference.)
+# USE_LOCAL_LLM=true
 
-# ── Task Runner ─────────────────────────────────────────────────────────────
-# Task runner backend for agent execution.
-# Valid values: cursor, anthropic
-# Default: anthropic
-# Determines which system executes agent tasks — Cursor IDE with Composer agent
-# or direct Anthropic API calls.
+# Ollama server base URL (no trailing slash).
+# From Docker, use host.docker.internal to reach a server on the host.
+# LOCAL_LLM_BASE_URL=http://host.docker.internal:11434
+
+# Chat completions path — default works for Ollama and most compatible servers.
+# LOCAL_LLM_CHAT_PATH=/v1/chat/completions
+
+# Model tag to send in every request.  Must exactly match an Ollama model name.
+# Recommended models (see docs/guides/local-llm.md for full RAM requirements):
+#   qwen3.5:35b-a3b-q4_K_M   — best quality (48+ GB RAM)
+#   qwen3.5:9b                — good quality (16-24 GB RAM)
+#   qwen3.5:4b                — fast (8-16 GB RAM)
+# LOCAL_LLM_MODEL=qwen3.5:35b-a3b-q4_K_M
+
+# ── Local LLM token / context caps ───────────────────────────────────────────
+# AgentCeption sends reasoning_effort="none" on every agent tool-call turn and
+# single-turn completion, which disables Qwen3-family chain-of-thought entirely.
+# With thinking OFF, agent turns cost 30–200 completion tokens; 32768 gives
+# ample headroom.  See docs/guides/local-llm.md § "Thinking mode and reasoning_effort".
+#
+# LOCAL_LLM_COMPLETION_TOKEN_CEILING=32768   # hard cap on max_tokens per request
+# LOCAL_LLM_MAX_TOKENS=8192                  # desired max output tokens (agent loop)
+# LOCAL_LLM_MAX_SYSTEM_CHARS=20000           # system-prompt character cap
+# LOCAL_LLM_MAX_CONTEXT_CHARS=60000          # user-message character cap (task briefing + files)
+
+# ── Local LLM — per-usecase model overrides (optional) ───────────────────────
+# Route planning calls to a large model and agent tool calls to a fast model.
+# When empty, all calls use LOCAL_LLM_BASE_URL / LOCAL_LLM_MODEL.
+# See docs/guides/local-llm-scaling.md for the full multi-model setup guide.
+#
+# LOCAL_LLM_BASE_URL_PLAN=     # base URL for Phase 1A planning/streaming calls
+# LOCAL_LLM_MODEL_PLAN=        # e.g. qwen3.5:35b-a3b-q4_K_M
+# LOCAL_LLM_BASE_URL_AGENT=    # base URL for agent tool-call turns
+# LOCAL_LLM_MODEL_AGENT=       # e.g. qwen3.5:9b
+
+# ── HuggingFace ──────────────────────────────────────────────────────────────
+# Optional: HuggingFace Hub read token.
+# Without it, model-metadata requests are rate-limited to ~1 req/s (unauthenticated).
+# The models used (jina-embeddings-v2-base-code, bge-reranker-base) are public;
+# the token is only needed to avoid rate-limit warnings.
+# Get one at https://huggingface.co/settings/tokens (read-only scope is fine).
+HF_TOKEN=
+
+# ── Task Runner ──────────────────────────────────────────────────────────────
+# Which backend executes agent tasks.
+# anthropic — direct Anthropic API calls (default, works with both Anthropic and local LLM)
+# Valid values: anthropic
 AC_TASK_RUNNER=anthropic
 
-# ── Paths ───────────────────────────────────────────────────────────────────
+# ── Paths ────────────────────────────────────────────────────────────────────
 # Host-side absolute path to the cloned agentception repo.
 # Used so the container can run git operations against the repo.
-# Defaults to /app (the container working directory) when not set.
-REPO_DIR=
+# Leave empty to use /app (the container working directory).
+HOST_REPO_DIR=
 
 # Host path where agent git worktrees are created.
-# Must be accessible from both the host (for Cursor) and the container.
-# Set this to an absolute path (no ~ expansion in compose env values).
+# Must be accessible from both the host and the container.
+# Use an absolute path — ~ is not expanded in compose env values.
 HOST_WORKTREES_DIR=~/.agentception/worktrees
 
-# Container-internal path that maps to HOST_WORKTREES_DIR.
-# Add a corresponding volume entry in docker-compose.override.yml if you change this.
+# Container-internal path that maps to HOST_WORKTREES_DIR via a volume mount.
+# Only change if you update the volume entry in docker-compose.override.yml.
 WORKTREES_DIR=/worktrees
 
-# ── Security ────────────────────────────────────────────────────────────────
-# ⚠️  IMPORTANT: Set this if the service is reachable from any network other
-# than localhost.  Without it, ALL /api/* endpoints — including dispatch,
-# reset-build, and sweep — are completely unauthenticated.
-# An attacker on the same LAN could drain your Anthropic credits or delete
-# your worktrees.  Generate a strong key with: openssl rand -hex 32
+# ── Security ─────────────────────────────────────────────────────────────────
+# ⚠️  Set this if AgentCeption is reachable from any network other than localhost.
+# Without it, ALL /api/* endpoints — including dispatch, reset-build, and sweep —
+# are completely unauthenticated.  Generate: openssl rand -hex 32
 # When set, every /api/* request must include:  Authorization: Bearer <key>
 AC_API_KEY=
 
-# ── Service ─────────────────────────────────────────────────────────────────
-# Port the AgentCeption FastAPI app listens on (inside the container).
+# ── Service ──────────────────────────────────────────────────────────────────
+# Port the FastAPI app listens on inside the container.
 PORT=1337
-
-# ── Polling / Cache ──────────────────────────────────────────────────────────
-# How often (seconds) the background poller fetches GitHub data.
-# Default: 5  (safe for GitHub rate limits; uncomment to override)
-# POLL_INTERVAL_SECONDS=5
-
-# GitHub API response cache TTL in seconds.
-# MUST be strictly less than POLL_INTERVAL_SECONDS so every poller tick sees
-# live GitHub data.  Default: 4  (just under the 5 s poll interval)
-# GITHUB_CACHE_SECONDS=4
 
 # Log level: DEBUG, INFO, WARNING, ERROR
 LOG_LEVEL=INFO
 
-# Disable per-agent worktree indexing 
+# ── Polling / Cache ───────────────────────────────────────────────────────────
+# How often (seconds) the background poller fetches GitHub data.
+# POLL_INTERVAL_SECONDS=5
+
+# GitHub API response cache TTL in seconds.
+# Must be strictly less than POLL_INTERVAL_SECONDS so every poller tick sees live data.
+# GITHUB_CACHE_SECONDS=4
+
+# ── Codebase indexing ─────────────────────────────────────────────────────────
+# Whether to index each agent worktree into Qdrant for semantic search.
+# Set false to skip indexing (saves startup time; search_codebase returns empty).
 WORKTREE_INDEX_ENABLED=false
 
-# Zero the turn delay for local LLM
+# ── Performance ───────────────────────────────────────────────────────────────
+# Minimum delay in seconds between agent turns (throttle for cloud LLMs).
+# Set to 0 for local LLM (no API rate limits to respect).
 AC_MIN_TURN_DELAY_SECS=0


### PR DESCRIPTION
## Summary

- Fixes outdated values and missing variables in `.env.example`
- Fixes `LOCAL_LLM_MAX_CONTEXT_CHARS` in the local (gitignored) `.env`

## Changes to `.env.example`

| Variable | Before | After |
|---|---|---|
| `LOCAL_LLM_COMPLETION_TOKEN_CEILING` | `16384` | `32768` |
| `LOCAL_LLM_MODEL` example | `qwen3:30b-a3b` | `qwen3.5:35b-a3b-q4_K_M` |
| Reasoning token comment | Describes CoT burning budget | Explains `reasoning_effort=none` eliminates CoT |
| `USE_LOCAL_LLM` | Missing | Documented |
| `HOST_REPO_DIR` | Missing | Documented |
| Multi-model override vars | Missing | Documented (BASE_URL_PLAN, MODEL_PLAN, BASE_URL_AGENT, MODEL_AGENT) |

## Changes to `.env` (gitignored, not committed)

- `LOCAL_LLM_MAX_CONTEXT_CHARS`: `24000` → `60000` (matches `docker-compose.yml` and `config.py` defaults)
- Removed stale `mlx-openai-server` reference from comment

## Test plan

- [x] All values match `docker-compose.yml` `${VAR:-default}` fallbacks
- [x] All values match `agentception/config.py` Python-level defaults