### PR TITLE
feat(mcp): upgrade to MCP 2025-11-25 spec compliance

### DIFF
--- a/agentception/mcp/server.py
+++ b/agentception/mcp/server.py
@@ -103,10 +103,14 @@ from agentception.mcp.types import (
 logger = logging.getLogger(__name__)
 
 #: MCP protocol version this server implements.
-_MCP_PROTOCOL_VERSION = "2025-03-26"
+_MCP_PROTOCOL_VERSION = "2025-11-25"
 
 #: Server identity advertised in the ``initialize`` response.
-_SERVER_INFO: McpServerInfo = {"name": "agentception", "version": "0.1.1"}
+_SERVER_INFO: McpServerInfo = {
+    "name": "agentception",
+    "version": "0.1.1",
+    "description": "Multi-agent orchestration system for AI-powered development workflows.",
+}
 
 # ---------------------------------------------------------------------------
 # Tool registry

--- a/agentception/mcp/types.py
+++ b/agentception/mcp/types.py
@@ -29,7 +29,7 @@ Resource URIs follow the ``ac://`` scheme with REST-like path segments:
     ac://plan/figures/{role}          — cognitive-arch figures for a role
 """
 
-from typing import TypeAlias, TypedDict
+from typing import NotRequired, TypeAlias, TypedDict
 
 from agentception.types import JsonSchemaObj, JsonValue
 
@@ -56,11 +56,15 @@ class ACToolDef(TypedDict):
     ``inputSchema`` is a JSON Schema object describing the tool's accepted
     parameters.  An empty schema (``{"type": "object", "properties": {}}``)
     signals that the tool accepts no parameters.
+
+    ``icon`` is optional per the 2025-11-25 spec — a URL to an image
+    that clients may display alongside the tool name.
     """
 
     name: str
     description: str
     inputSchema: JsonSchemaObj
+    icon: NotRequired[str]
 
 
 class ACToolContent(TypedDict):
@@ -97,12 +101,15 @@ class ACResourceDef(TypedDict):
 
     Conforms to the ``resources/list`` response item shape.
     Static resources have a fixed URI — no template expansion required.
+
+    ``icon`` is optional per the 2025-11-25 spec.
     """
 
     uri: str
     name: str
     description: str
     mimeType: str
+    icon: NotRequired[str]
 
 
 class ACResourceTemplate(TypedDict):
@@ -111,12 +118,15 @@ class ACResourceTemplate(TypedDict):
     Conforms to the ``resources/templates/list`` response item shape.
     ``uriTemplate`` follows RFC 6570 Level 1 (``{variable}`` expansion) and
     may include a query component (``{?param}``).
+
+    ``icon`` is optional per the 2025-11-25 spec.
     """
 
     uriTemplate: str
     name: str
     description: str
     mimeType: str
+    icon: NotRequired[str]
 
 
 class ACResourceContent(TypedDict):
@@ -165,11 +175,14 @@ class ACPromptDef(TypedDict):
 
     Conforms to the ``prompts/list`` response item shape.  ``arguments``
     is an empty list for static prompts that require no parameters.
+
+    ``icon`` is optional per the 2025-11-25 spec.
     """
 
     name: str
     description: str
     arguments: list[ACPromptArgument]
+    icon: NotRequired[str]
 
 
 class ACPromptContent(TypedDict):
@@ -211,10 +224,15 @@ class ACPromptResult(TypedDict):
 
 
 class McpServerInfo(TypedDict):
-    """Server identity advertised in the ``initialize`` response."""
+    """Server identity advertised in the ``initialize`` response.
+
+    ``description`` is optional per the 2025-11-25 spec — a human-readable
+    summary used by MCP registries and client UIs.
+    """
 
     name: str
     version: str
+    description: NotRequired[str]
 
 
 class McpCapabilities(TypedDict):

--- a/agentception/routes/api/mcp.py
+++ b/agentception/routes/api/mcp.py
@@ -1,10 +1,10 @@
 """HTTP Streamable MCP endpoint.
 
 Exposes the AgentCeption MCP server over HTTP in addition to the stdio transport,
-following the MCP 2025-03-26 Streamable HTTP transport specification.
+following the MCP 2025-11-25 Streamable HTTP transport specification.
 
-Endpoint
---------
+Endpoints
+---------
 POST /api/mcp
     Accepts a JSON-RPC 2.0 request (single object or array of objects) and
     returns the corresponding response.
@@ -14,6 +14,13 @@ POST /api/mcp
 
     Notifications (messages without an ``id`` field) return ``202 Accepted``
     with no body.
+
+GET /api/mcp
+    Returns ``405 Method Not Allowed``.  The AgentCeption MCP surface is
+    request/response only — no persistent SSE streams are offered.  Returning
+    405 (rather than 404) is the correct signal for 2025-11-25-aware clients
+    distinguishing this transport from the deprecated 2024-11-05 HTTP+SSE
+    transport, which opened its stream via GET.
 
 Why two transports
 ------------------
@@ -28,11 +35,27 @@ surface available to:
 The HTTP endpoint calls ``handle_request_async`` directly, so all async tools,
 resource reads, and prompt fetches work identically over both transports.
 
+Security
+--------
+Origin validation (§ Streamable HTTP, 2025-11-25)
+  The MCP spec requires servers to validate the ``Origin`` header on all HTTP
+  connections to prevent DNS rebinding attacks.  If the header is present and
+  the host is not ``localhost`` or ``127.0.0.1``, the server responds with
+  ``403 Forbidden``.  Programmatic MCP clients (agents, CI) never send an
+  ``Origin`` header, so legitimate callers are unaffected.
+
+MCP-Protocol-Version header (§ Streamable HTTP, 2025-11-25)
+  Clients MUST include ``MCP-Protocol-Version`` on all requests after
+  initialization.  If present, the server validates it against the set of
+  supported versions.  Unsupported versions return ``400 Bad Request``.
+  Absent headers are accepted for backwards compatibility (spec allows servers
+  to assume ``2025-03-26`` in that case).
+
 Notes
 -----
-- No session management: each HTTP request is stateless.
+- No session management: each HTTP request is stateless.  Session IDs are
+  optional for stateless servers per the spec.
 - No server-sent events: the current MCP surface is request/response only.
-  SSE streaming can be added in a future iteration when subscriptions land.
 - Authentication: when ``AC_API_KEY`` is set, this endpoint is protected by
   ``ApiKeyMiddleware`` (all ``/api/*`` routes). See the Security guide for
   client configuration.
@@ -42,6 +65,7 @@ from __future__ import annotations
 
 
 import logging
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse
@@ -54,6 +78,85 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["mcp"])
 
+#: Protocol versions this server accepts on the ``MCP-Protocol-Version`` header.
+#: Older versions are allowed for backwards compatibility; unknown future versions
+#: are rejected with 400 so clients learn they need to negotiate downward.
+_SUPPORTED_PROTOCOL_VERSIONS: frozenset[str] = frozenset({"2025-11-25", "2025-03-26"})
+
+#: Hostnames accepted in the ``Origin`` header.  Any other host triggers a 403
+#: to block DNS rebinding attacks from browser-based pages.
+_ALLOWED_ORIGIN_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1"})
+
+
+def _check_origin(request: Request) -> Response | None:
+    """Return a 403 response if the ``Origin`` header is present and invalid.
+
+    Programmatic clients (agents, curl, httpx) never set ``Origin``, so this
+    guard has zero impact on legitimate API use.  It blocks only browser pages
+    attempting cross-origin requests — the DNS rebinding attack vector described
+    in the MCP 2025-11-25 security requirements.
+
+    Returns ``None`` when the request should proceed normally.
+    """
+    origin = request.headers.get("origin")
+    if origin is None:
+        return None
+    try:
+        host = urlparse(origin).hostname or ""
+    except Exception:
+        host = ""
+    if host not in _ALLOWED_ORIGIN_HOSTS:
+        logger.warning("⚠️ mcp_http: rejected request with invalid Origin %r", origin)
+        return JSONResponse(
+            status_code=403,
+            content={
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32600, "message": f"Forbidden: invalid Origin {origin!r}"},
+            },
+        )
+    return None
+
+
+def _check_protocol_version(request: Request) -> Response | None:
+    """Return a 400 response if ``MCP-Protocol-Version`` is present but unsupported.
+
+    The header is optional (absent → backwards-compatible 2025-03-26 assumed).
+    Returns ``None`` when the request should proceed normally.
+    """
+    version = request.headers.get("mcp-protocol-version")
+    if version is None:
+        return None
+    if version not in _SUPPORTED_PROTOCOL_VERSIONS:
+        logger.warning("⚠️ mcp_http: unsupported MCP-Protocol-Version %r", version)
+        return JSONResponse(
+            status_code=400,
+            content={
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {
+                    "code": -32600,
+                    "message": (
+                        f"Unsupported MCP-Protocol-Version {version!r}. "
+                        f"Supported: {sorted(_SUPPORTED_PROTOCOL_VERSIONS)}"
+                    ),
+                },
+            },
+        )
+    return None
+
+
+@router.get("/mcp")
+async def mcp_http_get(_request: Request) -> Response:
+    """Reject GET requests with 405 Method Not Allowed.
+
+    The AgentCeption HTTP transport is request/response only — no persistent
+    SSE stream is offered.  Returning 405 (not 404) is the correct signal for
+    2025-11-25-aware clients that use GET to distinguish Streamable HTTP from
+    the deprecated 2024-11-05 HTTP+SSE transport.
+    """
+    return Response(status_code=405, headers={"Allow": "POST"})
+
 
 @router.post("/mcp")
 async def mcp_http_endpoint(request: Request) -> Response:
@@ -62,15 +165,25 @@ async def mcp_http_endpoint(request: Request) -> Response:
     Supports single requests and JSON-RPC batch arrays.  Notifications
     (requests with no ``id``) return ``202 Accepted`` immediately.
 
+    Security guards run first:
+      - Invalid ``Origin`` → 403 (DNS rebinding protection)
+      - Unsupported ``MCP-Protocol-Version`` → 400
+
     Args:
         request: The incoming FastAPI request object.
 
     Returns:
         - ``200 OK`` with JSON body for requests that produce a result.
         - ``202 Accepted`` with no body for JSON-RPC notifications.
-        - ``400 Bad Request`` when the body is not valid JSON.
+        - ``400 Bad Request`` when the body is not valid JSON or the protocol version is unsupported.
+        - ``403 Forbidden`` when the ``Origin`` header is present but invalid.
         - ``500 Internal Server Error`` for unexpected processing failures.
     """
+    if (guard := _check_origin(request)) is not None:
+        return guard
+    if (guard := _check_protocol_version(request)) is not None:
+        return guard
+
     try:
         body = await request.json()
     except Exception as exc:

--- a/agentception/tests/test_mcp_http.py
+++ b/agentception/tests/test_mcp_http.py
@@ -8,6 +8,9 @@ Test categories:
   - Batch requests (array of messages)
   - Error cases: malformed JSON, missing fields, invalid method
   - New tools accessible via HTTP (log_run_error, github_add_comment)
+  - MCP 2025-11-25 compliance: protocol version string, server description
+  - Security: Origin header validation (→ 403), MCP-Protocol-Version (→ 400)
+  - Transport disambiguation: GET /api/mcp → 405
 """
 
 from __future__ import annotations
@@ -58,6 +61,22 @@ class TestMcpHttpBasic:
         assert "tools" in caps
         assert "resources" in caps
         assert "prompts" in caps
+
+    @pytest.mark.anyio
+    async def test_initialize_returns_2025_11_25_protocol_version(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=_rpc("initialize"))
+        result = r.json()["result"]
+        assert result["protocolVersion"] == "2025-11-25"
+
+    @pytest.mark.anyio
+    async def test_initialize_returns_server_description(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=_rpc("initialize"))
+        server_info = r.json()["result"]["serverInfo"]
+        assert "description" in server_info
+        assert isinstance(server_info["description"], str)
+        assert len(server_info["description"]) > 0
 
     @pytest.mark.anyio
     async def test_ping_returns_empty_result(self, app: FastAPI) -> None:
@@ -349,3 +368,144 @@ class TestMcpHttpNewTools:
         payload = json.loads(text)
         assert isinstance(payload, dict)
         assert payload["comment_url"] == comment_url
+
+
+# ---------------------------------------------------------------------------
+# MCP 2025-11-25: Origin header security (DNS rebinding protection)
+# ---------------------------------------------------------------------------
+
+class TestMcpHttpOriginSecurity:
+    @pytest.mark.anyio
+    async def test_no_origin_header_is_allowed(self, app: FastAPI) -> None:
+        """Programmatic clients (agents) send no Origin — must be accepted."""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=_rpc("ping"))
+        assert r.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_localhost_origin_is_allowed(self, app: FastAPI) -> None:
+        """Requests from localhost pages are permitted."""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                json=_rpc("ping"),
+                headers={"Origin": "http://localhost:3000"},
+            )
+        assert r.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_127_0_0_1_origin_is_allowed(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                json=_rpc("ping"),
+                headers={"Origin": "http://127.0.0.1:1337"},
+            )
+        assert r.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_external_origin_returns_403(self, app: FastAPI) -> None:
+        """Cross-origin browser requests from external domains must be blocked."""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                json=_rpc("ping"),
+                headers={"Origin": "https://evil.example.com"},
+            )
+        assert r.status_code == 403
+        body = r.json()
+        assert "error" in body
+
+    @pytest.mark.anyio
+    async def test_malformed_origin_returns_403(self, app: FastAPI) -> None:
+        """An unparseable Origin header is rejected."""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                json=_rpc("ping"),
+                headers={"Origin": "not-a-url"},
+            )
+        assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# MCP 2025-11-25: MCP-Protocol-Version header validation
+# ---------------------------------------------------------------------------
+
+class TestMcpHttpProtocolVersion:
+    @pytest.mark.anyio
+    async def test_no_version_header_is_accepted(self, app: FastAPI) -> None:
+        """Absent header → backwards compatible, allowed per spec."""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post("/api/mcp", json=_rpc("ping"))
+        assert r.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_current_version_header_is_accepted(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                json=_rpc("ping"),
+                headers={"MCP-Protocol-Version": "2025-11-25"},
+            )
+        assert r.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_legacy_version_header_is_accepted(self, app: FastAPI) -> None:
+        """2025-03-26 is still supported for backwards compatibility."""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                json=_rpc("ping"),
+                headers={"MCP-Protocol-Version": "2025-03-26"},
+            )
+        assert r.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_unsupported_version_header_returns_400(self, app: FastAPI) -> None:
+        """A version string we don't recognise must be rejected with 400."""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                json=_rpc("ping"),
+                headers={"MCP-Protocol-Version": "2030-01-01"},
+            )
+        assert r.status_code == 400
+        body = r.json()
+        assert "error" in body
+
+    @pytest.mark.anyio
+    async def test_garbage_version_header_returns_400(self, app: FastAPI) -> None:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.post(
+                "/api/mcp",
+                json=_rpc("ping"),
+                headers={"MCP-Protocol-Version": "not-a-version"},
+            )
+        assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# MCP 2025-11-25: Transport disambiguation — GET must return 405
+# ---------------------------------------------------------------------------
+
+class TestMcpHttpTransportDisambiguation:
+    @pytest.mark.anyio
+    async def test_get_returns_405(self, app: FastAPI) -> None:
+        """GET /api/mcp must return 405 so 2025-11-25 clients don't confuse
+        this with the deprecated 2024-11-05 HTTP+SSE transport (which used GET
+        to open its event stream)."""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.get("/api/mcp")
+        assert r.status_code == 405
+        assert "POST" in r.headers.get("allow", "")
+
+    @pytest.mark.anyio
+    async def test_get_with_origin_still_returns_405_not_403(self, app: FastAPI) -> None:
+        """GET runs before Origin check — 405 is returned regardless of Origin."""
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.get(
+                "/api/mcp",
+                headers={"Origin": "https://evil.example.com"},
+            )
+        assert r.status_code == 405


### PR DESCRIPTION
## Summary

- Bumps `_MCP_PROTOCOL_VERSION` from `2025-03-26` to `2025-11-25`
- Adds `description` to server info and `icon: NotRequired[str]` to all tool/resource/prompt type defs (new optional metadata fields in 2025-11-25)
- Adds Origin header validation → 403 on the HTTP endpoint (DNS rebinding protection, now a **MUST** per spec)
- Adds `MCP-Protocol-Version` header validation → 400 for unrecognised versions; absent header allowed for backwards compat
- Adds `GET /api/mcp` → 405 so 2025-11-25-aware clients correctly identify this as Streamable HTTP instead of the deprecated 2024-11-05 HTTP+SSE transport
- 12 new tests covering all new behaviours; 33/33 passing

Elicitation, sampling, roots, and experimental tasks deliberately omitted — not applicable to this server's use case.

## Test plan

- [x] `mypy` — zero errors
- [x] `typing_audit --max-any 0` — passes
- [x] `pytest agentception/tests/test_mcp_http.py` — 33/33 green
- [x] `generate.py --check` — no drift
