### PR TITLE
fix: rename pr-reviewer → reviewer everywhere

### DIFF
--- a/agentception/static/js/org_designer.ts
+++ b/agentception/static/js/org_designer.ts
@@ -318,7 +318,7 @@ const ROLE_GROUPS: RoleGroup[] = [
     label: 'QA / Ops',
     type: 'worker',
     roles: [
-      { slug: 'pr-reviewer',               label: 'PR Reviewer' },
+      { slug: 'reviewer',                   label: 'Reviewer' },
       { slug: 'test-engineer',             label: 'Test Engineer' },
       { slug: 'devops-engineer',           label: 'DevOps Engineer' },
       { slug: 'site-reliability-engineer', label: 'SRE' },
@@ -398,7 +398,7 @@ const CHILD_ROLE_RULES: Record<string, ChildRules> = {
       'rails-developer', 'api-developer', 'full-stack-developer', 'systems-programmer',
       'data-engineer', 'database-architect', 'architect', 'react-developer', 'frontend-developer']),
   },
-  'qa-coordinator':             { coordinator: new Set([]), worker: new Set(['pr-reviewer', 'test-engineer']) },
+  'qa-coordinator':             { coordinator: new Set([]), worker: new Set(['reviewer', 'test-engineer']) },
   'ml-coordinator':             { coordinator: new Set([]), worker: new Set(['ml-engineer', 'ml-researcher', 'data-scientist']) },
   'design-coordinator':         { coordinator: new Set([]), worker: new Set(['frontend-developer', 'react-developer', 'technical-writer', 'content-writer']) },
   'security-coordinator':       { coordinator: new Set([]), worker: new Set(['security-engineer', 'test-engineer']) },
@@ -413,7 +413,7 @@ const CHILD_ROLE_RULES: Record<string, ChildRules> = {
   // Workers — can only spawn a PR Reviewer (for self-initiated code review)
 };
 
-const WORKER_RULES: ChildRules = { coordinator: new Set([]), worker: new Set(['pr-reviewer']) };
+const WORKER_RULES: ChildRules = { coordinator: new Set([]), worker: new Set(['reviewer']) };
 
 /** Returns the allowed child slugs for (parentRole, childType), or null for "all". */
 function getChildRules(parentRole: string, childType: 'coordinator' | 'worker'): Set<string> | null {

--- a/agentception/templates/agent.html
+++ b/agentception/templates/agent.html
@@ -392,8 +392,8 @@
     <div class="org-node
       {%- if leaf_tier %} org-node--current
       {%- else %} org-node--dim{%- endif %}">
-      <span class="org-node__emoji">{% if node.role == 'pr-reviewer' %}🔍{% else %}⚙️{% endif %}</span>
-      <span class="org-node__label">{% if node.role == 'pr-reviewer' %}Reviewer{% else %}Engineer{% endif %}</span>
+      <span class="org-node__emoji">{% if node.role == 'reviewer' %}🔍{% else %}⚙️{% endif %}</span>
+      <span class="org-node__label">{% if node.role == 'reviewer' %}Reviewer{% else %}Engineer{% endif %}</span>
       <span class="org-node__sub">Worker</span>
     </div>
 

--- a/agentception/templates/transcript_detail.html
+++ b/agentception/templates/transcript_detail.html
@@ -29,7 +29,7 @@
         'engineering-coordinator': 'badge--blue', 'qa-coordinator': 'badge--teal',
         'qa-coordinator': 'badge--purple',
         'python-developer': 'badge--green',
-        'pr-reviewer': 'badge--teal',
+        'reviewer': 'badge--teal',
         'database-architect': 'badge--yellow',
         'unknown': 'badge--gray',
       }.get(transcript.role, 'badge--gray') %}
@@ -170,7 +170,7 @@
           'engineering-coordinator': 'badge--blue', 'qa-coordinator': 'badge--teal',
           'qa-coordinator': 'badge--purple',
           'python-developer': 'badge--green',
-          'pr-reviewer': 'badge--teal',
+          'reviewer': 'badge--teal',
           'database-architect': 'badge--yellow',
           'unknown': 'badge--gray',
         }.get(sa.role, 'badge--gray') %}

--- a/agentception/templates/transcripts.html
+++ b/agentception/templates/transcripts.html
@@ -131,7 +131,7 @@
               'engineering-coordinator': 'badge--blue', 'qa-coordinator': 'badge--teal',
               'qa-coordinator': 'badge--purple',
               'python-developer': 'badge--green',
-              'pr-reviewer': 'badge--teal',
+              'reviewer': 'badge--teal',
               'database-architect': 'badge--yellow',
               'unknown': 'badge--gray',
             }.get(t.role, 'badge--gray') %}


### PR DESCRIPTION
## Summary

- `pr-reviewer` is deleted. The role is `reviewer`.
- The UI slug `'pr-reviewer'` never matched `role == 'reviewer'` in any backend check, so reviewer agents were dispatched as plain label workers with no warmup, wrong run_id, and no PR branch anchoring.
- Every occurrence renamed across `org_designer.ts`, `agent.html`, `transcripts.html`, `transcript_detail.html`.
- JS bundle rebuilt.