### PR TITLE
fix: remove task/briefing MCP call from reviewer role prompt

### DIFF
--- a/.agentception/roles/reviewer.md
+++ b/.agentception/roles/reviewer.md
@@ -7,22 +7,23 @@ defects.** That is the developer's job. If the code is not ready, reject it.
 
 ## Context
 
-All task context is in your `task/briefing` MCP prompt. Read it once, extract:
+Your initial message already contains everything you need — do not call
+`task/briefing` or any MCP prompt tool. That would return the same content
+already in front of you and waste a turn.
+
+Extract these values from the briefing header at the top of your initial message:
 
 ```
-PR_NUMBER   — from "PR_NUMBER: N" or the PR URL
-BRANCH      — from "Branch: agent/issue-N"
-GH_REPO     — from "GH_REPO: owner/repo"
-ISSUE_NUMBER — from "ISSUE_NUMBER: N"
-OWNER       — the part of GH_REPO before the "/" (e.g. GH_REPO=cgcardona/agentception → OWNER=cgcardona)
-REPO        — the part of GH_REPO after the "/" (e.g. GH_REPO=cgcardona/agentception → REPO=agentception)
+PR_NUMBER    — from "PR_NUMBER: N" in the briefing, or from the PR URL
+BRANCH       — from "Branch: agent/issue-N"
+GH_REPO      — from "**GH_REPO:** owner/repo"
+ISSUE_NUMBER — from "ISSUE_NUMBER: N" or "Issue #N"
+OWNER        — from "**OWNER:** cgcardona" (explicit field in the header)
+REPO         — from "**REPO:** agentception" (explicit field in the header)
 ```
 
-The briefing header contains explicit `**OWNER:**` and `**REPO:**` fields — use
-those directly. Do not call `get_me` to find the owner; that returns the token
-holder, not the repo owner.
-
-Do not read any file before extracting these.
+Do not call `get_me` to find the owner; that returns the token holder, not the
+repo owner.
 
 ## Review Steps — Follow in Order
 

--- a/scripts/gen_prompts/templates/roles/reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/reviewer.md.j2
@@ -6,22 +6,23 @@ defects.** That is the developer's job. If the code is not ready, reject it.
 
 ## Context
 
-All task context is in your `task/briefing` MCP prompt. Read it once, extract:
+Your initial message already contains everything you need — do not call
+`task/briefing` or any MCP prompt tool. That would return the same content
+already in front of you and waste a turn.
+
+Extract these values from the briefing header at the top of your initial message:
 
 ```
-PR_NUMBER   — from "PR_NUMBER: N" or the PR URL
-BRANCH      — from "Branch: agent/issue-N"
-GH_REPO     — from "GH_REPO: owner/repo"
-ISSUE_NUMBER — from "ISSUE_NUMBER: N"
-OWNER       — the part of GH_REPO before the "/" (e.g. GH_REPO=cgcardona/agentception → OWNER=cgcardona)
-REPO        — the part of GH_REPO after the "/" (e.g. GH_REPO=cgcardona/agentception → REPO=agentception)
+PR_NUMBER    — from "PR_NUMBER: N" in the briefing, or from the PR URL
+BRANCH       — from "Branch: agent/issue-N"
+GH_REPO      — from "**GH_REPO:** owner/repo"
+ISSUE_NUMBER — from "ISSUE_NUMBER: N" or "Issue #N"
+OWNER        — from "**OWNER:** cgcardona" (explicit field in the header)
+REPO         — from "**REPO:** agentception" (explicit field in the header)
 ```
 
-The briefing header contains explicit `**OWNER:**` and `**REPO:**` fields — use
-those directly. Do not call `get_me` to find the owner; that returns the token
-holder, not the repo owner.
-
-Do not read any file before extracting these.
+Do not call `get_me` to find the owner; that returns the token holder, not the
+repo owner.
 
 ## Review Steps — Follow in Order
 


### PR DESCRIPTION
## Summary

- Removes the instruction telling the reviewer to call `task/briefing` MCP tool
- Replaces it with an explicit "do NOT call any MCP prompt tool" instruction
- Points the reviewer at the briefing header fields already in the initial message

## Why

The reviewer's initial message already contains the full briefing header (OWNER, REPO, BRANCH, PR_NUMBER, ISSUE_NUMBER) plus the pre-loaded review context (git diff, mypy, pytest, issue body) injected by `_run_reviewer_warmup()`. The old instruction told the agent to call `task/briefing`, which returns the **exact same content** — wasting one full turn before any review work could begin.

With this change the reviewer can extract OWNER/REPO/etc. from the initial message and proceed directly to grading on iteration 1.

## Test plan

- [x] `generate.py --check` passes, no drift
- [x] Reviewed generated `.agentception/roles/reviewer.md` — correct