### PR TITLE
fix: remove ac://runs context directive from runtime note; trim reviewer prohibition

### DIFF
--- a/.agentception/roles/reviewer.md
+++ b/.agentception/roles/reviewer.md
@@ -7,11 +7,8 @@ defects.** That is the developer's job. If the code is not ready, reject it.
 
 ## Context
 
-Your initial message already contains everything you need — do not call
-`task/briefing` or any MCP prompt tool. That would return the same content
-already in front of you and waste a turn.
-
-Extract these values from the briefing header at the top of your initial message:
+Your initial message contains everything you need. Extract these values from
+the briefing header at the top:
 
 ```
 PR_NUMBER    — from "PR_NUMBER: N" in the briefing, or from the PR URL

--- a/agentception/services/agent_loop.py
+++ b/agentception/services/agent_loop.py
@@ -1279,7 +1279,7 @@ You are running **inside the AgentCeption Docker container**, not on the host ma
   you modified.  Full directory scans spawn a subprocess that cold-loads the entire project
   type graph (~1-2 GB extra RSS) on top of the loaded ONNX model weights and crash the container.
 - The repository is mounted at `/app`.  Your worktree path is provided in your
-  initial message.  Read `ac://runs/{run_id}/context` for your full task context.
+  initial message.
 - Git operations run in the worktree directory.
 - Use `run_command` for shell execution.  Use `read_file` / `write_file` for files.
 - Use GitHub MCP tools (`get_issue`, `list_issues`, `add_issue_comment`,

--- a/scripts/gen_prompts/templates/roles/reviewer.md.j2
+++ b/scripts/gen_prompts/templates/roles/reviewer.md.j2
@@ -6,11 +6,8 @@ defects.** That is the developer's job. If the code is not ready, reject it.
 
 ## Context
 
-Your initial message already contains everything you need — do not call
-`task/briefing` or any MCP prompt tool. That would return the same content
-already in front of you and waste a turn.
-
-Extract these values from the briefing header at the top of your initial message:
+Your initial message contains everything you need. Extract these values from
+the briefing header at the top:
 
 ```
 PR_NUMBER    — from "PR_NUMBER: N" in the briefing, or from the PR URL


### PR DESCRIPTION
## Summary

- Removes `ac://runs/{run_id}/context` from `_RUNTIME_ENV_NOTE` — it was going to every agent including the reviewer, which doesn't need it
- Removes the now-unnecessary `task/briefing` prohibition from the reviewer role template

## Root cause

`_RUNTIME_ENV_NOTE` is injected into every agent's system prompt. It contained a line telling agents to read `ac://runs/{run_id}/context` for their full task context. The reviewer doesn't need this — the warmup already pre-loads diff, mypy, pytest, and the issue into `messages[0]`. The developer gets directed to the resource in the briefing itself when the issue body isn't directly injected.

This was the "parent directive" the user identified: remove it at the source rather than adding overrides in each child.

## What changed

- `_RUNTIME_ENV_NOTE`: removed one line (`Read ac://runs/...`). The note is now purely about Docker/git/tools mechanics — which is what it should be.
- `reviewer.md.j2` + generated `.agentception/roles/reviewer.md`: removed the `do not call task/briefing` prohibition. With the source directive gone there's nothing to prohibit.

## Test plan

- [x] `mypy agentception/services/agent_loop.py` — clean
- [x] `generate.py --check` — no drift